### PR TITLE
Add normalized UV coordinates to the TextureViewer window.

### DIFF
--- a/renderdocui/Windows/TextureViewer.cs
+++ b/renderdocui/Windows/TextureViewer.cs
@@ -1415,14 +1415,9 @@ namespace renderdocui.Windows
             float invWidth = tex.width > 0 ? 1.0f / tex.width : 0.0f;
             float invHeight = tex.height > 0 ? 1.0f /tex.height : 0.0f;
 
-            int minCount = m_Core.Config.Formatter_MinFigures;
-            int maxCount = m_Core.Config.Formatter_MaxFigures;
-            string minFigures= new String('0', minCount);
-            string maxFigures= new String('#', maxCount-minCount);
-            string formatString= String.Format("{{0}}, {{1}} ({{2:0.{0}{1}}}, {{3:0.{2}{3}}})",
-                minFigures, maxFigures, minFigures, maxFigures);
+            string hoverCoords = String.Format("{0}, {1}, ({2}, {3})", 
+                x, y, Formatter.Format(x * invWidth), Formatter.Format(y * invHeight));
 
-            string hoverCoords = String.Format(formatString, x, y, x * invWidth, y * invHeight);
             string statusText = "Hover - " + hoverCoords;
 
             if (m_CurHoverPixel.X > tex.width || m_CurHoverPixel.Y > tex.height || m_CurHoverPixel.X < 0 || m_CurHoverPixel.Y < 0)


### PR DESCRIPTION
This is just my first tiny change to allow the viewer to see the normalized UV coordinates along with the actual UVs. It's based off the min & max figures found in the options window.
