### PR TITLE
Use DXGI 1.2 to call Present1(), not 1.3

### DIFF
--- a/renderdoc/driver/dxgi/dxgi_wrapped.cpp
+++ b/renderdoc/driver/dxgi/dxgi_wrapped.cpp
@@ -471,7 +471,7 @@ HRESULT WrappedIDXGISwapChain2::Present1(UINT SyncInterval, UINT Flags, const DX
 
 	m_pDevice->Present(this, SyncInterval, Flags);
 
-	return m_pReal2->Present1(SyncInterval, Flags, pPresentParameters);
+	return m_pReal1->Present1(SyncInterval, Flags, pPresentParameters);
 }
 #endif
 


### PR DESCRIPTION
Present1 is a method on IDXGISwapChain1 (1.2) not SwapChain2 (1.3); on Windows 8.0, m_pReal2 is null, leading to a crash if an app tries to call Present1 while hooked by renderdoc.