### PR TITLE
Add explicit cast when QI for IRenderDoc_uuid

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -674,7 +674,7 @@ HRESULT WrappedID3D11Device::QueryInterface(REFIID riid, void **ppvObject)
 	else if(riid == IRenderDoc_uuid)
 	{
 		AddRef();
-		*ppvObject = this;
+		*ppvObject = static_cast<IUnknown*>(this);
 		return S_OK;
 	}
 	else


### PR DESCRIPTION
When assigning to the void** output parameter in QueryInterface, ensure
that the pointer written into the output is a COM pointer by casting to
the correct branch of the multiple inheritance.

As commit 2558b2cde introducing this functionality claims to return an
IUnknown*, so does this commit.