### PR TITLE
Barries now use GENERAL layout instead of PRESENT_SRC

### DIFF
--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -109,6 +109,21 @@ int StageIndex(VkShaderStageFlagBits stageFlag)
 
 void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkImageMemoryBarrier *barriers)
 {
+	for (uint32_t n_barrier = 0;
+				  n_barrier < count;
+				++n_barrier)
+	{
+		if (barriers[n_barrier].newLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
+		{
+			barriers[n_barrier].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+		}
+
+		if (barriers[n_barrier].oldLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
+		{
+			barriers[n_barrier].oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+		}
+	}
+
 	ObjDisp(cmd)->CmdPipelineBarrier(Unwrap(cmd),
 		VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0,
 		0, NULL,          // global memory barriers


### PR DESCRIPTION
If the application records a x->PRESENT_SRC or PRESENT_SRC->y transition, we need to convert PRESENT_SRC part of the barrier to GENERAL, since target images are no longer swapchain images, as was the case when the application was running.