### PR TITLE
More Linux compile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,18 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
     set(warning_flags
         -Wall
+        -Wextra
         -Werror
-        -Wno-unused
+        -Wno-unused-variable
+        -Wno-type-limits
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
         -Wno-unknown-pragmas
         -Wno-reorder)
+    if(CMAKE_COMPILER_IS_GNUCXX)
+        list(APPEND warning_flags -Wno-unused-but-set-variable)
+    endif()
+
     string(REPLACE ";" " " warning_flags "${warning_flags}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${warning_flags}")
 endif()

--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -134,6 +134,11 @@ if(UNIX)
     list(APPEND sources os/linux/linux_libentry.cpp)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(3rdparty/tinyexr/tinyexr.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-extra -Wno-unused-function")
+endif()
+
 add_library(rdoc OBJECT ${sources})
 target_compile_definitions(rdoc ${RDOC_DEFINITIONS})
 target_include_directories(rdoc ${RDOC_INCLUDES})

--- a/renderdoc/common/common.h
+++ b/renderdoc/common/common.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
@@ -135,7 +135,7 @@ bool WrappedOpenGL::Serialise_glShaderSource(GLuint shader, GLsizei count, const
 	{
 		string s;
 		if(source && source[i])
-			s = length > 0 ? string(source[i], source[i] + length[i]) : string(source[i]);
+			s = (length && length[i] > 0) ? string(source[i], source[i] + length[i]) : string(source[i]);
 		
 		m_pSerialiser->SerialiseString("source", s);
 
@@ -1331,7 +1331,7 @@ bool WrappedOpenGL::Serialise_glCompileShaderIncludeARB(GLuint shader, GLsizei c
 	{
 		string s;
 		if(path && path[i])
-			s = length > 0 ? string(path[i], path[i] + length[i]) : string(path[i]);
+			s = (length && length[i] > 0) ? string(path[i], path[i] + length[i]) : string(path[i]);
 		
 		m_pSerialiser->SerialiseString("path", s);
 

--- a/renderdoc/driver/shaders/spirv/CMakeLists.txt
+++ b/renderdoc/driver/shaders/spirv/CMakeLists.txt
@@ -76,6 +76,11 @@ set(sources
     spirv_disassemble.cpp
     ${glslang_sources})
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(${glslang_dir}/SPIRV/GlslangToSpv.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-tautological-constant-out-of-range-compare")
+endif()
+
 add_library(rdoc_spirv OBJECT ${sources})
 target_compile_definitions(rdoc_spirv ${RDOC_DEFINITIONS})
 target_include_directories(rdoc_spirv ${RDOC_INCLUDES})

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -31,15 +31,6 @@
 
 #include "jpeg-compressor/jpge.h"
 
-static bool operator <(const VkExtensionProperties &a, const VkExtensionProperties &b)
-{
-	int cmp = strcmp(a.extensionName, b.extensionName);
-	if(cmp == 0)
-		return a.specVersion < b.specVersion;
-
-	return cmp < 0;
-}
-
 const char *VkChunkNames[] =
 {
 	"WrappedVulkan::Initialisation",

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -278,7 +278,7 @@ private:
 	{ return m_PhysicalDeviceData.features; }
 	const VkPhysicalDeviceProperties &GetDeviceProps()
 	{ return m_PhysicalDeviceData.props; }
-	const bool IsAMD()
+	bool IsAMD()
 	{ return m_PhysicalDeviceData.props.vendorID == 0x1002; }
 	const VkFormatProperties &GetFormatProperties(VkFormat f)
 	{ return m_PhysicalDeviceData.fmtprops[f]; }

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -1880,7 +1880,7 @@ void VulkanDebugManager::BeginText(const TextPrintState &textstate)
 {
 	const VkLayerDispatchTable *vt = ObjDisp(textstate.cmd);
 	
-	VkClearValue clearval = {0};
+	VkClearValue clearval = {};
 	VkRenderPassBeginInfo rpbegin = {
 		VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 		Unwrap(textstate.rp), Unwrap(textstate.fb),
@@ -2111,8 +2111,8 @@ void VulkanDebugManager::MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &
 
 	static VkPipelineVertexInputStateCreateInfo vi = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
 
-	static VkVertexInputAttributeDescription viattr[128] = {0};
-	static VkVertexInputBindingDescription vibind[128] = {0};
+	static VkVertexInputAttributeDescription viattr[128] = {};
+	static VkVertexInputBindingDescription vibind[128] = {};
 
 	vi.pVertexAttributeDescriptions = viattr;
 	vi.pVertexBindingDescriptions = vibind;
@@ -2149,8 +2149,8 @@ void VulkanDebugManager::MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &
 
 	static VkPipelineViewportStateCreateInfo vp = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
 
-	static VkViewport views[32] = {0};
-	static VkRect2D scissors[32] = {0};
+	static VkViewport views[32] = {};
+	static VkRect2D scissors[32] = {};
 
 	memcpy(views, &pipeInfo.viewports[0], pipeInfo.viewports.size()*sizeof(VkViewport));
 
@@ -2204,7 +2204,7 @@ void VulkanDebugManager::MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &
 	cb.logicOp = pipeInfo.logicOp;
 	memcpy(cb.blendConstants, pipeInfo.blendConst, sizeof(cb.blendConstants));
 
-	static VkPipelineColorBlendAttachmentState atts[32] = { 0 };
+	static VkPipelineColorBlendAttachmentState atts[32] = {};
 
 	cb.attachmentCount = (uint32_t)pipeInfo.attachments.size();
 	cb.pAttachments = atts;
@@ -2894,7 +2894,7 @@ ResourceId VulkanDebugManager::RenderOverlay(ResourceId texid, TextureDisplayOve
 		black[3] = 0.0f;
 
 		{
-			VkClearValue clearval = {0};
+			VkClearValue clearval = {};
 			VkRenderPassBeginInfo rpbegin = {
 				VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 				Unwrap(m_OverlayNoDepthRP), Unwrap(m_OverlayNoDepthFB),
@@ -2917,8 +2917,7 @@ ResourceId VulkanDebugManager::RenderOverlay(ResourceId texid, TextureDisplayOve
 				0, 1,
 			};
 			VkClearAttachment blackclear = {
-				VK_IMAGE_ASPECT_COLOR_BIT, 0,
-				{ 0.0f, 0.0f, 0.0f, 0.0f }
+				VK_IMAGE_ASPECT_COLOR_BIT, 0, {}
 			};
 			vt->CmdClearAttachments(Unwrap(cmd), 1, &blackclear, 1, &rect);
 			
@@ -3472,8 +3471,7 @@ ResourceId VulkanDebugManager::RenderOverlay(ResourceId texid, TextureDisplayOve
 			m_pDriver->m_RenderState.BeginRenderPassAndApplyState(cmd);
 
 			VkClearAttachment blackclear = {
-				VK_IMAGE_ASPECT_COLOR_BIT, 0,
-				{ 0.0f, 0.0f, 0.0f, 0.0f }
+				VK_IMAGE_ASPECT_COLOR_BIT, 0, {}
 			};
 			vector<VkClearAttachment> atts;
 
@@ -3662,7 +3660,7 @@ ResourceId VulkanDebugManager::RenderOverlay(ResourceId texid, TextureDisplayOve
 				// wait for writing to finish
 				DoPipelineBarrier(cmd, 1, &quadImBarrier);
 				
-				VkClearValue clearval = {0};
+				VkClearValue clearval = {};
 				VkRenderPassBeginInfo rpbegin = {
 					VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 					Unwrap(m_OverlayNoDepthRP), Unwrap(m_OverlayNoDepthFB),
@@ -4063,7 +4061,7 @@ static void AddOutputDumping(const ShaderReflection &refl, const char *entryName
 		uint32_t varID;        // we get this from the output signature, ID of actual variable
 		uint32_t childIdx;     // if the output variable is a struct, this is the member idx of this output
 	};
-	outputIDs outs[100] = {0};
+	outputIDs outs[100] = {};
 
 	RDCASSERT(numOutputs < 100);
 

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -4782,14 +4782,14 @@ void VulkanDebugManager::InitPostVSBuffers(uint32_t frameID, uint32_t eventID)
 	{
 		// empty vertex output signature
 		m_PostVSData[idx].vsin.topo = p.topology;
-		m_PostVSData[idx].vsout.buf = NULL;
+		m_PostVSData[idx].vsout.buf = VK_NULL_HANDLE;
 		m_PostVSData[idx].vsout.instStride = 0;
 		m_PostVSData[idx].vsout.vertStride = 0;
 		m_PostVSData[idx].vsout.nearPlane = 0.0f;
 		m_PostVSData[idx].vsout.farPlane = 0.0f;
 		m_PostVSData[idx].vsout.useIndices = false;
 		m_PostVSData[idx].vsout.hasPosOut = false;
-		m_PostVSData[idx].vsout.idxBuf = NULL;
+		m_PostVSData[idx].vsout.idxBuf = VK_NULL_HANDLE;
 
 		m_PostVSData[idx].vsout.topo = p.topology;
 

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -987,11 +987,11 @@ VulkanDebugManager::VulkanDebugManager(WrappedVulkan *driver, VkDevice dev)
 	stages[0].module = module[BLITVS];
 	stages[1].module = module[QUADRESOLVEFS];
 
-	pipeInfo.layout = m_QuadResolvePipeLayout;
-	pipeInfo.renderPass = wrappedRGBA8RP;
-	
 	if(m_State < WRITING)
 	{
+		pipeInfo.layout = m_QuadResolvePipeLayout;
+		pipeInfo.renderPass = wrappedRGBA8RP;
+
 		vkr = m_pDriver->vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &pipeInfo, NULL, &m_QuadResolvePipeline);
 		RDCASSERTEQUAL(vkr, VK_SUCCESS);
 	}
@@ -1078,10 +1078,10 @@ VulkanDebugManager::VulkanDebugManager(WrappedVulkan *driver, VkDevice dev)
 
 			GetResourceManager()->WrapResource(Unwrap(dev), m_HistogramPipe[t][f]);
 
-			compPipeInfo.stage.module = minmaxresult;
-
 			if(t == 1)
 			{
+				compPipeInfo.stage.module = minmaxresult;
+
 				vkr = vt->CreateComputePipelines(Unwrap(dev), VK_NULL_HANDLE, 1, &compPipeInfo, NULL, &m_MinMaxResultPipe[f]);
 				RDCASSERTEQUAL(vkr, VK_SUCCESS);
 

--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -859,7 +859,7 @@ bool WrappedVulkan::Apply_SparseInitialState(WrappedVkImage *im, VulkanResourceM
 	}
 
 	{
-		VkSparseImageMemoryBindInfo imgBinds[NUM_VK_IMAGE_ASPECTS] = { 0 };
+		VkSparseImageMemoryBindInfo imgBinds[NUM_VK_IMAGE_ASPECTS] = {};
 
 		VkBindSparseInfo bindsparse = {
 			VK_STRUCTURE_TYPE_BIND_SPARSE_INFO, NULL,
@@ -1839,7 +1839,7 @@ void WrappedVulkan::Apply_InitialState(WrappedVkRes *live, VulkanResourceManager
 					DoPipelineBarrier(cmd, 1, &barrier);
 				}
 				
-				VkClearColorValue clearval = { 0.0f, 0.0f, 0.0f, 0.0f };
+				VkClearColorValue clearval = {};
 				VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS };
 
 				ObjDisp(cmd)->CmdClearColorImage(Unwrap(cmd), ToHandle<VkImage>(live), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearval, 1, &range);

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -1633,7 +1633,7 @@ void VulkanReplay::RenderMesh(uint32_t frameID, uint32_t eventID, const vector<M
 	// solid render
 	if(cfg.solidShadeMode != eShade_None && cfg.position.topo < eTopology_PatchList)
 	{
-		VkPipeline pipe = NULL;
+		VkPipeline pipe = VK_NULL_HANDLE;
 		switch(cfg.solidShadeMode)
 		{
 			case eShade_Solid:

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -853,7 +853,7 @@ void VulkanReplay::PickPixel(ResourceId texture, uint32_t x, uint32_t y, uint32_
 				texDisplay.Red = texDisplay.Blue = texDisplay.Alpha = false;
 			}
 
-			VkClearValue clearval = {0};
+			VkClearValue clearval = {};
 			VkRenderPassBeginInfo rpbegin = {
 				VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 				Unwrap(GetDebugManager()->m_PickPixelRP), Unwrap(GetDebugManager()->m_PickPixelFB),
@@ -959,7 +959,7 @@ bool VulkanReplay::RenderTexture(TextureDisplay cfg)
 
 	OutputWindow &outw = it->second;
 	
-	VkClearValue clearval = {0};
+	VkClearValue clearval = {};
 	VkRenderPassBeginInfo rpbegin = {
 		VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 		Unwrap(outw.rp), Unwrap(outw.fb),
@@ -1308,7 +1308,7 @@ void VulkanReplay::RenderCheckerboard(Vec3f light, Vec3f dark)
 	GetDebugManager()->m_CheckerboardUBO.Unmap(vt, dev);
 
 	{
-		VkClearValue clearval = {0};
+		VkClearValue clearval = {};
 		VkRenderPassBeginInfo rpbegin = {
 			VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 			Unwrap(outw.rp), Unwrap(outw.fb),
@@ -1350,7 +1350,7 @@ void VulkanReplay::RenderHighlightBox(float w, float h, float scale)
 	RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
 	{
-		VkClearValue clearval = {0};
+		VkClearValue clearval = {};
 		VkRenderPassBeginInfo rpbegin = {
 			VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 			Unwrap(outw.rp), Unwrap(outw.fb),
@@ -1362,12 +1362,12 @@ void VulkanReplay::RenderHighlightBox(float w, float h, float scale)
 		VkClearAttachment black = {
 			VK_IMAGE_ASPECT_COLOR_BIT,
 			0,
-			{ 0.0f, 0.0f, 0.0f, 1.0f }
+			{{{ 0.0f, 0.0f, 0.0f, 1.0f }}}
 		};
 		VkClearAttachment white = {
 			VK_IMAGE_ASPECT_COLOR_BIT,
 			0,
-			{ 1.0f, 1.0f, 1.0f, 1.0f }
+			{{{ 1.0f, 1.0f, 1.0f, 1.0f }}}
 		};
 
 		uint32_t sz = uint32_t(scale);
@@ -1517,7 +1517,7 @@ void VulkanReplay::RenderMesh(uint32_t frameID, uint32_t eventID, const vector<M
 	vkr = vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
 	RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-	VkClearValue clearval = {0};
+	VkClearValue clearval = {};
 	VkRenderPassBeginInfo rpbegin = {
 		VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 		Unwrap(outw.rpdepth), Unwrap(outw.fbdepth),
@@ -4160,7 +4160,7 @@ byte *VulkanReplay::GetTextureData(ResourceId tex, uint32_t arrayIdx, uint32_t m
 			vkr = vt->CreateFramebuffer(Unwrap(dev), &fbinfo, NULL, &tmpFB[i]);
 			RDCASSERTEQUAL(vkr, VK_SUCCESS);
 			
-			VkClearValue clearval = {0};
+			VkClearValue clearval = {};
 			VkRenderPassBeginInfo rpbegin = {
 				VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, NULL,
 				tmpRP, tmpFB[i],

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -173,9 +173,20 @@ struct WrappedVkDispRes : public WrappedVkRes
 	WrappedVulkan *core;
 };
 
+struct WrappedVkDispResSizeCheck {
+    uintptr_t pad1[2];
+    uint64_t pad2[2];
+    void *pad3[2];
+};
+
+struct WrappedVkNonDispResSizeCheck {
+    uint64_t pad1[2];
+    void *pad2[1];
+};
+
 // ensure the structs don't accidentally get made larger
-RDCCOMPILE_ASSERT(sizeof(WrappedVkDispRes) == (sizeof(uint64_t)*2 + sizeof(uintptr_t)*4), "Wrapped resource struct has changed size! This is bad");
-RDCCOMPILE_ASSERT(sizeof(WrappedVkNonDispRes) == sizeof(uint64_t)*3, "Wrapped resource struct has changed size! This is bad");
+RDCCOMPILE_ASSERT(sizeof(WrappedVkDispRes) == sizeof(WrappedVkDispResSizeCheck), "Wrapped resource struct has changed size! This is bad");
+RDCCOMPILE_ASSERT(sizeof(WrappedVkNonDispRes) == sizeof(WrappedVkNonDispResSizeCheck), "Wrapped resource struct has changed size! This is bad");
 
 // these are expanded out so that IDE autocompletion etc works without having to process through macros
 struct WrappedVkInstance : WrappedVkDispRes

--- a/renderdoc/driver/vulkan/vk_state.cpp
+++ b/renderdoc/driver/vulkan/vk_state.cpp
@@ -93,7 +93,7 @@ void VulkanRenderState::BeginRenderPassAndApplyState(VkCommandBuffer cmd)
 	// has all load ops set to load (as we're doing a partial replay - can't
 	// just clear the targets that are partially written to).
 
-	VkClearValue empty[16] = {0};
+	VkClearValue empty[16] = {};
 
 	RDCASSERT(ARRAY_COUNT(empty) >= m_CreationInfo->m_RenderPass[renderPass].attachments.size());
 

--- a/renderdoc/maths/matrix.h
+++ b/renderdoc/maths/matrix.h
@@ -79,7 +79,7 @@ class Matrix4f
 
 		Vec3f Transform(const Vec3f &v, const float w=1.0f) const;
 
-		const float * const Data() const { return &f[0]; }
+		const float *Data() const { return &f[0]; }
 		
 		const Vec3f GetPosition() const;
 		const Vec3f GetForward() const;

--- a/renderdoc/os/linux/linux_process.cpp
+++ b/renderdoc/os/linux/linux_process.cpp
@@ -32,7 +32,6 @@
 #include <unistd.h>
 #include <dlfcn.h>
 #include <string.h>
-#include <libgen.h>
 
 #include "serialise/string_utils.h"
 
@@ -208,7 +207,7 @@ static pid_t RunProcess(const char *app, const char *workingDir, const char *cmd
 		else
 		{
 			string exedir = app;
-			chdir(dirname((char *)exedir.c_str()));
+			chdir(dirname(exedir).c_str());
 		}
 
 		execve(app, argv, envp);

--- a/renderdoc/os/linux/linux_stringio.cpp
+++ b/renderdoc/os/linux/linux_stringio.cpp
@@ -30,6 +30,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/renderdoc/os/linux/linux_stringio.cpp
+++ b/renderdoc/os/linux/linux_stringio.cpp
@@ -294,7 +294,7 @@ namespace FileIO
 
 		if(res == 0)
 		{
-			return (uint64_t)st.st_mtim.tv_sec;
+			return (uint64_t)st.st_mtime;
 		}
 		
 		return 0;

--- a/renderdoc/serialise/serialiser.cpp
+++ b/renderdoc/serialise/serialiser.cpp
@@ -24,6 +24,7 @@
  ******************************************************************************/
 
 
+#include <errno.h>
 #include "serialiser.h"
 
 #include "core/core.h"


### PR DESCRIPTION
This PR fixes compile warnings and errors on other toolchains or C runtimes.  The first commit (Fix glShaderSource with negative lengths) appears to fix a real bug.  The last 4 commits allow clang to be used to compile renderdoc, as well as add -Wextra.