### PR TITLE
Suppress warnings in MS's dbghelp.h.

### DIFF
--- a/pdblocate/pdblocate.cpp
+++ b/pdblocate/pdblocate.cpp
@@ -33,7 +33,10 @@
 
 #include <assert.h>
 
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
 #include <dbghelp.h>
+#pragma warning (pop)
 #include <shlobj.h>
 
 #include <vector>

--- a/renderdoc/3rdparty/breakpad/client/windows/common/ipc_protocol.h
+++ b/renderdoc/3rdparty/breakpad/client/windows/common/ipc_protocol.h
@@ -31,7 +31,10 @@
 #define CLIENT_WINDOWS_COMMON_IPC_PROTOCOL_H__
 
 #include <Windows.h>
-#include <DbgHelp.h>
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
+#include <dbghelp.h>
+#pragma warning (pop)
 #include <string>
 #include <utility>
 #include "breakpad/common/windows/string_utils-inl.h"

--- a/renderdoc/3rdparty/breakpad/client/windows/crash_generation/client_info.h
+++ b/renderdoc/3rdparty/breakpad/client/windows/crash_generation/client_info.h
@@ -31,7 +31,10 @@
 #define CLIENT_WINDOWS_CRASH_GENERATION_CLIENT_INFO_H__
 
 #include <Windows.h>
-#include <DbgHelp.h>
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
+#include <dbghelp.h>
+#pragma warning (pop)
 #include "breakpad/client/windows/common/ipc_protocol.h"
 #include "breakpad/common/scoped_ptr.h"
 #include "breakpad/google_breakpad/common/minidump_format.h"

--- a/renderdoc/3rdparty/breakpad/client/windows/crash_generation/crash_generation_client.h
+++ b/renderdoc/3rdparty/breakpad/client/windows/crash_generation/crash_generation_client.h
@@ -31,7 +31,10 @@
 #define CLIENT_WINDOWS_CRASH_GENERATION_CRASH_GENERATION_CLIENT_H_
 
 #include <windows.h>
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
 #include <dbghelp.h>
+#pragma warning (pop)
 #include <string>
 #include <vector>
 #include <utility>

--- a/renderdoc/3rdparty/breakpad/client/windows/crash_generation/minidump_generator.h
+++ b/renderdoc/3rdparty/breakpad/client/windows/crash_generation/minidump_generator.h
@@ -31,7 +31,10 @@
 #define CLIENT_WINDOWS_CRASH_GENERATION_MINIDUMP_GENERATOR_H_
 
 #include <windows.h>
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
 #include <dbghelp.h>
+#pragma warning (pop)
 #include <rpc.h>
 #include <list>
 #include "breakpad/google_breakpad/common/minidump_format.h"

--- a/renderdoc/3rdparty/breakpad/client/windows/handler/exception_handler.h
+++ b/renderdoc/3rdparty/breakpad/client/windows/handler/exception_handler.h
@@ -58,7 +58,10 @@
 
 #include <stdlib.h>
 #include <Windows.h>
-#include <DbgHelp.h>
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
+#include <dbghelp.h>
+#pragma warning (pop)
 #include <rpc.h>
 
 #pragma warning(push)


### PR DESCRIPTION
Here's a patch for issue 222. It seems as though the code had this warning suppression correctly instated in one file, but was missing it from the others. I left the comment as-is because it seemed appropriate. :p