### PR TITLE
Update Ubuntu compilation dependencies

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -35,10 +35,10 @@ There's no configuration or cmake setup, it assumes gcc/g++ (this can be overwri
 
 Requirements are linking against -lX11 and -lGL. For qrenderdoc you need qt5 along with the 'x11extras' package.
 
-This is the apt-get line you'd need to install the requirements on Ubuntu 15.04:
+This is the apt-get line you'd need to install the requirements on Ubuntu 14.04:
 
 ```
-sudo apt-get install libx11-dev mesa-common-dev libgl1-mesa-dev qt5-default libqt5x11extras5-dev
+sudo apt-get install libx11-dev mesa-common-dev libgl1-mesa-dev qt5-default libqt5x11extras5-dev libxcb-keysyms1-dev
 ```
 
 For Archlinux (as of 2016.02.01) you'll need:


### PR DESCRIPTION
- Add missing package to apt-get dependencies
- Switch reference version to Ubuntu 14.04 because 15.04 has reached
  end-of-life.