### PR TITLE
Fix Linux build

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -4264,6 +4264,9 @@ void WrappedOpenGL::AddUsage(FetchDrawcall d)
 							texList = rs.TexCubeArray;
 							listSize = sizeof(rs.TexCubeArray);
 							break;
+						case eResType_Count:
+							RDCASSERT(false);
+							break;
 					}
 					
 					if(texList != NULL && bind >= 0 && bind < listSize && texList[bind] != 0)

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -1219,6 +1219,9 @@ void GLReplay::SavePipelineState()
 						case eResType_TextureCubeArray:
 							target = eGL_TEXTURE_CUBE_MAP_ARRAY;
 							break;
+						case eResType_Count:
+							RDCASSERT(false);
+							break;
 					}
 					
 					if(target != eGL_NONE)
@@ -2682,6 +2685,11 @@ ResourceId GLReplay::CreateProxyTexture(FetchTexture templateTex)
 		{
 			gl.glBindTexture(eGL_TEXTURE_CUBE_MAP_ARRAY, tex);
 			gl.glTextureStorage3DEXT(tex, eGL_TEXTURE_CUBE_MAP_ARRAY, templateTex.mips, intFormat, templateTex.width, templateTex.height, templateTex.arraysize);
+			break;
+		}
+		case eResType_Count:
+		{
+			RDCASSERT(false);
 			break;
 		}
 	}

--- a/renderdoccmd/renderdoccmd_linux.cpp
+++ b/renderdoccmd/renderdoccmd_linux.cpp
@@ -120,7 +120,7 @@ void DisplayRendererPreview(ReplayRenderer *renderer, TextureDisplay displayCfg)
 			switch (event->response_type & 0x7f)
 			{
 				case XCB_EXPOSE:
-					ReplayRenderer_SetFrameEvent(renderer, 0, 10000000+rand()%1000, true);
+					ReplayRenderer_SetFrameEvent(renderer, 10000000+rand()%1000, true);
 					ReplayOutput_Display(out);
 					break;
 				case XCB_CLIENT_MESSAGE:
@@ -147,7 +147,7 @@ void DisplayRendererPreview(ReplayRenderer *renderer, TextureDisplay displayCfg)
 			free(event);
 		}
 
-		ReplayRenderer_SetFrameEvent(renderer, 0, 10000000+rand()%1000, true);
+		ReplayRenderer_SetFrameEvent(renderer, 10000000+rand()%1000, true);
 		ReplayOutput_Display(out);
 
 		usleep(100000);


### PR DESCRIPTION
I fixed a few compilation errors on Linux.

I think you may also want to consider disabling -Werror by default if users are likely to be building from source. As useful as it is for developers, it's nearly impossible to remain warning-free on all compilers on every system. New warnings are created all the time and they will result in build failures.