### PR TITLE
Add additional sections of API covered in statistics.

### DIFF
--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -229,6 +229,48 @@ struct FetchFrameLayoutBindStats
 	uint32_t nulls;
 };
 
+struct FetchFrameShaderStats
+{
+	uint32_t calls;
+	uint32_t sets;
+	uint32_t nulls;
+	uint32_t redundants;
+};
+
+struct FetchFrameBlendStats
+{
+	uint32_t calls;
+	uint32_t sets;
+	uint32_t nulls;
+	uint32_t redundants;
+};
+
+struct FetchFrameDepthStencilStats
+{
+	uint32_t calls;
+	uint32_t sets;
+	uint32_t nulls;
+	uint32_t redundants;
+};
+
+struct FetchFrameRasterizationStats
+{
+	uint32_t calls;
+	uint32_t sets;
+	uint32_t nulls;
+	uint32_t redundants;
+	rdctype::array<uint32_t> viewports;
+	rdctype::array<uint32_t> rects;
+};
+
+struct FetchFrameOutputStats
+{
+	uint32_t calls;
+	uint32_t sets;
+	uint32_t nulls;
+	rdctype::array<uint32_t> bindslots;
+};
+
 struct FetchFrameStatistics
 {
 	uint32_t recorded;
@@ -241,6 +283,11 @@ struct FetchFrameStatistics
 	FetchFrameIndexBindStats indices;
 	FetchFrameVertexBindStats vertices;
 	FetchFrameLayoutBindStats layouts;
+	FetchFrameShaderStats shaders[eShaderStage_Count];
+	FetchFrameBlendStats blends;
+	FetchFrameDepthStencilStats depths;
+	FetchFrameRasterizationStats rasters;
+	FetchFrameOutputStats outputs;
 };
 
 struct FetchFrameInfo

--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -1151,6 +1151,63 @@ void Serialiser::Serialise(const char *name, FetchFrameLayoutBindStats &el)
 }
 
 template<>
+void Serialiser::Serialise(const char *name, FetchFrameShaderStats &el)
+{
+	Serialise("", el.calls);
+	Serialise("", el.sets);
+	Serialise("", el.nulls);
+	Serialise("", el.redundants);
+
+	SIZE_CHECK(FetchFrameShaderStats, 16);
+}
+
+template<>
+void Serialiser::Serialise(const char *name, FetchFrameBlendStats &el)
+{
+	Serialise("", el.calls);
+	Serialise("", el.sets);
+	Serialise("", el.nulls);
+	Serialise("", el.redundants);
+
+	SIZE_CHECK(FetchFrameBlendStats, 16);
+}
+
+template<>
+void Serialiser::Serialise(const char *name, FetchFrameDepthStencilStats &el)
+{
+	Serialise("", el.calls);
+	Serialise("", el.sets);
+	Serialise("", el.nulls);
+	Serialise("", el.redundants);
+
+	SIZE_CHECK(FetchFrameDepthStencilStats, 16);
+}
+
+template<>
+void Serialiser::Serialise(const char *name, FetchFrameRasterizationStats &el)
+{
+	Serialise("", el.calls);
+	Serialise("", el.sets);
+	Serialise("", el.nulls);
+	Serialise("", el.redundants);
+	Serialise("", el.viewports);
+	Serialise("", el.rects);
+
+	SIZE_CHECK(FetchFrameRasterizationStats, 48);
+}
+
+template<>
+void Serialiser::Serialise(const char *name, FetchFrameOutputStats &el)
+{
+	Serialise("", el.calls);
+	Serialise("", el.sets);
+	Serialise("", el.nulls);
+	Serialise("", el.bindslots);
+
+	SIZE_CHECK(FetchFrameOutputStats, 32);
+}
+
+template<>
 void Serialiser::Serialise(const char *name, FetchFrameStatistics &el)
 {
 	Serialise("", el.recorded);
@@ -1170,8 +1227,14 @@ void Serialiser::Serialise(const char *name, FetchFrameStatistics &el)
 	Serialise("", el.indices);
 	Serialise("", el.vertices);
 	Serialise("", el.layouts);
+	FetchFrameShaderStats* shaders = el.shaders;
+	SerialiseComplexArray<eShaderStage_Count>("", shaders);
+	Serialise("", el.blends);
+	Serialise("", el.depths);
+	Serialise("", el.rasters);
+	Serialise("", el.outputs);
 
-	SIZE_CHECK(FetchFrameStatistics, 928);
+	SIZE_CHECK(FetchFrameStatistics, 1136);
 }
 
 template<>
@@ -1188,7 +1251,7 @@ void Serialiser::Serialise(const char *name, FetchFrameInfo &el)
 	Serialise("", el.stats);
 	Serialise("", el.debugMessages);
 
-	SIZE_CHECK(FetchFrameInfo, 1000);
+	SIZE_CHECK(FetchFrameInfo, 1208);
 }
 
 template<>
@@ -1197,7 +1260,7 @@ void Serialiser::Serialise(const char *name, FetchFrameRecord &el)
 	Serialise("", el.frameInfo);
 	Serialise("", el.drawcallList);
 	
-	SIZE_CHECK(FetchFrameRecord, 1016);
+	SIZE_CHECK(FetchFrameRecord, 1224);
 }
 
 template<>

--- a/renderdoc/driver/d3d11/d3d11_context.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context.cpp
@@ -1390,8 +1390,7 @@ HRESULT STDMETHODCALLTYPE WrappedID3D11DeviceContext::QueryInterface( REFIID rii
 
 void WrappedID3D11DeviceContext::RecordIndexBindStats(ID3D11Buffer* Buffer)
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	FetchFrameIndexBindStats& indices = stats.indices;
 	indices.calls += 1;
 	indices.sets += (Buffer != NULL);
@@ -1400,8 +1399,7 @@ void WrappedID3D11DeviceContext::RecordIndexBindStats(ID3D11Buffer* Buffer)
 
 void WrappedID3D11DeviceContext::RecordVertexBindStats(UINT NumBuffers, ID3D11Buffer* Buffers[])
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	FetchFrameVertexBindStats& vertices = stats.vertices;
 	vertices.calls += 1;
 	RDCASSERT(NumBuffers < vertices.bindslots.size());
@@ -1418,8 +1416,7 @@ void WrappedID3D11DeviceContext::RecordVertexBindStats(UINT NumBuffers, ID3D11Bu
 
 void WrappedID3D11DeviceContext::RecordLayoutBindStats(ID3D11InputLayout* Layout)
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	FetchFrameLayoutBindStats& layouts = stats.layouts;
 	layouts.calls += 1;
 	layouts.sets += (Layout != NULL);
@@ -1428,8 +1425,7 @@ void WrappedID3D11DeviceContext::RecordLayoutBindStats(ID3D11InputLayout* Layout
 
 void WrappedID3D11DeviceContext::RecordConstantStats(ShaderStageType stage, UINT NumBuffers, ID3D11Buffer* Buffers[])
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	RDCASSERT(stage < ARRAY_COUNT( stats.constants));
 	FetchFrameConstantBindStats& constants = stats.constants[stage];
 	constants.calls += 1;
@@ -1458,8 +1454,7 @@ void WrappedID3D11DeviceContext::RecordConstantStats(ShaderStageType stage, UINT
 
 void WrappedID3D11DeviceContext::RecordResourceStats(ShaderStageType stage, UINT NumResources, ID3D11ShaderResourceView* Resources[])
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	RDCASSERT(stage < ARRAY_COUNT(stats.resources));
 	FetchFrameResourceBindStats& resources = stats.resources[stage];
 	resources.calls += 1;
@@ -1506,8 +1501,7 @@ void WrappedID3D11DeviceContext::RecordResourceStats(ShaderStageType stage, UINT
 
 void WrappedID3D11DeviceContext::RecordSamplerStats(ShaderStageType stage, UINT NumSamplers, ID3D11SamplerState* Samplers[])
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	RDCASSERT(stage < ARRAY_COUNT(stats.samplers));
 	FetchFrameSamplerBindStats& samplers = stats.samplers[stage];
 	samplers.calls += 1;
@@ -1525,8 +1519,7 @@ void WrappedID3D11DeviceContext::RecordSamplerStats(ShaderStageType stage, UINT 
 
 void WrappedID3D11DeviceContext::RecordUpdateStats(ID3D11Resource* res, uint32_t Size, bool Server)
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	FetchFrameUpdateStats& updates = stats.updates;
 
 	if (res == NULL)
@@ -1560,8 +1553,7 @@ void WrappedID3D11DeviceContext::RecordUpdateStats(ID3D11Resource* res, uint32_t
 
 void WrappedID3D11DeviceContext::RecordDrawStats(bool instanced, bool indirect, UINT InstanceCount)
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	FetchFrameDrawStats& draws = stats.draws;
 
 	draws.calls += 1;
@@ -1578,12 +1570,129 @@ void WrappedID3D11DeviceContext::RecordDrawStats(bool instanced, bool indirect, 
 
 void WrappedID3D11DeviceContext::RecordDispatchStats(bool indirect)
 {
-	FetchFrameRecord& record = m_pDevice->GetFrameRecord();
-	FetchFrameStatistics& stats = record.frameInfo.stats;
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
 	FetchFrameDispatchStats& dispatches = stats.dispatches;
 
 	dispatches.calls += 1;
 	dispatches.indirect += (uint32_t)indirect;
+}
+
+void WrappedID3D11DeviceContext::RecordShaderStats(ShaderStageType stage, ID3D11DeviceChild* Current, ID3D11DeviceChild* Shader)
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	RDCASSERT(stage <= ARRAY_COUNT(stats.shaders));
+	FetchFrameShaderStats& shaders = stats.shaders[stage];
+
+	shaders.calls += 1;
+	shaders.sets += (Shader != NULL);
+	shaders.nulls += (Shader == NULL);
+	shaders.redundants += (Current == Shader);
+}
+
+void WrappedID3D11DeviceContext::RecordBlendStats(ID3D11BlendState* Blend, FLOAT BlendFactor[4], UINT SampleMask)
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	FetchFrameBlendStats& blends = stats.blends;
+
+	blends.calls += 1;
+	blends.sets += (Blend != NULL);
+	blends.nulls += (Blend == NULL);
+	const D3D11RenderState::outmerger* Current = &m_CurrentPipelineState->OM;
+	bool same = (Current->BlendState == Blend) && (memcmp(Current->BlendFactor, BlendFactor, sizeof(BlendFactor)) == 0) && (Current->SampleMask == SampleMask);
+	blends.redundants += (uint32_t)same;
+}
+
+void WrappedID3D11DeviceContext::RecordDepthStencilStats(ID3D11DepthStencilState* DepthStencil, UINT StencilRef)
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	FetchFrameDepthStencilStats& depths = stats.depths;
+
+	depths.calls += 1;
+	depths.sets += (DepthStencil != NULL);
+	depths.nulls += (DepthStencil == NULL);
+	const D3D11RenderState::outmerger* Current = &m_CurrentPipelineState->OM;
+	bool same = (Current->DepthStencilState == DepthStencil) && (Current->StencRef == StencilRef);
+	depths.redundants += (uint32_t)same;
+}
+
+void WrappedID3D11DeviceContext::RecordRasterizationStats(ID3D11RasterizerState* Rasterizer)
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	FetchFrameRasterizationStats& rasters = stats.rasters;
+
+	rasters.calls += 1;
+	rasters.sets += (Rasterizer != NULL);
+	rasters.nulls += (Rasterizer == NULL);
+	const D3D11RenderState::rasterizer* Current = &m_CurrentPipelineState->RS;
+	bool same = (Current->State == Rasterizer);
+	rasters.redundants += (uint32_t)same;
+}
+
+void WrappedID3D11DeviceContext::RecordViewportStats(UINT NumViewports, const D3D11_VIEWPORT *viewports)
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	FetchFrameRasterizationStats& rasters = stats.rasters;
+
+	rasters.calls += 1;
+	rasters.sets += 1;
+	// #mivance fairly sure setting 0 viewports/null viewports is illegal?
+	const D3D11RenderState::rasterizer* Current = &m_CurrentPipelineState->RS;
+	bool same = (Current->NumViews == NumViewports);
+	for (UINT index = 0; index < NumViewports; index++)
+	{
+		same = (same && (Current->Viewports[index] == viewports[index]));
+	}
+	rasters.redundants += (uint32_t)same;
+	RDCASSERT(NumViewports < rasters.viewports.size());
+	rasters.viewports[NumViewports] += 1;
+}
+
+void WrappedID3D11DeviceContext::RecordScissorStats(UINT NumRects, const D3D11_RECT *rects)
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	FetchFrameRasterizationStats& rasters = stats.rasters;
+
+	rasters.calls += 1;
+	rasters.sets += 1;
+	// #mivance see above
+	const D3D11RenderState::rasterizer* Current = &m_CurrentPipelineState->RS;
+	bool same = (Current->NumScissors == NumRects);
+	for (UINT index = 0; index < NumRects; index++)
+	{
+		same = (same && (Current->Scissors[index] == rects[index]));
+	}
+	rasters.redundants += (uint32_t)same;
+	RDCASSERT(NumRects < rasters.rects.size());
+	rasters.rects[NumRects] += 1;
+}
+
+void WrappedID3D11DeviceContext::RecordOutputMergerStats(UINT NumRTVs, ID3D11RenderTargetView* RTVs[], ID3D11DepthStencilView* DSV, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* UAVs[])
+{
+	FetchFrameStatistics& stats = m_pDevice->GetFrameStats();
+	FetchFrameOutputStats& outputs = stats.outputs;
+
+	outputs.calls += 1;
+	// #mivance is an elaborate redundancy here even useful?
+	//const D3D11RenderState::outmerger* Current = &m_CurrentPipelineState->OM;
+
+	for (UINT index = 0; index < NumRTVs; index++ )
+	{
+		outputs.sets += (RTVs[index] != NULL);
+		outputs.nulls += (RTVs[index] == NULL);
+	}
+
+	outputs.sets += (DSV != NULL);
+	outputs.nulls += (DSV == NULL);
+
+	for (UINT index = 0; index < NumUAVs; index++ )
+	{
+		outputs.sets += (UAVs[index] != NULL);
+		outputs.nulls += (UAVs[index] == NULL);
+	}
+
+	UINT NumSlots = NumRTVs + NumUAVs;
+	RDCASSERT(NumSlots < outputs.bindslots.size());
+	outputs.bindslots[NumSlots] += 1;
 }
 
 #pragma endregion

--- a/renderdoc/driver/d3d11/d3d11_context.h
+++ b/renderdoc/driver/d3d11/d3d11_context.h
@@ -253,6 +253,13 @@ private:
 	void RecordUpdateStats(ID3D11Resource* res, uint32_t Size, bool Server);
 	void RecordDrawStats(bool instanced, bool indirect, UINT InstanceCount);
 	void RecordDispatchStats(bool indirect);
+	void RecordShaderStats(ShaderStageType stage, ID3D11DeviceChild* Current, ID3D11DeviceChild* Shader);
+	void RecordBlendStats(ID3D11BlendState* Blend, FLOAT BlendFactor[4], UINT SampleMask);
+	void RecordDepthStencilStats(ID3D11DepthStencilState* DepthStencil, UINT StencilRef);
+	void RecordRasterizationStats(ID3D11RasterizerState* Rasterizer);
+	void RecordViewportStats(UINT NumViewports, const D3D11_VIEWPORT *viewports);
+	void RecordScissorStats(UINT NumRects, const D3D11_RECT *rects);
+	void RecordOutputMergerStats(UINT NumRTVs, ID3D11RenderTargetView* RTVs[], ID3D11DepthStencilView* DSV, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* UAVs[]);
 
 	////////////////////////////////////////////////////////////////
 	// implement InterceptorSystem privately, since it is not thread safe (like all other context functions)

--- a/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
@@ -834,6 +834,10 @@ bool WrappedID3D11DeviceContext::Serialise_VSSetShader(ID3D11VertexShader *pShad
 		ID3D11DeviceChild *pSH = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(Shader))
 			pSH = (ID3D11DeviceChild *)m_pDevice->GetResourceManager()->GetLiveResource(Shader);
+
+		if(m_State == READING)
+			RecordShaderStats(eShaderStage_Vertex, m_CurrentPipelineState->VS.Shader, pSH);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->VS.Shader, pSH);
 		m_pRealContext->VSSetShader(UNWRAP(WrappedID3D11Shader<ID3D11VertexShader>, pSH), Instances, NumClassInstances);
 		VerifyState();
@@ -1205,6 +1209,10 @@ bool WrappedID3D11DeviceContext::Serialise_HSSetShader(ID3D11HullShader *pShader
 		ID3D11DeviceChild *pSH = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(Shader))
 			pSH = (ID3D11DeviceChild *)m_pDevice->GetResourceManager()->GetLiveResource(Shader);
+
+		if(m_State == READING)
+			RecordShaderStats(eShaderStage_Hull, m_CurrentPipelineState->HS.Shader, pSH);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->HS.Shader, pSH);
 		m_pRealContext->HSSetShader(UNWRAP(WrappedID3D11Shader<ID3D11HullShader>, pSH), Instances, NumClassInstances);
 		VerifyState();
@@ -1575,6 +1583,10 @@ bool WrappedID3D11DeviceContext::Serialise_DSSetShader(ID3D11DomainShader *pShad
 		ID3D11DeviceChild *pSH = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(Shader))
 			pSH = (ID3D11DeviceChild *)m_pDevice->GetResourceManager()->GetLiveResource(Shader);
+
+		if(m_State == READING)
+			RecordShaderStats(eShaderStage_Domain, m_CurrentPipelineState->DS.Shader, pSH);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->DS.Shader, pSH);
 		m_pRealContext->DSSetShader(UNWRAP(WrappedID3D11Shader<ID3D11DomainShader>, pSH), Instances, NumClassInstances);
 		VerifyState();
@@ -1945,6 +1957,10 @@ bool WrappedID3D11DeviceContext::Serialise_GSSetShader(ID3D11GeometryShader *pSh
 		ID3D11DeviceChild *pSH = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(Shader))
 			pSH = (ID3D11DeviceChild *)m_pDevice->GetResourceManager()->GetLiveResource(Shader);
+
+		if(m_State == READING)
+			RecordShaderStats(eShaderStage_Geometry, m_CurrentPipelineState->GS.Shader, pSH);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->GS.Shader, pSH);
 		m_pRealContext->GSSetShader(UNWRAP(WrappedID3D11Shader<ID3D11GeometryShader>, pSH), Instances, NumClassInstances);
 		VerifyState();
@@ -2268,6 +2284,9 @@ bool WrappedID3D11DeviceContext::Serialise_RSSetViewports(UINT NumViewports_, co
 	
 	if(m_State <= EXECUTING)
 	{
+		if(m_State == READING)
+			RecordViewportStats(NumViewports, views);
+
 		m_CurrentPipelineState->Change(m_CurrentPipelineState->RS.Viewports, views, 0, NumViewports);
 		m_CurrentPipelineState->Change(m_CurrentPipelineState->RS.NumViews, NumViewports);
 		m_pRealContext->RSSetViewports(NumViewports, views);
@@ -2305,6 +2324,9 @@ bool WrappedID3D11DeviceContext::Serialise_RSSetScissorRects(UINT NumRects_, con
 	
 	if(m_State <= EXECUTING)
 	{
+		if(m_State == READING)
+			RecordScissorStats(NumRects, Rects);
+
 		m_CurrentPipelineState->Change(m_CurrentPipelineState->RS.Scissors, Rects, 0, NumRects);
 		m_CurrentPipelineState->Change(m_CurrentPipelineState->RS.NumScissors, NumRects);
 		RSSetScissorRects(NumRects, Rects);
@@ -2346,6 +2368,9 @@ bool WrappedID3D11DeviceContext::Serialise_RSSetState(ID3D11RasterizerState *pRa
 		ID3D11DeviceChild *live = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(id))
 			live = m_pDevice->GetResourceManager()->GetLiveResource(id);
+
+		if(m_State == READING)
+			RecordRasterizationStats((ID3D11RasterizerState*)live);
 
 		if(WrappedID3D11RasterizerState1::IsAlloc(live))
 		{
@@ -2713,6 +2738,10 @@ bool WrappedID3D11DeviceContext::Serialise_PSSetShader(ID3D11PixelShader *pShade
 		ID3D11DeviceChild *pSH = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(Shader))
 			pSH = (ID3D11DeviceChild *)m_pDevice->GetResourceManager()->GetLiveResource(Shader);
+
+		if(m_State == READING)
+			RecordShaderStats(eShaderStage_Pixel, m_CurrentPipelineState->PS.Shader, pSH);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->PS.Shader, pSH);
 		m_pRealContext->PSSetShader(UNWRAP(WrappedID3D11Shader<ID3D11PixelShader>, pSH), Instances, NumClassInstances);
 		VerifyState();
@@ -2941,6 +2970,9 @@ bool WrappedID3D11DeviceContext::Serialise_OMSetRenderTargets(UINT NumViews_, ID
 		for(UINT i=0; i < NumViews; i++)
 			RenderTargetViews[i] = UNWRAP(WrappedID3D11RenderTargetView, RenderTargetViews[i]);
 
+		if(m_State == READING)
+			RecordOutputMergerStats(NumViews, RenderTargetViews, pDepthStencilView, 0, 0, NULL);
+
 		m_pRealContext->OMSetRenderTargets(NumViews, RenderTargetViews,
 												UNWRAP(WrappedID3D11DepthStencilView, pDepthStencilView));
 		VerifyState();
@@ -3124,6 +3156,9 @@ bool WrappedID3D11DeviceContext::Serialise_OMSetRenderTargetsAndUnorderedAccessV
 		else
 			pDepthStencilView = NULL;
 
+		if(m_State == READING)
+			RecordOutputMergerStats(NumRTVs, RenderTargetViews, pDepthStencilView, UAVStartSlot, NumUAVs, UnorderedAccessViews);
+
 		m_pRealContext->OMSetRenderTargetsAndUnorderedAccessViews(NumRTVs, RenderTargetViews,
 												pDepthStencilView,
 												UAVStartSlot, NumUAVs, UnorderedAccessViews, UAVInitialCounts);
@@ -3299,6 +3334,9 @@ bool WrappedID3D11DeviceContext::Serialise_OMSetBlendState(ID3D11BlendState *pBl
 		if(m_pDevice->GetResourceManager()->HasLiveResource(State))
 			live = m_pDevice->GetResourceManager()->GetLiveResource(State);
 
+		if(m_State == READING)
+			RecordBlendStats((ID3D11BlendState*)live, BlendFactor, SampleMask);
+
 		if(WrappedID3D11BlendState1::IsAlloc(live))
 		{
 			ID3D11BlendState1 *state = (ID3D11BlendState1 *)live;
@@ -3361,6 +3399,10 @@ bool WrappedID3D11DeviceContext::Serialise_OMSetDepthStencilState(ID3D11DepthSte
 		pDepthStencilState = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(State))
 			pDepthStencilState = (ID3D11DepthStencilState *)m_pDevice->GetResourceManager()->GetLiveResource(State);
+
+		if(m_State == READING)
+			RecordDepthStencilStats(pDepthStencilState, StencilRef);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->OM.DepthStencilState, pDepthStencilState);
 		m_CurrentPipelineState->Change(m_CurrentPipelineState->OM.StencRef, StencilRef&0xff);
 		m_pRealContext->OMSetDepthStencilState(UNWRAP(WrappedID3D11DepthStencilState, pDepthStencilState), StencilRef);
@@ -4208,6 +4250,9 @@ bool WrappedID3D11DeviceContext::Serialise_CSSetShaderResources(UINT StartSlot_,
 		for(UINT i=0; i < NumViews; i++)
 			Views[i] = UNWRAP(WrappedID3D11ShaderResourceView, Views[i]);
 
+		if(m_State == READING)
+			RecordResourceStats(eShaderStage_Compute, NumViews, Views);
+
 		m_pRealContext->CSSetShaderResources(StartSlot, NumViews, Views);
 		VerifyState();
 	}
@@ -4278,6 +4323,10 @@ bool WrappedID3D11DeviceContext::Serialise_CSSetUnorderedAccessViews(UINT StartS
 
 		for(UINT i=0; i < NumUAVs; i++)
 			UAVs[i] = UNWRAP(WrappedID3D11UnorderedAccessView, UAVs[i]);
+
+		// #mivance this isn't strictly correct...
+		if(m_State == READING)
+			RecordOutputMergerStats(0, NULL, NULL, StartSlot, NumUAVs, UAVs);
 
 		m_pRealContext->CSSetUnorderedAccessViews(StartSlot, NumUAVs, UAVs, UAVInitialCounts);
 		VerifyState();
@@ -4413,6 +4462,10 @@ bool WrappedID3D11DeviceContext::Serialise_CSSetShader(ID3D11ComputeShader *pSha
 		ID3D11DeviceChild *pSH = NULL;
 		if(m_pDevice->GetResourceManager()->HasLiveResource(Shader))
 			pSH = (ID3D11DeviceChild *)m_pDevice->GetResourceManager()->GetLiveResource(Shader);
+
+		if(m_State == READING)
+			RecordShaderStats(eShaderStage_Compute, m_CurrentPipelineState->CS.Shader, pSH);
+
 		m_CurrentPipelineState->ChangeRefRead(m_CurrentPipelineState->CS.Shader, pSH);
 		m_pRealContext->CSSetShader(UNWRAP(WrappedID3D11Shader<ID3D11ComputeShader>, pSH), Instances, NumClassInstances);
 		VerifyState();

--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -1028,6 +1028,11 @@ void WrappedID3D11Device::Serialise_CaptureScope(uint64_t offset)
 
 		create_array(stats.vertices.bindslots, D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT + 1);
 
+		create_array(stats.rasters.viewports, D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX + 1);
+		create_array(stats.rasters.rects, D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX + 1);
+
+		create_array(stats.outputs.bindslots, D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT + D3D11_1_UAV_SLOT_COUNT + 1);
+
 		GetResourceManager()->CreateInitialContents();
 	}
 }

--- a/renderdoc/driver/d3d11/d3d11_device.h
+++ b/renderdoc/driver/d3d11/d3d11_device.h
@@ -295,6 +295,7 @@ public:
 	ResourceId GetResourceID() { return m_ResourceID; }
 
 	FetchFrameRecord &GetFrameRecord() { return m_FrameRecord; }
+	FetchFrameStatistics &GetFrameStats() { return m_FrameRecord.frameInfo.stats; }
 
 	const FetchDrawcall *GetDrawcall(uint32_t eventID);
 

--- a/renderdocui/Interop/FetchInfo.cs
+++ b/renderdocui/Interop/FetchInfo.cs
@@ -366,6 +366,56 @@ namespace renderdoc
     };
 
     [StructLayout(LayoutKind.Sequential)]
+    public class FetchFrameShaderStats
+    {
+        public UInt32 calls;
+        public UInt32 sets;
+        public UInt32 nulls;
+        public UInt32 redundants;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class FetchFrameBlendStats
+    {
+        public UInt32 calls;
+        public UInt32 sets;
+        public UInt32 nulls;
+        public UInt32 redundants;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class FetchFrameDepthStencilStats
+    {
+        public UInt32 calls;
+        public UInt32 sets;
+        public UInt32 nulls;
+        public UInt32 redundants;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class FetchFrameRasterizationStats
+    {
+        public UInt32 calls;
+        public UInt32 sets;
+        public UInt32 nulls;
+        public UInt32 redundants;
+        [CustomMarshalAs(CustomUnmanagedType.TemplatedArray)]
+        public UInt32[] viewports;
+        [CustomMarshalAs(CustomUnmanagedType.TemplatedArray)]
+        public UInt32[] rects;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class FetchFrameOutputStats
+    {
+        public UInt32 calls;
+        public UInt32 sets;
+        public UInt32 nulls;
+        [CustomMarshalAs(CustomUnmanagedType.TemplatedArray)]
+        public UInt32[] bindslots;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
     public class FetchFrameStatistics
     {
         public UInt32 recorded;
@@ -387,6 +437,16 @@ namespace renderdoc
         public FetchFrameVertexBindStats vertices;
         [CustomMarshalAs(CustomUnmanagedType.CustomClass)]
         public FetchFrameLayoutBindStats layouts;
+        [CustomMarshalAs(CustomUnmanagedType.FixedArray, FixedLength = (int)ShaderStageType.Count)]
+        public FetchFrameShaderStats[] shaders;
+        [CustomMarshalAs(CustomUnmanagedType.CustomClass)]
+        public FetchFrameBlendStats blends;
+        [CustomMarshalAs(CustomUnmanagedType.CustomClass)]
+        public FetchFrameDepthStencilStats depths;
+        [CustomMarshalAs(CustomUnmanagedType.CustomClass)]
+        public FetchFrameRasterizationStats rasters;
+        [CustomMarshalAs(CustomUnmanagedType.CustomClass)]
+        public FetchFrameOutputStats outputs;
     };
 
 [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Notes
======
- Added statistics recording for shader sets, blend state sets, depth/stencil state sets, rasterization state sets, and output merger/UAV sets.
- Some muddling of things like UAVs into the outputs set... additional "null" sets will be recorded and things, will clean that up in a future change.
- Added missing CS SRV set to the resources statistics.
- Added GetFrameStats() helper to simplify some prolog boilerplate.
- Hoist some of the histogram code out into a helper method, also hoist out the API summary to try to clean that messiness up.
- Change how the API call numbers are calculated--it's now just the API calls as distinct from draw/dispatches. Additionally the ratio is gainst the "pure" API call number, not with draws/dispatches included.

TODO
======
- Figure out where the missing ~4k API calls are in my game captures vs the numbers I'm seeing.