### PR TITLE
Fix for #259

### DIFF
--- a/renderdoc/driver/gl/gl_hooks_win32.cpp
+++ b/renderdoc/driver/gl/gl_hooks_win32.cpp
@@ -520,7 +520,10 @@ class OpenGLHook : LibraryHook
 
 			// don't continue if creation failed
 			if(ret == NULL)
+			{
+				glhooks.m_CreatingContext = false;
 				return ret;
+			}
 
 			GLWindowingData data;
 			data.DC = dc;


### PR DESCRIPTION
This seems to be the problem, let me know if it isn't.

On my Intel HD6000, it fails creation of the first context (GL4.5 Core), and falls back to GL4.4, and so on. First failure causes it to go into the first if statement, and not record the context creation (https://github.com/neilogd/renderdoc/blob/master/renderdoc/driver/gl/gl_hooks_win32.cpp#L454)

