### PR TITLE
vulkan: Add locations to fragment shader inputs

### DIFF
--- a/renderdoc/data/spv/text.frag
+++ b/renderdoc/data/spv/text.frag
@@ -25,22 +25,19 @@
 layout (binding = 3) uniform sampler2D tex0;
 layout (location = 0) out vec4 color_out;
 
-in v2f
-{
-	vec4 tex;
-	vec2 glyphuv;
-} IN;
+layout (location = 0) in vec4 tex;
+layout (location = 1) in vec2 glyphuv;
 
 void main(void)
 {
 	float text = 0;
 
-	if(IN.glyphuv.x >= 0.0f && IN.glyphuv.x <= 1.0f && 
-	   IN.glyphuv.y >= 0.0f && IN.glyphuv.y <= 1.0f)
+	if(glyphuv.x >= 0.0f && glyphuv.x <= 1.0f &&
+	   glyphuv.y >= 0.0f && glyphuv.y <= 1.0f)
 	{
 		vec2 uv;
-		uv.x = mix(IN.tex.x, IN.tex.z, IN.glyphuv.x);
-		uv.y = mix(IN.tex.y, IN.tex.w, IN.glyphuv.y);
+		uv.x = mix(tex.x, tex.z, glyphuv.x);
+		uv.y = mix(tex.y, tex.w, glyphuv.y);
 		text = texture(tex0, uv.xy).x;
 	}
 

--- a/renderdoc/data/spv/text.vert
+++ b/renderdoc/data/spv/text.vert
@@ -28,11 +28,8 @@ out gl_PerVertex
 	float gl_PointSize;
 };
 
-out v2f
-{
-	vec4 tex;
-	vec2 glyphuv;
-} OUT;
+layout (location = 0) out vec4 tex;
+layout (location = 1) out vec2 glyphuv;
 
 void main(void)
 {
@@ -50,6 +47,6 @@ void main(void)
 	FontGlyphData G = glyphs.data[ str.chars[strindex].x ];
 	
 	gl_Position = vec4(charPos.xy*2.0f*general.TextSize*general.FontScreenAspect.xy + vec2(-1, -1), 1, 1);
-	OUT.glyphuv.xy = (pos.xy - G.posdata.xy) * G.posdata.zw;
-	OUT.tex = G.uvdata * general.CharacterSize.xyxy;
+	glyphuv.xy = (pos.xy - G.posdata.xy) * G.posdata.zw;
+	tex = G.uvdata * general.CharacterSize.xyxy;
 }


### PR DESCRIPTION
As-is, glslang doesn't provide default locations on inputs so these weren't
getting any location decorations whatsoever.  While putting them in a
struct *should* be possible in theory, glslang doesn't like to do it with
the glsl version in the shader.  Just splitting them into separate inputs
seems like the most reliable solution.