### PR TITLE
Changed default histogram range to [-1,+1] for snorm textures.

### DIFF
--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -912,6 +912,7 @@ dds_data load_dds_from_file(FILE *f)
       case MAKE_FOURCC('D', 'X', 'T', '5'):
         ret.format = DXGIFormat2ResourceFormat(DXGI_FORMAT_BC3_UNORM);
         break;
+      case MAKE_FOURCC('A', 'T', 'I', '1'):
       case MAKE_FOURCC('B', 'C', '4', 'U'):
         ret.format = DXGIFormat2ResourceFormat(DXGI_FORMAT_BC4_UNORM);
         break;
@@ -919,6 +920,7 @@ dds_data load_dds_from_file(FILE *f)
         ret.format = DXGIFormat2ResourceFormat(DXGI_FORMAT_BC4_SNORM);
         break;
       case MAKE_FOURCC('A', 'T', 'I', '2'):
+      case MAKE_FOURCC('B', 'C', '5', 'U'):
         ret.format = DXGIFormat2ResourceFormat(DXGI_FORMAT_BC5_UNORM);
         break;
       case MAKE_FOURCC('B', 'C', '5', 'S'):

--- a/renderdocui/Windows/TextureViewer.cs
+++ b/renderdocui/Windows/TextureViewer.cs
@@ -1449,6 +1449,14 @@ namespace renderdocui.Windows
 
         private PointF m_PrevSize = PointF.Empty;
 
+        private void UI_SetHistogramRange(FetchTexture tex)
+        {
+            if (tex.format.compType == FormatComponentType.SNorm)
+                rangeHistogram.SetRange(-1.0f, 1.0f);
+            else
+                rangeHistogram.SetRange(0.0f, 1.0f);
+        }
+
         private void UI_OnTextureSelectionChanged()
         {
             FetchTexture tex = CurrentTexture;
@@ -1670,14 +1678,14 @@ namespace renderdocui.Windows
                     depthDisplay.Checked = true;
 
                     norangePaint = true;
-                    rangeHistogram.SetRange(0.0f, 1.0f);
+                    UI_SetHistogramRange(tex);
                     norangePaint = false;
                 }
 
                 // reset the range if desired
                 if (m_Core.Config.TextureViewer_ResetRange)
                 {
-                    rangeHistogram.SetRange(0.0f, 1.0f);
+                    UI_SetHistogramRange(tex);
                 }
             }
 
@@ -3075,7 +3083,7 @@ namespace renderdocui.Windows
 
         private void reset01_Click(object sender, EventArgs e)
         {
-            rangeHistogram.SetRange(0.0f, 1.0f);
+            UI_SetHistogramRange(CurrentTexture);
 
             autoFit.Checked = false;
 

--- a/renderdocui/Windows/TextureViewer.cs
+++ b/renderdocui/Windows/TextureViewer.cs
@@ -1451,7 +1451,7 @@ namespace renderdocui.Windows
 
         private void UI_SetHistogramRange(FetchTexture tex)
         {
-            if (tex.format.compType == FormatComponentType.SNorm)
+            if (tex != null && tex.format.compType == FormatComponentType.SNorm)
                 rangeHistogram.SetRange(-1.0f, 1.0f);
             else
                 rangeHistogram.SetRange(0.0f, 1.0f);


### PR DESCRIPTION
If viewing a SNORM texture, default histogram range is set to [-1,1]
instead of [0,1].
Added support for BC5U .dds fourcc code.