### PR TITLE
Fix problems when building on Linux for Android

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -18,6 +18,7 @@ if(ANDROID)
     list(APPEND RDOC_LIBRARIES
         PRIVATE m
         PRIVATE dl
+        PRIVATE log
         PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 elseif(APPLE)
     list(APPEND RDOC_LIBRARIES

--- a/renderdoc/driver/vulkan/vk_android.cpp
+++ b/renderdoc/driver/vulkan/vk_android.cpp
@@ -28,7 +28,7 @@
 void VulkanReplay::OutputWindow::SetWindowHandle(WindowingSystem system, void *data)
 {
   RDCASSERT(system == eWindowingSystem_Android, system);
-  wnd = (ANativeWindow *)wn;
+  wnd = (ANativeWindow *)data;
   m_WindowSystem = system;
 }
 

--- a/renderdoc/driver/vulkan/vk_posix.cpp
+++ b/renderdoc/driver/vulkan/vk_posix.cpp
@@ -55,6 +55,17 @@ bool WrappedVulkan::AddRequiredExtensions(bool instance, vector<string> &extensi
       extensionList.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 
     bool oneSurfaceTypeSupported = false;
+ 
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    // don't add duplicates
+    if(supportedExtensions.find(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) != supportedExtensions.end() &&
+       std::find(extensionList.begin(), extensionList.end(), VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) ==
+           extensionList.end())
+    {
+      extensionList.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+      oneSurfaceTypeSupported = true;
+    }
+#endif
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     // check if supported
@@ -108,8 +119,14 @@ bool WrappedVulkan::AddRequiredExtensions(bool instance, vector<string> &extensi
 
     if(!oneSurfaceTypeSupported)
     {
-      RDCERR("Required at least one of '%s' or '%s' extension to be present",
-             VK_KHR_XCB_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+      RDCERR("Require the '%s' extension to be present",
+             VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+#elif defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR)
+      RDCERR("Require either the '%s' or '%s' extension to be present",
+             VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+             VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
+#endif
       return false;
     }
   }

--- a/renderdoc/os/posix/android/android_process.cpp
+++ b/renderdoc/os/posix/android/android_process.cpp
@@ -87,6 +87,7 @@ bool debuggerPresent = false;
 void CacheDebuggerPresent()
 {
   FILE *f = FileIO::fopen("/proc/self/status", "r");
+  int ret = 0;
 
   if(f == NULL)
   {

--- a/renderdoc/os/posix/android/android_stringio.cpp
+++ b/renderdoc/os/posix/android/android_stringio.cpp
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include <android/log.h>
+#include <unistd.h>
 #include "os/os_specific.h"
 
 #define LOGCAT_TAG "renderdoc"


### PR DESCRIPTION
There were some typos, some Android-specific WSI code missing, an
uninitialized variable, and a missing library, etc.