### PR TITLE
Disable the "always show vertical scroll" bar in the settings menu.

### DIFF
--- a/renderdocui/Windows/Dialogs/SettingsDialog.Designer.cs
+++ b/renderdocui/Windows/Dialogs/SettingsDialog.Designer.cs
@@ -875,7 +875,6 @@
             // 
             // pagesTree
             // 
-            this.pagesTree.AlwaysDisplayVScroll = true;
             treeListColumn3.AutoSize = true;
             treeListColumn3.AutoSizeMinSize = 0;
             treeListColumn3.Width = 50;


### PR DESCRIPTION
The window is always big enough that the scroll bar remains disabled, so just get rid of it by default.