### PR TITLE
Norbert fix retries proc gather

### DIFF
--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -88,6 +88,8 @@ public:
       m_Vendor = AMD;
     else if(physProps.vendorID == NV_PCI_ID)
       m_Vendor = NV;
+    else
+      m_Vendor = UNKNOWN;
 
     m_Major = VK_VERSION_MAJOR(physProps.driverVersion);
     m_Minor = VK_VERSION_MINOR(physProps.driverVersion);
@@ -113,6 +115,7 @@ private:
   {
     AMD,
     NV,
+	UNKNOWN
   } m_Vendor;
 
   uint32_t m_Major, m_Minor, m_Patch;

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -115,7 +115,7 @@ private:
   {
     AMD,
     NV,
-	UNKNOWN
+    UNKNOWN,
   } m_Vendor;
 
   uint32_t m_Major, m_Minor, m_Patch;

--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -45,7 +45,7 @@ int GetIdentPort(pid_t childPid)
   int totalWaitTime = 0;
 
   // try for a little while for the /proc entry to appear
-  while(totalWaitTime <= MAX_WAIT_TIME)
+  while(totalWaitTime < MAX_WAIT_TIME)
   {
     // back-off for each retry
     usleep(waitTime);

--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -27,6 +27,9 @@
 
 extern char **environ;
 
+#define INITIAL_WAIT_TIME 1000
+#define MAX_WAIT_TIME 63000
+
 char **GetCurrentEnvironment()
 {
   return environ;
@@ -38,11 +41,17 @@ int GetIdentPort(pid_t childPid)
 
   string procfile = StringFormat::Fmt("/proc/%d/net/tcp", (int)childPid);
 
+  int waitTime = INITIAL_WAIT_TIME;
+  int totalWaitTime = 0;
+
   // try for a little while for the /proc entry to appear
-  for(int retry = 0; retry < 10; retry++)
+  while(totalWaitTime <= MAX_WAIT_TIME)
   {
     // back-off for each retry
-    usleep(1000 + 500 * retry);
+    usleep(waitTime);
+
+    totalWaitTime += waitTime;
+    waitTime *= 2;
 
     FILE *f = FileIO::fopen(procfile.c_str(), "r");
 


### PR DESCRIPTION
This fix increases and changes the wait time and retry behaviour, when the proc entries are gathered and parsed.

On an embedded system, the current solution fails too early.
