### PR TITLE
Handle NULL arrays passed to GL_ARB_multi_bind functions

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -1190,8 +1190,8 @@ bool WrappedOpenGL::Serialise_glBindBuffersBase(GLenum target, GLuint first, GLs
   {
     SERIALISE_ELEMENT(ResourceId, id,
                       buffers && buffers[i]
-                      ? GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i]))
-                      : ResourceId());
+                          ? GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i]))
+                          : ResourceId());
 
     if(m_State <= EXECUTING)
     {

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -1188,7 +1188,10 @@ bool WrappedOpenGL::Serialise_glBindBuffersBase(GLenum target, GLuint first, GLs
 
   for(int32_t i = 0; i < Count; i++)
   {
-    SERIALISE_ELEMENT(ResourceId, id, GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i])));
+    SERIALISE_ELEMENT(ResourceId, id,
+                      buffers && buffers[i]
+                      ? GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i]))
+                      : ResourceId());
 
     if(m_State <= EXECUTING)
     {
@@ -1329,9 +1332,12 @@ bool WrappedOpenGL::Serialise_glBindBuffersRange(GLenum target, GLuint first, GL
 
   for(int32_t i = 0; i < Count; i++)
   {
-    SERIALISE_ELEMENT(ResourceId, id, GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i])));
-    SERIALISE_ELEMENT(uint64_t, offset, (uint64_t)offsets[i]);
-    SERIALISE_ELEMENT(uint64_t, size, (uint64_t)sizes[i]);
+    SERIALISE_ELEMENT(ResourceId, id,
+                      buffers && buffers[i]
+                          ? GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i]))
+                          : ResourceId());
+    SERIALISE_ELEMENT(uint64_t, offset, buffers ? (uint64_t)offsets[i] : 0);
+    SERIALISE_ELEMENT(uint64_t, size, buffers ? (uint64_t)sizes[i] : 0);
 
     if(m_State <= EXECUTING)
     {

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -4064,9 +4064,12 @@ bool WrappedOpenGL::Serialise_glVertexArrayVertexBuffers(GLuint vaobj, GLuint fi
 
   for(int32_t i = 0; i < Count; i++)
   {
-    SERIALISE_ELEMENT(ResourceId, id, GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i])));
-    SERIALISE_ELEMENT(uint64_t, offset, (uint64_t)offsets[i]);
-    SERIALISE_ELEMENT(uint64_t, stride, (uint64_t)strides[i]);
+    SERIALISE_ELEMENT(ResourceId, id,
+                      buffers && buffers[i]
+                          ? GetResourceManager()->GetID(BufferRes(GetCtx(), buffers[i]))
+                          : ResourceId());
+    SERIALISE_ELEMENT(uint64_t, offset, buffers ? 0 : (uint64_t)offsets[i]);
+    SERIALISE_ELEMENT(uint64_t, stride, buffers ? 0 : (uint64_t)strides[i]);
 
     if(m_State <= EXECUTING)
     {
@@ -4138,7 +4141,7 @@ void WrappedOpenGL::glVertexArrayVertexBuffers(GLuint vaobj, GLuint first, GLsiz
       {
         for(GLsizei i = 0; i < count; i++)
         {
-          if(buffers[i] != 0)
+          if(buffers != NULL && buffers[i] != 0)
           {
             GLResourceRecord *bufrecord =
                 GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffers[i]));
@@ -4182,7 +4185,7 @@ void WrappedOpenGL::glBindVertexBuffers(GLuint first, GLsizei count, const GLuin
       {
         for(GLsizei i = 0; i < count; i++)
         {
-          if(buffers[i] != 0)
+          if(buffers != NULL && buffers[i] != 0)
           {
             GLResourceRecord *bufrecord =
                 GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffers[i]));

--- a/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
@@ -177,7 +177,10 @@ bool WrappedOpenGL::Serialise_glBindSamplers(GLuint first, GLsizei count, const 
 
   for(int32_t i = 0; i < Count; i++)
   {
-    SERIALISE_ELEMENT(ResourceId, id, GetResourceManager()->GetID(SamplerRes(GetCtx(), samplers[i])));
+    SERIALISE_ELEMENT(ResourceId, id,
+                      samplers && samplers[i]
+                          ? GetResourceManager()->GetID(SamplerRes(GetCtx(), samplers[i]))
+                          : ResourceId());
 
     if(m_State <= EXECUTING)
     {
@@ -209,8 +212,9 @@ void WrappedOpenGL::glBindSamplers(GLuint first, GLsizei count, const GLuint *sa
 
     m_ContextRecord->AddChunk(scope.Get());
     for(GLsizei i = 0; i < count; i++)
-      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), samplers[i]),
-                                                        eFrameRef_Read);
+      if (samplers != NULL && samplers[i] != 0)
+        GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), samplers[i]),
+                                                          eFrameRef_Read);
   }
 }
 

--- a/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
@@ -212,7 +212,7 @@ void WrappedOpenGL::glBindSamplers(GLuint first, GLsizei count, const GLuint *sa
 
     m_ContextRecord->AddChunk(scope.Get());
     for(GLsizei i = 0; i < count; i++)
-      if (samplers != NULL && samplers[i] != 0)
+      if(samplers != NULL && samplers[i] != 0)
         GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), samplers[i]),
                                                           eFrameRef_Read);
   }

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -557,7 +557,10 @@ bool WrappedOpenGL::Serialise_glBindImageTextures(GLuint first, GLsizei count, c
 
   for(int32_t i = 0; i < Count; i++)
   {
-    SERIALISE_ELEMENT(ResourceId, id, GetResourceManager()->GetID(TextureRes(GetCtx(), textures[i])));
+    SERIALISE_ELEMENT(ResourceId, id,
+                      textures && textures[i]
+                          ? GetResourceManager()->GetID(TextureRes(GetCtx(), textures[i]))
+                          : ResourceId());
 
     if(m_State <= EXECUTING)
     {
@@ -596,7 +599,7 @@ void WrappedOpenGL::glBindImageTextures(GLuint first, GLsizei count, const GLuin
     m_ContextRecord->AddChunk(scope.Get());
 
     for(GLsizei i = 0; i < count; i++)
-      if(textures[i])
+      if(textures != NULL && textures[i] != 0)
         GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), textures[i]),
                                                           eFrameRef_Read);
   }


### PR DESCRIPTION
If a `NULL` array is passed to `GL_ARB_multi_bind` functions, they have an alternate behavior that acts as if an array of 0s was passed in for the resources to bind. This was recently fixed for `glBindTextures` (446874e), but not the other multi-bind functions. See the following statements in the [spec](https://www.opengl.org/registry/specs/ARB/multi_bind.txt):

glBindImageTextures:

    BindImageTextures is equivalent to

      for (i = 0; i < count; i++) {
        if (textures == NULL || textures[i] = 0) {
          glBindImageTexture(first + i, 0, 0, FALSE, 0, READ_ONLY, R8);
        } else {
          glBindImageTexture(first + i, textures[i], 0, TRUE, 0, READ_WRITE,
                             lookupInternalFormat(textures[i]));
        }
      }

glBindSamplers:

    BindSamplers is equivalent to

      for (i = 0; i < count; i++) {
        if (samplers == NULL) {
          glBindSampler(first + i, 0);
        } else {
          glBindSampler(first + i, samplers[i]);
        }
      }

glBindVertexBuffers:

    BindVertexBuffers is equivalent to

      for (i = 0; i < count; i++) {
        if (buffers == NULL) {
          glBindVertexBuffer(first + i, 0, 0, 16);
        } else {
          glBindVertexBuffer(first + i, buffers[i], offsets[i], strides[i]);
        }
      }

glBindBuffersBase:

    BindBuffersBase is equivalent to:

      for (i = 0; i < count; i++) {
        if (buffers == NULL) {
          glBindBufferBase(target, first + i, 0);
        } else {
          glBindBufferBase(target, first + i, buffers[i]);
        }
      }

glBindBuffersRange:

    BindBuffersRange is equivalent to:

      for (i = 0; i < count; i++) {
        if (buffers == NULL) {
          glBindBufferRange(target, first + i, 0, 0, 0);
        } else {
          glBindBufferRange(target, first + i, buffers[i], offsets[i], 
                            sizes[i]);
        }
      }