### PR TITLE
Fix glVertexAttribI3iv serialization

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -4392,7 +4392,7 @@ bool WrappedOpenGL::Serialise_glVertexAttrib(GLuint index, int count, GLenum typ
         else if(attr == Attrib_GLuint)
           m_Real.glVertexAttribI2uiv(idx, (GLuint *)value);
       }
-      else if(Count == 2)
+      else if(Count == 3)
       {
         if(attr == Attrib_GLint)
           m_Real.glVertexAttribI3iv(idx, (GLint *)value);


### PR DESCRIPTION
` WrappedOpenGL::Serialise_glVertexAttrib()` contained broken branching logic, probably caused by copy/paste bug:

```
else if(Count == 2)
{
...
}
else if(Count == 2)
```

This pull request changes the latter `2` to `3` because the branch deals with `glVertexAttribI3iv`.