### PR TITLE
Changes to "AndroidManifest.xml" file

### DIFF
--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.renderdoc.renderdoccmd" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="9"/>
+
+  <!-- This is the platform API where NativeActivity was introduced. -->
+  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>
 
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.INTERNET" />

--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -9,11 +9,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
 
   <application android:label="RenderDocCmd" android:hasCode="true">
-    <activity android:name=".Loader" android:label="RenderDocCmdLoader" android:configChanges="orientation|keyboardHidden">
-      <meta-data android:name="android.app.lib_name" android:value="renderdoccmd"/>
-    </activity>
-
-    <activity android:name="android.app.NativeActivity" android:label="RenderDocCmd" android:configChanges="orientation|keyboardHidden">
+    <activity android:name=".Loader" android:label="RenderDocCmdLoader" android:exported="true" android:configChanges="orientation|keyboardHidden">
       <meta-data android:name="android.app.lib_name" android:value="renderdoccmd"/>
     </activity>
 


### PR DESCRIPTION
Two changes:

1) Use API level 23 (for Vulkan).
2) Add "exported" for non-rooted devices.