### PR TITLE
Fix missing <math.h> header in qrenderdoc for Arch/clang++

### DIFF
--- a/qrenderdoc/Widgets/CustomPaintWidget.cpp
+++ b/qrenderdoc/Widgets/CustomPaintWidget.cpp
@@ -23,10 +23,10 @@
  ******************************************************************************/
 
 #include "CustomPaintWidget.h"
+#include <math.h>
 #include <QPainter>
 #include "Code/CaptureContext.h"
 #include "renderdoc_replay.h"
-#include <math.h>
 
 CustomPaintWidget::CustomPaintWidget(QWidget *parent) : QWidget(parent)
 {

--- a/qrenderdoc/Widgets/CustomPaintWidget.cpp
+++ b/qrenderdoc/Widgets/CustomPaintWidget.cpp
@@ -26,6 +26,7 @@
 #include <QPainter>
 #include "Code/CaptureContext.h"
 #include "renderdoc_replay.h"
+#include <math.h>
 
 CustomPaintWidget::CustomPaintWidget(QWidget *parent) : QWidget(parent)
 {

--- a/qrenderdoc/Widgets/RangeHistogram.cpp
+++ b/qrenderdoc/Widgets/RangeHistogram.cpp
@@ -24,9 +24,9 @@
 
 #include "RangeHistogram.h"
 #include <float.h>
+#include <math.h>
 #include <QMouseEvent>
 #include <QPainter>
-#include <math.h>
 
 RangeHistogram::RangeHistogram(QWidget *parent) : QWidget(parent)
 {

--- a/qrenderdoc/Widgets/RangeHistogram.cpp
+++ b/qrenderdoc/Widgets/RangeHistogram.cpp
@@ -26,6 +26,7 @@
 #include <float.h>
 #include <QMouseEvent>
 #include <QPainter>
+#include <math.h>
 
 RangeHistogram::RangeHistogram(QWidget *parent) : QWidget(parent)
 {

--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -24,6 +24,7 @@
 
 #include "TextureViewer.h"
 #include <float.h>
+#include <math.h>
 #include <QClipboard>
 #include <QColorDialog>
 #include <QJsonDocument>
@@ -37,7 +38,6 @@
 #include "Widgets/TextureGoto.h"
 #include "FlowLayout.h"
 #include "ui_TextureViewer.h"
-#include <math.h>
 
 float area(const QSizeF &s)
 {

--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -37,6 +37,7 @@
 #include "Widgets/TextureGoto.h"
 #include "FlowLayout.h"
 #include "ui_TextureViewer.h"
+#include <math.h>
 
 float area(const QSizeF &s)
 {


### PR DESCRIPTION
Add the <math.h> header to some of the source files for the target
qrenderdoc. The build would not have succeded without these headers
declaration under Arch Linux/clang++.