### PR TITLE
Fix for glBindBuffersRange() impl.

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -1368,7 +1368,7 @@ bool WrappedOpenGL::Serialise_glBindBuffersRange(GLenum target, GLuint first, GL
       else
         bufs[i] = 0;
       offs[i] = (GLintptr)offset;
-      sz[i] = (GLsizeiptr)sizes;
+      sz[i] = (GLsizeiptr)size;
     }
   }
 


### PR DESCRIPTION
There's a typo in glBindBuffersRange() handler which does all sort of whack stuff to happen if you try to debug a GL app which uses GL_ARB_multi_bind. This one-line PR does what's needed to restore world's order.
