### PR TITLE
Implement QueryInterface for IDXGISwapChain4

### DIFF
--- a/renderdoc/driver/dxgi/dxgi_wrapped.cpp
+++ b/renderdoc/driver/dxgi/dxgi_wrapped.cpp
@@ -272,6 +272,19 @@ HRESULT STDMETHODCALLTYPE WrappedIDXGISwapChain4::QueryInterface(REFIID riid, vo
       return E_NOINTERFACE;
     }
   }
+  else if(riid == __uuidof(IDXGISwapChain4))
+  {
+    if(m_pReal4)
+    {
+      AddRef();
+      *ppvObject = (IDXGISwapChain4 *)this;
+      return S_OK;
+    }
+    else
+    {
+      return E_NOINTERFACE;
+    }
+  }
   else
   {
     string guid = ToStr::Get(riid);


### PR DESCRIPTION
Without this fix, QueryInterface would return an unwrapped swap chain, which later causes errors when using its unwrapped swap chain buffers.