### PR TITLE
Inject into the process upon a double-click

### DIFF
--- a/renderdocui/Windows/Dialogs/CaptureDialog.Designer.cs
+++ b/renderdocui/Windows/Dialogs/CaptureDialog.Designer.cs
@@ -647,6 +647,7 @@
             this.pidList.UseCompatibleStateImageBehavior = false;
             this.pidList.View = System.Windows.Forms.View.Details;
             this.pidList.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.pidList_ColumnClick);
+            this.pidList.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.pidList_MouseDoubleClick);
             this.pidList.Resize += new System.EventHandler(this.pidList_Resize);
             // 
             // winTitle

--- a/renderdocui/Windows/Dialogs/CaptureDialog.cs
+++ b/renderdocui/Windows/Dialogs/CaptureDialog.cs
@@ -1245,5 +1245,10 @@ namespace renderdocui.Windows.Dialogs
                 mainTableLayout.MinimumSize = new Size(0, mainTableLayout.ClientRectangle.Height - margin);
             }
         }
+
+        private void pidList_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            TriggerCapture();
+        }
     }
 }


### PR DESCRIPTION
A canonical UI paradigm is that when you have a dialog with a list of
items as a central element and an "Ok" action, double-clicking the item
results in the dialog confirmation.

This change adds this behavior to the Capture dialog.