### PR TITLE
Extended data collection

### DIFF
--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -316,22 +316,57 @@ struct FetchFrameInfo
 struct EventUsage
 {
 #ifdef __cplusplus
-  EventUsage() : eventID(0), usage(eUsage_None) {}
-  EventUsage(uint32_t e, ResourceUsage u) : eventID(e), usage(u) {}
-  EventUsage(uint32_t e, ResourceUsage u, ResourceId v) : eventID(e), usage(u), view(v) {}
+  EventUsage() : eventID(0), usage(eUsage_None), slot(0) {}
+  EventUsage(uint32_t e, ResourceUsage u) : eventID(e), usage(u), slot(0) {}
+  EventUsage(uint32_t e, ResourceUsage u, uint32_t s) : eventID(e), usage(u), slot(s) {}
+  EventUsage(uint32_t e, ResourceUsage u, ResourceId v) : eventID(e), usage(u), slot(0), view(v) {}
+  EventUsage(uint32_t e, ResourceUsage u, uint32_t s, ResourceId v)
+      : eventID(e), usage(u), slot(s), view(v)
+  {
+  }
   bool operator<(const EventUsage &o) const
   {
     if(eventID != o.eventID)
       return eventID < o.eventID;
-    return usage < o.usage;
+    if(usage != o.usage)
+      return usage < o.usage;
+    return slot < o.slot;
   }
 
-  bool operator==(const EventUsage &o) const { return eventID == o.eventID && usage == o.usage; }
+  bool operator==(const EventUsage &o) const
+  {
+    return eventID == o.eventID && usage == o.usage && slot == o.slot;
+  }
 #endif
 
   uint32_t eventID;
   ResourceUsage usage;
+  uint32_t slot;
   ResourceId view;
+};
+
+template <typename T>
+struct DrawcallPipelineState
+{
+  DrawcallPipelineState<T>() : eventID(0) {}
+  DrawcallPipelineState<T>(uint32_t EID, T pipestate) : eventID(EID), pipelineState(pipeState) {}
+  bool operator<(const DrawcallPipelineState<T> &o) const
+  {
+    if(eventID != o.eventID)
+      return eventID < o.eventID;
+
+    // don't compare values, just consider equal
+    return false;
+  }
+
+  bool operator==(const DrawcallPipelineState<T> &o) const
+  {
+    // don't compare values, just consider equal by EID/counterID
+    return eventID == o.eventID && counterID == o.counterID;
+  }
+
+  uint32_t eventID;
+  T pipelineState;
 };
 
 struct FetchDrawcall

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -400,6 +400,8 @@ struct FetchDrawcall
   ResourceId outputs[8];
   ResourceId depthOut;
 
+  ResourceId shaders[6];
+
   rdctype::array<FetchAPIEvent> events;
   rdctype::array<FetchDrawcall> children;
 };

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -400,6 +400,9 @@ extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_DebugThread(ReplayRe
 extern "C" RENDERDOC_API bool32 RENDERDOC_CC
 ReplayRenderer_GetUsage(ReplayRenderer *rend, ResourceId id, rdctype::array<EventUsage> *usage);
 
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC
+ReplayRenderer_GetShader(ReplayRenderer *rend, ResourceId id, const char *entry, ShaderReflection *shader);
+
 extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetCBufferVariableContents(
     ReplayRenderer *rend, ResourceId shader, const char *entryPoint, uint32_t cbufslot,
     ResourceId buffer, uint64_t offs, rdctype::array<ShaderVariable> *vars);

--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -180,6 +180,23 @@ public:
   {
     return vector<CounterResult>();
   }
+  void CaptureDrawCallsPipelineState() {}
+  vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState()
+  {
+    return vector<DrawcallPipelineState<D3D11PipelineState>>();
+  }
+  vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState()
+  {
+    return vector<DrawcallPipelineState<D3D12PipelineState>>();
+  }
+  vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState()
+  {
+    return vector<DrawcallPipelineState<GLPipelineState>>();
+  }
+  vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState()
+  {
+    return vector<DrawcallPipelineState<VulkanPipelineState>>();
+  }
   void FillCBufferVariables(ResourceId shader, string entryPoint, uint32_t cbufSlot,
                             vector<ShaderVariable> &outvars, const vector<byte> &data)
   {

--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -2130,6 +2130,7 @@ bool ReplayProxy::Tick(int type, Serialiser *incomingPacket)
     case eReplayProxy_GetShader: GetShader(ResourceId(), ""); break;
     case eReplayProxy_GetDebugMessages: GetDebugMessages(); break;
     case eReplayProxy_SavePipelineState: SavePipelineState(); break;
+    case eReplayProxy_CaptureDrawCallsPipelineState: CaptureDrawCallsPipelineState(); break;
     case eReplayProxy_GetUsage: GetUsage(ResourceId()); break;
     case eReplayProxy_GetLiveID: GetLiveID(ResourceId()); break;
     case eReplayProxy_GetFrameRecord: GetFrameRecord(); break;
@@ -2378,6 +2379,34 @@ void ReplayProxy::SavePipelineState()
   m_FromReplaySerialiser->Serialise("", m_D3D12PipelineState);
   m_FromReplaySerialiser->Serialise("", m_GLPipelineState);
   m_FromReplaySerialiser->Serialise("", m_VulkanPipelineState);
+}
+
+void ReplayProxy::CaptureDrawCallsPipelineState()
+{
+  /*if(m_RemoteServer)
+  {
+    m_Remote->CaptureDrawCallsPipelineState();
+    m_DrawcallsD3D11PipelineState = m_Remote->GetDrawCallsD3D11PipelineState();
+    m_DrawcallsD3D12PipelineState = m_Remote->GetDrawCallsD3D12PipelineState();
+    m_DrawcallsGLPipelineState = m_Remote->GetDrawCallsGLPipelineState();
+    m_DrawcallsVulkanPipelineState = m_Remote->GetDrawCallsVulkanPipelineState();
+  }
+  else
+  {
+    if(!SendReplayCommand(eReplayProxy_CaptureDrawCallsPipelineState))
+      return;
+
+    m_DrawcallsD3D11PipelineState = vector<DrawcallPipelineState<D3D11PipelineState>>();
+    m_DrawcallsD3D12PipelineState = vector<DrawcallPipelineState<D3D12PipelineState>>();
+    m_DrawcallsGLPipelineState = vector<DrawcallPipelineState<GLPipelineState>>();
+    m_DrawcallsVulkanPipelineState = vector<DrawcallPipelineState<VulkanPipelineState>>();
+  }
+
+// TODO : Implement serialize for vector<DrawcallPipelineState<T>>!!
+  m_FromReplaySerialiser->Serialise("", m_DrawcallsD3D11PipelineState);
+  m_FromReplaySerialiser->Serialise("", m_DrawcallsD3D12PipelineState);
+  m_FromReplaySerialiser->Serialise("", m_DrawcallsGLPipelineState);
+  m_FromReplaySerialiser->Serialise("", m_DrawcallsVulkanPipelineState);*/
 }
 
 void ReplayProxy::ReplayLog(uint32_t endEventID, ReplayLogType replayType)

--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -1365,11 +1365,12 @@ void Serialiser::Serialise(const char *name, FetchDrawcall &el)
 
   SerialisePODArray<8>("", el.outputs);
   Serialise("", el.depthOut);
+  SerialisePODArray<6>("", el.shaders);
 
   Serialise("", el.events);
   Serialise("", el.children);
 
-  SIZE_CHECK(248);
+  SIZE_CHECK(296);
 }
 
 template <>

--- a/renderdoc/core/replay_proxy.h
+++ b/renderdoc/core/replay_proxy.h
@@ -51,6 +51,7 @@ enum ReplayProxyPacket
   eReplayProxy_GetTextureData,
 
   eReplayProxy_SavePipelineState,
+  eReplayProxy_CaptureDrawCallsPipelineState,
   eReplayProxy_GetUsage,
   eReplayProxy_GetLiveID,
   eReplayProxy_GetFrameRecord,
@@ -401,6 +402,24 @@ public:
   D3D12PipelineState GetD3D12PipelineState() { return m_D3D12PipelineState; }
   GLPipelineState GetGLPipelineState() { return m_GLPipelineState; }
   VulkanPipelineState GetVulkanPipelineState() { return m_VulkanPipelineState; }
+  void CaptureDrawCallsPipelineState();
+  vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState()
+  {
+    return m_DrawcallsD3D11PipelineState;
+  }
+  vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState()
+  {
+    return m_DrawcallsD3D12PipelineState;
+  }
+  vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState()
+  {
+    return m_DrawcallsGLPipelineState;
+  }
+  vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState()
+  {
+    return m_DrawcallsVulkanPipelineState;
+  }
+
   void ReplayLog(uint32_t endEventID, ReplayLogType replayType);
 
   vector<uint32_t> GetPassEvents(uint32_t eventID);
@@ -556,4 +575,9 @@ private:
   D3D12PipelineState m_D3D12PipelineState;
   GLPipelineState m_GLPipelineState;
   VulkanPipelineState m_VulkanPipelineState;
+
+  vector<DrawcallPipelineState<D3D11PipelineState>> m_DrawcallsD3D11PipelineState;
+  vector<DrawcallPipelineState<D3D12PipelineState>> m_DrawcallsD3D12PipelineState;
+  vector<DrawcallPipelineState<GLPipelineState>> m_DrawcallsGLPipelineState;
+  vector<DrawcallPipelineState<VulkanPipelineState>> m_DrawcallsVulkanPipelineState;
 };

--- a/renderdoc/driver/d3d11/d3d11_context.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context.cpp
@@ -966,6 +966,19 @@ void WrappedID3D11DeviceContext::AddDrawcall(const FetchDrawcall &d, bool hasEve
           ((WrappedID3D11DepthStencilView *)m_CurrentPipelineState->OM.DepthView)->GetResourceResID();
   }
 
+  const D3D11RenderState *pipe = m_CurrentPipelineState;
+
+  const D3D11RenderState::shader *shArr[6] = {
+      &pipe->VS, &pipe->HS, &pipe->DS, &pipe->GS, &pipe->PS, &pipe->CS,
+  };
+
+  for(int s = 0; s < 6; s++)
+  {
+    const D3D11RenderState::shader &sh = *shArr[s];
+
+    draw.shaders[s] = GetIDForResource(sh.Shader);
+  } 
+
   // markers don't increment drawcall ID
   if((draw.flags & (eDraw_SetMarker | eDraw_PushMarker)) == 0)
     m_CurDrawcallID++;

--- a/renderdoc/driver/d3d11/d3d11_context.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context.cpp
@@ -852,7 +852,8 @@ void WrappedID3D11DeviceContext::AddUsage(const FetchDrawcall &d)
 
   for(int i = 0; i < D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT; i++)
     if(pipe->IA.Used_VB(m_pDevice, i))
-      m_ResourceUses[GetIDForResource(pipe->IA.VBs[i])].push_back(EventUsage(e, eUsage_VertexBuffer));
+      m_ResourceUses[GetIDForResource(pipe->IA.VBs[i])].push_back(
+          EventUsage(e, eUsage_VertexBuffer, i));
 
   //////////////////////////////
   // Shaders
@@ -875,7 +876,7 @@ void WrappedID3D11DeviceContext::AddUsage(const FetchDrawcall &d)
       {
         WrappedID3D11ShaderResourceView1 *view = (WrappedID3D11ShaderResourceView1 *)sh.SRVs[i];
         m_ResourceUses[view->GetResourceResID()].push_back(
-            EventUsage(e, (ResourceUsage)(eUsage_VS_Resource + s), view->GetResourceID()));
+            EventUsage(e, (ResourceUsage)(eUsage_VS_Resource + s), i, view->GetResourceID()));
       }
     }
 
@@ -888,7 +889,7 @@ void WrappedID3D11DeviceContext::AddUsage(const FetchDrawcall &d)
           WrappedID3D11UnorderedAccessView1 *view =
               (WrappedID3D11UnorderedAccessView1 *)pipe->CSUAVs[i];
           m_ResourceUses[view->GetResourceResID()].push_back(
-              EventUsage(e, eUsage_CS_RWResource, view->GetResourceID()));
+              EventUsage(e, eUsage_CS_RWResource, i, view->GetResourceID()));
         }
       }
     }
@@ -899,7 +900,7 @@ void WrappedID3D11DeviceContext::AddUsage(const FetchDrawcall &d)
 
   for(int i = 0; i < D3D11_SO_BUFFER_SLOT_COUNT; i++)
     if(pipe->SO.Buffers[i])    // assuming for now that any SO target bound is used.
-      m_ResourceUses[GetIDForResource(pipe->SO.Buffers[i])].push_back(EventUsage(e, eUsage_SO));
+      m_ResourceUses[GetIDForResource(pipe->SO.Buffers[i])].push_back(EventUsage(e, eUsage_SO, i));
 
   //////////////////////////////
   // OM
@@ -910,7 +911,7 @@ void WrappedID3D11DeviceContext::AddUsage(const FetchDrawcall &d)
     {
       WrappedID3D11UnorderedAccessView1 *view = (WrappedID3D11UnorderedAccessView1 *)pipe->OM.UAVs[i];
       m_ResourceUses[view->GetResourceResID()].push_back(
-          EventUsage(e, eUsage_PS_RWResource, view->GetResourceID()));
+          EventUsage(e, eUsage_PS_RWResource, i, view->GetResourceID()));
     }
   }
 
@@ -928,7 +929,7 @@ void WrappedID3D11DeviceContext::AddUsage(const FetchDrawcall &d)
       WrappedID3D11RenderTargetView1 *view =
           (WrappedID3D11RenderTargetView1 *)pipe->OM.RenderTargets[i];
       m_ResourceUses[view->GetResourceResID()].push_back(
-          EventUsage(e, eUsage_ColourTarget, view->GetResourceID()));
+          EventUsage(e, eUsage_ColourTarget, i, view->GetResourceID()));
     }
   }
 }
@@ -976,8 +977,9 @@ void WrappedID3D11DeviceContext::AddDrawcall(const FetchDrawcall &d, bool hasEve
   {
     const D3D11RenderState::shader &sh = *shArr[s];
 
-    draw.shaders[s] = GetIDForResource(sh.Shader);
-  } 
+    // draw.shaders[s] = GetIDForResource(sh.Shader);
+    draw.shaders[s] = m_pDevice->GetResourceManager()->GetOriginalID(GetIDForResource(sh.Shader));
+  }
 
   // markers don't increment drawcall ID
   if((draw.flags & (eDraw_SetMarker | eDraw_PushMarker)) == 0)

--- a/renderdoc/driver/d3d11/d3d11_replay.h
+++ b/renderdoc/driver/d3d11/d3d11_replay.h
@@ -29,6 +29,7 @@
 #include "core/core.h"
 #include "replay/replay_driver.h"
 #include "d3d11_common.h"
+#include "d3d11_context.h"
 
 class WrappedID3D11Device;
 
@@ -67,6 +68,24 @@ public:
   D3D12PipelineState GetD3D12PipelineState() { return D3D12PipelineState(); }
   GLPipelineState GetGLPipelineState() { return GLPipelineState(); }
   VulkanPipelineState GetVulkanPipelineState() { return VulkanPipelineState(); }
+  void CaptureDrawCallsPipelineState();
+  vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState()
+  {
+    return m_DrawcallsPipelineState;
+  };
+  vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState()
+  {
+    return vector<DrawcallPipelineState<D3D12PipelineState>>();
+  };
+  vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState()
+  {
+    return vector<DrawcallPipelineState<GLPipelineState>>();
+  };
+  vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState()
+  {
+    return vector<DrawcallPipelineState<VulkanPipelineState>>();
+  };
+
   void FreeTargetResource(ResourceId id);
   void FreeCustomShader(ResourceId id);
 
@@ -168,6 +187,8 @@ public:
 private:
   D3D11PipelineState MakePipelineState();
 
+  void CaptureDrawCallPipelineState(const DrawcallTreeNode &drawnode, uint32_t &eventStart);
+
   bool m_WARP;
   bool m_Proxy;
 
@@ -176,4 +197,5 @@ private:
   WrappedID3D11Device *m_pDevice;
 
   D3D11PipelineState m_CurPipelineState;
+  vector<DrawcallPipelineState<D3D11PipelineState>> m_DrawcallsPipelineState;
 };

--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -65,6 +65,24 @@ public:
   D3D12PipelineState GetD3D12PipelineState() { return m_PipelineState; }
   GLPipelineState GetGLPipelineState() { return GLPipelineState(); }
   VulkanPipelineState GetVulkanPipelineState() { return VulkanPipelineState(); }
+  void CaptureDrawCallsPipelineState() {}
+  vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState()
+  {
+    return vector<DrawcallPipelineState<D3D11PipelineState>>();
+  }
+  vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState()
+  {
+    return m_DrawcallsPipelineState;
+  }
+  vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState()
+  {
+    return vector<DrawcallPipelineState<GLPipelineState>>();
+  }
+  vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState()
+  {
+    return vector<DrawcallPipelineState<VulkanPipelineState>>();
+  }
+
   void FreeTargetResource(ResourceId id);
   void FreeCustomShader(ResourceId id);
 
@@ -186,6 +204,7 @@ private:
   vector<ID3D12Resource *> m_ProxyResources;
 
   D3D12PipelineState m_PipelineState;
+  vector<DrawcallPipelineState<D3D12PipelineState>> m_DrawcallsPipelineState;
 
   WrappedID3D12Device *m_pDevice;
 };

--- a/renderdoc/driver/gl/gl_replay.h
+++ b/renderdoc/driver/gl/gl_replay.h
@@ -108,6 +108,13 @@ public:
   D3D12PipelineState GetD3D12PipelineState() { return D3D12PipelineState(); }
   GLPipelineState GetGLPipelineState() { return m_CurPipelineState; }
   VulkanPipelineState GetVulkanPipelineState() { return VulkanPipelineState(); }
+
+  void CaptureDrawCallsPipelineState() {}
+  vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState() {return vector<DrawcallPipelineState<D3D11PipelineState>>();}
+  vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState() {return vector<DrawcallPipelineState<D3D12PipelineState>>();}
+  vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState() {return m_DrawcallsPipelineState;}
+  vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState() {return vector<DrawcallPipelineState<VulkanPipelineState>>();}
+
   void FreeTargetResource(ResourceId id);
 
   void ReadLogInitialisation();
@@ -413,4 +420,5 @@ private:
   WrappedOpenGL *m_pDriver;
 
   GLPipelineState m_CurPipelineState;
+  vector<DrawcallPipelineState<GLPipelineState>> m_DrawcallsPipelineState;
 };

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -154,6 +154,24 @@ public:
   D3D12PipelineState GetD3D12PipelineState() { return D3D12PipelineState(); }
   GLPipelineState GetGLPipelineState() { return GLPipelineState(); }
   VulkanPipelineState GetVulkanPipelineState() { return m_VulkanPipelineState; }
+  void CaptureDrawCallsPipelineState() {}
+  vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState()
+  {
+    return vector<DrawcallPipelineState<D3D11PipelineState>>();
+  }
+  vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState()
+  {
+    return vector<DrawcallPipelineState<D3D12PipelineState>>();
+  }
+  vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState()
+  {
+    return vector<DrawcallPipelineState<GLPipelineState>>();
+  }
+  vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState()
+  {
+    return m_DrawcallsPipelineState;
+  }
+
   void FreeTargetResource(ResourceId id);
 
   void ReadLogInitialisation();
@@ -309,6 +327,7 @@ private:
   };
 
   VulkanPipelineState m_VulkanPipelineState;
+  vector<DrawcallPipelineState<VulkanPipelineState>> m_DrawcallsPipelineState;
 
   map<uint64_t, OutputWindow> m_OutputWindows;
   uint64_t m_OutputWinID;

--- a/renderdoc/replay/replay_driver.h
+++ b/renderdoc/replay/replay_driver.h
@@ -101,6 +101,13 @@ public:
   virtual GLPipelineState GetGLPipelineState() = 0;
   virtual VulkanPipelineState GetVulkanPipelineState() = 0;
 
+  virtual void CaptureDrawCallsPipelineState() = 0;
+
+  virtual vector<DrawcallPipelineState<D3D11PipelineState>> GetDrawCallsD3D11PipelineState() = 0;
+  virtual vector<DrawcallPipelineState<D3D12PipelineState>> GetDrawCallsD3D12PipelineState() = 0;
+  virtual vector<DrawcallPipelineState<GLPipelineState>> GetDrawCallsGLPipelineState() = 0;
+  virtual vector<DrawcallPipelineState<VulkanPipelineState>> GetDrawCallsVulkanPipelineState() = 0;
+
   virtual FetchFrameRecord GetFrameRecord() = 0;
 
   virtual void ReadLogInitialisation() = 0;

--- a/renderdoc/replay/replay_renderer.cpp
+++ b/renderdoc/replay/replay_renderer.cpp
@@ -377,6 +377,17 @@ bool ReplayRenderer::GetUsage(ResourceId id, rdctype::array<EventUsage> *usage)
   return false;
 }
 
+bool ReplayRenderer::GetShader(ResourceId id, const char *entry, ShaderReflection *shader)
+{
+  if(entry && shader)
+  {
+    *shader = *m_pDevice->GetShader(id, entry);
+    return true;
+  }
+
+  return false;
+}
+
 bool ReplayRenderer::GetPostVSData(uint32_t instID, MeshDataStage stage, MeshFormat *data)
 {
   if(data == NULL)
@@ -1846,6 +1857,12 @@ extern "C" RENDERDOC_API bool32 RENDERDOC_CC
 ReplayRenderer_GetUsage(ReplayRenderer *rend, ResourceId id, rdctype::array<EventUsage> *usage)
 {
   return rend->GetUsage(id, usage);
+}
+
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC
+ReplayRenderer_GetShader(ReplayRenderer *rend, ResourceId id, const char *entry, ShaderReflection *shader)
+{
+  return rend->GetShader(id, entry, shader);
 }
 
 extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetCBufferVariableContents(

--- a/renderdoc/replay/replay_renderer.cpp
+++ b/renderdoc/replay/replay_renderer.cpp
@@ -377,11 +377,67 @@ bool ReplayRenderer::GetUsage(ResourceId id, rdctype::array<EventUsage> *usage)
   return false;
 }
 
+bool ReplayRenderer::CaptureDrawCallsPipelineState()
+{
+  m_pDevice->CaptureDrawCallsPipelineState();
+
+  m_DrawCallsD3D11PipelineState = m_pDevice->GetDrawCallsD3D11PipelineState();
+  m_DrawCallsD3D12PipelineState = m_pDevice->GetDrawCallsD3D12PipelineState();
+  m_DrawCallsGLPipelineState = m_pDevice->GetDrawCallsGLPipelineState();
+  m_DrawCallsVulkanPipelineState = m_pDevice->GetDrawCallsVulkanPipelineState();
+
+  return true;
+}
+
+bool ReplayRenderer::GetDrawCallsD3D11PipelineState(
+    rdctype::array<DrawcallPipelineState<D3D11PipelineState>> *drawcallsPipeState)
+{
+  if(drawcallsPipeState)
+  {
+    *drawcallsPipeState = m_DrawCallsD3D11PipelineState;
+    return true;
+  }
+  return false;
+}
+
+bool ReplayRenderer::GetDrawCallsD3D12PipelineState(
+    rdctype::array<DrawcallPipelineState<D3D12PipelineState>> *drawcallsPipeState)
+{
+  if(drawcallsPipeState)
+  {
+    *drawcallsPipeState = m_DrawCallsD3D12PipelineState;
+    return true;
+  }
+  return false;
+}
+
+bool ReplayRenderer::GetDrawCallsGLPipelineState(
+    rdctype::array<DrawcallPipelineState<GLPipelineState>> *drawcallsPipeState)
+{
+  if(drawcallsPipeState)
+  {
+    *drawcallsPipeState = m_DrawCallsGLPipelineState;
+    return true;
+  }
+  return false;
+}
+
+bool ReplayRenderer::GetDrawCallsVulkanPipelineState(
+    rdctype::array<DrawcallPipelineState<VulkanPipelineState>> *drawcallsPipeState)
+{
+  if(drawcallsPipeState)
+  {
+    *drawcallsPipeState = m_DrawCallsVulkanPipelineState;
+    return true;
+  }
+  return false;
+}
+
 bool ReplayRenderer::GetShader(ResourceId id, const char *entry, ShaderReflection *shader)
 {
   if(entry && shader)
   {
-    *shader = *m_pDevice->GetShader(id, entry);
+    *shader = *m_pDevice->GetShader(m_pDevice->GetLiveID(id), entry);
     return true;
   }
 
@@ -1735,6 +1791,35 @@ ReplayRenderer_GetVulkanPipelineState(ReplayRenderer *rend, VulkanPipelineState 
   return rend->GetVulkanPipelineState(state);
 }
 
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC
+ReplayRenderer_CaptureDrawCallsPipelineState(ReplayRenderer *rend)
+{
+  return rend->CaptureDrawCallsPipelineState();
+}
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetDrawCallsD3D11PipelineState(
+    ReplayRenderer *rend,
+    rdctype::array<DrawcallPipelineState<D3D11PipelineState>> *drawcallsPipestate)
+{
+  return rend->GetDrawCallsD3D11PipelineState(drawcallsPipestate);
+}
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetDrawCallsD3D12PipelineState(
+    ReplayRenderer *rend,
+    rdctype::array<DrawcallPipelineState<D3D12PipelineState>> *drawcallsPipestate)
+{
+  return rend->GetDrawCallsD3D12PipelineState(drawcallsPipestate);
+}
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetDrawCallsGLPipelineState(
+    ReplayRenderer *rend, rdctype::array<DrawcallPipelineState<GLPipelineState>> *drawcallsPipestate)
+{
+  return rend->GetDrawCallsGLPipelineState(drawcallsPipestate);
+}
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetDrawCallsVulkanPipelineState(
+    ReplayRenderer *rend,
+    rdctype::array<DrawcallPipelineState<VulkanPipelineState>> *drawcallsPipestate)
+{
+  return rend->GetDrawCallsVulkanPipelineState(drawcallsPipestate);
+}
+
 extern "C" RENDERDOC_API void RENDERDOC_CC ReplayRenderer_BuildCustomShader(
     ReplayRenderer *rend, const char *entry, const char *source, const uint32_t compileFlags,
     ShaderStageType type, ResourceId *shaderID, rdctype::str *errors)
@@ -1859,8 +1944,10 @@ ReplayRenderer_GetUsage(ReplayRenderer *rend, ResourceId id, rdctype::array<Even
   return rend->GetUsage(id, usage);
 }
 
-extern "C" RENDERDOC_API bool32 RENDERDOC_CC
-ReplayRenderer_GetShader(ReplayRenderer *rend, ResourceId id, const char *entry, ShaderReflection *shader)
+extern "C" RENDERDOC_API bool32 RENDERDOC_CC ReplayRenderer_GetShader(ReplayRenderer *rend,
+                                                                      ResourceId id,
+                                                                      const char *entry,
+                                                                      ShaderReflection *shader)
 {
   return rend->GetShader(id, entry, shader);
 }

--- a/renderdoc/replay/replay_renderer.h
+++ b/renderdoc/replay/replay_renderer.h
@@ -178,6 +178,8 @@ public:
 
   bool GetUsage(ResourceId id, rdctype::array<EventUsage> *usage);
 
+  bool GetShader(ResourceId id, const char *entry, ShaderReflection *shader);
+
   bool GetBufferData(ResourceId buff, uint64_t offset, uint64_t len, rdctype::array<byte> *data);
   bool GetTextureData(ResourceId buff, uint32_t arrayIdx, uint32_t mip, rdctype::array<byte> *data);
 

--- a/renderdoc/replay/replay_renderer.h
+++ b/renderdoc/replay/replay_renderer.h
@@ -165,6 +165,16 @@ public:
   bool GetResolve(uint64_t *callstack, uint32_t callstackLen, rdctype::array<rdctype::str> *trace);
   bool GetDebugMessages(rdctype::array<DebugMessage> *msgs);
 
+  bool CaptureDrawCallsPipelineState();
+  bool GetDrawCallsD3D11PipelineState(
+      rdctype::array<DrawcallPipelineState<D3D11PipelineState>> *drawcallsPipeState);
+  bool GetDrawCallsD3D12PipelineState(
+      rdctype::array<DrawcallPipelineState<D3D12PipelineState>> *drawcallsPipeState);
+  bool GetDrawCallsGLPipelineState(
+      rdctype::array<DrawcallPipelineState<GLPipelineState>> *drawcallsPipeState);
+  bool GetDrawCallsVulkanPipelineState(
+      rdctype::array<DrawcallPipelineState<VulkanPipelineState>> *drawcallsPipeState);
+
   bool PixelHistory(ResourceId target, uint32_t x, uint32_t y, uint32_t slice, uint32_t mip,
                     uint32_t sampleIdx, FormatComponentType typeHint,
                     rdctype::array<PixelModification> *history);
@@ -217,6 +227,11 @@ private:
   D3D12PipelineState m_D3D12PipelineState;
   GLPipelineState m_GLPipelineState;
   VulkanPipelineState m_VulkanPipelineState;
+
+  vector<DrawcallPipelineState<D3D11PipelineState>> m_DrawCallsD3D11PipelineState;
+  vector<DrawcallPipelineState<D3D12PipelineState>> m_DrawCallsD3D12PipelineState;
+  vector<DrawcallPipelineState<GLPipelineState>> m_DrawCallsGLPipelineState;
+  vector<DrawcallPipelineState<VulkanPipelineState>> m_DrawCallsVulkanPipelineState;
 
   std::vector<ReplayOutput *> m_Outputs;
 

--- a/renderdocui/Interop/Enums.cs
+++ b/renderdocui/Interop/Enums.cs
@@ -946,5 +946,100 @@ namespace renderdoc
 
             return "Unknown";
         }
+        
+        public static string Str(this BufferCreationFlags creationFlags)
+        {
+            string str = "";
+            bool first = true;
+            if ((creationFlags & BufferCreationFlags.VB) == BufferCreationFlags.VB)
+            {
+                str = str + "Vertex Buffer";
+                first = false;
+            }
+            if ((creationFlags & BufferCreationFlags.CB) == BufferCreationFlags.CB)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str = str + "Constat Buffer";
+            }
+            if ((creationFlags & BufferCreationFlags.IB) == BufferCreationFlags.IB)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str = str + "Index Buffer";
+            }
+            if ((creationFlags & BufferCreationFlags.UAV) == BufferCreationFlags.UAV)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str = str + "UAV";
+            }
+            if ((creationFlags & BufferCreationFlags.Indirect) == BufferCreationFlags.Indirect)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str = str + "Indirect";
+            }
+
+            if (str == "")
+                str = "Undefined";
+
+            return str;
+        }
+
+        public static string Str(this TextureCreationFlags creationFlags)
+        {
+            string str = "";
+            bool first = true;
+            if ((creationFlags & TextureCreationFlags.SRV) == TextureCreationFlags.SRV)
+            { 
+                str += "Shader Resource View";
+                first = false;
+            }
+            if ((creationFlags & TextureCreationFlags.RTV) == TextureCreationFlags.RTV)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str += "Render Target View";
+            }
+            if ((creationFlags & TextureCreationFlags.DSV) == TextureCreationFlags.DSV)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str += "Depth Stencil View";
+            }
+            if ((creationFlags & TextureCreationFlags.UAV) == TextureCreationFlags.UAV)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str += "UAV View ";
+            }
+            if ((creationFlags & TextureCreationFlags.SwapBuffer) == TextureCreationFlags.SwapBuffer)
+            {
+                if (!first)
+                    str += ", ";
+                else
+                    first = false;
+                str += "Swap Buffer";
+            }
+
+            if (str == "")
+                str = "Undefined";
+            return str;
+        }
     }
 }

--- a/renderdocui/Interop/FetchInfo.cs
+++ b/renderdocui/Interop/FetchInfo.cs
@@ -542,6 +542,7 @@ namespace renderdoc
     {
         public UInt32 eventID;
         public ResourceUsage usage;
+        public UInt32 slot;
         public ResourceId view;
     };
 
@@ -818,6 +819,14 @@ namespace renderdoc
 
         [CustomMarshalAs(CustomUnmanagedType.Union)]
         public ValueUnion value;
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class DrawCallD3D11PipelineState
+    {
+        public UInt32 eventID;
+        [CustomMarshalAs(CustomUnmanagedType.CustomClass)]
+        public D3D11PipelineState pipelineState;
     };
 
     [StructLayout(LayoutKind.Sequential)]

--- a/renderdocui/Interop/FetchInfo.cs
+++ b/renderdocui/Interop/FetchInfo.cs
@@ -625,6 +625,9 @@ namespace renderdoc
         public ResourceId[] outputs;
         public ResourceId depthOut;
 
+        [CustomMarshalAs(CustomUnmanagedType.FixedArray, FixedLength = 6)]
+        public ResourceId[] shaders;
+
         [CustomMarshalAs(CustomUnmanagedType.TemplatedArray)]
         public FetchAPIEvent[] events;
         [CustomMarshalAs(CustomUnmanagedType.TemplatedArray)]

--- a/renderdocui/Interop/ReplayRenderer.cs
+++ b/renderdocui/Interop/ReplayRenderer.cs
@@ -354,6 +354,9 @@ namespace renderdoc
         private static extern bool ReplayRenderer_GetUsage(IntPtr real, ResourceId id, IntPtr outusage);
 
         [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool ReplayRenderer_GetShader(IntPtr real, ResourceId id, IntPtr entry, IntPtr outshader);
+
+        [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         private static extern bool ReplayRenderer_GetCBufferVariableContents(IntPtr real, ResourceId shader, IntPtr entryPoint, UInt32 cbufslot, ResourceId buffer, UInt64 offs, IntPtr outvars);
 
         [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
@@ -812,6 +815,23 @@ namespace renderdoc
 
             if (success)
                 ret = (EventUsage[])CustomMarshal.GetTemplatedArray(mem, typeof(EventUsage), true);
+
+            CustomMarshal.Free(mem);
+
+            return ret;
+        }
+
+        public ShaderReflection GetShader(ResourceId id, string entrypoint)
+        {
+            IntPtr entry_mem = CustomMarshal.MakeUTF8String(entrypoint);
+            IntPtr mem = CustomMarshal.Alloc(typeof(ShaderReflection));
+
+            bool success = ReplayRenderer_GetShader(m_Real, id, entry_mem, mem);
+
+            ShaderReflection ret = null;
+
+            if (success)
+                ret = (ShaderReflection)CustomMarshal.PtrToStructure(mem, typeof(ShaderReflection), true);
 
             CustomMarshal.Free(mem);
 

--- a/renderdocui/Interop/ReplayRenderer.cs
+++ b/renderdocui/Interop/ReplayRenderer.cs
@@ -309,6 +309,17 @@ namespace renderdoc
         private static extern bool ReplayRenderer_GetVulkanPipelineState(IntPtr real, IntPtr mem);
 
         [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool ReplayRenderer_CaptureDrawCallsPipelineState(IntPtr real);
+        [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool ReplayRenderer_GetDrawCallsD3D11PipelineState(IntPtr real, IntPtr mem);
+        [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool ReplayRenderer_GetDrawCallsGetD3D12PipelineState(IntPtr real, IntPtr mem);
+        [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool ReplayRenderer_GetDrawCallsGetGLPipelineState(IntPtr real, IntPtr mem);
+        [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool ReplayRenderer_GetDrawCallsGetVulkanPipelineState(IntPtr real, IntPtr mem);
+
+        [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         private static extern void ReplayRenderer_BuildCustomShader(IntPtr real, IntPtr entry, IntPtr source, UInt32 compileFlags, ShaderStageType type, ref ResourceId shaderID, IntPtr errorMem);
         [DllImport("renderdoc.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         private static extern bool ReplayRenderer_FreeCustomShader(IntPtr real, ResourceId id);
@@ -480,6 +491,27 @@ namespace renderdoc
 
             if (success)
                 ret = (VulkanPipelineState)CustomMarshal.PtrToStructure(mem, typeof(VulkanPipelineState), true);
+
+            CustomMarshal.Free(mem);
+
+            return ret;
+        }
+
+        public void CaptureDrawCallsPipelineState()
+        {
+            bool success = ReplayRenderer_CaptureDrawCallsPipelineState(m_Real);
+        }
+
+        public DrawCallD3D11PipelineState[] GetDrawCallsD3D11PipelineState()
+        {
+            IntPtr mem = CustomMarshal.Alloc(typeof(templated_array));
+
+            bool success = ReplayRenderer_GetDrawCallsD3D11PipelineState(m_Real, mem);
+
+            DrawCallD3D11PipelineState[] ret = null;
+
+            if (success)
+                ret = (DrawCallD3D11PipelineState[])CustomMarshal.GetTemplatedArray(mem, typeof(DrawCallD3D11PipelineState), true);
 
             CustomMarshal.Free(mem);
 


### PR DESCRIPTION
This is actually more of an 'opinion request' than a real pull request.

On my attempt to improve whole frame information gathering I made two small changes and one larger addition. 

I exposed the GetShaders interface to the Python scripts that already existed internally.  Then I added a 'slot' field to the texture/buffer per event usage structure to identify where the resource is attached at a given stage (expanding on the usage flags).

The larger addition is a new interface to return the pipeline state per drawcall.  The reason I finally attempted this (makes the other two somewhat redundant) is that stepping over the whole frame with pyrenderdoc.SetEventID() was very slow (tens of minutes).  This alternative takes a couple minutes by using a script like this:

```
drawcalls_state = None

def get_drawcalls_state(renderer):
	global drawcalls_state
	renderer.CaptureDrawCallsPipelineState()
	drawcalls_state = renderer.GetDrawCallsD3D11PipelineState()

pyrenderdoc.Renderer.Invoke(get_drawcalls_state)

for drawcall_state in drawcalls_state:
	do_something_on_the_state(drawcall_state.pipelineState)
```

For now this branch is for my personal use but if you have any suggestion or think something like this may be useful on renderdoc I'm open to contribute.
