### PR TITLE
Fixed boolean condition for empty list check

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_state.cpp
+++ b/renderdoc/driver/d3d12/d3d12_state.cpp
@@ -187,7 +187,7 @@ void D3D12RenderState::ApplyState(ID3D12GraphicsCommandList *cmd) const
   if(!descHeaps.empty())
     cmd->SetDescriptorHeaps((UINT)descHeaps.size(), &descHeaps[0]);
 
-  if(!rts.empty() || dsv.heap != ResourceId())
+  if(!rts.empty() && dsv.heap != ResourceId())
   {
     D3D12_CPU_DESCRIPTOR_HANDLE rtHandles[8];
     D3D12_CPU_DESCRIPTOR_HANDLE dsvHandle = CPUHandleFromPortableHandle(GetResourceManager(), dsv);


### PR DESCRIPTION
When replaying I encounter a crash when `rts` is empty. I guess the condition in line 190 is there to check for both conditions to be true so I changed it to an `&&`.
This fixes the crash and everything seems to work.