### PR TITLE
Add missing strings for VK_PIPELINE_STAGE_ALL_{GRAPHICS,COMMANDS}_BIT

### DIFF
--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -1301,6 +1301,10 @@ string ToStrHelper<false, VkPipelineStageFlagBits>::Get(const VkPipelineStageFla
     ret += " | VK_PIPELINE_STAGE_TRANSFER_BIT";
   if(el & VK_PIPELINE_STAGE_HOST_BIT)
     ret += " | VK_PIPELINE_STAGE_HOST_BIT";
+  if(el & VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT)
+    ret += " | VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT";
+  if(el & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT)
+    ret += " | VK_PIPELINE_STAGE_ALL_COMMANDS_BIT";
 
   if(!ret.empty())
     ret = ret.substr(3);


### PR DESCRIPTION
Just a trivial change to add some missing pipeline stage  enumeration strings.