### PR TITLE
qrenderdoc: Allow vkCmdExecuteCommands events to be viewed in the API inspector

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -366,8 +366,12 @@ void CaptureContext::CloseLogfile()
   }
 }
 
-void CaptureContext::SetEventID(ILogViewerForm *exclude, uint32_t eventID, bool force)
+void CaptureContext::SetEventID(ILogViewerForm *exclude, uint32_t selectedEventID, uint32_t eventID,
+                                bool force)
 {
+  uint32_t prevSelectedEventID = m_SelectedEventID;
+  m_SelectedEventID = selectedEventID;
+  uint32_t prevEventID = m_EventID;
   m_EventID = eventID;
 
   m_Renderer.BlockInvoke([this, eventID, force](IReplayRenderer *r) {
@@ -385,7 +389,10 @@ void CaptureContext::SetEventID(ILogViewerForm *exclude, uint32_t eventID, bool 
     if(logviewer == exclude)
       continue;
 
-    logviewer->OnEventSelected(eventID);
+    if(force || prevSelectedEventID != selectedEventID)
+      logviewer->OnSelectedEventChanged(selectedEventID);
+    if(force || prevEventID != eventID)
+      logviewer->OnEventChanged(eventID);
   }
 }
 

--- a/qrenderdoc/Windows/APIInspector.cpp
+++ b/qrenderdoc/Windows/APIInspector.cpp
@@ -59,7 +59,7 @@ void APIInspector::OnLogfileClosed()
   ui->callstack->clear();
 }
 
-void APIInspector::OnEventSelected(uint32_t eventID)
+void APIInspector::OnSelectedEventChanged(uint32_t eventID)
 {
   ui->apiEvents->clearSelection();
 
@@ -116,7 +116,7 @@ void APIInspector::fillAPIView()
   QRegularExpression rgxopen("^\\s*{");
   QRegularExpression rgxclose("^\\s*}");
 
-  const FetchDrawcall *draw = m_Ctx->CurDrawcall();
+  const FetchDrawcall *draw = m_Ctx->CurSelectedDrawcall();
 
   if(draw != NULL && draw->events.count > 0)
   {

--- a/qrenderdoc/Windows/APIInspector.h
+++ b/qrenderdoc/Windows/APIInspector.h
@@ -42,8 +42,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
-
+  void OnSelectedEventChanged(uint32_t eventID);
+  void OnEventChanged(uint32_t eventID) {}
 public slots:
   void on_apiEvents_itemSelectionChanged();
 

--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -295,7 +295,7 @@ void BufferViewer::OnLogfileLoaded()
 
     RT_UpdateAndDisplay(r);
 
-    GUIInvoke::call([this]() { OnEventSelected(m_Ctx->CurEvent()); });
+    GUIInvoke::call([this]() { OnEventChanged(m_Ctx->CurEvent()); });
   });
 }
 
@@ -304,7 +304,7 @@ void BufferViewer::OnLogfileClosed()
   Reset();
 }
 
-void BufferViewer::OnEventSelected(uint32_t eventID)
+void BufferViewer::OnEventChanged(uint32_t eventID)
 {
   m_ModelVSIn->beginReset();
   m_ModelVSOut->beginReset();

--- a/qrenderdoc/Windows/BufferViewer.h
+++ b/qrenderdoc/Windows/BufferViewer.h
@@ -44,7 +44,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private slots:
   // automatic slots

--- a/qrenderdoc/Windows/ConstantBufferPreviewer.cpp
+++ b/qrenderdoc/Windows/ConstantBufferPreviewer.cpp
@@ -91,7 +91,7 @@ void ConstantBufferPreviewer::OnLogfileClosed()
   ui->saveCSV->setEnabled(false);
 }
 
-void ConstantBufferPreviewer::OnEventSelected(uint32_t eventID)
+void ConstantBufferPreviewer::OnEventChanged(uint32_t eventID)
 {
   uint64_t offs = 0;
   uint64_t size = 0;
@@ -165,7 +165,7 @@ void ConstantBufferPreviewer::processFormat(const QString &format)
     ui->formatSpecifier->setErrors(errors);
   }
 
-  OnEventSelected(m_Ctx->CurEvent());
+  OnEventChanged(m_Ctx->CurEvent());
 }
 
 void ConstantBufferPreviewer::addVariables(QTreeWidgetItem *root,

--- a/qrenderdoc/Windows/ConstantBufferPreviewer.h
+++ b/qrenderdoc/Windows/ConstantBufferPreviewer.h
@@ -47,7 +47,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private slots:
   // automatic slots

--- a/qrenderdoc/Windows/EventBrowser.h
+++ b/qrenderdoc/Windows/EventBrowser.h
@@ -48,7 +48,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private slots:
   // automatic slots

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -936,7 +936,7 @@ void MainWindow::OnLogfileClosed()
   */
 }
 
-void MainWindow::OnEventSelected(uint32_t eventID)
+void MainWindow::OnEventChanged(uint32_t eventID)
 {
 }
 

--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -52,7 +52,8 @@ public:
 
   void OnLogfileLoaded() override;
   void OnLogfileClosed() override;
-  void OnEventSelected(uint32_t eventID) override;
+  void OnSelectedEventChanged(uint32_t eventID) override {}
+  void OnEventChanged(uint32_t eventID) override;
 
   void setProgress(float val);
   void takeLogOwnership() { m_OwnTempLog = true; }

--- a/qrenderdoc/Windows/PipelineState/D3D11PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D11PipelineStateViewer.cpp
@@ -44,6 +44,6 @@ void D3D11PipelineStateViewer::OnLogfileClosed()
 {
 }
 
-void D3D11PipelineStateViewer::OnEventSelected(uint32_t eventID)
+void D3D11PipelineStateViewer::OnEventChanged(uint32_t eventID)
 {
 }

--- a/qrenderdoc/Windows/PipelineState/D3D11PipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/D3D11PipelineStateViewer.h
@@ -42,7 +42,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private:
   Ui::D3D11PipelineStateViewer *ui;

--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
@@ -44,6 +44,6 @@ void D3D12PipelineStateViewer::OnLogfileClosed()
 {
 }
 
-void D3D12PipelineStateViewer::OnEventSelected(uint32_t eventID)
+void D3D12PipelineStateViewer::OnEventChanged(uint32_t eventID)
 {
 }

--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.h
@@ -42,7 +42,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private:
   Ui::D3D12PipelineStateViewer *ui;

--- a/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
@@ -44,6 +44,6 @@ void GLPipelineStateViewer::OnLogfileClosed()
 {
 }
 
-void GLPipelineStateViewer::OnEventSelected(uint32_t eventID)
+void GLPipelineStateViewer::OnEventChanged(uint32_t eventID)
 {
 }

--- a/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.h
@@ -42,7 +42,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private:
   Ui::GLPipelineStateViewer *ui;

--- a/qrenderdoc/Windows/PipelineState/PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/PipelineStateViewer.cpp
@@ -77,10 +77,10 @@ void PipelineStateViewer::OnLogfileClosed()
     m_Current->OnLogfileClosed();
 }
 
-void PipelineStateViewer::OnEventSelected(uint32_t eventID)
+void PipelineStateViewer::OnEventChanged(uint32_t eventID)
 {
   if(m_Current)
-    m_Current->OnEventSelected(eventID);
+    m_Current->OnEventChanged(eventID);
 }
 
 QVariant PipelineStateViewer::persistData()

--- a/qrenderdoc/Windows/PipelineState/PipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/PipelineStateViewer.h
@@ -49,7 +49,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
   QVariant persistData();
   void setPersistData(const QVariant &persistData);

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -288,7 +288,7 @@ VulkanPipelineStateViewer::~VulkanPipelineStateViewer()
 
 void VulkanPipelineStateViewer::OnLogfileLoaded()
 {
-  OnEventSelected(m_Ctx->CurEvent());
+  OnEventChanged(m_Ctx->CurEvent());
 }
 
 void VulkanPipelineStateViewer::OnLogfileClosed()
@@ -296,7 +296,7 @@ void VulkanPipelineStateViewer::OnLogfileClosed()
   clearState();
 }
 
-void VulkanPipelineStateViewer::OnEventSelected(uint32_t eventID)
+void VulkanPipelineStateViewer::OnEventChanged(uint32_t eventID)
 {
   setState();
 }

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.h
@@ -52,7 +52,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
 private slots:
   // automatic slots

--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -1715,7 +1715,7 @@ void TextureViewer::texContextItem_triggered()
   QVariant eid = act->property("eid");
   if(eid.isValid())
   {
-    m_Ctx->SetEventID(NULL, eid.toUInt());
+    m_Ctx->SetEventID(NULL, eid.toUInt(), eid.toUInt());
     return;
   }
 
@@ -2479,7 +2479,7 @@ void TextureViewer::OnLogfileLoaded()
 
     RT_UpdateAndDisplay(r);
 
-    GUIInvoke::call([this]() { OnEventSelected(m_Ctx->CurEvent()); });
+    GUIInvoke::call([this]() { OnEventChanged(m_Ctx->CurEvent()); });
   });
 }
 
@@ -2540,7 +2540,7 @@ void TextureViewer::OnLogfileClosed()
   ui->viewTexBuffer->setEnabled(false);
 }
 
-void TextureViewer::OnEventSelected(uint32_t eventID)
+void TextureViewer::OnEventChanged(uint32_t eventID)
 {
   UI_UpdateCachedTexture();
 

--- a/qrenderdoc/Windows/TextureViewer.h
+++ b/qrenderdoc/Windows/TextureViewer.h
@@ -126,7 +126,8 @@ public:
 
   void OnLogfileLoaded();
   void OnLogfileClosed();
-  void OnEventSelected(uint32_t eventID);
+  void OnSelectedEventChanged(uint32_t eventID) {}
+  void OnEventChanged(uint32_t eventID);
 
   void GotoLocation(int x, int y);
   void ViewTexture(ResourceId ID, bool focus);


### PR DESCRIPTION
Currently, selecting a vkCmdExecuteCommands event in the event browser will cause the API inspector window to show the final child event of the command buffer being executed (i.e. the "vkEndCommandBuffer" marker rather than the vkCmdExecuteCommands event itself), which means it is not possible to inspect that API call and calls just prior to it in the API inspector (e.g. I have some vkCmdPipelineBarrier calls prior to vkCmdExecuteCommands that I want to be able to inspect).

This happens because EventBrowser::AddDrawcalls sets COL_SELECT_ID for events with children to the event ID of the last child event. This behaviour makes sense for debug markers because they're not real events (I think is the only other case where an event can have children?).

Therefore this change makes it possible to inspect vkCmdExecuteCommands events by setting COL_SELECT_ID to the ID of the event itself rather than that of the last child if the event has eDraw_CmdList set. This keeps the previous behaviour for other types of event with children.

This seemed like the best way to handle this to me, though if you can think of anything better let me know and I can change this.