### PR TITLE
Fix editing compute shader modules, with new MakeComputePipelineInfo().

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -334,6 +334,7 @@ public:
   MeshDisplayPipelines CacheMeshDisplayPipelines(const MeshFormat &primary,
                                                  const MeshFormat &secondary);
   void MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &pipeCreateInfo, ResourceId pipeline);
+  void MakeComputePipelineInfo(VkComputePipelineCreateInfo &pipeCreateInfo, ResourceId pipeline);
 
 private:
   void InitDebugData();


### PR DESCRIPTION
Before editing a pipeline, we need to recreate its creation info struct.
Compute pipelines have their own VkComputePipelineCreateInfo instead of
VkGraphicsPipelineCreateInfo, and we now make that distinction.