### PR TITLE
histogram result is not writeonly

### DIFF
--- a/renderdoc/data/glsl/histogram.comp
+++ b/renderdoc/data/glsl/histogram.comp
@@ -24,7 +24,7 @@
 
 //#include "texsample.h" // while includes aren't supported in glslang, this will be added in code
 
-layout(binding=0, std140) writeonly buffer minmaxresultdest
+layout(binding=0, std140) buffer minmaxresultdest
 {
 	uvec4 result[HGRAM_NUM_BUCKETS];
 } dest;


### PR DESCRIPTION
result is written with atomicAdd(dest.result[bucketIdx].x, 1U);

The intel mesa driver rightly complains about this and does not build
the shader.