### PR TITLE
GLWindowingData context functions are now virtual methods.

### DIFF
--- a/renderdoc/driver/gl/gl_common.cpp
+++ b/renderdoc/driver/gl/gl_common.cpp
@@ -34,12 +34,6 @@ bool VendorCheck[VendorCheck_Count];
 int GLCoreVersion = 0;
 bool GLIsCore = false;
 
-// simple wrapper for OS functions to make/delete a context
-GLWindowingData MakeContext(GLWindowingData share);
-void DeleteContext(GLWindowingData context);
-
-void MakeContextCurrent(GLWindowingData data);
-
 bool CheckReplayContext(PFNGLGETSTRINGPROC getStr, PFNGLGETINTEGERVPROC getInt,
                         PFNGLGETSTRINGIPROC getStri)
 {
@@ -413,7 +407,7 @@ void CheckExtensions(const GLHookSet &gl)
   }
 }
 
-void DoVendorChecks(const GLHookSet &gl, GLWindowingData context)
+void DoVendorChecks(const GLHookSet &gl, GLPlatform &platform, GLWindowingData context)
 {
   //////////////////////////////////////////////////////////
   // version/driver/vendor specific hacks and checks go here
@@ -618,12 +612,12 @@ void DoVendorChecks(const GLHookSet &gl, GLWindowingData context)
     gl.glBindVertexArray(vao);
 
     // make a context that shares with the current one, and switch to it
-    GLWindowingData child = MakeContext(context);
+    GLWindowingData child = platform.MakeContext(context);
 
     if(child.ctx)
     {
       // switch to child
-      MakeContextCurrent(child);
+      platform.MakeContextCurrent(child);
 
       // these shouldn't be visible
       VendorCheck[VendorCheck_EXT_fbo_shared] = (gl.glIsFramebuffer(fbo) != GL_FALSE);
@@ -635,9 +629,9 @@ void DoVendorChecks(const GLHookSet &gl, GLWindowingData context)
         RDCWARN("VAOs are shared on this implementation");
 
       // switch back to context
-      MakeContextCurrent(context);
+      platform.MakeContextCurrent(context);
 
-      DeleteContext(child);
+      platform.DeleteContext(child);
     }
 
     gl.glDeleteFramebuffers(1, &fbo);

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "common/common.h"
+#include "maths/vec.h"
 
 // typed enum so that templates will pick up specialisations
 // header must be included before the official headers, so we/
@@ -159,6 +160,17 @@ struct GLWindowingData
 #else
 #error "Unknown platform"
 #endif
+
+struct GLPlatform
+{
+  // simple wrapper for OS functions to make/delete a context
+  virtual GLWindowingData MakeContext(GLWindowingData share) = 0;
+  virtual void DeleteContext(GLWindowingData context) = 0;
+  virtual void MakeContextCurrent(GLWindowingData data) = 0;
+
+  // for 'backwards compatible' overlay rendering
+  virtual bool DrawQuads(float width, float height, const std::vector<Vec4f> &vertices) = 0;
+};
 
 // define stubs so other platforms can define these functions, but empty
 #if DISABLED(RDOC_WIN32)
@@ -309,7 +321,7 @@ enum VendorCheckEnum
 extern bool VendorCheck[VendorCheck_Count];
 
 // fills out the extension supported array and the version-specific checks above
-void DoVendorChecks(const GLHookSet &gl, GLWindowingData context);
+void DoVendorChecks(const GLHookSet &gl, GLPlatform &platform, GLWindowingData context);
 void CheckExtensions(const GLHookSet &gl);
 
 // verify that we got a replay context that we can work with

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -110,6 +110,7 @@ class WrappedOpenGL : public IFrameCapturer
 {
 private:
   const GLHookSet &m_Real;
+  GLPlatform &m_Platform;
 
   // Used to clarify when we're making an internal call that isn't just part of
   // forwarding the capture, and allows us to emulate extensions like EXT_direct_state_access
@@ -493,7 +494,7 @@ private:
   WrappedOpenGL &operator=(const WrappedOpenGL &);
 
 public:
-  WrappedOpenGL(const char *logfile, const GLHookSet &funcs);
+  WrappedOpenGL(const char *logfile, const GLHookSet &funcs, GLPlatform &platform);
   virtual ~WrappedOpenGL();
 
   static const char *GetChunkName(uint32_t idx);

--- a/renderdoc/driver/gl/gl_hooks_apple.cpp
+++ b/renderdoc/driver/gl/gl_hooks_apple.cpp
@@ -43,6 +43,18 @@ public:
   bool CreateHooks(const char *libName) { return false; }
   void EnableHooks(const char *libName, bool enable) {}
   void OptionsUpdated(const char *libName) {}
+  virtual GLWindowingData MakeContext(GLWindowingData share)
+  {
+    RDCUNIMPLEMENTED("MakeContext");
+    return GLWindowingData();
+  }
+  virtual void DeleteContext(GLWindowingData context) { RDCUNIMPLEMENTED("DeleteContext"); }
+  virtual void MakeContextCurrent(GLWindowingData data) { RDCUNIMPLEMENTED("MakeContextCurrent"); }
+  virtual bool DrawQuads(float width, float height, const std::vector<Vec4f> &vertices)
+  {
+    RDCUNIMPLEMENTED("DrawQuads");
+    return false;
+  }
 };
 
 const GLHookSet &GetRealGLFunctions()
@@ -52,39 +64,7 @@ const GLHookSet &GetRealGLFunctions()
   return dummyHookset;
 }
 
-void MakeContextCurrent(GLWindowingData data)
-{
-  RDCUNIMPLEMENTED("MakeContextCurrent");
-}
-
-GLWindowingData MakeContext(GLWindowingData share)
-{
-  RDCUNIMPLEMENTED("MakeContext");
-  return GLWindowingData();
-}
-
 Threading::CriticalSection &GetGLLock()
 {
   return glLock;
-}
-
-void DeleteContext(GLWindowingData context)
-{
-  RDCUNIMPLEMENTED("DeleteContext");
-}
-
-bool immediateBegin(GLenum mode, float width, float height)
-{
-  RDCUNIMPLEMENTED("immediateBegin");
-  return false;
-}
-
-void immediateVert(float x, float y, float u, float v)
-{
-  RDCUNIMPLEMENTED("immediateVert");
-}
-
-void immediateEnd()
-{
-  RDCUNIMPLEMENTED("immediateEnd");
 }

--- a/renderdoc/driver/gl/gl_hooks_linux_shared.cpp
+++ b/renderdoc/driver/gl/gl_hooks_linux_shared.cpp
@@ -38,14 +38,6 @@ Threading::CriticalSection glLock;
 void *libGLdlsymHandle =
     RTLD_NEXT;    // default to RTLD_NEXT, but overwritten if app calls dlopen() on real libGL
 
-WrappedOpenGL *GetDriver()
-{
-  if(m_GLDriver == NULL)
-    m_GLDriver = new WrappedOpenGL("", GL);
-
-  return m_GLDriver;
-}
-
 Threading::CriticalSection &GetGLLock()
 {
   return glLock;
@@ -111,7 +103,7 @@ Threading::CriticalSection &GetGLLock()
   done;
         echo ") \\";
 
-        echo -en "\t{ SCOPED_LOCK(glLock); return OpenGLHook::glhooks.GetDriver()->function(";
+        echo -en "\t{ SCOPED_LOCK(glLock); return m_GLDriver->function(";
             for I in `seq 1 $N`; do echo -n "p$I"; if [ $I -ne $N ]; then echo -n ", "; fi; done;
         echo "); } \\";
 
@@ -120,7 +112,7 @@ Threading::CriticalSection &GetGLLock()
   done;
         echo ") \\";
 
-        echo -en "\t{ SCOPED_LOCK(glLock); return OpenGLHook::glhooks.GetDriver()->function(";
+        echo -en "\t{ SCOPED_LOCK(glLock); return m_GLDriver->function(";
             for I in `seq 1 $N`; do echo -n "p$I"; if [ $I -ne $N ]; then echo -n ", "; fi; done;
         echo -n "); }";
     }
@@ -149,72 +141,72 @@ Threading::CriticalSection &GetGLLock()
   extern "C" __attribute__((visibility("default"))) ret function() \
   {                                                                \
     SCOPED_LOCK(glLock);                                           \
-    return GetDriver()->function();                                \
+    return m_GLDriver->function();                                 \
   }                                                                \
   ret CONCAT(function, _renderdoc_hooked)()                        \
   {                                                                \
     SCOPED_LOCK(glLock);                                           \
-    return GetDriver()->function();                                \
+    return m_GLDriver->function();                                 \
   }
 #define HookWrapper1(ret, function, t1, p1)                             \
   typedef ret (*CONCAT(function, _hooktype))(t1);                       \
   extern "C" __attribute__((visibility("default"))) ret function(t1 p1) \
   {                                                                     \
     SCOPED_LOCK(glLock);                                                \
-    return GetDriver()->function(p1);                                   \
+    return m_GLDriver->function(p1);                                    \
   }                                                                     \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1)                        \
   {                                                                     \
     SCOPED_LOCK(glLock);                                                \
-    return GetDriver()->function(p1);                                   \
+    return m_GLDriver->function(p1);                                    \
   }
 #define HookWrapper2(ret, function, t1, p1, t2, p2)                            \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2);                          \
   extern "C" __attribute__((visibility("default"))) ret function(t1 p1, t2 p2) \
   {                                                                            \
     SCOPED_LOCK(glLock);                                                       \
-    return GetDriver()->function(p1, p2);                                      \
+    return m_GLDriver->function(p1, p2);                                       \
   }                                                                            \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2)                        \
   {                                                                            \
     SCOPED_LOCK(glLock);                                                       \
-    return GetDriver()->function(p1, p2);                                      \
+    return m_GLDriver->function(p1, p2);                                       \
   }
 #define HookWrapper3(ret, function, t1, p1, t2, p2, t3, p3)                           \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3);                             \
   extern "C" __attribute__((visibility("default"))) ret function(t1 p1, t2 p2, t3 p3) \
   {                                                                                   \
     SCOPED_LOCK(glLock);                                                              \
-    return GetDriver()->function(p1, p2, p3);                                         \
+    return m_GLDriver->function(p1, p2, p3);                                          \
   }                                                                                   \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3)                        \
   {                                                                                   \
     SCOPED_LOCK(glLock);                                                              \
-    return GetDriver()->function(p1, p2, p3);                                         \
+    return m_GLDriver->function(p1, p2, p3);                                          \
   }
 #define HookWrapper4(ret, function, t1, p1, t2, p2, t3, p3, t4, p4)                          \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4);                                \
   extern "C" __attribute__((visibility("default"))) ret function(t1 p1, t2 p2, t3 p3, t4 p4) \
   {                                                                                          \
     SCOPED_LOCK(glLock);                                                                     \
-    return GetDriver()->function(p1, p2, p3, p4);                                            \
+    return m_GLDriver->function(p1, p2, p3, p4);                                             \
   }                                                                                          \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4)                        \
   {                                                                                          \
     SCOPED_LOCK(glLock);                                                                     \
-    return GetDriver()->function(p1, p2, p3, p4);                                            \
+    return m_GLDriver->function(p1, p2, p3, p4);                                             \
   }
 #define HookWrapper5(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5)                         \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4, t5);                                   \
   extern "C" __attribute__((visibility("default"))) ret function(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5) \
   {                                                                                                 \
     SCOPED_LOCK(glLock);                                                                            \
-    return GetDriver()->function(p1, p2, p3, p4, p5);                                               \
+    return m_GLDriver->function(p1, p2, p3, p4, p5);                                                \
   }                                                                                                 \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5)                        \
   {                                                                                                 \
     SCOPED_LOCK(glLock);                                                                            \
-    return GetDriver()->function(p1, p2, p3, p4, p5);                                               \
+    return m_GLDriver->function(p1, p2, p3, p4, p5);                                                \
   }
 #define HookWrapper6(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6)          \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4, t5, t6);                        \
@@ -222,12 +214,12 @@ Threading::CriticalSection &GetGLLock()
                                                                  t5 p5, t6 p6)               \
   {                                                                                          \
     SCOPED_LOCK(glLock);                                                                     \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6);                                    \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6);                                     \
   }                                                                                          \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6)          \
   {                                                                                          \
     SCOPED_LOCK(glLock);                                                                     \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6);                                    \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6);                                     \
   }
 #define HookWrapper7(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7)  \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4, t5, t6, t7);                    \
@@ -235,12 +227,12 @@ Threading::CriticalSection &GetGLLock()
                                                                  t5 p5, t6 p6, t7 p7)        \
   {                                                                                          \
     SCOPED_LOCK(glLock);                                                                     \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7);                                \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7);                                 \
   }                                                                                          \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7)   \
   {                                                                                          \
     SCOPED_LOCK(glLock);                                                                     \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7);                                \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7);                                 \
   }
 #define HookWrapper8(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8, p8) \
   typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4, t5, t6, t7, t8);                       \
@@ -248,12 +240,12 @@ Threading::CriticalSection &GetGLLock()
                                                                  t5 p5, t6 p6, t7 p7, t8 p8)        \
   {                                                                                                 \
     SCOPED_LOCK(glLock);                                                                            \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8);                                   \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8);                                    \
   }                                                                                                 \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8)   \
   {                                                                                                 \
     SCOPED_LOCK(glLock);                                                                            \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8);                                   \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8);                                    \
   }
 #define HookWrapper9(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,   \
                      p8, t9, p9)                                                                  \
@@ -262,13 +254,13 @@ Threading::CriticalSection &GetGLLock()
       t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9)                              \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9);                             \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9);                              \
   }                                                                                               \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, \
                                           t9 p9)                                                  \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9);                             \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9);                              \
   }
 #define HookWrapper10(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,  \
                       p8, t9, p9, t10, p10)                                                       \
@@ -277,13 +269,13 @@ Threading::CriticalSection &GetGLLock()
       t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10)                     \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                        \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                         \
   }                                                                                               \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, \
                                           t9 p9, t10 p10)                                         \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                        \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                         \
   }
 #define HookWrapper11(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,  \
                       p8, t9, p9, t10, p10, t11, p11)                                             \
@@ -292,13 +284,13 @@ Threading::CriticalSection &GetGLLock()
       t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10, t11 p11)            \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                   \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                    \
   }                                                                                               \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, \
                                           t9 p9, t10 p10, t11 p11)                                \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                   \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                    \
   }
 #define HookWrapper12(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,  \
                       p8, t9, p9, t10, p10, t11, p11, t12, p12)                                   \
@@ -307,13 +299,13 @@ Threading::CriticalSection &GetGLLock()
       t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10, t11 p11, t12 p12)   \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);              \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);               \
   }                                                                                               \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, \
                                           t9 p9, t10 p10, t11 p11, t12 p12)                       \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);              \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);               \
   }
 #define HookWrapper13(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,  \
                       p8, t9, p9, t10, p10, t11, p11, t12, p12, t13, p13)                         \
@@ -324,13 +316,13 @@ Threading::CriticalSection &GetGLLock()
       t13 p13)                                                                                    \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);         \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);          \
   }                                                                                               \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, \
                                           t9 p9, t10 p10, t11 p11, t12 p12, t13 p13)              \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);         \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);          \
   }
 #define HookWrapper14(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,  \
                       p8, t9, p9, t10, p10, t11, p11, t12, p12, t13, p13, t14, p14)               \
@@ -341,31 +333,31 @@ Threading::CriticalSection &GetGLLock()
       t13 p13, t14 p14)                                                                           \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);    \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);     \
   }                                                                                               \
   ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, \
                                           t9 p9, t10 p10, t11 p11, t12 p12, t13 p13, t14 p14)     \
   {                                                                                               \
     SCOPED_LOCK(glLock);                                                                          \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);    \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);     \
   }
-#define HookWrapper15(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,    \
-                      p8, t9, p9, t10, p10, t11, p11, t12, p12, t13, p13, t14, p14, t15, p15)       \
-  typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12,     \
-                                             t13, t14, t15);                                        \
-  extern "C" __attribute__((visibility("default"))) ret function(                                   \
-      t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10, t11 p11, t12 p12,     \
-      t13 p13, t14 p14, t15 p15)                                                                    \
-  {                                                                                                 \
-    SCOPED_LOCK(glLock);                                                                            \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15); \
-  }                                                                                                 \
-  ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8,   \
-                                          t9 p9, t10 p10, t11 p11, t12 p12, t13 p13, t14 p14,       \
-                                          t15 p15)                                                  \
-  {                                                                                                 \
-    SCOPED_LOCK(glLock);                                                                            \
-    return GetDriver()->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15); \
+#define HookWrapper15(ret, function, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6, t7, p7, t8,   \
+                      p8, t9, p9, t10, p10, t11, p11, t12, p12, t13, p13, t14, p14, t15, p15)      \
+  typedef ret (*CONCAT(function, _hooktype))(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12,    \
+                                             t13, t14, t15);                                       \
+  extern "C" __attribute__((visibility("default"))) ret function(                                  \
+      t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10, t11 p11, t12 p12,    \
+      t13 p13, t14 p14, t15 p15)                                                                   \
+  {                                                                                                \
+    SCOPED_LOCK(glLock);                                                                           \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15); \
+  }                                                                                                \
+  ret CONCAT(function, _renderdoc_hooked)(t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8,  \
+                                          t9 p9, t10 p10, t11 p11, t12 p12, t13 p13, t14 p14,      \
+                                          t15 p15)                                                 \
+  {                                                                                                \
+    SCOPED_LOCK(glLock);                                                                           \
+    return m_GLDriver->function(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15); \
   }
 
 DefineDLLExportHooks();

--- a/renderdoc/driver/gl/gl_hooks_linux_shared.h
+++ b/renderdoc/driver/gl/gl_hooks_linux_shared.h
@@ -30,7 +30,6 @@ void CloneDisplay(Display *dpy);
 
 void *SharedLookupFuncPtr(const char *func, void *realFunc);
 bool SharedPopulateHooks(void *(*lookupFunc)(const char *));
-WrappedOpenGL *GetDriver();
 
 extern GLHookSet GL;
 extern WrappedOpenGL *m_GLDriver;

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -3203,8 +3203,6 @@ ShaderDebugTrace GLReplay::DebugThread(uint32_t eventID, uint32_t groupid[3], ui
   return ShaderDebugTrace();
 }
 
-const GLHookSet &GetRealGLFunctions();
-
 #if defined(RENDERDOC_SUPPORT_GL)
 
 // defined in gl_replay_<platform>.cpp

--- a/renderdoc/driver/gl/gl_replay.h
+++ b/renderdoc/driver/gl/gl_replay.h
@@ -417,3 +417,6 @@ private:
 
   GLPipelineState m_CurPipelineState;
 };
+
+const GLHookSet &GetRealGLFunctions();
+GLPlatform &GetGLPlatform();

--- a/renderdoc/driver/gl/gl_replay_egl.cpp
+++ b/renderdoc/driver/gl/gl_replay_egl.cpp
@@ -217,6 +217,7 @@ bool GLReplay::IsOutputWindowVisible(uint64_t id)
 }
 
 const GLHookSet &GetRealGLFunctionsEGL();
+GLPlatform &GetGLPlatformEGL();
 
 ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **driver)
 {
@@ -357,7 +358,7 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
     return eReplayCreate_APIHardwareUnsupported;
   }
 
-  WrappedOpenGL *gl = new WrappedOpenGL(logfile, real);
+  WrappedOpenGL *gl = new WrappedOpenGL(logfile, real, GetGLPlatformEGL());
   gl->SetDriverType(RDC_OpenGLES);
   gl->Initialise(initParams);
 

--- a/renderdoc/driver/gl/gl_replay_linux.cpp
+++ b/renderdoc/driver/gl/gl_replay_linux.cpp
@@ -246,8 +246,6 @@ bool GLReplay::IsOutputWindowVisible(uint64_t id)
   return true;
 }
 
-const GLHookSet &GetRealGLFunctions();
-
 static bool X11ErrorSeen = false;
 
 int NonFatalX11ErrorHandler(Display *display, XErrorEvent *error)
@@ -456,7 +454,7 @@ ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **dr
     return eReplayCreate_APIHardwareUnsupported;
   }
 
-  WrappedOpenGL *gl = new WrappedOpenGL(logfile, real);
+  WrappedOpenGL *gl = new WrappedOpenGL(logfile, real, GetGLPlatform());
   gl->Initialise(initParams);
 
   if(gl->GetSerialiser()->HasError())

--- a/renderdoc/driver/gl/gl_replay_win32.cpp
+++ b/renderdoc/driver/gl/gl_replay_win32.cpp
@@ -249,8 +249,6 @@ bool GLReplay::IsOutputWindowVisible(uint64_t id)
   return (IsWindowVisible(m_OutputWindows[id].wnd) == TRUE);
 }
 
-const GLHookSet &GetRealGLFunctions();
-
 ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **driver)
 {
   RDCDEBUG("Creating an OpenGL replay device");
@@ -498,7 +496,7 @@ ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **dr
     return eReplayCreate_APIInitFailed;
   }
 
-  WrappedOpenGL *gl = new WrappedOpenGL(logfile, real);
+  WrappedOpenGL *gl = new WrappedOpenGL(logfile, real, GetGLPlatform());
   gl->Initialise(initParams);
 
   if(gl->GetSerialiser()->HasError())


### PR DESCRIPTION
On Linux we inherit into GLXWindowingData and EGLWindowingData.
GLWindowingData is passed around by value, so the copy constructor and
assignment operator keep the vtable.