### PR TITLE
Add new OpenGL ES driver type

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -61,6 +61,7 @@ string ToStrHelper<false, RDCDriver>::Get(const RDCDriver &el)
   {
     case RDC_Unknown: return "Unknown";
     case RDC_OpenGL: return "OpenGL";
+    case RDC_OpenGLES: return "OpenGLES";
     case RDC_Mantle: return "Mantle";
     case RDC_D3D12: return "D3D12";
     case RDC_D3D11: return "D3D11";

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -97,6 +97,7 @@ enum RDCDriver
   RDC_D3D9 = 6,
   RDC_Image = 7,
   RDC_Vulkan = 8,
+  RDC_OpenGLES = 9,
   RDC_Custom = 100000,
   RDC_Custom0 = RDC_Custom,
   RDC_Custom1,

--- a/renderdoc/driver/gl/CMakeLists.txt
+++ b/renderdoc/driver/gl/CMakeLists.txt
@@ -53,13 +53,11 @@ elseif(UNIX)
             gl_replay_linux.cpp
             glx_hooks_linux.cpp
             gl_hooks_linux.cpp)
-    elseif(ENABLE_GLES)
-        list(APPEND sources
-            gl_replay_egl.cpp)
     endif()
     if(ENABLE_GLES)
         list(APPEND sources
-            gl_hooks_egl.cpp)
+            gl_hooks_egl.cpp
+            gl_replay_egl.cpp)
     endif()
 endif()
 

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -717,6 +717,9 @@ WrappedOpenGL::WrappedOpenGL(const char *logfile, const GLHookSet &funcs) : m_Re
   // sorts are identical so we can do the intersection easily
   std::sort(globalExts.begin(), globalExts.end());
 
+  // by default we assume OpenGL driver
+  SetDriverType(RDC_OpenGL);
+
   m_Replay.SetDriver(this);
 
   m_FrameCounter = 0;
@@ -2307,7 +2310,7 @@ void WrappedOpenGL::SwapBuffers(void *windowHandle)
       int flags = activeWindow ? RenderDoc::eOverlay_ActiveWindow : 0;
       if(ctxdata.Legacy())
         flags |= RenderDoc::eOverlay_CaptureDisabled;
-      string overlayText = RenderDoc::Inst().GetOverlayText(RDC_OpenGL, m_FrameCounter, flags);
+      string overlayText = RenderDoc::Inst().GetOverlayText(GetDriverType(), m_FrameCounter, flags);
 
       if(ctxdata.Legacy())
       {
@@ -2353,7 +2356,7 @@ void WrappedOpenGL::SwapBuffers(void *windowHandle)
   if(!activeWindow)
     return;
 
-  RenderDoc::Inst().SetCurrentDriver(RDC_OpenGL);
+  RenderDoc::Inst().SetCurrentDriver(GetDriverType());
 
   // only allow capturing on 'modern' created contexts
   if(ctxdata.Legacy())
@@ -2416,7 +2419,7 @@ void WrappedOpenGL::StartFrameCapture(void *dev, void *wnd)
 
   SCOPED_LOCK(GetGLLock());
 
-  RenderDoc::Inst().SetCurrentDriver(RDC_OpenGL);
+  RenderDoc::Inst().SetCurrentDriver(GetDriverType());
 
   m_State = WRITING_CAPFRAME;
 

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -155,6 +155,7 @@ private:
   bool m_AppControlledCapture;
 
   GLReplay m_Replay;
+  RDCDriver m_DriverType;
 
   GLInitParams m_InitParams;
 
@@ -500,6 +501,9 @@ public:
   ResourceId GetDeviceResourceID() { return m_DeviceResourceID; }
   ResourceId GetContextResourceID() { return m_ContextResourceID; }
   GLReplay *GetReplay() { return &m_Replay; }
+  void SetDriverType(RDCDriver type) { m_DriverType = type; }
+  bool isGLESMode() { return m_DriverType == RDC_OpenGLES; }
+  RDCDriver GetDriverType() { return m_DriverType; }
   void *GetCtx();
 
   void SetFetchCounters(bool in) { m_FetchCounters = in; };

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -3205,7 +3205,20 @@ ShaderDebugTrace GLReplay::DebugThread(uint32_t eventID, uint32_t groupid[3], ui
 
 const GLHookSet &GetRealGLFunctions();
 
+#if defined(RENDERDOC_SUPPORT_GL)
+
 // defined in gl_replay_<platform>.cpp
 ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **driver);
 
 static DriverRegistration GLDriverRegistration(RDC_OpenGL, "OpenGL", &GL_CreateReplayDevice);
+
+#endif
+
+#if defined(RENDERDOC_SUPPORT_GLES)
+
+// defined in gl_replay_egl.cpp
+ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **driver);
+
+static DriverRegistration GLESDriverRegistration(RDC_OpenGLES, "OpenGLES", &GLES_CreateReplayDevice);
+
+#endif

--- a/renderdoc/driver/gl/gl_replay_egl.cpp
+++ b/renderdoc/driver/gl/gl_replay_egl.cpp
@@ -218,7 +218,7 @@ bool GLReplay::IsOutputWindowVisible(uint64_t id)
 
 const GLHookSet &GetRealGLFunctionsEGL();
 
-ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **driver)
+ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **driver)
 {
   RDCDEBUG("Creating an OpenGL ES replay device");
 
@@ -255,8 +255,8 @@ ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **dr
   }
 
   GLInitParams initParams;
-  RDCDriver driverType = RDC_OpenGL;
-  string driverName = "OpenGL";
+  RDCDriver driverType = RDC_OpenGLES;
+  string driverName = "OpenGLES";
   uint64_t machineIdent = 0;
 
   if(logfile)
@@ -358,6 +358,7 @@ ReplayCreateStatus GL_CreateReplayDevice(const char *logfile, IReplayDriver **dr
   }
 
   WrappedOpenGL *gl = new WrappedOpenGL(logfile, real);
+  gl->SetDriverType(RDC_OpenGLES);
   gl->Initialise(initParams);
 
   if(gl->GetSerialiser()->HasError())


### PR DESCRIPTION
Introduce the OpenGL ES driver type and use it in the
EGL replay code path. Also propagate the GLES mode info
into the OpenGL driver class.