### PR TITLE
Build spirv when GL ES is enabled

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -286,7 +286,7 @@ if(ENABLE_VULKAN)
     list(APPEND renderdoc_objects $<TARGET_OBJECTS:rdoc_vulkan>)
 endif()
 
-if(ENABLE_GL OR ENABLE_VULKAN)
+if(ENABLE_GL OR ENABLE_GLES OR ENABLE_VULKAN)
     add_subdirectory(driver/shaders/spirv)
     list(APPEND renderdoc_objects $<TARGET_OBJECTS:rdoc_spirv>)
 endif()


### PR DESCRIPTION
With the -DENABLE_GL=OFF -DENABLE_GLES=ON -DENABLE_VULKAN=OFF
build config the spirv library was not build before resulting in a link error.