### PR TITLE
Title and double-clicking handling for the APIInspector window

### DIFF
--- a/qrenderdoc/Widgets/Extended/RDSplitter.cpp
+++ b/qrenderdoc/Widgets/Extended/RDSplitter.cpp
@@ -1,0 +1,136 @@
+#include "RDSplitter.h"
+
+#include <QApplication>
+#include <QPaintEvent>
+#include <QPainter>
+
+RDSplitterDoubleClickEvent::RDSplitterDoubleClickEvent(int index)
+    : QEvent(staticType()), m_index(index)
+{
+}
+
+int RDSplitterDoubleClickEvent::index() const
+{
+  return m_index;
+}
+
+QEvent::Type RDSplitterDoubleClickEvent::staticType()
+{
+  static int type = registerEventType();
+  return (QEvent::Type)type;
+}
+
+RDSplitterHandle::RDSplitterHandle(Qt::Orientation orientation, QSplitter *parent)
+    : QSplitterHandle(orientation, parent), m_index(-1), m_isCollapsed(false)
+{
+}
+
+void RDSplitterHandle::setIndex(int index)
+{
+  m_index = index;
+}
+
+int RDSplitterHandle::index() const
+{
+  return m_index;
+}
+
+void RDSplitterHandle::setTitle(const QString &title)
+{
+  m_title = title;
+}
+
+const QString &RDSplitterHandle::title() const
+{
+  return m_title;
+}
+
+void RDSplitterHandle::setCollapsed(bool collapsed)
+{
+  m_isCollapsed = collapsed;
+}
+
+bool RDSplitterHandle::collapsed() const
+{
+  return m_isCollapsed;
+}
+
+void RDSplitterHandle::paintEvent(QPaintEvent *event)
+{
+  QPainter painter(this);
+  painter.setPen(Qt::black);
+
+  QString text(m_title);
+  if(m_isCollapsed)
+    text.append(" ...");
+
+  painter.drawText(event->rect(), Qt::AlignCenter | Qt::TextWordWrap, text);
+}
+
+void RDSplitterHandle::mouseDoubleClickEvent(QMouseEvent *event)
+{
+  // post the event to the parent
+  RDSplitterDoubleClickEvent *rdEvent = new RDSplitterDoubleClickEvent(m_index);
+  QApplication::postEvent(parent(), rdEvent);
+}
+
+RDSplitter::RDSplitter(Qt::Orientation orientation, QWidget *parent)
+    : QSplitter(orientation, parent)
+{
+  initialize();
+}
+
+RDSplitter::RDSplitter(QWidget *parent) : QSplitter(parent)
+{
+  initialize();
+}
+
+void RDSplitter::setHandleCollapsed(int pos, int index)
+{
+  QList<int> totalSizes = sizes();
+  RDSplitterHandle *rdHandle = static_cast<RDSplitterHandle *>(handle(index));
+  if(totalSizes[index] == 0)
+    rdHandle->setCollapsed(true);
+  else
+    rdHandle->setCollapsed(false);
+}
+
+void RDSplitter::initialize()
+{
+  connect(this, SIGNAL(splitterMoved(int, int)), this, SLOT(setHandleCollapsed(int, int)));
+}
+
+QSplitterHandle *RDSplitter::createHandle()
+{
+  return new RDSplitterHandle(orientation(), this);
+}
+
+bool RDSplitter::event(QEvent *event)
+{
+  if(event->type() == RDSplitterDoubleClickEvent::staticType())
+  {
+    RDSplitterDoubleClickEvent *rdEvent = static_cast<RDSplitterDoubleClickEvent *>(event);
+    int index = rdEvent->index();
+    RDSplitterHandle *rdHandle = static_cast<RDSplitterHandle *>(handle(index));
+    QList<int> totalSizes = sizes();
+    if(totalSizes[index] > 0)
+    {
+      // add to the previous handle the size of the current one
+      totalSizes[index - 1] += totalSizes[index];
+      // set the current handle's size to 0
+      totalSizes[index] = 0;
+      rdHandle->setCollapsed(true);
+    }
+    else
+    {
+      // split the sizes in half
+      int s = totalSizes[index - 1] / 2;
+      totalSizes[index] = totalSizes[index - 1] = s;
+      rdHandle->setCollapsed(false);
+    }
+    setSizes(totalSizes);
+    return true;
+  }
+
+  return QSplitter::event(event);
+}

--- a/qrenderdoc/Widgets/Extended/RDSplitter.h
+++ b/qrenderdoc/Widgets/Extended/RDSplitter.h
@@ -1,0 +1,77 @@
+#ifndef RDSPLITTER_H
+#define RDSPLITTER_H
+
+#include <QEvent>
+#include <QSplitter>
+#include <QString>
+
+// A custom event class the is posted by a QSplitter handle
+// when double clicking on it
+// it contains the index of the handle or -1 of the handle
+// does not know its index
+class RDSplitterDoubleClickEvent : public QEvent
+{
+public:
+  RDSplitterDoubleClickEvent(int index);
+
+  // returns the index of the handle that posted the event
+  // or -1 if the handle does not know its index
+  int index() const;
+
+  // registers the event in the Qt Event system
+  static QEvent::Type staticType();
+
+protected:
+  int m_index;
+};
+
+// a splitter handle.
+// it draws a text as the title and "..." if it's collapsed
+// You need to set a title and its index.
+class RDSplitterHandle : public QSplitterHandle
+{
+  Q_OBJECT
+
+public:
+  RDSplitterHandle(Qt::Orientation orientation, QSplitter *parent);
+
+  void setIndex(int index);
+  int index() const;
+
+  void setTitle(const QString &title);
+  const QString &title() const;
+
+  void setCollapsed(bool collapsed);
+  bool collapsed() const;
+
+protected:
+  virtual void paintEvent(QPaintEvent *event);
+  virtual void mouseDoubleClickEvent(QMouseEvent *event);
+
+  QString m_title;
+  int m_index;
+  bool m_isCollapsed;
+};
+
+// A Splitter that contains RDSplitterHandles
+// when setting up, you need to get the handles for every index
+// and set their title as well as their indexes
+class RDSplitter : public QSplitter
+{
+  Q_OBJECT
+
+public:
+  RDSplitter(QWidget *parent = 0);
+  RDSplitter(Qt::Orientation orientation, QWidget *parent = 0);
+
+protected slots:
+  void setHandleCollapsed(int pos, int index);
+
+protected:
+  void initialize();
+  virtual QSplitterHandle *createHandle();
+
+  virtual bool event(QEvent *event);
+};
+
+#endif    // RDSPLITTER_H

--- a/qrenderdoc/Windows/APIInspector.cpp
+++ b/qrenderdoc/Windows/APIInspector.cpp
@@ -39,6 +39,11 @@ APIInspector::APIInspector(CaptureContext &ctx, QWidget *parent)
   ui->splitter->setCollapsible(1, true);
   ui->splitter->setSizes({1, 0});
 
+  RDSplitterHandle *handle = (RDSplitterHandle *)ui->splitter->handle(1);
+  handle->setTitle("Callstack");
+  handle->setIndex(1);
+  handle->setCollapsed(true);
+
   m_Ctx.AddLogViewer(this);
 }
 

--- a/qrenderdoc/Windows/APIInspector.ui
+++ b/qrenderdoc/Windows/APIInspector.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QSplitter" name="splitter">
+    <widget class="RDSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -85,6 +85,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>RDSplitter</class>
+   <extends>QSplitter</extends>
+   <header>Widgets/Extended/RDSplitter.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/qrenderdoc/qrenderdoc.pro
+++ b/qrenderdoc/qrenderdoc.pro
@@ -162,7 +162,8 @@ SOURCES += Code/qrenderdoc.cpp \
     Windows/PixelHistoryView.cpp \
     Widgets/PipelineFlowChart.cpp \
     Windows/Dialogs/EnvironmentEditor.cpp \
-    Widgets/FindReplace.cpp
+    Widgets/FindReplace.cpp \
+    Widgets/Extended/RDSplitter.cpp
 
 HEADERS += Code/CaptureContext.h \
     Code/qprocessinfo.h \
@@ -213,7 +214,8 @@ HEADERS += Code/CaptureContext.h \
     Windows/PixelHistoryView.h \
     Widgets/PipelineFlowChart.h \
     Windows/Dialogs/EnvironmentEditor.h \
-    Widgets/FindReplace.h
+    Widgets/FindReplace.h \
+    Widgets/Extended/RDSplitter.h
 
 FORMS    += Windows/Dialogs/AboutDialog.ui \
     Windows/MainWindow.ui \


### PR DESCRIPTION
- Added custom Splitter widget, RDSplitter, that contains custom handles which draw titles and post events to parent Splitter when double-clicking on them