### PR TITLE
[In progress] GLES allows drawing from client memory or without an explicit VAO.

### DIFF
--- a/renderdoc/driver/gl/gl_common.cpp
+++ b/renderdoc/driver/gl/gl_common.cpp
@@ -806,6 +806,24 @@ GLenum QueryEnum(size_t idx)
   return eGL_NONE;
 }
 
+size_t GLTypeSize(GLenum type)
+{
+  switch(type)
+  {
+    case eGL_UNSIGNED_BYTE:
+    case eGL_BYTE: return 1;
+    case eGL_UNSIGNED_SHORT:
+    case eGL_SHORT:
+    case eGL_HALF_FLOAT: return 2;
+    case eGL_UNSIGNED_INT:
+    case eGL_INT:
+    case eGL_FLOAT: return 4;
+    case eGL_DOUBLE: return 8;
+    default: RDCWARN("Unhandled element type %s", ToStr::Get(type).c_str());
+  }
+  return 0;
+}
+
 size_t ShaderIdx(GLenum buf)
 {
   switch(buf)

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -236,6 +236,8 @@ struct GLMarkerRegion
   static const GLHookSet *gl;
 };
 
+size_t GLTypeSize(GLenum type);
+
 size_t BufferIdx(GLenum buf);
 GLenum BufferEnum(size_t idx);
 

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -818,6 +818,8 @@ WrappedOpenGL::WrappedOpenGL(const char *logfile, const GLHookSet &funcs, GLPlat
     RenderDoc::Inst().RegisterShutdownFunction(&ShutdownSPIRVCompiler);
   }
 
+  m_TempClientVAO = 0;
+
   m_FakeBB_FBO = 0;
   m_FakeBB_Color = 0;
   m_FakeBB_DepthStencil = 0;

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -106,6 +106,19 @@ struct Replacement
   GLResource res;
 };
 
+struct ClientVertexAttrib
+{
+  // GLuint index is the map key.
+  GLint size;
+  GLenum type;
+  GLboolean normalized;
+  GLsizei stride;
+  const void *pointer;
+
+  GLuint currentBuffer;    // GL_ARRAY_BUFFER_BINDING
+  GLuint tempBuffer;       // Create around calls if client memory was used
+};
+
 class WrappedOpenGL : public IFrameCapturer
 {
 private:
@@ -337,6 +350,14 @@ private:
   map<ResourceId, ProgramData> m_Programs;
   map<ResourceId, PipelineData> m_Pipelines;
   vector<pair<ResourceId, Replacement> > m_DependentReplacements;
+
+  // GLES allows drawing from client memory or without an explicit VAO.
+  // In this case we will create a temporary VAO with VBOs if needed so that
+  // input mesh data is recorded.
+  map<GLuint, ClientVertexAttrib> m_ClientVertexAttribs;
+  GLuint m_TempClientVAO;
+  void CreateTemporaryVAO(GLint first, GLsizei count);
+  void DeleteTemporaryVAO();
 
   GLuint m_FakeBB_FBO;
   GLuint m_FakeBB_Color;

--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -181,20 +181,7 @@ byte *PixelUnpackState::Unpack(byte *pixels, GLsizei width, GLsizei height, GLsi
   size_t destrowstride = pixelSize * width;
   size_t destimgstride = destrowstride * height;
 
-  size_t elemSize = 1;
-  switch(basetype)
-  {
-    case eGL_UNSIGNED_BYTE:
-    case eGL_BYTE: elemSize = 1; break;
-    case eGL_UNSIGNED_SHORT:
-    case eGL_SHORT:
-    case eGL_HALF_FLOAT: elemSize = 2; break;
-    case eGL_UNSIGNED_INT:
-    case eGL_INT:
-    case eGL_FLOAT: elemSize = 4; break;
-    case eGL_DOUBLE: elemSize = 8; break;
-    default: break;
-  }
+  size_t elemSize = GLTypeSize(basetype);
 
   size_t allocsize = width * RDCMAX(1, height) * RDCMAX(1, depth) * pixelSize;
   byte *ret = new byte[allocsize];

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -3025,6 +3025,13 @@ void WrappedOpenGL::glVertexAttribPointer(GLuint index, GLint size, GLenum type,
         r->AddChunk(scope.Get());
       }
     }
+    else if(IsGLES)
+    {
+      ClientVertexAttrib attrib = {size, type, normalized, stride, pointer};
+
+      glGetIntegerv(eGL_ARRAY_BUFFER_BINDING, (GLint *)&attrib.currentBuffer);
+      m_ClientVertexAttribs[index] = attrib;
+    }
   }
 }
 

--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -284,14 +284,14 @@ vector<CounterResult> VulkanReplay::FetchCounters(const vector<uint32_t> &counte
       ObjDisp(dev)->CreateQueryPool(Unwrap(dev), &timeStampPoolCreateInfo, NULL, &timeStampPool);
   RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-  VkQueryPool occlusionPool = NULL;
+  VkQueryPool occlusionPool = VK_NULL_HANDLE;
   if(availableFeatures.occlusionQueryPrecise)
   {
     vkr = ObjDisp(dev)->CreateQueryPool(Unwrap(dev), &occlusionPoolCreateInfo, NULL, &occlusionPool);
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
   }
 
-  VkQueryPool pipeStatsPool = NULL;
+  VkQueryPool pipeStatsPool = VK_NULL_HANDLE;
   if(availableFeatures.pipelineStatisticsQuery)
   {
     vkr = ObjDisp(dev)->CreateQueryPool(Unwrap(dev), &pipeStatsPoolCreateInfo, NULL, &pipeStatsPool);


### PR DESCRIPTION
In this case we will create a temporary VAO with VBOs if needed so that
input mesh data is recorded.