### PR TITLE
Add Android build support for GL ES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(ANDROID)
         message(STATUS "Disabling GL driver on android and enabling GLES")
     endif()
     set(ENABLE_GL OFF CACHE BOOL "" FORCE)
-    set(ENABLE_GLES OFF CACHE BOOL "" FORCE)
+    set(ENABLE_GLES ON CACHE BOOL "" FORCE)
 
     # Android doesn't support the Qt UI for obvious reasons
     message(STATUS "Disabling qrenderdoc for android build")

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -141,19 +141,33 @@ struct GLWindowingData
 
 #elif ENABLED(RDOC_ANDROID)
 
-#include "EGL/egl.h"
-#include "EGL/eglext.h"
+// force include the eglplatform.h, as we want to use
+// our own because the system one could be a bit older and
+// propably not suitable for the given egl.h
+#include "official/eglplatform.h"
+
+#include "official/egl.h"
+#include "official/eglext.h"
 
 struct GLWindowingData
 {
   GLWindowingData()
   {
-    ctx = NULL;
+    egl_ctx = 0;
+    egl_dpy = 0;
+    egl_wnd = 0;
     wnd = 0;
   }
 
-  void SetCtx(void *c) { ctx = (void *)c; }
-  EGLContext ctx;
+  void SetCtx(void *c) { egl_ctx = (void *)c; }
+  union
+  {
+    // currently required to allow compatiblity with the driver parts
+    void *ctx;
+    EGLContext egl_ctx;
+  };
+  EGLDisplay egl_dpy;
+  EGLSurface egl_wnd;
   ANativeWindow *wnd;
 };
 

--- a/renderdoc/driver/gl/gl_hooks_linux_shared.h
+++ b/renderdoc/driver/gl/gl_hooks_linux_shared.h
@@ -23,10 +23,12 @@
  ******************************************************************************/
 
 // bit of a hack
+#if DISABLED(RDOC_ANDROID)
 namespace Keyboard
 {
 void CloneDisplay(Display *dpy);
 }
+#endif
 
 void *SharedLookupFuncPtr(const char *func, void *realFunc);
 bool SharedPopulateHooks(void *(*lookupFunc)(const char *));

--- a/renderdoc/driver/gl/gl_replay_egl.cpp
+++ b/renderdoc/driver/gl/gl_replay_egl.cpp
@@ -113,6 +113,7 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
       return status;
   }
 
+#if DISABLED(RDOC_ANDROID)
   Display *dpy = XOpenDisplay(NULL);
 
   if(dpy == NULL)
@@ -120,6 +121,7 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
     RDCERR("Couldn't open default X display");
     return eReplayCreate_APIInitFailed;
   }
+#endif
 
   eglBindAPIProc(EGL_OPENGL_ES_API);
 
@@ -161,7 +163,9 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
   EGLContext ctx = eglCreateContextProc(eglDisplay, config, EGL_NO_CONTEXT, ctxAttribs);
   if(ctx == NULL)
   {
+#if DISABLED(RDOC_ANDROID)
     XCloseDisplay(dpy);
+#endif
     GLReplay::PostContextShutdownCounters();
     RDCERR("Couldn't create GL ES 3.x context - RenderDoc requires OpenGL ES 3.x availability");
     return eReplayCreate_APIHardwareUnsupported;
@@ -174,7 +178,9 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
   {
     RDCERR("Couldn't create a suitable PBuffer");
     eglDestroySurfaceProc(eglDisplay, pbuffer);
+#if DISABLED(RDOC_ANDROID)
     XCloseDisplay(dpy);
+#endif
     GLReplay::PostContextShutdownCounters();
     return eReplayCreate_APIInitFailed;
   }
@@ -185,7 +191,9 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
     RDCERR("Couldn't active the created GL ES context");
     eglDestroySurfaceProc(eglDisplay, pbuffer);
     eglDestroyContextProc(eglDisplay, ctx);
+#if DISABLED(RDOC_ANDROID)
     XCloseDisplay(dpy);
+#endif
     GLReplay::PostContextShutdownCounters();
     return eReplayCreate_APIInitFailed;
   }
@@ -198,7 +206,9 @@ ReplayCreateStatus GLES_CreateReplayDevice(const char *logfile, IReplayDriver **
   {
     eglDestroySurfaceProc(eglDisplay, pbuffer);
     eglDestroyContextProc(eglDisplay, ctx);
+#if DISABLED(RDOC_ANDROID)
     XCloseDisplay(dpy);
+#endif
     GLReplay::PostContextShutdownCounters();
     return eReplayCreate_APIHardwareUnsupported;
   }


### PR DESCRIPTION
Allow building GL ES for Android.
Minimal guards are added to avoid using X11 calls
in case of Android and added support for Android
windowing system.