### PR TITLE
Specify GL ES version for the Android renderdoccmd

### DIFF
--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -8,6 +8,9 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.INTERNET" />
 
+  <!-- Use GL ES 3.2 version -->
+  <uses-feature android:glEsVersion="0x00030002" android:required="true" />
+
   <application android:label="RenderDocCmd" android:hasCode="true">
     <activity android:name=".Loader" android:label="RenderDocCmdLoader" android:exported="true" android:configChanges="orientation|keyboardHidden">
       <meta-data android:name="android.app.lib_name" android:value="renderdoccmd"/>


### PR DESCRIPTION
For Android the minimum GL ES version must be configured in the AndroidManifest.xml so we would not end up with an old ES version.