### PR TITLE
VkCommandBuffer missed capture references to renderPass & framebuffer.

### DIFF
--- a/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
@@ -576,10 +576,10 @@ VirtualFileDialog::VirtualFileDialog(CaptureContext &ctx, QWidget *parent)
 
   ui->fileList->sortByColumn(0, Qt::AscendingOrder);
 
-  ui->fileList->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-  ui->fileList->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
-  ui->fileList->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
-  ui->fileList->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+  ui->fileList->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+  ui->fileList->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+  ui->fileList->header()->setSectionResizeMode(2, QHeaderView::Stretch);
+  ui->fileList->header()->setSectionResizeMode(3, QHeaderView::Stretch);
 
   ui->filter->addItems({tr("Executables"), tr("All Files")});
 

--- a/qrenderdoc/Windows/Dialogs/VirtualFileDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/VirtualFileDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>594</width>
+    <width>750</width>
     <height>454</height>
    </rect>
   </property>

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -2825,16 +2825,26 @@ string ToStrHelper<false, VkPresentModeKHR>::Get(const VkPresentModeKHR &el)
 }
 
 // we know the object will be a non-dispatchable object type
-#define SerialiseObject(type, name, obj)                                                            \
-  {                                                                                                 \
-    VulkanResourceManager *rm = (VulkanResourceManager *)GetUserData();                             \
-    ResourceId id;                                                                                  \
-    if(m_Mode >= WRITING)                                                                           \
-      id = GetResID(obj);                                                                           \
-    Serialise(name, id);                                                                            \
-    if(m_Mode < WRITING)                                                                            \
-      obj = (id == ResourceId() || !rm->HasLiveResource(id)) ? VK_NULL_HANDLE                       \
-                                                             : Unwrap(rm->GetLiveHandle<type>(id)); \
+#define SerialiseObject(type, name, obj)                                      \
+  {                                                                           \
+    VulkanResourceManager *rm = (VulkanResourceManager *)GetUserData();       \
+    ResourceId id;                                                            \
+    if(m_Mode >= WRITING)                                                     \
+      id = GetResID(obj);                                                     \
+    Serialise(name, id);                                                      \
+    if(m_Mode < WRITING)                                                      \
+    {                                                                         \
+      obj = VK_NULL_HANDLE;                                                   \
+      if(id != ResourceId())                                                  \
+      {                                                                       \
+        if(rm->HasLiveResource(id))                                           \
+          obj = Unwrap(rm->GetLiveHandle<type>(id));                          \
+        else                                                                  \
+          /* It can be OK for a resource to have no live equivalent if the    \
+          capture decided its not needed, which some APIs do fairly often. */ \
+          RDCWARN("Capture may be missing reference to " #type " resource."); \
+      }                                                                       \
+    }                                                                         \
   }
 
 static void SerialiseNext(Serialiser *ser, VkStructureType &sType, const void *&pNext)

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -650,6 +650,14 @@ VkResult WrappedVulkan::vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
 
       record->AddChunk(scope.Get());
     }
+
+    if(pBeginInfo->pInheritanceInfo)
+    {
+      record->MarkResourceFrameReferenced(GetResID(pBeginInfo->pInheritanceInfo->renderPass),
+                                          eFrameRef_Read);
+      record->MarkResourceFrameReferenced(GetResID(pBeginInfo->pInheritanceInfo->framebuffer),
+                                          eFrameRef_Read);
+    }
   }
 
   VkCommandBufferInheritanceInfo unwrappedInfo;


### PR DESCRIPTION
Added a warning in SerialiseObject that may help to detect other similar
cases of this problem.