### PR TITLE
Guard glPolygonMode call in GL ES

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1702,7 +1702,8 @@ struct RenderTextState
       gl.glBlendEquationSeparate(EquationRGB, EquationAlpha);
     }
 
-    gl.glPolygonMode(eGL_FRONT_AND_BACK, PolygonMode);
+    if(!IsGLES)
+      gl.glPolygonMode(eGL_FRONT_AND_BACK, PolygonMode);
 
     if(modern && HasExt[ARB_viewport_array])
       gl.glViewportIndexedf(0, Viewportf[0], Viewportf[1], Viewportf[2], Viewportf[3]);
@@ -1877,7 +1878,9 @@ void WrappedOpenGL::RenderOverlayStr(float x, float y, const char *text)
       gl.glViewport(0, 0, m_InitParams.width, m_InitParams.height);
       gl.glDisable(eGL_SCISSOR_TEST);
     }
-    gl.glPolygonMode(eGL_FRONT_AND_BACK, eGL_FILL);
+
+    if(!IsGLES)
+      gl.glPolygonMode(eGL_FRONT_AND_BACK, eGL_FILL);
 
     if(gl.glClipControl && HasExt[ARB_clip_control])
       gl.glClipControl(eGL_LOWER_LEFT, eGL_NEGATIVE_ONE_TO_ONE);

--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -1500,7 +1500,9 @@ void GLRenderState::ApplyState(void *ctx, WrappedOpenGL *gl)
     }
   }
 
-  m_Real->glPolygonMode(eGL_FRONT_AND_BACK, PolygonMode);
+  if(!IsGLES)
+    m_Real->glPolygonMode(eGL_FRONT_AND_BACK, PolygonMode);
+
   if(HasExt[EXT_polygon_offset_clamp] && m_Real->glPolygonOffsetClampEXT)
     m_Real->glPolygonOffsetClampEXT(PolygonOffset[0], PolygonOffset[1], PolygonOffset[2]);
   else


### PR DESCRIPTION
In GL ES the glPolygonMode is not supported so we'll ignore calls to it.