### PR TITLE
Support LIB_SUFFIX for lib64-using distros

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -303,7 +303,7 @@ target_compile_definitions(renderdoc ${RDOC_DEFINITIONS})
 target_include_directories(renderdoc ${RDOC_INCLUDES})
 target_link_libraries(renderdoc ${RDOC_LIBRARIES})
 
-install (TARGETS renderdoc DESTINATION lib)
+install (TARGETS renderdoc DESTINATION lib${LIB_SUFFIX})
 
 # Copy in application API header to include
 install (FILES api/app/renderdoc_app.h DESTINATION include RENAME renderdoc.h)

--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -65,7 +65,7 @@ elseif(UNIX)
     set(json_in ${CMAKE_CURRENT_SOURCE_DIR}/renderdoc.json)
     set(json_out ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/renderdoc_capture.json)
     add_custom_command(OUTPUT ${json_out}
-        COMMAND sed '{s%...renderdoc.dll%${CMAKE_INSTALL_PREFIX}/lib/librenderdoc.so%}' < ${json_in} > ${json_out}
+        COMMAND sed '{s%...renderdoc.dll%${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/librenderdoc.so%}' < ${json_in} > ${json_out}
         DEPENDS ${json_in})
     add_custom_target(generate-json ALL DEPENDS ${json_out})
 


### PR DESCRIPTION
Some Linux distros (typically RPM-based, such as Fedora, Mageia, openSUSE) handle multilib on x86_64 by using `/usr/lib64` for 64-bit libraries and `/usr/lib` for 32-bit libraries.

The convention for CMake project is to use the `${LIB_SUFFIX}` variable which is set to `64` when building on x86_64 (at least on Mageia and Fedora, but IIRC last I checked on openSUSE too).

So this patch allows to install to the proper location on those distros out of the box (packagers use specific `%cmake` macros which define it), without a priori impacting other distros using `lib`.