### PR TITLE
Load wrapped library early in case of Android

### DIFF
--- a/renderdoc/os/posix/android/android_hook.cpp
+++ b/renderdoc/os/posix/android/android_hook.cpp
@@ -24,10 +24,13 @@
 
 #include "os/posix/posix_hook.h"
 
+#include <dlfcn.h>
+
 void PosixHookInit()
 {
 }
 
 void PosixHookLibrary(const char *name, dlopenCallback cb)
 {
+  cb(dlopen(name, RTLD_NOW));
 }


### PR DESCRIPTION
On newer Android it is not possible to use the
LD_PRELOAD functionality. The target application
should be directly linked with the RenderDoc library.
However in that case we also need to load the
target library early, so a simple implementation
for the PosixHookLibrary is added.