### PR TITLE
Only create client memory VBOs the first time context is activated.

### DIFF
--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -389,6 +389,7 @@ private:
       m_Renderbuffer = ResourceId();
       m_TextureUnit = 0;
       m_ProgramPipeline = m_Program = 0;
+      RDCEraseEl(m_ClientMemoryVBOs);
     }
 
     void *ctx;


### PR DESCRIPTION
Also added corresponding deletion code in WrappedOpenGL::DeleteContext.