### PR TITLE
Android documentation and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,29 +17,36 @@ matrix:
     - os: linux
       dist: trusty
       sudo: false
-      env: CODE_BUILD=0 LINUX_BUILD=0 APPLE_BUILD=0 DOCS_BUILD=1
+      env: CODE_BUILD=0 LINUX_BUILD=0 APPLE_BUILD=0 DOCS_BUILD=1 ANDROID_BUILD=0
     - os: linux
       dist: trusty
       sudo: required
-      env: CODE_BUILD=1 LINUX_BUILD=1 APPLE_BUILD=0 DOCS_BUILD=0
+      env: CODE_BUILD=1 LINUX_BUILD=1 APPLE_BUILD=0 DOCS_BUILD=0 ANDROID_BUILD=0
       compiler: gcc
     - os: linux
       dist: trusty
       sudo: required
-      env: CODE_BUILD=1 LINUX_BUILD=1 APPLE_BUILD=0 DOCS_BUILD=0
+      env: CODE_BUILD=1 LINUX_BUILD=1 APPLE_BUILD=0 DOCS_BUILD=0 ANDROID_BUILD=0
+      compiler: clang
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: CODE_BUILD=1 LINUX_BUILD=0 APPLE_BUILD=0 DOCS_BUILD=0 ANDROID_BUILD=1
       compiler: clang
     - os: osx
       osx_image: xcode8.2
-      env: CODE_BUILD=1 LINUX_BUILD=0 APPLE_BUILD=1 DOCS_BUILD=0
+      env: CODE_BUILD=1 LINUX_BUILD=0 APPLE_BUILD=1 DOCS_BUILD=0 ANDROID_BUILD=0
       compiler: clang
 
 # install dependencies
 install:
   - if [[ "$DOCS_BUILD" == "1" ]]; then . ./scripts/travis/docs_setup.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CODE_BUILD" == "1" ]]; then . ./scripts/travis/linux_setup.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$CODE_BUILD" == "1" ]]; then . ./scripts/travis/osx_setup.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CODE_BUILD" == "1" ]] && [[ "$LINUX_BUILD" == 1 ]]; then . ./scripts/travis/linux_setup.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CODE_BUILD" == "1" ]] && [[ "$ANDROID_BUILD" == 1 ]]; then . ./scripts/travis/android_setup.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$CODE_BUILD" == "1" ]] && [[ "$APPLE_BUILD" == 1 ]]; then . ./scripts/travis/osx_setup.sh ; fi
 
 script:
   - if [[ "$DOCS_BUILD" == "1" ]]; then . ./scripts/travis/docs_compile.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CODE_BUILD" == "1" ]]; then . ./scripts/travis/linux_compile.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$CODE_BUILD" == "1" ]]; then . ./scripts/travis/osx_compile.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CODE_BUILD" == "1" ]] && [[ "$LINUX_BUILD" == 1 ]]; then . ./scripts/travis/linux_compile.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CODE_BUILD" == "1" ]] && [[ "$ANDROID_BUILD" == 1 ]]; then . ./scripts/travis/android_compile.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$CODE_BUILD" == "1" ]] && [[ "$APPLE_BUILD" == 1 ]]; then . ./scripts/travis/osx_compile.sh ; fi

--- a/docs/behind_scenes/vulkan_support.rst
+++ b/docs/behind_scenes/vulkan_support.rst
@@ -47,6 +47,11 @@ Non-windows platforms
 
 Linux and other pltaform support follows naturally when thinking about Vulkan support. There is full support for capturing and replaying on linux, with the UI based on Qt. It is also possible to capture on another platform, and then replay on windows or windows. For more information on this see :doc:`../how/how_network_capture_replay`.
 
+Android
+```````
+
+Vulkan debugging on Android is supported from Linux and Windows currently, with macOS support in the works.  For details on how to target Android, see  :doc:`../how/how_android`.
+
 See Also
 --------
 

--- a/docs/how/how_android.rst
+++ b/docs/how/how_android.rst
@@ -1,0 +1,108 @@
+How do I use Renderdoc for Android?
+======================================
+
+Renderdoc supports debugging Vulkan applications on Android from host machines.  It is similar to using a network to target a remote machine, as in :doc:`../how/how_network_capture_replay`, but talks over ``adb`` to a device.
+
+Getting started
+---------------
+
+Download a release or nightly build for your host OS from the `Builds page <https://renderdoc.org/builds>`_.
+Android bits will be in ``android`` directory.
+
+Or, you can build from source for each platform by following the steps on `github <https://github.com/baldurk/renderdoc/blob/master/CONTRIBUTING.md>`_.
+
+Set up your APK for debugging
+-----------------------------
+
+In order to capture APIs from a package, the APK needs to be compiled with the following manifest permissions:
+
+.. code::
+
+        <manifest ...
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.INTERNET" />
+
+It also must contain the RenderDoc Vulkan layer.  You must provide the layer for the ABI you are going to target, or the layer will not be loaded, i.e.:
+
+.. code::
+
+        $ jar tf game.apk | grep libVkLayer_RenderDoc
+        lib/armeabi-v7a/libVkLayer_RenderDoc.so
+        lib/arm64-v8a/libVkLayer_RenderDoc.so
+        lib/x86/libVkLayer_RenderDoc.so
+        lib/x86_64/libVkLayer_RenderDoc.so
+        lib/mips/libVkLayer_RenderDoc.so
+        lib/mips64/libVkLayer_RenderDoc.so
+
+You can add the layer to your APK in many ways.  One easy way is using ``aapt``, which can be downloaded using Android Studio.
+
+.. code::
+
+        aapt add game.apk lib/armeabi-v7a/libVkLayer_RenderDoc.so
+        aapt add game.apk lib/arm64-v8a/libVkLayer_RenderDoc.so
+
+You may also need to re-sign your APK in order to install it.
+
+.. code::
+
+        mv game.apk game-unaligned.apk
+        zip -d game-unaligned.apk META-INF/\*
+        jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android game-unaligned.apk androiddebugkey
+        zipalign 4 game-unaligned.apk game.apk
+
+Set up your Android device
+--------------------------
+
+RenderDoc uses an APK on the target in order to capture and replay Vulkan events.  To install it, determine your target architecture and then install both APKs:
+
+.. code::
+
+        adb install -r --abi <target abi> RenderDocCmd.apk
+        adb install -r --abi <target abi> game.apk
+
+Steps to use RenderDoc UI for Android
+----------------------------------
+
+1. In ``Tools -> Options -> Android``, set the path to your ``adb`` executable.
+
+#. Connect your Android device and look for ``"Allow USB debugging?"`` on its screen.  Click ``OK``
+
+   * You may need to enable Developer Mode for this prompt to appear.
+   * Check that your device is listed using ``adb devices``
+
+#. Restart the RenderDoc UI.
+
+#. Your device will be automatically listed in the Remote Hosts menu in the bottom left.  It will appear Offline until the following step.
+
+#. Start the Remote Server using ``Tools -> Start Android Remote Server``
+
+#. Check your device's screen and ``Allow`` RenderDocCmd to access files on your device.
+
+   * This is required to store capture files on ``/sdcard/``
+
+#. Change your current Replay Context to your device using the bottom left menu, which should now show your device as Online.
+
+#. In the capture executable tab, there is a button on the right of ``Executable Path`` that lets you select an installed Android package for capture.
+
+#. Select your package and press the ``Launch`` button in the bottom right of the tab to start the package on the device.
+
+#. If everything went successfully, a new tab will open with a button to Trigger captures.
+
+#. If any of these operations failed, (e.g. you dont have the RenderDocCmd.apk installed), you can see adb command output in ``Help -> View Diagnostic Log File``
+
+
+Troubleshooting
+---------------
+
+1. If you see ``Didn't get proper handshake`` in your log, that may the RenderDoc layer wasn't loaded properly, which is critical for this workflow.  Double check the following:
+
+   - Ensure your APK was packaged with the required permissions.
+
+     * They will be granted automatically by the RenderDoc UI.
+
+   - Ensure you have inserted the layer into the correct location in the APK, i.e. correct ABI.
+
+   - Ensure you installed the correct ABI of both APKs, RenderDocCmd and target.
+
+   - Check the device's screen and ensure RenderDocCmd.apk has been granted permissions.
+

--- a/docs/how/index.rst
+++ b/docs/how/index.rst
@@ -12,3 +12,4 @@ How do I ...?
 	how_custom_visualisation
 	how_edit_shader
 	how_network_capture_replay
+	how_android

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -544,6 +544,16 @@ bool IsHostADB(const char *hostname)
 string adbExecCommand(const string &args)
 {
   string adbExePath = RenderDoc::Inst().GetConfigSetting("adbExePath");
+  if(adbExePath.empty())
+  {
+    static bool warnPath = true;
+    if(warnPath)
+    {
+      RDCWARN("adbExePath not set, attempting to call 'adb' in working env");
+      warnPath = false;
+    }
+    adbExePath.append("adb");
+  }
   Process::ProcessResult result;
   Process::LaunchProcess(adbExePath.c_str(), "", args.c_str(), &result);
   RDCLOG("COMMAND: adb %s", args.c_str());

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(renderdoccmd ${libraries})
 install (TARGETS renderdoccmd DESTINATION bin)
 
 if(ANDROID)
-    set(APK_TARGET_ID "1" CACHE STRING "The Target ID to build the APK for, use <android list targets> to choose another one.")
+    set(APK_TARGET_ID "android-23" CACHE STRING "The Target ID to build the APK for, use <android list targets> to choose another one.")
 
     set(APK_FILE ${CMAKE_BINARY_DIR}/bin/RenderDocCmd.apk)
     add_custom_target(apk ALL

--- a/scripts/travis/android_compile.sh
+++ b/scripts/travis/android_compile.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+CORES=$(nproc) || echo 4
+mkdir -p build-android && cd build-android
+cmake -DBUILD_ANDROID=On -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=23 ..
+make -j $CORES

--- a/scripts/travis/android_setup.sh
+++ b/scripts/travis/android_setup.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -ev
+
+sudo apt-get -qq update
+sudo apt-get install -y cmake
+
+export ARCH=`uname -m`
+
+# Pull known working tools toward the end of 2016
+wget http://dl.google.com/android/repository/android-ndk-r13b-linux-${ARCH}.zip
+wget https://dl.google.com/android/repository/tools_r25.2.5-linux.zip
+wget https://dl.google.com/android/repository/platform-tools_r25.0.3-linux.zip
+wget https://dl.google.com/android/repository/build-tools_r25.0.2-linux.zip
+unzip -u -q android-ndk-r13b-linux-${ARCH}.zip
+unzip -u -q tools_r25.2.5-linux.zip
+unzip -u -q platform-tools_r25.0.3-linux.zip
+unzip -u -q build-tools_r25.0.2-linux.zip
+
+# Munge the build-tools layout
+mkdir -p build-tools/25.0.2
+mv android-7.1.1/* build-tools/25.0.2/
+
+export ANDROID_HOME=`pwd`/tools
+export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
+export ANDROID_NDK=`pwd`/android-ndk-r13b
+export PATH=`pwd`/android-ndk-r13b:$PATH
+export PATH=`pwd`/tools:$PATH
+export PATH=`pwd`/platform-tools:$PATH
+export PATH=`pwd`/build-tools/25.0.2:$PATH
+
+# Answer "yes" to any license acceptance requests
+(while sleep 3; do echo "y"; done) | android update sdk --no-ui -s -t android-23


### PR DESCRIPTION
This series primarily adds CI and Documentation for Vulkan on Android.  A couple of other minor fixes I found when building RenderDoc on Linux.

Thanks to @michaelrgb for providing the basis of the documentation.

- docs: Add Android documentation
Added a "How to" for Android.  Walks through how to modify your APK for debugging, and how to use the interface to target Android.

- build: Add Android to travis config
Only targets one ABI, but is sufficient for smoke testing Android builds.  Also packages the RenderDocCmd APK.  All the builds could probably be sped up with some caching, but I did not introduce that here.

- android: Attempt to call adb directly if path not provided
Before I had documentation, I lost some time when "adb" calls from the interface weren't succeeding.  This change simply tries to use adb from PATH if not provided in the UI.

- android: Target android-23 explicitly for APK
Using "1" here was very specific to the build system, as noted by the comment.  When run on systems with older APIs install, it resulted in java compile errors.  This will still run on Marshmallow and newer Android installs.