### PR TITLE
Various fixes for OpenGL ES support

### DIFF
--- a/renderdoc/data/glsl/debuguniforms.h
+++ b/renderdoc/data/glsl/debuguniforms.h
@@ -91,6 +91,7 @@ struct Vec4u
 #else
 #define PRECISION mediump
 precision PRECISION float;
+precision PRECISION int;
 #endif
 
 #endif

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -292,57 +292,58 @@ extern bool IsGLES;
 // taken into account.
 // 99 means the extension never became core, so you can easily just do a check of CoreVersion >= NN
 // and they will always fail.
-#define EXTENSION_CHECKS()                                   \
-  EXT_TO_CHECK(33, 30, ARB_explicit_attrib_location)         \
-  EXT_TO_CHECK(33, 30, ARB_sampler_objects)                  \
-  EXT_TO_CHECK(33, 30, ARB_texture_swizzle)                  \
-  EXT_TO_CHECK(40, 32, ARB_draw_buffers_blend)               \
-  EXT_TO_CHECK(40, 31, ARB_draw_indirect)                    \
-  EXT_TO_CHECK(40, 32, ARB_gpu_shader5)                      \
-  EXT_TO_CHECK(40, 32, ARB_sample_shading)                   \
-  EXT_TO_CHECK(40, 99, ARB_shader_subroutine)                \
-  EXT_TO_CHECK(40, 32, ARB_tessellation_shader)              \
-  EXT_TO_CHECK(40, 32, ARB_texture_cube_map_array)           \
-  EXT_TO_CHECK(40, 30, ARB_transform_feedback2)              \
-  EXT_TO_CHECK(41, 31, ARB_separate_shader_objects)          \
-  EXT_TO_CHECK(41, 99, ARB_viewport_array)                   \
-  EXT_TO_CHECK(42, 99, ARB_base_instance)                    \
-  EXT_TO_CHECK(42, 31, ARB_shader_atomic_counters)           \
-  EXT_TO_CHECK(42, 31, ARB_shader_image_load_store)          \
-  EXT_TO_CHECK(42, 31, ARB_shading_language_420pack)         \
-  EXT_TO_CHECK(42, 30, ARB_texture_storage)                  \
-  EXT_TO_CHECK(43, 99, ARB_clear_buffer_object)              \
-  EXT_TO_CHECK(43, 31, ARB_compute_shader)                   \
-  EXT_TO_CHECK(43, 32, ARB_copy_image)                       \
-  EXT_TO_CHECK(43, 30, ARB_ES3_compatibility)                \
-  EXT_TO_CHECK(43, 99, ARB_internalformat_query2)            \
-  EXT_TO_CHECK(43, 31, ARB_program_interface_query)          \
-  EXT_TO_CHECK(43, 31, ARB_shader_storage_buffer_object)     \
-  EXT_TO_CHECK(43, 31, ARB_stencil_texturing)                \
-  EXT_TO_CHECK(43, 32, ARB_texture_storage_multisample)      \
-  EXT_TO_CHECK(43, 99, ARB_texture_view)                     \
-  EXT_TO_CHECK(43, 31, ARB_vertex_attrib_binding)            \
-  EXT_TO_CHECK(43, 32, KHR_debug)                            \
-  EXT_TO_CHECK(44, 99, ARB_enhanced_layouts)                 \
-  EXT_TO_CHECK(44, 99, ARB_query_buffer_object)              \
-  EXT_TO_CHECK(45, 99, ARB_clip_control)                     \
-  EXT_TO_CHECK(99, 99, ARB_indirect_parameters)              \
-  EXT_TO_CHECK(99, 99, ARB_seamless_cubemap_per_texture)     \
-  EXT_TO_CHECK(99, 99, EXT_depth_bounds_test)                \
-  EXT_TO_CHECK(99, 99, EXT_direct_state_access)              \
-  EXT_TO_CHECK(99, 99, EXT_polygon_offset_clamp)             \
-  EXT_TO_CHECK(99, 99, EXT_raster_multisample)               \
-  EXT_TO_CHECK(99, 99, EXT_texture_filter_anisotropic)       \
-  EXT_TO_CHECK(99, 30, EXT_texture_swizzle)                  \
-  EXT_TO_CHECK(99, 99, KHR_blend_equation_advanced_coherent) \
-  /* OpenGL ES extensions */                                 \
-  EXT_TO_CHECK(99, 99, EXT_clip_cull_distance)               \
-  EXT_TO_CHECK(99, 99, EXT_multisample_compatibility)        \
-  EXT_TO_CHECK(99, 99, NV_polygon_mode)                      \
-  EXT_TO_CHECK(99, 99, NV_read_depth)                        \
-  EXT_TO_CHECK(99, 99, NV_read_stencil)                      \
-  EXT_TO_CHECK(99, 99, NV_read_depth_stencil)                \
-  EXT_TO_CHECK(99, 32, OES_texture_storage_multisample_2d_array)
+#define EXTENSION_CHECKS()                                       \
+  EXT_TO_CHECK(33, 30, ARB_explicit_attrib_location)             \
+  EXT_TO_CHECK(33, 30, ARB_sampler_objects)                      \
+  EXT_TO_CHECK(33, 30, ARB_texture_swizzle)                      \
+  EXT_TO_CHECK(40, 32, ARB_draw_buffers_blend)                   \
+  EXT_TO_CHECK(40, 31, ARB_draw_indirect)                        \
+  EXT_TO_CHECK(40, 32, ARB_gpu_shader5)                          \
+  EXT_TO_CHECK(40, 32, ARB_sample_shading)                       \
+  EXT_TO_CHECK(40, 99, ARB_shader_subroutine)                    \
+  EXT_TO_CHECK(40, 32, ARB_tessellation_shader)                  \
+  EXT_TO_CHECK(40, 32, ARB_texture_cube_map_array)               \
+  EXT_TO_CHECK(40, 30, ARB_transform_feedback2)                  \
+  EXT_TO_CHECK(41, 31, ARB_separate_shader_objects)              \
+  EXT_TO_CHECK(41, 99, ARB_viewport_array)                       \
+  EXT_TO_CHECK(42, 99, ARB_base_instance)                        \
+  EXT_TO_CHECK(42, 31, ARB_shader_atomic_counters)               \
+  EXT_TO_CHECK(42, 31, ARB_shader_image_load_store)              \
+  EXT_TO_CHECK(42, 31, ARB_shading_language_420pack)             \
+  EXT_TO_CHECK(42, 30, ARB_texture_storage)                      \
+  EXT_TO_CHECK(43, 99, ARB_clear_buffer_object)                  \
+  EXT_TO_CHECK(43, 31, ARB_compute_shader)                       \
+  EXT_TO_CHECK(43, 32, ARB_copy_image)                           \
+  EXT_TO_CHECK(43, 30, ARB_ES3_compatibility)                    \
+  EXT_TO_CHECK(43, 99, ARB_internalformat_query2)                \
+  EXT_TO_CHECK(43, 31, ARB_program_interface_query)              \
+  EXT_TO_CHECK(43, 31, ARB_shader_storage_buffer_object)         \
+  EXT_TO_CHECK(43, 31, ARB_stencil_texturing)                    \
+  EXT_TO_CHECK(43, 32, ARB_texture_storage_multisample)          \
+  EXT_TO_CHECK(43, 99, ARB_texture_view)                         \
+  EXT_TO_CHECK(43, 31, ARB_vertex_attrib_binding)                \
+  EXT_TO_CHECK(43, 32, KHR_debug)                                \
+  EXT_TO_CHECK(44, 99, ARB_enhanced_layouts)                     \
+  EXT_TO_CHECK(44, 99, ARB_query_buffer_object)                  \
+  EXT_TO_CHECK(45, 99, ARB_clip_control)                         \
+  EXT_TO_CHECK(99, 99, ARB_indirect_parameters)                  \
+  EXT_TO_CHECK(99, 99, ARB_seamless_cubemap_per_texture)         \
+  EXT_TO_CHECK(99, 99, EXT_depth_bounds_test)                    \
+  EXT_TO_CHECK(99, 99, EXT_direct_state_access)                  \
+  EXT_TO_CHECK(99, 99, EXT_polygon_offset_clamp)                 \
+  EXT_TO_CHECK(99, 99, EXT_raster_multisample)                   \
+  EXT_TO_CHECK(99, 99, EXT_texture_filter_anisotropic)           \
+  EXT_TO_CHECK(99, 30, EXT_texture_swizzle)                      \
+  EXT_TO_CHECK(99, 99, KHR_blend_equation_advanced_coherent)     \
+  /* OpenGL ES extensions */                                     \
+  EXT_TO_CHECK(99, 99, EXT_clip_cull_distance)                   \
+  EXT_TO_CHECK(99, 99, EXT_multisample_compatibility)            \
+  EXT_TO_CHECK(99, 99, NV_polygon_mode)                          \
+  EXT_TO_CHECK(99, 99, NV_read_depth)                            \
+  EXT_TO_CHECK(99, 99, NV_read_stencil)                          \
+  EXT_TO_CHECK(99, 99, NV_read_depth_stencil)                    \
+  EXT_TO_CHECK(99, 32, OES_texture_storage_multisample_2d_array) \
+  EXT_TO_CHECK(99, 32, EXT_color_buffer_float)
 
 // GL extensions and their roughly equivalent GLES alternatives
 #define EXTENSION_COMPATIBILITY_CHECKS()                                                    \

--- a/renderdoc/driver/gl/gl_debug.cpp
+++ b/renderdoc/driver/gl/gl_debug.cpp
@@ -2249,8 +2249,18 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, CompType typeHint, DebugOve
     }
     else
     {
-      gl.glTextureImage2DEXT(DebugData.overlayTex, texBindingEnum, 0, eGL_RGBA16, texDetails.width,
-                             texDetails.height, 0, eGL_RGBA, eGL_FLOAT, NULL);
+      GLint internalFormat = eGL_RGBA16;
+      GLenum format = eGL_RGBA;
+      GLenum type = eGL_FLOAT;
+
+      if(IsGLES && !HasExt[EXT_color_buffer_float])
+      {
+        internalFormat = eGL_RGBA8;
+        type = eGL_UNSIGNED_BYTE;
+      }
+
+      gl.glTextureImage2DEXT(DebugData.overlayTex, texBindingEnum, 0, internalFormat,
+                             texDetails.width, texDetails.height, 0, format, type, NULL);
       gl.glTexParameteri(texBindingEnum, eGL_TEXTURE_MAX_LEVEL, 0);
       gl.glTexParameteri(texBindingEnum, eGL_TEXTURE_MIN_FILTER, eGL_NEAREST);
       gl.glTexParameteri(texBindingEnum, eGL_TEXTURE_MAG_FILTER, eGL_NEAREST);

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -2881,6 +2881,9 @@ WrappedOpenGL::BackbufferImage *WrappedOpenGL::SaveBackbufferImage()
 
   if(len > 0)
   {
+    // jpge::compress_image_to_jpeg_file_in_memory requires at least 1024 bytes
+    len = len >= 1024 ? len : 1024;
+
     jpgbuf = new byte[len];
 
     jpge::params p;

--- a/renderdoc/driver/gl/gl_hookset_defs.h
+++ b/renderdoc/driver/gl/gl_hookset_defs.h
@@ -175,8 +175,10 @@
   HookExtensionAlias(PFNGLGETBUFFERSUBDATAPROC, glGetBufferSubData, glGetBufferSubDataARB); \
   HookExtension(PFNGLMAPBUFFERPROC, glMapBuffer); \
   HookExtensionAlias(PFNGLMAPBUFFERPROC, glMapBuffer, glMapBufferARB); \
+  HookExtensionAlias(PFNGLMAPBUFFERPROC, glMapBuffer, glMapBufferOES); \
   HookExtension(PFNGLUNMAPBUFFERPROC, glUnmapBuffer); \
   HookExtensionAlias(PFNGLUNMAPBUFFERPROC, glUnmapBuffer, glUnmapBufferARB); \
+  HookExtensionAlias(PFNGLUNMAPBUFFERPROC, glUnmapBuffer, glUnmapBufferOES); \
   HookExtension(PFNGLGETBUFFERPARAMETERIVPROC, glGetBufferParameteriv); \
   HookExtensionAlias(PFNGLGETBUFFERPARAMETERIVPROC, glGetBufferParameteriv, glGetBufferParameterivARB); \
   HookExtension(PFNGLGETBUFFERPOINTERVPROC, glGetBufferPointerv); \

--- a/renderdoc/driver/gl/gl_resources.cpp
+++ b/renderdoc/driver/gl/gl_resources.cpp
@@ -362,6 +362,8 @@ GLenum GetBaseFormat(GLenum internalFormat)
     case eGL_RGBA16UI:
     case eGL_RGBA32UI:
     case eGL_RGBA32I: return eGL_RGBA_INTEGER;
+    case eGL_BGRA:
+    case eGL_BGRA8_EXT: return eGL_BGRA;
     case eGL_DEPTH_COMPONENT16:
     case eGL_DEPTH_COMPONENT24:
     case eGL_DEPTH_COMPONENT32:
@@ -392,6 +394,8 @@ GLenum GetDataType(GLenum internalFormat)
     case eGL_R8:
     case eGL_RGB8:
     case eGL_RGB8UI:
+    case eGL_BGRA:
+    case eGL_BGRA8_EXT:
     case eGL_SRGB8_ALPHA8:
     case eGL_SRGB8: return eGL_UNSIGNED_BYTE;
     case eGL_RGBA8I:


### PR DESCRIPTION
debuguniforms.h - doesn't compile on Samsung Galaxy S6, need to specify precision qualifier for int as well
dxgi_common.cpp - support for 24bit depth
gl_debug.cpp - binding floating point rendertarget results in incomplete framebuffer GLError
gl_driver.cpp - jpg routine requires a minimum size of 1024
gl_enum.h - added GL_BGRA8_EXT enum
gl_hookset_defs.h - glMapBufferOES/glUnmapBufferOES can be used when glMapBuffer/glUnmapBuffer is missing 
gl_resources.cpp - BGRA support