### PR TITLE
Expose GL_KHR_debug for GL ES backend

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -722,6 +722,7 @@ void WrappedOpenGL::BuildGLESExtensions()
 {
   m_GLESExtensions.push_back("GL_ARM_rgba8");
 
+  m_GLESExtensions.push_back("GL_KHR_debug");
   m_GLESExtensions.push_back("GL_KHR_no_error");
   m_GLESExtensions.push_back("GL_KHR_context_flush_control");
   m_GLESExtensions.push_back("GL_KHR_robust_buffer_access_behavior");

--- a/renderdoc/driver/gl/gl_hookset.h
+++ b/renderdoc/driver/gl/gl_hookset.h
@@ -163,10 +163,10 @@ struct GLHookSet
   PFNGLGETPROGRAMRESOURCELOCATIONINDEXPROC glGetProgramResourceLocationIndex;
   PFNGLGETPROGRAMSTAGEIVPROC glGetProgramStageiv;
   PFNGLGETGRAPHICSRESETSTATUSPROC glGetGraphicsResetStatus;    // aliases glGetGraphicsResetStatusARB
-  PFNGLGETOBJECTLABELPROC glGetObjectLabel;
+  PFNGLGETOBJECTLABELPROC glGetObjectLabel;            // aliases glGetObjectLabelKHR
   PFNGLGETOBJECTLABELEXTPROC glGetObjectLabelEXT;
-  PFNGLGETOBJECTPTRLABELPROC glGetObjectPtrLabel;
-  PFNGLGETDEBUGMESSAGELOGPROC glGetDebugMessageLog;    // aliases glGetDebugMessageLogARB
+  PFNGLGETOBJECTPTRLABELPROC glGetObjectPtrLabel;      // aliases glGetObjectPtrLabelKHR
+  PFNGLGETDEBUGMESSAGELOGPROC glGetDebugMessageLog;    // aliases glGetDebugMessageLogARB, glGetDebugMessageLogKHR
   PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;    // aliases glGetFramebufferAttachmentParameterivEXT
   PFNGLGETFRAMEBUFFERPARAMETERIVPROC glGetFramebufferParameteriv;
   PFNGLGETRENDERBUFFERPARAMETERIVPROC glGetRenderbufferParameteriv;    // aliases glGetRenderbufferParameterivEXT
@@ -268,14 +268,14 @@ struct GLHookSet
   PFNGLACTIVESHADERPROGRAMPROC glActiveShaderProgram;
   PFNGLDELETEPROGRAMPIPELINESPROC glDeleteProgramPipelines;
   PFNGLVALIDATEPROGRAMPIPELINEPROC glValidateProgramPipeline;
-  PFNGLDEBUGMESSAGECALLBACKPROC glDebugMessageCallback;    // aliases glDebugMessageCallbackARB
-  PFNGLDEBUGMESSAGECONTROLPROC glDebugMessageControl;      // aliases glDebugMessageControlARB
-  PFNGLDEBUGMESSAGEINSERTPROC glDebugMessageInsert;        // aliases glDebugMessageInsertARB
-  PFNGLPUSHDEBUGGROUPPROC glPushDebugGroup;
-  PFNGLPOPDEBUGGROUPPROC glPopDebugGroup;
-  PFNGLOBJECTLABELPROC glObjectLabel;
+  PFNGLDEBUGMESSAGECALLBACKPROC glDebugMessageCallback;    // aliases glDebugMessageCallbackARB, glDebugMessageCallbackKHR
+  PFNGLDEBUGMESSAGECONTROLPROC glDebugMessageControl;      // aliases glDebugMessageControlARB, glDebugMessageControlKHR
+  PFNGLDEBUGMESSAGEINSERTPROC glDebugMessageInsert;        // aliases glDebugMessageInsertARB, glDebugMessageInsertKHR
+  PFNGLPUSHDEBUGGROUPPROC glPushDebugGroup;                // aliases glPushDebugGroupKHR
+  PFNGLPOPDEBUGGROUPPROC glPopDebugGroup;                  // aliases glPopDebugGroupKHR
+  PFNGLOBJECTLABELPROC glObjectLabel;                      // aliases glObjectLabelKHR
   PFNGLLABELOBJECTEXTPROC glLabelObjectEXT;
-  PFNGLOBJECTPTRLABELPROC glObjectPtrLabel;
+  PFNGLOBJECTPTRLABELPROC glObjectPtrLabel;                // aliases glObjectPtrLabelKHR
   PFNGLENABLEIPROC glEnablei;                // aliases glEnableIndexedEXT
   PFNGLDISABLEIPROC glDisablei;              // aliases glDisableIndexedEXT
   PFNGLISENABLEDIPROC glIsEnabledi;          // aliases glIsEnabledIndexedEXT

--- a/renderdoc/driver/gl/gl_hookset_defs.h
+++ b/renderdoc/driver/gl/gl_hookset_defs.h
@@ -798,18 +798,28 @@
   HookExtension(PFNGLVERTEXBINDINGDIVISORPROC, glVertexBindingDivisor); \
   HookExtension(PFNGLDEBUGMESSAGECONTROLPROC, glDebugMessageControl); \
   HookExtensionAlias(PFNGLDEBUGMESSAGECONTROLPROC, glDebugMessageControl, glDebugMessageControlARB); \
+  HookExtensionAlias(PFNGLDEBUGMESSAGECONTROLPROC, glDebugMessageControl, glDebugMessageControlKHR); \
   HookExtension(PFNGLDEBUGMESSAGEINSERTPROC, glDebugMessageInsert); \
   HookExtensionAlias(PFNGLDEBUGMESSAGEINSERTPROC, glDebugMessageInsert, glDebugMessageInsertARB); \
+  HookExtensionAlias(PFNGLDEBUGMESSAGEINSERTPROC, glDebugMessageInsert, glDebugMessageInsertKHR); \
   HookExtension(PFNGLDEBUGMESSAGECALLBACKPROC, glDebugMessageCallback); \
   HookExtensionAlias(PFNGLDEBUGMESSAGECALLBACKPROC, glDebugMessageCallback, glDebugMessageCallbackARB); \
+  HookExtensionAlias(PFNGLDEBUGMESSAGECALLBACKPROC, glDebugMessageCallback, glDebugMessageCallbackKHR); \
   HookExtension(PFNGLGETDEBUGMESSAGELOGPROC, glGetDebugMessageLog); \
   HookExtensionAlias(PFNGLGETDEBUGMESSAGELOGPROC, glGetDebugMessageLog, glGetDebugMessageLogARB); \
+  HookExtensionAlias(PFNGLGETDEBUGMESSAGELOGPROC, glGetDebugMessageLog, glGetDebugMessageLogKHR); \
   HookExtension(PFNGLPUSHDEBUGGROUPPROC, glPushDebugGroup); \
+  HookExtensionAlias(PFNGLPUSHDEBUGGROUPPROC, glPushDebugGroup, glPushDebugGroupKHR); \
   HookExtension(PFNGLPOPDEBUGGROUPPROC, glPopDebugGroup); \
+  HookExtensionAlias(PFNGLPOPDEBUGGROUPPROC, glPopDebugGroup, glPopDebugGroupKHR); \
   HookExtension(PFNGLOBJECTLABELPROC, glObjectLabel); \
+  HookExtensionAlias(PFNGLOBJECTLABELPROC, glObjectLabel, glObjectLabelKHR); \
   HookExtension(PFNGLGETOBJECTLABELPROC, glGetObjectLabel); \
+  HookExtensionAlias(PFNGLGETOBJECTLABELPROC, glGetObjectLabel, glGetObjectLabelKHR); \
   HookExtension(PFNGLOBJECTPTRLABELPROC, glObjectPtrLabel); \
+  HookExtensionAlias(PFNGLOBJECTPTRLABELPROC, glObjectPtrLabel, glObjectPtrLabelKHR); \
   HookExtension(PFNGLGETOBJECTPTRLABELPROC, glGetObjectPtrLabel); \
+  HookExtensionAlias(PFNGLGETOBJECTPTRLABELPROC, glGetObjectPtrLabel, glGetObjectPtrLabelKHR); \
   HookExtension(PFNGLBUFFERSTORAGEPROC, glBufferStorage); \
   HookExtension(PFNGLCLEARTEXIMAGEPROC, glClearTexImage); \
   HookExtension(PFNGLCLEARTEXSUBIMAGEPROC, glClearTexSubImage); \


### PR DESCRIPTION
Added KHR suffixed aliases for the methods defined in
the GL_KHR_debug extension:
* glDebugMessageControlKHR
* glDebugMessageInsertKHR
* glDebugMessageCallbackKHR
* glGetDebugMessageLogKHR
* glPushDebugGroupKHR
* glPopDebugGroupKHR
* glObjectLabelKHR
* glGetObjectLabelKHR
* glObjectPtrLabelKHR
* glGetObjectPtrLabelKHR