### PR TITLE
Add GL_HALF_FLOAT_OES support when querying size informations

### DIFF
--- a/renderdoc/driver/gl/gl_common.cpp
+++ b/renderdoc/driver/gl/gl_common.cpp
@@ -880,6 +880,7 @@ size_t GLTypeSize(GLenum type)
     case eGL_BYTE: return 1;
     case eGL_UNSIGNED_SHORT:
     case eGL_SHORT:
+    case eGL_HALF_FLOAT_OES:
     case eGL_HALF_FLOAT: return 2;
     case eGL_UNSIGNED_INT:
     case eGL_INT:

--- a/renderdoc/driver/gl/gl_resources.cpp
+++ b/renderdoc/driver/gl/gl_resources.cpp
@@ -226,6 +226,7 @@ size_t GetByteSize(GLsizei w, GLsizei h, GLsizei d, GLenum format, GLenum type)
     case eGL_BYTE: elemSize = 1; break;
     case eGL_UNSIGNED_SHORT:
     case eGL_SHORT:
+    case eGL_HALF_FLOAT_OES:
     case eGL_HALF_FLOAT: elemSize = 2; break;
     case eGL_UNSIGNED_INT:
     case eGL_INT:


### PR DESCRIPTION
When GL_OES_texture_half_float or GL_OES_texture_float extensions
are available the GL_HALF_FLOAT_OES should be defined.