### PR TITLE
Various GLES fixes found when using Mesa.

### DIFF
--- a/renderdoc/driver/gl/gl_common.cpp
+++ b/renderdoc/driver/gl/gl_common.cpp
@@ -2391,6 +2391,9 @@ void CopyProgramFragDataBindings(const GLHookSet &gl, GLuint progsrc, GLuint pro
     if(refl->OutputSig[i].systemValue != ShaderBuiltin::ColorOutput)
       continue;
 
+    if(!strncmp("gl_", refl->OutputSig[i].varName.elems, 3))
+      continue;    // GL_INVALID_OPERATION if name starts with reserved gl_ prefix
+
     GLint idx = gl.glGetFragDataLocation(progsrc, refl->OutputSig[i].varName.elems);
     if(idx >= 0)
     {

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -533,6 +533,7 @@ public:
   void SetDriverType(RDCDriver type) { m_DriverType = type; }
   bool isGLESMode() { return m_DriverType == RDC_OpenGLES; }
   RDCDriver GetDriverType() { return m_DriverType; }
+  GLInitParams &GetInitParams() { return m_InitParams; }
   void *GetCtx();
 
   void SetFetchCounters(bool in) { m_FetchCounters = in; };

--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -637,6 +637,7 @@ bool GLRenderState::CheckEnableDisableParam(GLenum pname)
       case eGL_PROGRAM_POINT_SIZE:
       case eGL_PRIMITIVE_RESTART:
       case eGL_TEXTURE_CUBE_MAP_SEAMLESS:
+      case eGL_FRAMEBUFFER_SRGB:
         // these are not supported by OpenGL ES
         return false;
 


### PR DESCRIPTION
-Disable sRGB for GLES.
-glFramebufferTexture emulated with glFramebufferTexture2D
-glBindFragDataLocation not allowed for gl_ prefix outputs.