### PR TITLE
Expose glDrawBuffersEXT and allow GL_EXT_draw_buffers

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -748,6 +748,7 @@ void WrappedOpenGL::BuildGLESExtensions()
   m_GLESExtensions.push_back("GL_OES_texture_half_float_linear");
 
   m_GLESExtensions.push_back("GL_EXT_copy_image");
+  m_GLESExtensions.push_back("GL_EXT_draw_buffers");
   m_GLESExtensions.push_back("GL_EXT_draw_buffers_indexed");
   m_GLESExtensions.push_back("GL_EXT_geometry_point_size");
   m_GLESExtensions.push_back("GL_EXT_geometry_shader");

--- a/renderdoc/driver/gl/gl_hookset.h
+++ b/renderdoc/driver/gl/gl_hookset.h
@@ -292,7 +292,7 @@ struct GLHookSet
   PFNGLISVERTEXARRAYPROC glIsVertexArray;
   PFNGLGENBUFFERSPROC glGenBuffers;                        // aliases glGenBuffersARB
   PFNGLBINDBUFFERPROC glBindBuffer;                        // aliases glBindBufferARB
-  PFNGLDRAWBUFFERSPROC glDrawBuffers;                      // aliases glDrawBuffersARB
+  PFNGLDRAWBUFFERSPROC glDrawBuffers;                      // aliases glDrawBuffersARB, glDrawBuffersEXT
   PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers;              // aliases glGenFramebuffersEXT
   PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer;              // aliases glBindFramebufferEXT
   PFNGLFRAMEBUFFERTEXTUREPROC glFramebufferTexture;        // aliases glFramebufferTextureARB, glFramebufferTextureOES, glFramebufferTextureEXT

--- a/renderdoc/driver/gl/gl_hookset_defs.h
+++ b/renderdoc/driver/gl/gl_hookset_defs.h
@@ -189,6 +189,7 @@
   HookExtensionAlias(PFNGLBLENDEQUATIONSEPARATEPROC, glBlendEquationSeparate, glBlendEquationSeparateEXT); \
   HookExtension(PFNGLDRAWBUFFERSPROC, glDrawBuffers); \
   HookExtensionAlias(PFNGLDRAWBUFFERSPROC, glDrawBuffers, glDrawBuffersARB); \
+  HookExtensionAlias(PFNGLDRAWBUFFERSPROC, glDrawBuffers, glDrawBuffersEXT); \
   HookExtension(PFNGLSTENCILOPSEPARATEPROC, glStencilOpSeparate); \
   HookExtension(PFNGLSTENCILFUNCSEPARATEPROC, glStencilFuncSeparate); \
   HookExtension(PFNGLSTENCILMASKSEPARATEPROC, glStencilMaskSeparate); \


### PR DESCRIPTION
The GL_EXT_draw_buffers extension defines the glDrawBuffersEXT method
which can be aliased to the glDrawBuffers method.