### PR TITLE
Fix division by zero when patch list topo is 12

### DIFF
--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -1457,7 +1457,7 @@ constexpr inline uint32_t PatchList_Count(Topology topology)
 {
   return uint32_t(topology) < uint32_t(Topology::PatchList_1CPs)
              ? 0
-             : uint32_t(topology) - uint32_t(Topology::PatchList_1CPs);
+             : uint32_t(topology) - uint32_t(Topology::PatchList_1CPs) + 1;
 }
 
 DOCUMENT(R"(Check whether or not this is a strip-type topology.


### PR DESCRIPTION
Description
---
Initial issue happens when viewing a patch list.

Steps to reproduce
---
Running displacement.exe from https://github.com/SaschaWillems/Vulkan and viewing `VS Output` of the second `vkCmdDrawIndexed` mesh output.