### PR TITLE
Use case-insensitive comparison for process filter

### DIFF
--- a/renderdocui/Windows/Dialogs/CaptureDialog.cs
+++ b/renderdocui/Windows/Dialogs/CaptureDialog.cs
@@ -330,7 +330,7 @@ namespace renderdocui.Windows.Dialogs
                     bool match = false;
 
                     foreach(var v in values)
-                        if (v.Contains(processFilter.Text))
+                        if (v.IndexOf(processFilter.Text, StringComparison.InvariantCultureIgnoreCase) >= 0)
                             match = true;
 
                     if(!match)


### PR DESCRIPTION
This makes it easier to filter processes that have upper case letters -
for example, you can now type 'calc' to filter out 'Calculator'.