### PR TITLE
Fix for double delete in Vulkan DescSetLayout::Init

### DIFF
--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -55,7 +55,7 @@ void DescSetLayout::Init(VulkanResourceManager *resourceMan, VulkanCreationInfo 
 
     if(pCreateInfo->pBindings[i].pImmutableSamplers)
     {
-      bindings[b].immutableSampler = new ResourceId[bindings[i].descriptorCount];
+      bindings[b].immutableSampler = new ResourceId[bindings[b].descriptorCount];
 
       for(uint32_t s = 0; s < bindings[b].descriptorCount; s++)
       {

--- a/renderdoc/driver/vulkan/vk_info.h
+++ b/renderdoc/driver/vulkan/vk_info.h
@@ -49,6 +49,19 @@ struct DescSetLayout
           immutableSampler(NULL)
     {
     }
+    // Copy the immutable sampler
+    Binding(const Binding &b)
+        : descriptorType(b.descriptorType),
+          descriptorCount(b.descriptorCount),
+          stageFlags(b.stageFlags),
+          immutableSampler(NULL)
+    {
+      if(b.immutableSampler)
+      {
+        immutableSampler = new ResourceId[descriptorCount];
+        memcpy(immutableSampler, b.immutableSampler, sizeof(ResourceId) * descriptorCount);
+      }
+    }
     ~Binding() { SAFE_DELETE_ARRAY(immutableSampler); }
     VkDescriptorType descriptorType;
     uint32_t descriptorCount;


### PR DESCRIPTION
DescSetLayout::Init can crash when Immutable Samplers are provided.
When the vector containing the Binding info is resized, the pointer to
immutableSamplers is copied and then deleted in the old copy.
A move constructor has been added to the Binding struct to
keep only a single pointer to the array.