### PR TITLE
Various fixes/improvements from Android OpenGL ES development

### DIFF
--- a/renderdoc/data/glsl/gles_texsample.h
+++ b/renderdoc/data/glsl/gles_texsample.h
@@ -25,6 +25,7 @@
 // enable these extensions if possible
 //#extension GL_OES_texture_cube_map_array : enable
 //#extension GL_EXT_texture_cube_map_array : enable
+//#extension GL_EXT_texture_buffer : enable
 
 #if __VERSION__ >= 310
 #define GLES_texture_multisample 1
@@ -32,6 +33,10 @@
 
 #if defined(GL_OES_texture_cube_map_array) || defined(GL_EXT_texture_cube_map_array)
 #define GLES_texture_cube_map_array 1
+#endif
+
+#if defined(GL_EXT_texture_buffer)
+#define GLES_texture_buffer 1
 #endif
 
 #if UINT_TEX
@@ -46,7 +51,9 @@ layout(binding = 3) uniform PRECISION usampler3D texUInt3D;
 layout(binding = 6) uniform PRECISION usampler2DArray texUInt2DArray;
 // cube array = 7
 // 2d rect = 8
+#ifdef GLES_texture_buffer
 layout(binding = 9) uniform PRECISION usamplerBuffer texUIntBuffer;
+#endif
 #ifdef GLES_texture_multisample
 layout(binding = 10) uniform PRECISION usampler2DMS texUInt2DMS;
 #endif
@@ -65,7 +72,11 @@ uvec4 SampleTextureUInt4(int type, vec2 pos, float slice, int mipLevel, int samp
   }
   else if(type == RESTYPE_TEXBUFFER)
   {
+#ifdef GLES_texture_buffer
     col = texelFetch(texUIntBuffer, int(pos.x * texRes.x));
+#else
+    col = uvec4(0u, 0u, 0u, 0u);
+#endif
   }
   else if(type == RESTYPE_TEX2DMS)
   {
@@ -107,7 +118,9 @@ layout(binding = 3) uniform PRECISION isampler3D texSInt3D;
 layout(binding = 6) uniform PRECISION isampler2DArray texSInt2DArray;
 // cube array = 7
 // 2d rect = 8
+#ifdef GLES_texture_buffer
 layout(binding = 9) uniform PRECISION isamplerBuffer texSIntBuffer;
+#endif
 #ifdef GLES_texture_multisample
 layout(binding = 10) uniform PRECISION isampler2DMS texSInt2DMS;
 #endif
@@ -131,7 +144,11 @@ ivec4 SampleTextureSInt4(int type, vec2 pos, float slice, int mipLevel, int samp
   }
   else if(type == RESTYPE_TEXBUFFER)
   {
+#ifdef GLES_texture_buffer
     col = texelFetch(texSIntBuffer, int(pos.x * texRes.x));
+#else
+    col = ivec4(0, 0, 0, 0);
+#endif
   }
   else if(type == RESTYPE_TEX2DMS)
   {
@@ -170,7 +187,9 @@ layout(binding = 6) uniform PRECISION sampler2DArray tex2DArray;
 layout(binding = 7) uniform PRECISION samplerCubeArray texCubeArray;
 #endif
 // 2d rect = 8
+#ifdef GLES_texture_buffer
 layout(binding = 9) uniform PRECISION samplerBuffer texBuffer;
+#endif
 #ifdef GLES_texture_multisample
 layout(binding = 10) uniform PRECISION sampler2DMS tex2DMS;
 #endif
@@ -184,7 +203,12 @@ vec4 SampleTextureFloat4(int type, vec2 pos, float slice, int mipLevel, int samp
   }
   else if(type == RESTYPE_TEXBUFFER)
   {
+#ifdef GLES_texture_buffer
     col = texelFetch(texBuffer, int(pos.x * texRes.x));
+#else
+    col = vec4(0.0f, 0.0f, 0.0f, 0.0f);
+#endif
+
 #ifdef OPENGL_ES
     // This hack is needed for an Android device to let the compiler optimize out the texBuffer,
     // because otherwise due to some compiler bug the RESTYPE_TEX2D case won't work normally.

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -297,6 +297,7 @@ extern bool IsGLES;
 // 99 means the extension never became core, so you can easily just do a check of CoreVersion >= NN
 // and they will always fail.
 #define EXTENSION_CHECKS()                                       \
+  EXT_TO_CHECK(31, 99, ARB_texture_buffer_object)                \
   EXT_TO_CHECK(33, 30, ARB_explicit_attrib_location)             \
   EXT_TO_CHECK(33, 30, ARB_sampler_objects)                      \
   EXT_TO_CHECK(33, 30, ARB_texture_swizzle)                      \
@@ -308,6 +309,7 @@ extern bool IsGLES;
   EXT_TO_CHECK(40, 32, ARB_tessellation_shader)                  \
   EXT_TO_CHECK(40, 32, ARB_texture_cube_map_array)               \
   EXT_TO_CHECK(40, 30, ARB_transform_feedback2)                  \
+  EXT_TO_CHECK(41, 99, ARB_geometry_shader4)                     \
   EXT_TO_CHECK(41, 31, ARB_separate_shader_objects)              \
   EXT_TO_CHECK(41, 99, ARB_viewport_array)                       \
   EXT_TO_CHECK(42, 99, ARB_base_instance)                        \
@@ -349,7 +351,8 @@ extern bool IsGLES;
   EXT_TO_CHECK(99, 99, NV_polygon_mode)                          \
   EXT_TO_CHECK(99, 99, NV_read_depth)                            \
   EXT_TO_CHECK(99, 99, NV_read_stencil)                          \
-  EXT_TO_CHECK(99, 99, NV_read_depth_stencil)
+  EXT_TO_CHECK(99, 99, NV_read_depth_stencil)                    \
+  EXT_TO_CHECK(99, 99, EXT_disjoint_timer_query)
 
 // GL extensions and their roughly equivalent GLES alternatives
 #define EXTENSION_COMPATIBILITY_CHECKS()                                                    \
@@ -358,6 +361,8 @@ extern bool IsGLES;
   EXT_COMP_CHECK(ARB_copy_image, OES_copy_image)                                            \
   EXT_COMP_CHECK(ARB_draw_buffers_blend, EXT_draw_buffers_indexed)                          \
   EXT_COMP_CHECK(ARB_draw_buffers_blend, OES_draw_buffers_indexed)                          \
+  EXT_COMP_CHECK(ARB_geometry_shader4, EXT_geometry_shader)                                 \
+  EXT_COMP_CHECK(ARB_geometry_shader4, OES_geometry_shader)                                 \
   EXT_COMP_CHECK(ARB_gpu_shader5, EXT_gpu_shader5)                                          \
   EXT_COMP_CHECK(ARB_gpu_shader5, OES_gpu_shader5)                                          \
   EXT_COMP_CHECK(ARB_sample_shading, OES_sample_shading)                                    \
@@ -371,7 +376,9 @@ extern bool IsGLES;
   EXT_COMP_CHECK(ARB_texture_view, EXT_texture_view)                                        \
   EXT_COMP_CHECK(ARB_texture_view, OES_texture_view)                                        \
   EXT_COMP_CHECK(ARB_viewport_array, NV_viewport_array)                                     \
-  EXT_COMP_CHECK(ARB_viewport_array, OES_viewport_array)
+  EXT_COMP_CHECK(ARB_viewport_array, OES_viewport_array)                                    \
+  EXT_COMP_CHECK(ARB_texture_buffer_object, EXT_texture_buffer)                             \
+  EXT_COMP_CHECK(ARB_texture_buffer_object, OES_texture_buffer)
 
 // extensions we know we want to check for are precached, indexd by this enum
 enum ExtensionCheckEnum

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -976,7 +976,7 @@ void WrappedOpenGL::Initialise(GLInitParams &params)
     gl.glTexParameteri(target, eGL_TEXTURE_WRAP_S, eGL_CLAMP_TO_EDGE);
     gl.glTexParameteri(target, eGL_TEXTURE_WRAP_T, eGL_CLAMP_TO_EDGE);
   }
-  gl.glFramebufferTexture(eGL_FRAMEBUFFER, eGL_COLOR_ATTACHMENT0, m_FakeBB_Color, 0);
+  gl.glFramebufferTexture2D(eGL_FRAMEBUFFER, eGL_COLOR_ATTACHMENT0, target, m_FakeBB_Color, 0);
 
   gl.glViewport(0, 0, params.width, params.height);
 
@@ -2026,7 +2026,8 @@ void WrappedOpenGL::RenderOverlayStr(float x, float y, const char *text)
     // set viewport & scissor
     gl.glViewport(0, 0, (GLsizei)m_InitParams.width, (GLsizei)m_InitParams.height);
     gl.glDisable(eGL_SCISSOR_TEST);
-    gl.glPolygonMode(eGL_FRONT_AND_BACK, eGL_FILL);
+    if(!IsGLES)
+      gl.glPolygonMode(eGL_FRONT_AND_BACK, eGL_FILL);
 
     // bind textures
     gl.glActiveTexture(eGL_TEXTURE0);

--- a/renderdoc/driver/gl/gl_hooks_linux_shared.cpp
+++ b/renderdoc/driver/gl/gl_hooks_linux_shared.cpp
@@ -708,7 +708,7 @@ bool SharedPopulateHooks(void *(*lookupFunc)(const char *))
 #undef HookExtension
 #define HookExtension(funcPtrType, function) lookupFunc((const char *)STRINGIZE(function))
 #undef HookExtensionAlias
-#define HookExtensionAlias(funcPtrType, function, alias)
+#define HookExtensionAlias(funcPtrType, function, alias) lookupFunc((const char *)STRINGIZE(alias))
 
   DLLExportHooks();
   HookCheckGLExtensions();

--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -740,7 +740,8 @@ void GLRenderState::FetchState(void *ctx, WrappedOpenGL *gl)
       m_Real->glGetIntegerv(eGL_TEXTURE_BINDING_RECTANGLE, (GLint *)&TexRect[i]);
     else
       TexRect[i] = 0;
-    m_Real->glGetIntegerv(eGL_TEXTURE_BINDING_BUFFER, (GLint *)&TexBuffer[i]);
+    if(HasExt[ARB_texture_buffer_object])
+      m_Real->glGetIntegerv(eGL_TEXTURE_BINDING_BUFFER, (GLint *)&TexBuffer[i]);
     m_Real->glGetIntegerv(eGL_TEXTURE_BINDING_2D_MULTISAMPLE, (GLint *)&Tex2DMS[i]);
     m_Real->glGetIntegerv(eGL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY, (GLint *)&Tex2DMSArray[i]);
 
@@ -870,7 +871,8 @@ void GLRenderState::FetchState(void *ctx, WrappedOpenGL *gl)
   m_Real->glGetIntegerv(eGL_PIXEL_PACK_BUFFER_BINDING, (GLint *)&BufferBindings[eBufIdx_Pixel_Pack]);
   m_Real->glGetIntegerv(eGL_PIXEL_UNPACK_BUFFER_BINDING,
                         (GLint *)&BufferBindings[eBufIdx_Pixel_Unpack]);
-  m_Real->glGetIntegerv(eGL_TEXTURE_BUFFER_BINDING, (GLint *)&BufferBindings[eBufIdx_Texture]);
+  if(HasExt[ARB_texture_buffer_object])
+    m_Real->glGetIntegerv(eGL_TEXTURE_BUFFER_BINDING, (GLint *)&BufferBindings[eBufIdx_Texture]);
 
   if(HasExt[ARB_draw_indirect])
     m_Real->glGetIntegerv(eGL_DRAW_INDIRECT_BUFFER_BINDING,
@@ -1194,7 +1196,8 @@ void GLRenderState::ApplyState(void *ctx, WrappedOpenGL *gl)
     m_Real->glBindTexture(eGL_TEXTURE_2D_ARRAY, Tex2DArray[i]);
     if(!IsGLES)
       m_Real->glBindTexture(eGL_TEXTURE_RECTANGLE, TexRect[i]);
-    m_Real->glBindTexture(eGL_TEXTURE_BUFFER, TexBuffer[i]);
+    if(HasExt[ARB_texture_buffer_object])
+      m_Real->glBindTexture(eGL_TEXTURE_BUFFER, TexBuffer[i]);
     m_Real->glBindTexture(eGL_TEXTURE_CUBE_MAP, TexCube[i]);
     m_Real->glBindTexture(eGL_TEXTURE_2D_MULTISAMPLE, Tex2DMS[i]);
     m_Real->glBindTexture(eGL_TEXTURE_2D_MULTISAMPLE_ARRAY, Tex2DMSArray[i]);
@@ -1277,7 +1280,8 @@ void GLRenderState::ApplyState(void *ctx, WrappedOpenGL *gl)
   m_Real->glBindBuffer(eGL_COPY_WRITE_BUFFER, BufferBindings[eBufIdx_Copy_Write]);
   m_Real->glBindBuffer(eGL_PIXEL_PACK_BUFFER, BufferBindings[eBufIdx_Pixel_Pack]);
   m_Real->glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, BufferBindings[eBufIdx_Pixel_Unpack]);
-  m_Real->glBindBuffer(eGL_TEXTURE_BUFFER, BufferBindings[eBufIdx_Texture]);
+  if(HasExt[ARB_texture_buffer_object])
+    m_Real->glBindBuffer(eGL_TEXTURE_BUFFER, BufferBindings[eBufIdx_Texture]);
   if(HasExt[ARB_draw_indirect])
     m_Real->glBindBuffer(eGL_DRAW_INDIRECT_BUFFER, BufferBindings[eBufIdx_Draw_Indirect]);
   if(HasExt[ARB_compute_shader])

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -2269,6 +2269,8 @@ byte *GLReplay::GetTextureData(ResourceId tex, uint32_t arrayIdx, uint32_t mip,
     if(newtarget == eGL_TEXTURE_3D)
       gl.glFramebufferTexture3D(eGL_FRAMEBUFFER, eGL_COLOR_ATTACHMENT0, eGL_TEXTURE_3D, tempTex, 0,
                                 0);
+    else if(newtarget == eGL_TEXTURE_2D || newtarget == eGL_TEXTURE_2D_MULTISAMPLE)
+      gl.glFramebufferTexture2D(eGL_FRAMEBUFFER, eGL_COLOR_ATTACHMENT0, newtarget, tempTex, 0);
     else
       gl.glFramebufferTexture(eGL_FRAMEBUFFER, eGL_COLOR_ATTACHMENT0, tempTex, 0);
 

--- a/renderdoc/driver/gl/gl_resources.cpp
+++ b/renderdoc/driver/gl/gl_resources.cpp
@@ -302,7 +302,9 @@ GLenum GetBaseFormat(GLenum internalFormat)
     case eGL_R16:
     case eGL_R16_SNORM:
     case eGL_R16F:
-    case eGL_R32F: return eGL_RED;
+    case eGL_R32F:
+    case eGL_RED: return eGL_RED;
+    case eGL_ALPHA:
     case eGL_ALPHA8_EXT: return eGL_ALPHA;
     case eGL_LUMINANCE: return eGL_LUMINANCE;
     case eGL_LUMINANCE_ALPHA: return eGL_LUMINANCE_ALPHA;
@@ -318,7 +320,8 @@ GLenum GetBaseFormat(GLenum internalFormat)
     case eGL_RG16:
     case eGL_RG16_SNORM:
     case eGL_RG16F:
-    case eGL_RG32F: return eGL_RG;
+    case eGL_RG32F:
+    case eGL_RG: return eGL_RG;
     case eGL_RG8I:
     case eGL_RG8UI:
     case eGL_RG16I:
@@ -339,7 +342,8 @@ GLenum GetBaseFormat(GLenum internalFormat)
     case eGL_RGB16F:
     case eGL_RGB32F:
     case eGL_R11F_G11F_B10F:
-    case eGL_RGB9_E5: return eGL_RGB;
+    case eGL_RGB9_E5:
+    case eGL_RGB: return eGL_RGB;
     case eGL_RGB8I:
     case eGL_RGB8UI:
     case eGL_RGB16I:
@@ -357,7 +361,8 @@ GLenum GetBaseFormat(GLenum internalFormat)
     case eGL_RGBA16_SNORM:
     case eGL_SRGB8_ALPHA8:
     case eGL_RGBA16F:
-    case eGL_RGBA32F: return eGL_RGBA;
+    case eGL_RGBA32F:
+    case eGL_RGBA: return eGL_RGBA;
     case eGL_RGB10_A2UI:
     case eGL_RGBA8I:
     case eGL_RGBA8UI:
@@ -400,7 +405,11 @@ GLenum GetDataType(GLenum internalFormat)
     case eGL_BGRA:
     case eGL_BGRA8_EXT:
     case eGL_SRGB8_ALPHA8:
-    case eGL_SRGB8: return eGL_UNSIGNED_BYTE;
+    case eGL_SRGB8:
+    case eGL_RED:
+    case eGL_RG:
+    case eGL_RGB:
+    case eGL_RGBA: return eGL_UNSIGNED_BYTE;
     case eGL_RGBA8I:
     case eGL_RG8I:
     case eGL_R8I:
@@ -459,6 +468,7 @@ GLenum GetDataType(GLenum internalFormat)
     case eGL_DEPTH24_STENCIL8: return eGL_UNSIGNED_INT_24_8;
     case eGL_DEPTH32F_STENCIL8: return eGL_FLOAT_32_UNSIGNED_INT_24_8_REV;
     case eGL_STENCIL_INDEX8: return eGL_UNSIGNED_BYTE;
+    case eGL_ALPHA:
     case eGL_ALPHA8_EXT:
     case eGL_LUMINANCE_ALPHA:
     case eGL_LUMINANCE:

--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -949,6 +949,13 @@ static const format_data formats[] = {
 
     {eGL_BGRA8_EXT, eGL_UNSIGNED_BYTE, 4, 8, 0, 0},
 
+    // unsized formats
+    {eGL_RED, eGL_UNSIGNED_BYTE, 1, 8, 0, 0},
+    {eGL_RG, eGL_UNSIGNED_BYTE, 2, 8, 0, 0},
+    {eGL_RGB, eGL_UNSIGNED_BYTE, 3, 8, 0, 0},
+    {eGL_RGBA, eGL_UNSIGNED_BYTE, 4, 8, 0, 0},
+    {eGL_BGRA_EXT, eGL_UNSIGNED_BYTE, 4, 8, 0, 0},
+
     // depth and stencil formats
     {eGL_DEPTH_COMPONENT16, eGL_NONE, 0, 0, 16, 0},
     {eGL_DEPTH_COMPONENT24, eGL_NONE, 0, 0, 24, 0},
@@ -1188,11 +1195,21 @@ void APIENTRY _glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint srcLev
         // simple case, non-layered. If we have a layered copy we need to loop and rebind
         if(!layered)
         {
-          hookset->glFramebufferTexture(eGL_READ_FRAMEBUFFER, attach, srcName, srcLevel);
           // we assume the destination texture is the same format, and we asserted that it's the
           // same
           // target.
-          hookset->glFramebufferTexture(eGL_DRAW_FRAMEBUFFER, attach, dstName, dstLevel);
+          if(srcTarget == eGL_TEXTURE_2D || srcTarget == eGL_TEXTURE_2D_MULTISAMPLE)
+          {
+            hookset->glFramebufferTexture2D(eGL_READ_FRAMEBUFFER, attach, srcTarget, srcName,
+                                            srcLevel);
+            hookset->glFramebufferTexture2D(eGL_DRAW_FRAMEBUFFER, attach, dstTarget, dstName,
+                                            dstLevel);
+          }
+          else
+          {
+            hookset->glFramebufferTexture(eGL_READ_FRAMEBUFFER, attach, srcName, srcLevel);
+            hookset->glFramebufferTexture(eGL_DRAW_FRAMEBUFFER, attach, dstName, dstLevel);
+          }
         }
       }
     }


### PR DESCRIPTION
Hi! I have more changes while working on Android GLES. Please let me know if I should change anything!

Some notes:
The preference of glFramebufferTexture2D over glFramebufferTexture would allow gles 3.1 devices to run without crashing. But I understand if you want to keep the code clean, just let me know and I'll remove the change.