### PR TITLE
Fix aliases for EXT_disjoint_timer_query

### DIFF
--- a/renderdoc/driver/gl/gl_hookset.h
+++ b/renderdoc/driver/gl/gl_hookset.h
@@ -174,7 +174,7 @@ struct GLHookSet
   PFNGLGETQUERYINDEXEDIVPROC glGetQueryIndexediv;
   PFNGLGETQUERYOBJECTUI64VPROC glGetQueryObjectui64v;    // aliases glGetQueryObjectui64vEXT
   PFNGLGETQUERYOBJECTUIVPROC glGetQueryObjectuiv;        // aliases glGetQueryObjectuivARB, glGetQueryObjectuivEXT
-  PFNGLGETQUERYOBJECTI64VPROC glGetQueryObjecti64v;      // aliases glGetQueryObjecti64vEXT, glGetQueryObjecti64vEXT
+  PFNGLGETQUERYOBJECTI64VPROC glGetQueryObjecti64v;      // aliases glGetQueryObjecti64vEXT
   PFNGLGETQUERYOBJECTIVPROC glGetQueryObjectiv;          // aliases glGetQueryObjectivARB, glGetQueryObjectivEXT
   PFNGLGETQUERYIVPROC glGetQueryiv;                      // aliases glGetQueryivARB, glGetQueryivEXT
   PFNGLGETSYNCIVPROC glGetSynciv;
@@ -283,7 +283,7 @@ struct GLHookSet
   PFNGLISFRAMEBUFFERPROC glIsFramebuffer;    // aliases glIsFramebufferEXT
   PFNGLISPROGRAMPROC glIsProgram;
   PFNGLISPROGRAMPIPELINEPROC glIsProgramPipeline;
-  PFNGLISQUERYPROC glIsQuery;                  // aliases glIsQueryARB
+  PFNGLISQUERYPROC glIsQuery;                  // aliases glIsQueryARB, glIsQueryEXT
   PFNGLISRENDERBUFFERPROC glIsRenderbuffer;    // aliases glIsRenderbufferEXT
   PFNGLISSAMPLERPROC glIsSampler;
   PFNGLISSHADERPROC glIsShader;

--- a/renderdoc/driver/gl/gl_hookset_defs.h
+++ b/renderdoc/driver/gl/gl_hookset_defs.h
@@ -3604,15 +3604,6 @@
     HookWrapper5(void, glclearteximageext, GLuint, texture, GLint, level, GLenum, format, GLenum, type, const void *, data); \
     HookWrapper11(void, glcleartexsubimageext, GLuint, texture, GLint, level, GLint, xoffset, GLint, yoffset, GLint, zoffset, GLsizei, width, GLsizei, height, GLsizei, depth, GLenum, format, GLenum, type, const void *, data); \
     HookWrapper3(void, gldiscardframebufferext, GLenum, target, GLsizei, numAttachments, const GLenum *, attachments); \
-    HookWrapper2(void, glgenqueriesext, GLsizei, n, GLuint *, ids); \
-    HookWrapper2(void, gldeletequeriesext, GLsizei, n, const GLuint *, ids); \
-    HookWrapper1(GLboolean, glisqueryext, GLuint, id); \
-    HookWrapper2(void, glbeginqueryext, GLenum, target, GLuint, id); \
-    HookWrapper1(void, glendqueryext, GLenum, target); \
-    HookWrapper2(void, glquerycounterext, GLuint, id, GLenum, target); \
-    HookWrapper3(void, glgetqueryivext, GLenum, target, GLenum, pname, GLint *, params); \
-    HookWrapper3(void, glgetqueryobjectivext, GLuint, id, GLenum, pname, GLint *, params); \
-    HookWrapper3(void, glgetqueryobjectuivext, GLuint, id, GLenum, pname, GLuint *, params); \
     HookWrapper5(void, gldrawelementsbasevertexext, GLenum, mode, GLsizei, count, GLenum, type, const void *, indices, GLint, basevertex); \
     HookWrapper7(void, gldrawrangeelementsbasevertexext, GLenum, mode, GLuint, start, GLuint, end, GLsizei, count, GLenum, type, const void *, indices, GLint, basevertex); \
     HookWrapper6(void, gldrawelementsinstancedbasevertexext, GLenum, mode, GLsizei, count, GLenum, type, const void *, indices, GLsizei, instancecount, GLint, basevertex); \
@@ -5612,15 +5603,6 @@
     HandleUnsupported(PFNGLCLEARTEXIMAGEEXTPROC, glclearteximageext); \
     HandleUnsupported(PFNGLCLEARTEXSUBIMAGEEXTPROC, glcleartexsubimageext); \
     HandleUnsupported(PFNGLDISCARDFRAMEBUFFEREXTPROC, gldiscardframebufferext); \
-    HandleUnsupported(PFNGLGENQUERIESEXTPROC, glgenqueriesext); \
-    HandleUnsupported(PFNGLDELETEQUERIESEXTPROC, gldeletequeriesext); \
-    HandleUnsupported(PFNGLISQUERYEXTPROC, glisqueryext); \
-    HandleUnsupported(PFNGLBEGINQUERYEXTPROC, glbeginqueryext); \
-    HandleUnsupported(PFNGLENDQUERYEXTPROC, glendqueryext); \
-    HandleUnsupported(PFNGLQUERYCOUNTEREXTPROC, glquerycounterext); \
-    HandleUnsupported(PFNGLGETQUERYIVEXTPROC, glgetqueryivext); \
-    HandleUnsupported(PFNGLGETQUERYOBJECTIVEXTPROC, glgetqueryobjectivext); \
-    HandleUnsupported(PFNGLGETQUERYOBJECTUIVEXTPROC, glgetqueryobjectuivext); \
     HandleUnsupported(PFNGLDRAWELEMENTSBASEVERTEXEXTPROC, gldrawelementsbasevertexext); \
     HandleUnsupported(PFNGLDRAWRANGEELEMENTSBASEVERTEXEXTPROC, gldrawrangeelementsbasevertexext); \
     HandleUnsupported(PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXEXTPROC, gldrawelementsinstancedbasevertexext); \


### PR DESCRIPTION
* glGetQueryObjecti64vEXT was used twice as an alias.
* Added missing glIsQueryEXT alias.
* Removed the query related methods from the unhandled block.