### PR TITLE
Fix enum flag usages in the qrenderdoc

### DIFF
--- a/qrenderdoc/Widgets/Extended/RDTextEdit.cpp
+++ b/qrenderdoc/Widgets/Extended/RDTextEdit.cpp
@@ -49,11 +49,11 @@ void RDTextEdit::focusOutEvent(QFocusEvent *e)
 void RDTextEdit::keyPressEvent(QKeyEvent *e)
 {
   // add ctrl-end and ctrl-home shortcuts, which aren't implemented for read-only edits
-  if(e->key() == Qt::Key_End && e->modifiers() && Qt::ControlModifier)
+  if(e->key() == Qt::Key_End && (e->modifiers() & Qt::ControlModifier))
   {
     verticalScrollBar()->setValue(verticalScrollBar()->maximum());
   }
-  else if(e->key() == Qt::Key_Home && e->modifiers() && Qt::ControlModifier)
+  else if(e->key() == Qt::Key_Home && (e->modifiers() & Qt::ControlModifier))
   {
     verticalScrollBar()->setValue(verticalScrollBar()->minimum());
   }

--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -70,7 +70,7 @@ public:
     if(e->key() == Qt::Key_W || e->key() == Qt::Key_S)
       setMove(Direction::Fwd, 0);
 
-    if(e->modifiers() && Qt::ShiftModifier)
+    if(e->modifiers() & Qt::ShiftModifier)
       m_CurrentSpeed = 3.0f;
     else
       m_CurrentSpeed = 1.0f;
@@ -91,7 +91,7 @@ public:
     if(e->key() == Qt::Key_A)
       setMove(Direction::Horiz, -1);
 
-    if(e->modifiers() && Qt::ShiftModifier)
+    if(e->modifiers() & Qt::ShiftModifier)
       m_CurrentSpeed = 3.0f;
     else
       m_CurrentSpeed = 1.0f;


### PR DESCRIPTION
There are a few places where the logical 'and' operator
was used to check if a given flag is enabled however
that is not the correct operator.

The binary 'and' operator should be used where
the enum acts as a flag.