### PR TITLE
Fix reading back index buffer to determine client vertex range.

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -774,8 +774,8 @@ WrappedOpenGL::ClientMemoryData *WrappedOpenGL::CopyClientMemoryArrays(GLint fir
       if(idxbuf != 0)
       {
         // If we were using a real index buffer, read it back to check its range.
-        mmIndices = m_Real.glMapBufferRange(eGL_ELEMENT_ARRAY_BUFFER, (size_t)indices,
-                                            idxlen - (size_t)indices, eGL_MAP_READ_BIT);
+        mmIndices = m_Real.glMapBufferRange(eGL_ELEMENT_ARRAY_BUFFER, (size_t)indices, idxlen,
+                                            eGL_MAP_READ_BIT);
       }
 
       size_t min = ~0u, max = 0;


### PR DESCRIPTION
idxlen is already the total size of indices, not the buffer containing them.

Btw it seems like I can no longer attach to an existing captured app in the Qt gui, I have to start an app for capture every time.