### PR TITLE
Add initial D3D8 driver

### DIFF
--- a/renderdoc.sln
+++ b/renderdoc.sln
@@ -77,6 +77,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AMD", "renderdoc\driver\ihv
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IHV", "IHV", "{4DA2F3E3-9A65-45DD-A69B-82C7757D4904}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "d3d8", "renderdoc\driver\d3d8\renderdoc_d3d8.vcxproj", "{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Development|x64 = Development|x64
@@ -222,6 +224,14 @@ Global
 		{5DE5A561-548A-4DD7-90F0-06A2B39EAE9A}.Release|x64.Build.0 = Release|x64
 		{5DE5A561-548A-4DD7-90F0-06A2B39EAE9A}.Release|x86.ActiveCfg = Release|Win32
 		{5DE5A561-548A-4DD7-90F0-06A2B39EAE9A}.Release|x86.Build.0 = Release|Win32
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Development|x64.ActiveCfg = Development|x64
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Development|x64.Build.0 = Development|x64
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Development|x86.ActiveCfg = Development|Win32
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Development|x86.Build.0 = Development|Win32
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Release|x64.ActiveCfg = Release|x64
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Release|x64.Build.0 = Release|x64
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Release|x86.ActiveCfg = Release|Win32
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,5 +259,6 @@ Global
 		{44044776-9469-4079-B587-ABFFF6574AA4} = {864A44B0-5612-451A-857F-41E3EF785EF6}
 		{5DE5A561-548A-4DD7-90F0-06A2B39EAE9A} = {4DA2F3E3-9A65-45DD-A69B-82C7757D4904}
 		{4DA2F3E3-9A65-45DD-A69B-82C7757D4904} = {864A44B0-5612-451A-857F-41E3EF785EF6}
+		{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22} = {864A44B0-5612-451A-857F-41E3EF785EF6}
 	EndGlobalSection
 EndGlobal

--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -71,6 +71,7 @@ string ToStrHelper<false, RDCDriver>::Get(const RDCDriver &el)
     case RDC_D3D11: return "D3D11";
     case RDC_D3D10: return "D3D10";
     case RDC_D3D9: return "D3D9";
+    case RDC_D3D8: return "D3D8";
     case RDC_Image: return "Image";
     case RDC_Vulkan: return "Vulkan";
     default: break;

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -107,6 +107,7 @@ enum RDCDriver
   RDC_Image = 7,
   RDC_Vulkan = 8,
   RDC_OpenGLES = 9,
+  RDC_D3D8 = 10,
   RDC_Custom = 100000,
   RDC_Custom0 = RDC_Custom,
   RDC_Custom1,

--- a/renderdoc/driver/d3d8/d3d8_common.cpp
+++ b/renderdoc/driver/d3d8/d3d8_common.cpp
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "d3d8_common.h"
+#include "d3d8_device.h"
+
+unsigned int RefCounter8::SoftRef(WrappedD3DDevice8 *device)
+{
+  unsigned int ret = AddRef();
+  if(device)
+    device->SoftRef();
+  else
+    RDCWARN("No device pointer, is a deleted resource being AddRef()d?");
+  return ret;
+}
+
+unsigned int RefCounter8::SoftRelease(WrappedD3DDevice8 *device)
+{
+  unsigned int ret = Release();
+  if(device)
+    device->SoftRelease();
+  else
+    RDCWARN("No device pointer, is a deleted resource being Release()d?");
+  return ret;
+}
+
+void RefCounter8::AddDeviceSoftref(WrappedD3DDevice8 *device)
+{
+  if(device)
+    device->SoftRef();
+}
+
+void RefCounter8::ReleaseDeviceSoftref(WrappedD3DDevice8 *device)
+{
+  if(device)
+    device->SoftRelease();
+}

--- a/renderdoc/driver/d3d8/d3d8_common.h
+++ b/renderdoc/driver/d3d8/d3d8_common.h
@@ -1,0 +1,79 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "api/replay/renderdoc_replay.h"
+#include "core/core.h"
+#include "driver/dx/official/d3d8.h"
+
+class WrappedD3DDevice8;
+
+class RefCounter8
+{
+private:
+  IUnknown *m_pReal;
+  unsigned int m_iRefcount;
+  bool m_SelfDeleting;
+
+protected:
+  void SetSelfDeleting(bool selfDelete) { m_SelfDeleting = selfDelete; }
+  // used for derived classes that need to soft ref but are handling their
+  // own self-deletion
+  static void AddDeviceSoftref(WrappedD3DDevice8 *device);
+  static void ReleaseDeviceSoftref(WrappedD3DDevice8 *device);
+
+public:
+  RefCounter8(IUnknown *real, bool selfDelete = true)
+      : m_pReal(real), m_iRefcount(1), m_SelfDeleting(selfDelete)
+  {
+  }
+  virtual ~RefCounter8() {}
+  unsigned int GetRefCount() { return m_iRefcount; }
+  //////////////////////////////
+  // implement IUnknown
+  HRESULT STDMETHODCALLTYPE QueryInterface(
+      /* [in] */ REFIID riid,
+      /* [annotation][iid_is][out] */
+      __RPC__deref_out void **ppvObject)
+  {
+    return E_NOINTERFACE;
+  }
+
+  ULONG STDMETHODCALLTYPE AddRef()
+  {
+    InterlockedIncrement(&m_iRefcount);
+    return m_iRefcount;
+  }
+  ULONG STDMETHODCALLTYPE Release()
+  {
+    unsigned int ret = InterlockedDecrement(&m_iRefcount);
+    if(ret == 0 && m_SelfDeleting)
+      delete this;
+    return ret;
+  }
+
+  unsigned int SoftRef(WrappedD3DDevice8 *device);
+  unsigned int SoftRelease(WrappedD3DDevice8 *device);
+};

--- a/renderdoc/driver/d3d8/d3d8_debug.cpp
+++ b/renderdoc/driver/d3d8/d3d8_debug.cpp
@@ -1,0 +1,318 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "d3d8_debug.h"
+#include "os/os_specific.h"
+#include "stb/stb_truetype.h"
+
+D3D8DebugManager::D3D8DebugManager(WrappedD3DDevice8 *wrapper)
+    : m_WrappedDevice(wrapper), m_fvf(D3DFVF_XYZ | D3DFVF_TEX1)
+{
+  InitFontRendering();
+}
+
+D3D8DebugManager::~D3D8DebugManager()
+{
+  ShutdownFontRendering();
+}
+
+bool D3D8DebugManager::InitFontRendering()
+{
+  HRESULT hr = S_OK;
+
+  int width = FONT_TEX_WIDTH;
+  int height = FONT_TEX_HEIGHT;
+
+  string font = GetEmbeddedResource(sourcecodepro_ttf);
+  byte *ttfdata = (byte *)font.c_str();
+
+  const int firstChar = int(' ') + 1;
+  const int lastChar = 127;
+  const int numChars = lastChar - firstChar;
+
+  byte *buf = new byte[width * height];
+
+  const float pixelHeight = 20.0f;
+
+  stbtt_BakeFontBitmap(ttfdata, 0, pixelHeight, buf, width, height, firstChar, numChars,
+                       m_Font.charData);
+
+  stbtt_fontinfo f = {0};
+  stbtt_InitFont(&f, ttfdata, 0);
+
+  int ascent = 0;
+  stbtt_GetFontVMetrics(&f, &ascent, NULL, NULL);
+
+  m_Font.maxHeight = float(ascent) * stbtt_ScaleForPixelHeight(&f, pixelHeight);
+
+  IDirect3DTexture8 *fontTex = NULL;
+
+  hr = m_WrappedDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8,
+                                      D3DPOOL_DEFAULT, &fontTex);
+
+  if(FAILED(hr))
+  {
+    RDCERR("Failed to create font texture %08x", hr);
+  }
+
+  D3DLOCKED_RECT lockedRegion;
+  hr = fontTex->LockRect(0, &lockedRegion, NULL, D3DLOCK_DISCARD);
+
+  if(FAILED(hr))
+  {
+    RDCERR("Failed to lock font texture %08x", hr);
+  }
+  else
+  {
+    BYTE *texBase = (BYTE *)lockedRegion.pBits;
+
+    for(int y = 0; y < height; y++)
+    {
+      byte *curRow = (texBase + (y * lockedRegion.Pitch));
+
+      for(int x = 0; x < width; x++)
+      {
+        curRow[x * 4 + 0] = buf[(y * width) + x];
+        curRow[x * 4 + 1] = buf[(y * width) + x];
+        curRow[x * 4 + 2] = buf[(y * width) + x];
+        curRow[x * 4 + 3] = buf[(y * width) + x];
+      }
+    }
+
+    hr = fontTex->UnlockRect(0);
+    if(hr != S_OK)
+    {
+      RDCERR("Failed to unlock font texture %08x", hr);
+    }
+  }
+
+  m_Font.Tex = fontTex;
+
+  delete[] buf;
+
+  return true;
+}
+
+void D3D8DebugManager::ShutdownFontRendering()
+{
+  SAFE_RELEASE(m_Font.Tex);
+}
+
+void D3D8DebugManager::SetOutputWindow(HWND w)
+{
+  // RECT rect;
+  // GetClientRect(w, &rect);
+  // m_supersamplingX = float(m_width) / float(rect.right - rect.left);
+  // m_supersamplingY = float(m_height) / float(rect.bottom - rect.top);
+}
+
+void D3D8DebugManager::RenderText(float x, float y, const char *textfmt, ...)
+{
+  static char tmpBuf[4096];
+
+  va_list args;
+  va_start(args, textfmt);
+  StringFormat::vsnprintf(tmpBuf, 4095, textfmt, args);
+  tmpBuf[4095] = '\0';
+  va_end(args);
+
+  RenderTextInternal(x, y, tmpBuf);
+}
+
+void D3D8DebugManager::RenderTextInternal(float x, float y, const char *text)
+{
+  if(char *t = strchr((char *)text, '\n'))
+  {
+    *t = 0;
+    RenderTextInternal(x, y, text);
+    RenderTextInternal(x, y + 1.0f, t + 1);
+    *t = '\n';
+    return;
+  }
+
+  if(strlen(text) == 0)
+    return;
+
+  RDCASSERT(strlen(text) < FONT_MAX_CHARS);
+
+  // transforms
+  float width = (float)m_width;
+  float height = (float)m_height;
+  float nearPlane = 0.001f;
+  float farPlane = 1.f;
+  D3DMATRIX identity = {1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f,
+                        0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f};
+  D3DMATRIX ortho = {2.f / width,
+                     0.f,
+                     0.f,
+                     0.f,
+                     0.f,
+                     -(2.f / height),
+                     0.f,
+                     0.f,
+                     0.f,
+                     0.f,
+                     1.f / (farPlane - nearPlane),
+                     0.f,
+                     0.f,
+                     0.f,
+                     nearPlane / (nearPlane - farPlane),
+                     1.f};
+
+  HRESULT res = S_OK;
+  res |= m_WrappedDevice->SetTransform(D3DTS_PROJECTION, &ortho);
+  res |= m_WrappedDevice->SetTransform(D3DTS_WORLD, &identity);
+  res |= m_WrappedDevice->SetTransform(D3DTS_VIEW, &identity);
+
+  // enable fixed function pipeline
+  res |= m_WrappedDevice->SetVertexShader(NULL);
+  res |= m_WrappedDevice->SetPixelShader(NULL);
+
+  // default render states
+  res |= m_WrappedDevice->SetRenderState(D3DRS_ZENABLE, D3DZB_FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_CLIPPLANEENABLE, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_FOGENABLE, FALSE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_COLORWRITEENABLE, 0x0000000F);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_VERTEXBLEND, D3DVBF_DISABLE);
+  res |= m_WrappedDevice->SetRenderState(D3DRS_INDEXEDVERTEXBLENDENABLE, FALSE);
+
+  // texture stage states
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_ADDRESSU, D3DTADDRESS_CLAMP);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_ADDRESSV, D3DTADDRESS_CLAMP);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR /*D3DTEXF_POINT*/);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR /*D3DTEXF_POINT*/);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_MIPFILTER, D3DTEXF_LINEAR /*D3DTEXF_POINT*/);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_CURRENT);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_CURRENT);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_TEXCOORDINDEX, 0);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_DISABLE);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_COLORARG0, D3DTA_CURRENT);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_ALPHAARG0, D3DTA_CURRENT);
+  res |= m_WrappedDevice->SetTextureStageState(0, D3DTSS_RESULTARG, D3DTA_CURRENT);
+
+  res |= m_WrappedDevice->SetVertexShader(m_fvf);
+  res |= m_WrappedDevice->SetTexture(0, m_Font.Tex);
+  for(uint32_t stage = 1; stage < 8; stage++)
+  {
+    res |= m_WrappedDevice->SetTexture(stage, NULL);
+  }
+
+  struct Vertex
+  {
+    float pos[3];
+    float uv[2];
+
+    Vertex() {}
+    Vertex(float posx, float posy, float posz, float texu, float texv)
+    {
+      pos[0] = posx;
+      pos[1] = posy;
+      pos[2] = posz;
+      uv[0] = texu;
+      uv[1] = texv;
+    }
+  };
+
+  struct Quad
+  {
+    Vertex vertices[6];
+
+    Quad() {}
+    Quad(float x0, float y0, float z, float s0, float t0, float x1, float y1, float s1, float t1)
+    {
+      vertices[0] = Vertex(x0, y0, z, s0, t0);
+      vertices[1] = Vertex(x1, y0, z, s1, t0);
+      vertices[2] = Vertex(x0, y1, z, s0, t1);
+      vertices[3] = Vertex(x1, y0, z, s1, t0);
+      vertices[4] = Vertex(x1, y1, z, s1, t1);
+      vertices[5] = Vertex(x0, y1, z, s0, t1);
+    }
+  };
+
+  Quad *quads = NULL;
+  Quad background;
+  UINT triangleCount = 0;
+  {
+    UINT quadCount = (UINT)strlen(text);    // calculate string length
+
+    triangleCount = quadCount * 2;
+    // create text VB
+    quads = new Quad[quadCount];
+
+    float textStartingPositionX = (-width / 2.f) + (x * m_Font.charData->xadvance);
+    float textStartingPositionY = (-height / 2.f) + ((y + 1.f) * m_Font.maxHeight);
+
+    float textPositionX = textStartingPositionX;
+    float textPositionY = textStartingPositionY;
+
+    for(UINT i = 0; i < quadCount; ++i)
+    {
+      char glyphIndex = text[i] - (' ' + 1);
+      if(glyphIndex < 0)
+      {
+        float currentX = textPositionX;
+        textPositionX += m_Font.charData->xadvance;
+        quads[i] = Quad(currentX, textPositionY - m_Font.maxHeight, 0.5f, 0.f, 0.f, textPositionX,
+                        textPositionY, 0.f, 0.f);
+      }
+      else
+      {
+        stbtt_aligned_quad quad;
+        stbtt_GetBakedQuad(m_Font.charData, 256, 128, glyphIndex, &textPositionX, &textPositionY,
+                           &quad, 0);
+        quads[i] = Quad(quad.x0, quad.y0, 0.5f, quad.s0, quad.t0, quad.x1, quad.y1, quad.s1, quad.t1);
+      }
+    }
+
+    background = Quad(textStartingPositionX, textStartingPositionY - m_Font.maxHeight, 0.6f, 0.f,
+                      0.f, textPositionX, textPositionY + 3.f, 0.f, 0.f);
+  }
+
+  if(quads != NULL)
+  {
+    // overlay render states
+    res |= m_WrappedDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+    res |= m_WrappedDevice->DrawPrimitiveUP(D3DPT_TRIANGLELIST, 2, &background, sizeof(Vertex));
+
+    //// overlay render states
+    res |= m_WrappedDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+    res |= m_WrappedDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
+    res |= m_WrappedDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+
+    res |= m_WrappedDevice->DrawPrimitiveUP(D3DPT_TRIANGLELIST, triangleCount, &quads[0],
+                                            sizeof(Vertex));
+    delete[] quads;
+  }
+}

--- a/renderdoc/driver/d3d8/d3d8_debug.h
+++ b/renderdoc/driver/d3d8/d3d8_debug.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include <list>
+#include <map>
+#include <utility>
+#include "driver/dx/official/d3d8.h"
+#include "stb/stb_truetype.h"
+#include "d3d8_common.h"
+#include "d3d8_device.h"
+
+class D3D8DebugManager
+{
+public:
+  D3D8DebugManager(WrappedD3DDevice8 *wrapper);
+  ~D3D8DebugManager();
+
+  void RenderText(float x, float y, const char *textfmt, ...);
+
+  void SetOutputDimensions(int w, int h)
+  {
+    m_width = w;
+    m_height = h;
+  }
+  void SetOutputWindow(HWND w);
+
+  // font/text rendering
+  bool InitFontRendering();
+  void ShutdownFontRendering();
+
+  void RenderTextInternal(float x, float y, const char *text);
+
+  static const int FONT_TEX_WIDTH = 256;
+  static const int FONT_TEX_HEIGHT = 128;
+  static const int FONT_MAX_CHARS = 256;
+
+  static const uint32_t STAGE_BUFFER_BYTE_SIZE = 4 * 1024 * 1024;
+
+  struct FontData
+  {
+    FontData() { RDCEraseMem(this, sizeof(FontData)); }
+    ~FontData() { SAFE_RELEASE(Tex); }
+    IDirect3DTexture8 *Tex;
+    stbtt_bakedchar charData[FONT_MAX_CHARS];
+    float maxHeight;
+  } m_Font;
+
+  DWORD m_fvf;
+
+  int m_width;
+  int m_height;
+  WrappedD3DDevice8 *m_WrappedDevice;
+};

--- a/renderdoc/driver/d3d8/d3d8_device.cpp
+++ b/renderdoc/driver/d3d8/d3d8_device.cpp
@@ -1,0 +1,840 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "d3d8_device.h"
+#include "core/core.h"
+#include "serialise/serialiser.h"
+#include "d3d8_debug.h"
+
+WrappedD3DDevice8::WrappedD3DDevice8(IDirect3DDevice8 *device, HWND wnd,
+                                     D3DPRESENT_PARAMETERS *pPresentationParameters)
+    : m_RefCounter(device, false),
+      m_SoftRefCounter(NULL, false),
+      m_device(device),
+      m_DebugManager(NULL),
+      m_PresentParameters(*pPresentationParameters)
+{
+  m_FrameCounter = 0;
+
+  // refcounters implicitly construct with one reference, but we don't start with any soft
+  // references.
+  m_SoftRefCounter.Release();
+  m_InternalRefcount = 0;
+  m_Alive = true;
+
+  if(!RenderDoc::Inst().IsReplayApp())
+  {
+    RenderDoc::Inst().AddDeviceFrameCapturer((IDirect3DDevice8 *)this, this);
+
+    m_Wnd = wnd;
+
+    if(wnd != NULL)
+      RenderDoc::Inst().AddFrameCapturer((IDirect3DDevice8 *)this, wnd, this);
+  }
+}
+
+void WrappedD3DDevice8::CheckForDeath()
+{
+  if(!m_Alive)
+    return;
+
+  if(m_RefCounter.GetRefCount() == 0)
+  {
+    RDCASSERT(m_SoftRefCounter.GetRefCount() >= m_InternalRefcount);
+
+    if(m_SoftRefCounter.GetRefCount() <= m_InternalRefcount)
+    {
+      m_Alive = false;
+      delete this;
+    }
+  }
+}
+
+WrappedD3DDevice8::~WrappedD3DDevice8()
+{
+  RenderDoc::Inst().RemoveDeviceFrameCapturer((IDirect3DDevice8 *)this);
+
+  if(m_Wnd != NULL)
+    RenderDoc::Inst().RemoveFrameCapturer((IDirect3DDevice8 *)this, m_Wnd);
+
+  SAFE_DELETE(m_DebugManager);
+
+  SAFE_RELEASE(m_device);
+}
+
+HRESULT WrappedD3DDevice8::QueryInterface(REFIID riid, void **ppvObject)
+{
+  // RenderDoc UUID {A7AA6116-9C8D-4BBA-9083-B4D816B71B78}
+  static const GUID IRenderDoc_uuid = {
+      0xa7aa6116, 0x9c8d, 0x4bba, {0x90, 0x83, 0xb4, 0xd8, 0x16, 0xb7, 0x1b, 0x78}};
+
+  if(riid == IRenderDoc_uuid)
+  {
+    AddRef();
+    *ppvObject = (IUnknown *)this;
+    return S_OK;
+  }
+  else
+  {
+    string guid = ToStr::Get(riid);
+    RDCWARN("Querying IDirect3DDevice8 for interface: %s", guid.c_str());
+  }
+
+  return m_device->QueryInterface(riid, ppvObject);
+}
+
+void WrappedD3DDevice8::LazyInit()
+{
+  m_DebugManager = new D3D8DebugManager(this);
+}
+
+void WrappedD3DDevice8::StartFrameCapture(void *dev, void *wnd)
+{
+  RDCERR("Capture not supported on D3D8");
+}
+
+bool WrappedD3DDevice8::EndFrameCapture(void *dev, void *wnd)
+{
+  RDCERR("Capture not supported on D3D8");
+  return false;
+}
+
+HRESULT __stdcall WrappedD3DDevice8::TestCooperativeLevel()
+{
+  return m_device->TestCooperativeLevel();
+}
+
+UINT __stdcall WrappedD3DDevice8::GetAvailableTextureMem()
+{
+  return m_device->GetAvailableTextureMem();
+}
+
+HRESULT __stdcall WrappedD3DDevice8::ResourceManagerDiscardBytes(DWORD Bytes)
+{
+  return m_device->ResourceManagerDiscardBytes(Bytes);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetDirect3D(IDirect3D8 **ppD3D8)
+{
+  return m_device->GetDirect3D(ppD3D8);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetDeviceCaps(D3DCAPS8 *pCaps)
+{
+  return m_device->GetDeviceCaps(pCaps);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetDisplayMode(D3DDISPLAYMODE *pMode)
+{
+  return m_device->GetDisplayMode(pMode);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS *pParameters)
+{
+  return m_device->GetCreationParameters(pParameters);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetCursorProperties(UINT XHotSpot, UINT YHotSpot,
+                                                         IDirect3DSurface8 *pCursorBitmap)
+{
+  return m_device->SetCursorProperties(XHotSpot, YHotSpot, pCursorBitmap);
+}
+
+void __stdcall WrappedD3DDevice8::SetCursorPosition(int X, int Y, DWORD Flags)
+{
+  m_device->SetCursorPosition(X, Y, Flags);
+}
+
+BOOL __stdcall WrappedD3DDevice8::ShowCursor(BOOL bShow)
+{
+  return m_device->ShowCursor(bShow);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateAdditionalSwapChain(
+    D3DPRESENT_PARAMETERS *pPresentationParameters, IDirect3DSwapChain8 **pSwapChain)
+{
+  return m_device->CreateAdditionalSwapChain(pPresentationParameters, pSwapChain);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::Reset(D3DPRESENT_PARAMETERS *pPresentationParameters)
+{
+  m_PresentParameters = *pPresentationParameters;
+  return m_device->Reset(pPresentationParameters);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::Present(CONST RECT *pSourceRect, CONST RECT *pDestRect,
+                                             HWND hDestWindowOverride, CONST RGNDATA *pDirtyRegion)
+{
+  // if(m_State == WRITING_IDLE)
+  RenderDoc::Inst().Tick();
+
+  HWND wnd = m_PresentParameters.hDeviceWindow;
+  if(hDestWindowOverride != NULL)
+    wnd = hDestWindowOverride;
+
+  bool activeWindow = RenderDoc::Inst().IsActiveWindow((IDirect3DDevice8 *)this, wnd);
+
+  m_FrameCounter++;
+
+  // if (m_State == WRITING_IDLE)
+  {
+    uint32_t overlay = RenderDoc::Inst().GetOverlayBits();
+
+    static bool debugRenderOverlay = true;
+
+    if(overlay & eRENDERDOC_Overlay_Enabled && debugRenderOverlay)
+    {
+      HRESULT res = S_OK;
+      res = m_device->BeginScene();
+      DWORD stateBlock;
+      HRESULT stateBlockRes = m_device->CreateStateBlock(D3DSBT_ALL, &stateBlock);
+
+      IDirect3DSurface8 *backBuffer;
+      res |= m_device->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &backBuffer);
+      res |= m_device->SetRenderTarget(0, backBuffer);
+
+      D3DSURFACE_DESC bbDesc;
+      backBuffer->GetDesc(&bbDesc);
+
+      //
+      D3DVIEWPORT8 viewport = {0, 0, bbDesc.Width, bbDesc.Height, 0.f, 1.f};
+      res |= m_device->SetViewport(&viewport);
+
+      GetDebugManager()->SetOutputDimensions(bbDesc.Width, bbDesc.Height);
+      GetDebugManager()->SetOutputWindow(m_PresentParameters.hDeviceWindow);
+
+      int flags = activeWindow ? RenderDoc::eOverlay_ActiveWindow : 0;
+      flags |= RenderDoc::eOverlay_CaptureDisabled;
+
+      string overlayText = RenderDoc::Inst().GetOverlayText(RDC_D3D8, m_FrameCounter, flags);
+
+      overlayText += "Captures not supported with D3D8\n";
+
+      if(!overlayText.empty())
+        GetDebugManager()->RenderText(0.0f, 0.0f, overlayText.c_str());
+
+      stateBlockRes = m_device->ApplyStateBlock(stateBlock);
+      res |= m_device->EndScene();
+    }
+  }
+
+  if(activeWindow)
+  {
+    RenderDoc::Inst().SetCurrentDriver(RDC_D3D8);
+  }
+
+  return m_device->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type,
+                                                   IDirect3DSurface8 **ppBackBuffer)
+{
+  return m_device->GetBackBuffer(iBackBuffer, Type, ppBackBuffer);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetRasterStatus(D3DRASTER_STATUS *pRasterStatus)
+{
+  return m_device->GetRasterStatus(pRasterStatus);
+}
+
+void __stdcall WrappedD3DDevice8::SetGammaRamp(DWORD Flags, CONST D3DGAMMARAMP *pRamp)
+{
+  m_device->SetGammaRamp(Flags, pRamp);
+}
+
+void __stdcall WrappedD3DDevice8::GetGammaRamp(D3DGAMMARAMP *pRamp)
+{
+  m_device->GetGammaRamp(pRamp);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateTexture(UINT Width, UINT Height, UINT Levels,
+                                                   DWORD Usage, D3DFORMAT Format, D3DPOOL Pool,
+                                                   IDirect3DTexture8 **ppTexture)
+{
+  return m_device->CreateTexture(Width, Height, Levels, Usage, Format, Pool, ppTexture);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateVolumeTexture(UINT Width, UINT Height, UINT Depth,
+                                                         UINT Levels, DWORD Usage, D3DFORMAT Format,
+                                                         D3DPOOL Pool,
+                                                         IDirect3DVolumeTexture8 **ppVolumeTexture)
+{
+  return m_device->CreateVolumeTexture(Width, Height, Depth, Levels, Usage, Format, Pool,
+                                       ppVolumeTexture);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage,
+                                                       D3DFORMAT Format, D3DPOOL Pool,
+                                                       IDirect3DCubeTexture8 **ppCubeTexture)
+{
+  return m_device->CreateCubeTexture(EdgeLength, Levels, Usage, Format, Pool, ppCubeTexture);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF,
+                                                        D3DPOOL Pool,
+                                                        IDirect3DVertexBuffer8 **ppVertexBuffer)
+{
+  return m_device->CreateVertexBuffer(Length, Usage, FVF, Pool, ppVertexBuffer);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format,
+                                                       D3DPOOL Pool,
+                                                       IDirect3DIndexBuffer8 **ppIndexBuffer)
+{
+  return m_device->CreateIndexBuffer(Length, Usage, Format, Pool, ppIndexBuffer);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format,
+                                                        D3DMULTISAMPLE_TYPE MultiSample,
+                                                        BOOL Lockable, IDirect3DSurface8 **ppSurface)
+{
+  return m_device->CreateRenderTarget(Width, Height, Format, MultiSample, Lockable, ppSurface);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateDepthStencilSurface(UINT Width, UINT Height,
+                                                               D3DFORMAT Format,
+                                                               D3DMULTISAMPLE_TYPE MultiSample,
+                                                               IDirect3DSurface8 **ppSurface)
+{
+  return m_device->CreateDepthStencilSurface(Width, Height, Format, MultiSample, ppSurface);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format,
+                                                        IDirect3DSurface8 **ppSurface)
+{
+  return m_device->CreateImageSurface(Width, Height, Format, ppSurface);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CopyRects(IDirect3DSurface8 *pSourceSurface,
+                                               CONST RECT *pSourceRectsArray, UINT NumRects,
+                                               IDirect3DSurface8 *pDestinationSurface,
+                                               CONST POINT *pDestPointsArray)
+{
+  return m_device->CopyRects(pSourceSurface, pSourceRectsArray, NumRects, pDestinationSurface,
+                             pDestPointsArray);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::UpdateTexture(IDirect3DBaseTexture8 *pSourceTexture,
+                                                   IDirect3DBaseTexture8 *pDestinationTexture)
+{
+  return m_device->UpdateTexture(pSourceTexture, pDestinationTexture);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetFrontBuffer(IDirect3DSurface8 *pDestSurface)
+{
+  return m_device->GetFrontBuffer(pDestSurface);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetRenderTarget(IDirect3DSurface8 *pRenderTarget,
+                                                     IDirect3DSurface8 *pNewZStencil)
+{
+  return m_device->SetRenderTarget(pRenderTarget, pNewZStencil);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetRenderTarget(IDirect3DSurface8 **ppRenderTarget)
+{
+  return m_device->GetRenderTarget(ppRenderTarget);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetDepthStencilSurface(IDirect3DSurface8 **ppZStencilSurface)
+{
+  return m_device->GetDepthStencilSurface(ppZStencilSurface);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::BeginScene()
+{
+  return m_device->BeginScene();
+}
+
+HRESULT __stdcall WrappedD3DDevice8::EndScene()
+{
+  return m_device->EndScene();
+}
+
+HRESULT __stdcall WrappedD3DDevice8::Clear(DWORD Count, CONST D3DRECT *pRects, DWORD Flags,
+                                           D3DCOLOR Color, float Z, DWORD Stencil)
+{
+  return m_device->Clear(Count, pRects, Flags, Color, Z, Stencil);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetTransform(D3DTRANSFORMSTATETYPE State,
+                                                  CONST D3DMATRIX *pMatrix)
+{
+  return m_device->SetTransform(State, pMatrix);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix)
+{
+  return m_device->GetTransform(State, pMatrix);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::MultiplyTransform(D3DTRANSFORMSTATETYPE _arg1,
+                                                       CONST D3DMATRIX *_arg2)
+{
+  return m_device->MultiplyTransform(_arg1, _arg2);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetViewport(CONST D3DVIEWPORT8 *pViewport)
+{
+  return m_device->SetViewport(pViewport);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetViewport(D3DVIEWPORT8 *pViewport)
+{
+  return m_device->GetViewport(pViewport);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetMaterial(CONST D3DMATERIAL8 *pMaterial)
+{
+  return m_device->SetMaterial(pMaterial);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetMaterial(D3DMATERIAL8 *pMaterial)
+{
+  return m_device->GetMaterial(pMaterial);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetLight(DWORD Index, CONST D3DLIGHT8 *_arg2)
+{
+  return m_device->SetLight(Index, _arg2);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetLight(DWORD Index, D3DLIGHT8 *_arg2)
+{
+  return m_device->GetLight(Index, _arg2);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::LightEnable(DWORD Index, BOOL Enable)
+{
+  return m_device->LightEnable(Index, Enable);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetLightEnable(DWORD Index, BOOL *pEnable)
+{
+  return m_device->GetLightEnable(Index, pEnable);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetClipPlane(DWORD Index, CONST float *pPlane)
+{
+  return m_device->SetClipPlane(Index, pPlane);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetClipPlane(DWORD Index, float *pPlane)
+{
+  return m_device->GetClipPlane(Index, pPlane);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value)
+{
+  return m_device->SetRenderState(State, Value);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue)
+{
+  return m_device->GetRenderState(State, pValue);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::BeginStateBlock()
+{
+  return m_device->BeginStateBlock();
+}
+
+HRESULT __stdcall WrappedD3DDevice8::EndStateBlock(DWORD *pToken)
+{
+  return m_device->EndStateBlock(pToken);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::ApplyStateBlock(DWORD Token)
+{
+  return m_device->ApplyStateBlock(Token);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CaptureStateBlock(DWORD Token)
+{
+  return m_device->CaptureStateBlock(Token);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DeleteStateBlock(DWORD Token)
+{
+  return m_device->DeleteStateBlock(Token);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateStateBlock(D3DSTATEBLOCKTYPE Type, DWORD *pToken)
+{
+  return m_device->CreateStateBlock(Type, pToken);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetClipStatus(CONST D3DCLIPSTATUS8 *pClipStatus)
+{
+  return m_device->SetClipStatus(pClipStatus);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetClipStatus(D3DCLIPSTATUS8 *pClipStatus)
+{
+  return m_device->GetClipStatus(pClipStatus);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetTexture(DWORD Stage, IDirect3DBaseTexture8 **ppTexture)
+{
+  return m_device->GetTexture(Stage, ppTexture);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetTexture(DWORD Stage, IDirect3DBaseTexture8 *pTexture)
+{
+  return m_device->SetTexture(Stage, pTexture);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type,
+                                                          DWORD *pValue)
+{
+  return m_device->GetTextureStageState(Stage, Type, pValue);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetTextureStageState(DWORD Stage,
+                                                          D3DTEXTURESTAGESTATETYPE Type, DWORD Value)
+{
+  return m_device->SetTextureStageState(Stage, Type, Value);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::ValidateDevice(DWORD *pNumPasses)
+{
+  return m_device->ValidateDevice(pNumPasses);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetInfo(DWORD DevInfoID, void *pDevInfoStruct,
+                                             DWORD DevInfoStructSize)
+{
+  return m_device->GetInfo(DevInfoID, pDevInfoStruct, DevInfoStructSize);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetPaletteEntries(UINT PaletteNumber,
+                                                       CONST PALETTEENTRY *pEntries)
+{
+  return m_device->SetPaletteEntries(PaletteNumber, pEntries);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY *pEntries)
+{
+  return m_device->GetPaletteEntries(PaletteNumber, pEntries);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetCurrentTexturePalette(UINT PaletteNumber)
+{
+  return m_device->SetCurrentTexturePalette(PaletteNumber);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetCurrentTexturePalette(UINT *PaletteNumber)
+{
+  return m_device->GetCurrentTexturePalette(PaletteNumber);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex,
+                                                   UINT PrimitiveCount)
+{
+  return m_device->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DrawIndexedPrimitive(D3DPRIMITIVETYPE _arg1,
+                                                          UINT MinVertexIndex, UINT NumVertices,
+                                                          UINT startIndex, UINT primCount)
+{
+  return m_device->DrawIndexedPrimitive(_arg1, MinVertexIndex, NumVertices, startIndex, primCount);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType,
+                                                     UINT PrimitiveCount,
+                                                     CONST void *pVertexStreamZeroData,
+                                                     UINT VertexStreamZeroStride)
+{
+  return m_device->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData,
+                                   VertexStreamZeroStride);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DrawIndexedPrimitiveUP(
+    D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount,
+    CONST void *pIndexData, D3DFORMAT IndexDataFormat, CONST void *pVertexStreamZeroData,
+    UINT VertexStreamZeroStride)
+{
+  return m_device->DrawIndexedPrimitiveUP(PrimitiveType, MinVertexIndex, NumVertices,
+                                          PrimitiveCount, pIndexData, IndexDataFormat,
+                                          pVertexStreamZeroData, VertexStreamZeroStride);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::ProcessVertices(UINT SrcStartIndex, UINT DestIndex,
+                                                     UINT VertexCount,
+                                                     IDirect3DVertexBuffer8 *pDestBuffer, DWORD Flags)
+{
+  return m_device->ProcessVertices(SrcStartIndex, DestIndex, VertexCount, pDestBuffer, Flags);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreateVertexShader(CONST DWORD *pDeclaration,
+                                                        CONST DWORD *pFunction, DWORD *pHandle,
+                                                        DWORD Usage)
+{
+  return m_device->CreateVertexShader(pDeclaration, pFunction, pHandle, Usage);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetVertexShader(DWORD Handle)
+{
+  return m_device->SetVertexShader(Handle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetVertexShader(DWORD *pHandle)
+{
+  return m_device->GetVertexShader(pHandle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DeleteVertexShader(DWORD Handle)
+{
+  return m_device->DeleteVertexShader(Handle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetVertexShaderConstant(DWORD Register,
+                                                             CONST void *pConstantData,
+                                                             DWORD ConstantCount)
+{
+  return m_device->SetVertexShaderConstant(Register, pConstantData, ConstantCount);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetVertexShaderConstant(DWORD Register, void *pConstantData,
+                                                             DWORD ConstantCount)
+{
+  return m_device->GetVertexShaderConstant(Register, pConstantData, ConstantCount);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetVertexShaderDeclaration(DWORD Handle, void *pData,
+                                                                DWORD *pSizeOfData)
+{
+  return m_device->GetVertexShaderDeclaration(Handle, pData, pSizeOfData);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetVertexShaderFunction(DWORD Handle, void *pData,
+                                                             DWORD *pSizeOfData)
+{
+  return m_device->GetVertexShaderFunction(Handle, pData, pSizeOfData);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetStreamSource(UINT StreamNumber,
+                                                     IDirect3DVertexBuffer8 *pStreamData, UINT Stride)
+{
+  return m_device->SetStreamSource(StreamNumber, pStreamData, Stride);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetStreamSource(UINT StreamNumber,
+                                                     IDirect3DVertexBuffer8 **ppStreamData,
+                                                     UINT *pStride)
+{
+  return m_device->GetStreamSource(StreamNumber, ppStreamData, pStride);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetIndices(IDirect3DIndexBuffer8 *pIndexData,
+                                                UINT BaseVertexIndex)
+{
+  return m_device->SetIndices(pIndexData, BaseVertexIndex);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetIndices(IDirect3DIndexBuffer8 **ppIndexData,
+                                                UINT *pBaseVertexIndex)
+{
+  return m_device->GetIndices(ppIndexData, pBaseVertexIndex);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::CreatePixelShader(CONST DWORD *pFunction, DWORD *pHandle)
+{
+  return m_device->CreatePixelShader(pFunction, pHandle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetPixelShader(DWORD Handle)
+{
+  return m_device->SetPixelShader(Handle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetPixelShader(DWORD *pHandle)
+{
+  return m_device->GetPixelShader(pHandle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DeletePixelShader(DWORD Handle)
+{
+  return m_device->DeletePixelShader(Handle);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::SetPixelShaderConstant(DWORD Register, CONST void *pConstantData,
+                                                            DWORD ConstantCount)
+{
+  return m_device->SetPixelShaderConstant(Register, pConstantData, ConstantCount);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetPixelShaderConstant(DWORD Register, void *pConstantData,
+                                                            DWORD ConstantCount)
+{
+  return m_device->GetPixelShaderConstant(Register, pConstantData, ConstantCount);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::GetPixelShaderFunction(DWORD Handle, void *pData,
+                                                            DWORD *pSizeOfData)
+{
+  return m_device->GetPixelShaderFunction(Handle, pData, pSizeOfData);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DrawRectPatch(UINT Handle, CONST float *pNumSegs,
+                                                   CONST D3DRECTPATCH_INFO *pRectPatchInfo)
+{
+  return m_device->DrawRectPatch(Handle, pNumSegs, pRectPatchInfo);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DrawTriPatch(UINT Handle, CONST float *pNumSegs,
+                                                  CONST D3DTRIPATCH_INFO *pTriPatchInfo)
+{
+  return m_device->DrawTriPatch(Handle, pNumSegs, pTriPatchInfo);
+}
+
+HRESULT __stdcall WrappedD3DDevice8::DeletePatch(UINT Handle)
+{
+  return m_device->DeletePatch(Handle);
+}
+
+HRESULT __stdcall WrappedD3D8::QueryInterface(REFIID riid, void **ppvObj)
+{
+  return m_direct3D->QueryInterface(riid, ppvObj);
+}
+
+ULONG __stdcall WrappedD3D8::AddRef()
+{
+  ULONG refCount;
+  refCount = m_direct3D->AddRef();
+  return refCount;
+}
+
+ULONG __stdcall WrappedD3D8::Release()
+{
+  ULONG refCount = m_direct3D->Release();
+  if(refCount == 0)
+  {
+    delete this;
+  }
+  return refCount;
+}
+
+HRESULT __stdcall WrappedD3D8::RegisterSoftwareDevice(void *pInitializeFunction)
+{
+  return m_direct3D->RegisterSoftwareDevice(pInitializeFunction);
+}
+
+UINT __stdcall WrappedD3D8::GetAdapterCount()
+{
+  return m_direct3D->GetAdapterCount();
+}
+
+HRESULT __stdcall WrappedD3D8::GetAdapterIdentifier(UINT Adapter, DWORD Flags,
+                                                    D3DADAPTER_IDENTIFIER8 *pIdentifier)
+{
+  return m_direct3D->GetAdapterIdentifier(Adapter, Flags, pIdentifier);
+}
+
+UINT __stdcall WrappedD3D8::GetAdapterModeCount(UINT Adapter)
+{
+  return m_direct3D->GetAdapterModeCount(Adapter);
+}
+
+HRESULT __stdcall WrappedD3D8::EnumAdapterModes(UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode)
+{
+  return m_direct3D->EnumAdapterModes(Adapter, Mode, pMode);
+}
+
+HRESULT __stdcall WrappedD3D8::GetAdapterDisplayMode(UINT Adapter, D3DDISPLAYMODE *pMode)
+{
+  return m_direct3D->GetAdapterDisplayMode(Adapter, pMode);
+}
+
+HRESULT __stdcall WrappedD3D8::CheckDeviceType(UINT Adapter, D3DDEVTYPE DevType,
+                                               D3DFORMAT AdapterFormat, D3DFORMAT BackBufferFormat,
+                                               BOOL bWindowed)
+{
+  return m_direct3D->CheckDeviceType(Adapter, DevType, AdapterFormat, BackBufferFormat, bWindowed);
+}
+
+HRESULT __stdcall WrappedD3D8::CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType,
+                                                 D3DFORMAT AdapterFormat, DWORD Usage,
+                                                 D3DRESOURCETYPE RType, D3DFORMAT CheckFormat)
+{
+  return m_direct3D->CheckDeviceFormat(Adapter, DeviceType, AdapterFormat, Usage, RType, CheckFormat);
+}
+
+HRESULT __stdcall WrappedD3D8::CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType,
+                                                          D3DFORMAT SurfaceFormat, BOOL Windowed,
+                                                          D3DMULTISAMPLE_TYPE MultiSampleType)
+{
+  return m_direct3D->CheckDeviceMultiSampleType(Adapter, DeviceType, SurfaceFormat, Windowed,
+                                                MultiSampleType);
+}
+
+HRESULT __stdcall WrappedD3D8::CheckDepthStencilMatch(UINT Adapter, D3DDEVTYPE DeviceType,
+                                                      D3DFORMAT AdapterFormat,
+                                                      D3DFORMAT RenderTargetFormat,
+                                                      D3DFORMAT DepthStencilFormat)
+{
+  return m_direct3D->CheckDepthStencilMatch(Adapter, DeviceType, AdapterFormat, RenderTargetFormat,
+                                            DepthStencilFormat);
+}
+
+HRESULT __stdcall WrappedD3D8::GetDeviceCaps(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS8 *pCaps)
+{
+  return m_direct3D->GetDeviceCaps(Adapter, DeviceType, pCaps);
+}
+
+HMONITOR __stdcall WrappedD3D8::GetAdapterMonitor(UINT Adapter)
+{
+  return m_direct3D->GetAdapterMonitor(Adapter);
+}
+
+HRESULT __stdcall WrappedD3D8::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow,
+                                            DWORD BehaviorFlags,
+                                            D3DPRESENT_PARAMETERS *pPresentationParameters,
+                                            IDirect3DDevice8 **ppReturnedDeviceInterface)
+{
+  IDirect3DDevice8 *device = NULL;
+  HRESULT res = m_direct3D->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags,
+                                         pPresentationParameters, &device);
+  if(res == S_OK)
+  {
+    RDCLOG("App creating d3d8 device");
+
+    HWND wnd = pPresentationParameters->hDeviceWindow;
+    if(wnd == NULL)
+      wnd = hFocusWindow;
+
+    if(!wnd)
+      RDCWARN("Couldn't find valid non-NULL window at CreateDevice time");
+
+    WrappedD3DDevice8 *wrappedDevice = new WrappedD3DDevice8(device, wnd, pPresentationParameters);
+    wrappedDevice->LazyInit();    // TODO this can be moved later probably
+    *ppReturnedDeviceInterface = wrappedDevice;
+  }
+  else
+  {
+    *ppReturnedDeviceInterface = NULL;
+  }
+  return res;
+}

--- a/renderdoc/driver/d3d8/d3d8_device.h
+++ b/renderdoc/driver/d3d8/d3d8_device.h
@@ -1,0 +1,264 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+#include "common/timing.h"
+#include "d3d8_common.h"
+
+class D3D8DebugManager;
+
+class WrappedD3DDevice8 : public IDirect3DDevice8, public IFrameCapturer
+{
+public:
+  WrappedD3DDevice8(IDirect3DDevice8 *device, HWND wnd,
+                    D3DPRESENT_PARAMETERS *pPresentationParameters);
+  ~WrappedD3DDevice8();
+
+  void LazyInit();
+
+  void StartFrameCapture(void *dev, void *wnd);
+  bool EndFrameCapture(void *dev, void *wnd);
+
+  void InternalRef() { InterlockedIncrement(&m_InternalRefcount); }
+  void InternalRelease() { InterlockedDecrement(&m_InternalRefcount); }
+  void SoftRef() { m_SoftRefCounter.AddRef(); }
+  void SoftRelease()
+  {
+    m_SoftRefCounter.Release();
+    CheckForDeath();
+  }
+
+  D3D8DebugManager *GetDebugManager() { return m_DebugManager; }
+  /*** IUnknown methods ***/
+  ULONG STDMETHODCALLTYPE AddRef() { return m_RefCounter.AddRef(); }
+  ULONG STDMETHODCALLTYPE Release()
+  {
+    unsigned int ret = m_RefCounter.Release();
+    CheckForDeath();
+    return ret;
+  }
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject);
+
+  /*** IDirect3DDevice8 methods ***/
+  virtual HRESULT __stdcall TestCooperativeLevel();
+  virtual UINT __stdcall GetAvailableTextureMem();
+  virtual HRESULT __stdcall ResourceManagerDiscardBytes(DWORD Bytes);
+  virtual HRESULT __stdcall GetDirect3D(IDirect3D8 **ppD3D8);
+  virtual HRESULT __stdcall GetDeviceCaps(D3DCAPS8 *pCaps);
+  virtual HRESULT __stdcall GetDisplayMode(D3DDISPLAYMODE *pMode);
+  virtual HRESULT __stdcall GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS *pParameters);
+  virtual HRESULT __stdcall SetCursorProperties(UINT XHotSpot, UINT YHotSpot,
+                                                IDirect3DSurface8 *pCursorBitmap);
+  virtual void __stdcall SetCursorPosition(int X, int Y, DWORD Flags);
+  virtual BOOL __stdcall ShowCursor(BOOL bShow);
+  virtual HRESULT __stdcall CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS *pPresentationParameters,
+                                                      IDirect3DSwapChain8 **pSwapChain);
+  virtual HRESULT __stdcall Reset(D3DPRESENT_PARAMETERS *pPresentationParameters);
+  virtual HRESULT __stdcall Present(CONST RECT *pSourceRect, CONST RECT *pDestRect,
+                                    HWND hDestWindow, CONST RGNDATA *pDirtyRegion);
+  virtual HRESULT __stdcall GetBackBuffer(UINT iBackBuffer, D3DBACKBUFFER_TYPE Type,
+                                          IDirect3DSurface8 **ppBackBuffer);
+  virtual HRESULT __stdcall GetRasterStatus(D3DRASTER_STATUS *pRasterStatus);
+  virtual void __stdcall SetGammaRamp(DWORD Flags, CONST D3DGAMMARAMP *pRamp);
+  virtual void __stdcall GetGammaRamp(D3DGAMMARAMP *pRamp);
+  virtual HRESULT __stdcall CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage,
+                                          D3DFORMAT Format, D3DPOOL Pool,
+                                          IDirect3DTexture8 **ppTexture);
+  virtual HRESULT __stdcall CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels,
+                                                DWORD Usage, D3DFORMAT Format, D3DPOOL Pool,
+                                                IDirect3DVolumeTexture8 **ppVolumeTexture);
+  virtual HRESULT __stdcall CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage,
+                                              D3DFORMAT Format, D3DPOOL Pool,
+                                              IDirect3DCubeTexture8 **ppCubeTexture);
+  virtual HRESULT __stdcall CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool,
+                                               IDirect3DVertexBuffer8 **ppVertexBuffer);
+  virtual HRESULT __stdcall CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format,
+                                              D3DPOOL Pool, IDirect3DIndexBuffer8 **ppIndexBuffer);
+  virtual HRESULT __stdcall CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format,
+                                               D3DMULTISAMPLE_TYPE MultiSample, BOOL Lockable,
+                                               IDirect3DSurface8 **ppSurface);
+  virtual HRESULT __stdcall CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format,
+                                                      D3DMULTISAMPLE_TYPE MultiSample,
+                                                      IDirect3DSurface8 **ppSurface);
+  virtual HRESULT __stdcall CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format,
+                                               IDirect3DSurface8 **ppSurface);
+  virtual HRESULT __stdcall CopyRects(IDirect3DSurface8 *pSourceSurface,
+                                      CONST RECT *pSourceRectsArray, UINT NumRects,
+                                      IDirect3DSurface8 *pDestinationSurface,
+                                      CONST POINT *pDestPointsArray);
+  virtual HRESULT __stdcall UpdateTexture(IDirect3DBaseTexture8 *pSourceTexture,
+                                          IDirect3DBaseTexture8 *pDestinationTexture);
+  virtual HRESULT __stdcall GetFrontBuffer(IDirect3DSurface8 *pDestSurface);
+  virtual HRESULT __stdcall SetRenderTarget(IDirect3DSurface8 *pRenderTarget,
+                                            IDirect3DSurface8 *pNewZStencil);
+  virtual HRESULT __stdcall GetRenderTarget(IDirect3DSurface8 **ppRenderTarget);
+  virtual HRESULT __stdcall GetDepthStencilSurface(IDirect3DSurface8 **ppZStencilSurface);
+  virtual HRESULT __stdcall BeginScene();
+  virtual HRESULT __stdcall EndScene();
+  virtual HRESULT __stdcall Clear(DWORD Count, CONST D3DRECT *pRects, DWORD Flags, D3DCOLOR Color,
+                                  float Z, DWORD Stencil);
+  virtual HRESULT __stdcall SetTransform(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX *pMatrix);
+  virtual HRESULT __stdcall GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix);
+  virtual HRESULT __stdcall MultiplyTransform(D3DTRANSFORMSTATETYPE, CONST D3DMATRIX *);
+  virtual HRESULT __stdcall SetViewport(CONST D3DVIEWPORT8 *pViewport);
+  virtual HRESULT __stdcall GetViewport(D3DVIEWPORT8 *pViewport);
+  virtual HRESULT __stdcall SetMaterial(CONST D3DMATERIAL8 *pMaterial);
+  virtual HRESULT __stdcall GetMaterial(D3DMATERIAL8 *pMaterial);
+  virtual HRESULT __stdcall SetLight(DWORD Index, CONST D3DLIGHT8 *);
+  virtual HRESULT __stdcall GetLight(DWORD Index, D3DLIGHT8 *);
+  virtual HRESULT __stdcall LightEnable(DWORD Index, BOOL Enable);
+  virtual HRESULT __stdcall GetLightEnable(DWORD Index, BOOL *pEnable);
+  virtual HRESULT __stdcall SetClipPlane(DWORD Index, CONST float *pPlane);
+  virtual HRESULT __stdcall GetClipPlane(DWORD Index, float *pPlane);
+  virtual HRESULT __stdcall SetRenderState(D3DRENDERSTATETYPE State, DWORD Value);
+  virtual HRESULT __stdcall GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue);
+  virtual HRESULT __stdcall BeginStateBlock();
+  virtual HRESULT __stdcall EndStateBlock(DWORD *pToken);
+  virtual HRESULT __stdcall ApplyStateBlock(DWORD Token);
+  virtual HRESULT __stdcall CaptureStateBlock(DWORD Token);
+  virtual HRESULT __stdcall DeleteStateBlock(DWORD Token);
+  virtual HRESULT __stdcall CreateStateBlock(D3DSTATEBLOCKTYPE Type, DWORD *pToken);
+  virtual HRESULT __stdcall SetClipStatus(CONST D3DCLIPSTATUS8 *pClipStatus);
+  virtual HRESULT __stdcall GetClipStatus(D3DCLIPSTATUS8 *pClipStatus);
+  virtual HRESULT __stdcall GetTexture(DWORD Stage, IDirect3DBaseTexture8 **ppTexture);
+  virtual HRESULT __stdcall SetTexture(DWORD Stage, IDirect3DBaseTexture8 *pTexture);
+  virtual HRESULT __stdcall GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type,
+                                                 DWORD *pValue);
+  virtual HRESULT __stdcall SetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type,
+                                                 DWORD Value);
+  virtual HRESULT __stdcall ValidateDevice(DWORD *pNumPasses);
+  virtual HRESULT __stdcall GetInfo(DWORD DevInfoID, void *pDevInfoStruct, DWORD DevInfoStructSize);
+  virtual HRESULT __stdcall SetPaletteEntries(UINT PaletteNumber, CONST PALETTEENTRY *pEntries);
+  virtual HRESULT __stdcall GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY *pEntries);
+  virtual HRESULT __stdcall SetCurrentTexturePalette(UINT PaletteNumber);
+  virtual HRESULT __stdcall GetCurrentTexturePalette(UINT *PaletteNumber);
+  virtual HRESULT __stdcall DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex,
+                                          UINT PrimitiveCount);
+  virtual HRESULT __stdcall DrawIndexedPrimitive(D3DPRIMITIVETYPE, UINT MinVertexIndex,
+                                                 UINT NumVertices, UINT startIndex, UINT primCount);
+  virtual HRESULT __stdcall DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount,
+                                            CONST void *pVertexStreamZeroData,
+                                            UINT VertexStreamZeroStride);
+  virtual HRESULT __stdcall DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType,
+                                                   UINT MinVertexIndex, UINT NumVertices,
+                                                   UINT PrimitiveCount, CONST void *pIndexData,
+                                                   D3DFORMAT IndexDataFormat,
+                                                   CONST void *pVertexStreamZeroData,
+                                                   UINT VertexStreamZeroStride);
+  virtual HRESULT __stdcall ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount,
+                                            IDirect3DVertexBuffer8 *pDestBuffer, DWORD Flags);
+  virtual HRESULT __stdcall CreateVertexShader(CONST DWORD *pDeclaration, CONST DWORD *pFunction,
+                                               DWORD *pHandle, DWORD Usage);
+  virtual HRESULT __stdcall SetVertexShader(DWORD Handle);
+  virtual HRESULT __stdcall GetVertexShader(DWORD *pHandle);
+  virtual HRESULT __stdcall DeleteVertexShader(DWORD HHandle);
+  virtual HRESULT __stdcall SetVertexShaderConstant(DWORD Register, CONST void *pConstantData,
+                                                    DWORD ConstantCount);
+  virtual HRESULT __stdcall GetVertexShaderConstant(DWORD Register, void *pConstantData,
+                                                    DWORD ConstantCount);
+  virtual HRESULT __stdcall GetVertexShaderDeclaration(DWORD Handle, void *pData, DWORD *pSizeOfData);
+  virtual HRESULT __stdcall GetVertexShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData);
+  virtual HRESULT __stdcall SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8 *pStreamData,
+                                            UINT Stride);
+  virtual HRESULT __stdcall GetStreamSource(UINT StreamNumber,
+                                            IDirect3DVertexBuffer8 **ppStreamData, UINT *pStride);
+  virtual HRESULT __stdcall SetIndices(IDirect3DIndexBuffer8 *pIndexData, UINT BaseVertexIndex);
+  virtual HRESULT __stdcall GetIndices(IDirect3DIndexBuffer8 **ppIndexData, UINT *pBaseVertexIndex);
+  virtual HRESULT __stdcall CreatePixelShader(CONST DWORD *pFunction, DWORD *pHandle);
+  virtual HRESULT __stdcall SetPixelShader(DWORD Handle);
+  virtual HRESULT __stdcall GetPixelShader(DWORD *pHandle);
+  virtual HRESULT __stdcall DeletePixelShader(DWORD Handle);
+  virtual HRESULT __stdcall SetPixelShaderConstant(DWORD Register, CONST void *pConstantData,
+                                                   DWORD ConstantCount);
+  virtual HRESULT __stdcall GetPixelShaderConstant(DWORD Register, void *pConstantData,
+                                                   DWORD ConstantCount);
+  virtual HRESULT __stdcall GetPixelShaderFunction(DWORD Handle, void *pData, DWORD *pSizeOfData);
+  virtual HRESULT __stdcall DrawRectPatch(UINT Handle, CONST float *pNumSegs,
+                                          CONST D3DRECTPATCH_INFO *pRectPatchInfo);
+  virtual HRESULT __stdcall DrawTriPatch(UINT Handle, CONST float *pNumSegs,
+                                         CONST D3DTRIPATCH_INFO *pTriPatchInfo);
+  virtual HRESULT __stdcall DeletePatch(UINT Handle);
+
+private:
+  void CheckForDeath();
+
+  IDirect3DDevice8 *m_device;
+  D3D8DebugManager *m_DebugManager;
+
+  D3DPRESENT_PARAMETERS m_PresentParameters;
+
+  HWND m_Wnd;
+
+  unsigned int m_InternalRefcount;
+  RefCounter8 m_RefCounter;
+  RefCounter8 m_SoftRefCounter;
+  bool m_Alive;
+
+  uint32_t m_FrameCounter;
+};
+
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+// WrappedD3D8
+
+class WrappedD3D8 : public IDirect3D8
+{
+public:
+  WrappedD3D8(IDirect3D8 *direct3D8) : m_direct3D(direct3D8) {}
+  /*** IUnknown methods ***/
+  virtual HRESULT __stdcall QueryInterface(REFIID riid, void **ppvObj);
+  virtual ULONG __stdcall AddRef();
+  virtual ULONG __stdcall Release();
+
+  /*** IDirect3D8 methods ***/
+  virtual HRESULT __stdcall RegisterSoftwareDevice(void *pInitializeFunction);
+  virtual UINT __stdcall GetAdapterCount();
+  virtual HRESULT __stdcall GetAdapterIdentifier(UINT Adapter, DWORD Flags,
+                                                 D3DADAPTER_IDENTIFIER8 *pIdentifier);
+  virtual UINT __stdcall GetAdapterModeCount(UINT Adapter);
+  virtual HRESULT __stdcall EnumAdapterModes(UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode);
+  virtual HRESULT __stdcall GetAdapterDisplayMode(UINT Adapter, D3DDISPLAYMODE *pMode);
+  virtual HRESULT __stdcall CheckDeviceType(UINT Adapter, D3DDEVTYPE DevType, D3DFORMAT AdapterFormat,
+                                            D3DFORMAT BackBufferFormat, BOOL bWindowed);
+  virtual HRESULT __stdcall CheckDeviceFormat(UINT Adapter, D3DDEVTYPE DeviceType,
+                                              D3DFORMAT AdapterFormat, DWORD Usage,
+                                              D3DRESOURCETYPE RType, D3DFORMAT CheckFormat);
+  virtual HRESULT __stdcall CheckDeviceMultiSampleType(UINT Adapter, D3DDEVTYPE DeviceType,
+                                                       D3DFORMAT SurfaceFormat, BOOL Windowed,
+                                                       D3DMULTISAMPLE_TYPE MultiSampleType);
+  virtual HRESULT __stdcall CheckDepthStencilMatch(UINT Adapter, D3DDEVTYPE DeviceType,
+                                                   D3DFORMAT AdapterFormat,
+                                                   D3DFORMAT RenderTargetFormat,
+                                                   D3DFORMAT DepthStencilFormat);
+  virtual HRESULT __stdcall GetDeviceCaps(UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS8 *pCaps);
+  virtual HMONITOR __stdcall GetAdapterMonitor(UINT Adapter);
+  virtual HRESULT __stdcall CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow,
+                                         DWORD BehaviorFlags,
+                                         D3DPRESENT_PARAMETERS *pPresentationParameters,
+                                         IDirect3DDevice8 **ppReturnedDeviceInterface);
+
+private:
+  IDirect3D8 *m_direct3D;
+};

--- a/renderdoc/driver/d3d8/d3d8_hooks.cpp
+++ b/renderdoc/driver/d3d8/d3d8_hooks.cpp
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "driver/dx/official/d3d8.h"
+#include "hooks/hooks.h"
+#include "d3d8_device.h"
+
+#define DLL_NAME "d3d8.dll"
+
+typedef IDirect3D8 *(WINAPI *PFN_D3D8_CREATE)(UINT);
+
+class D3D8Hook : LibraryHook
+{
+public:
+  D3D8Hook()
+  {
+    LibraryHooks::GetInstance().RegisterHook(DLL_NAME, this);
+    m_HasHooks = false;
+    m_EnabledHooks = true;
+  }
+
+  bool CreateHooks(const char *libName)
+  {
+    bool success = true;
+
+    success &= Create8.Initialize("Direct3DCreate8", DLL_NAME, Create8_hook);
+
+    if(!success)
+      return false;
+
+    m_HasHooks = true;
+    m_EnabledHooks = true;
+
+    return true;
+  }
+
+  void EnableHooks(const char *libName, bool enable) { m_EnabledHooks = enable; }
+  void OptionsUpdated(const char *libName) {}
+private:
+  static D3D8Hook d3d8hooks;
+
+  bool m_HasHooks;
+  bool m_EnabledHooks;
+
+  Hook<PFN_D3D8_CREATE> Create8;
+
+  static IDirect3D8 *WINAPI Create8_hook(UINT SDKVersion)
+  {
+    RDCLOG("App creating d3d8 %x", SDKVersion);
+
+    IDirect3D8 *realD3D = d3d8hooks.Create8()(SDKVersion);
+
+    return new WrappedD3D8(realD3D);
+  }
+};
+
+D3D8Hook D3D8Hook::d3d8hooks;

--- a/renderdoc/driver/d3d8/d3d8_replay.cpp
+++ b/renderdoc/driver/d3d8/d3d8_replay.cpp
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "d3d8_common.h"
+
+ReplayStatus D3D8_CreateReplayDevice(const char *logfile, IReplayDriver **driver)
+{
+  RDCERR("D3D8 captures are not currently supported");
+  return ReplayStatus::APIUnsupported;
+}
+
+static DriverRegistration D3D8DriverRegistration(RDC_D3D8, "D3D8", &D3D8_CreateReplayDevice);

--- a/renderdoc/driver/d3d8/precompiled.cpp
+++ b/renderdoc/driver/d3d8/precompiled.cpp
@@ -1,0 +1,25 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "precompiled.h"

--- a/renderdoc/driver/d3d8/precompiled.h
+++ b/renderdoc/driver/d3d8/precompiled.h
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "api/app/renderdoc_app.h"
+#include "api/replay/renderdoc_replay.h"
+#include "common/common.h"
+
+#include "d3d8_common.h"

--- a/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj
+++ b/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Development|Win32">
+      <Configuration>Development</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development|x64">
+      <Configuration>Development</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9C4487E8-EEB0-4A7F-BD81-23F81CD24E22}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>renderdoc_d3d8</RootNamespace>
+    <ProjectName>d3d8</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <ExecutablePath>$(ExecutablePath)</ExecutablePath>
+    <IncludePath>$(SolutionDir)\breakpad;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
+    <ExcludePath>$(ExcludePath)</ExcludePath>
+    <TargetName>driver_$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir)renderdoc\;$(SolutionDir)renderdoc\3rdparty\</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>RENDERDOC_EXPORTS;RENDERDOC_PLATFORM_WIN32;WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <DisableSpecificWarnings>4100</DisableSpecificWarnings>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>precompiled.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Development'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="d3d8_common.cpp" />
+    <ClCompile Include="d3d8_debug.cpp" />
+    <ClCompile Include="d3d8_device.cpp" />
+    <ClCompile Include="d3d8_hooks.cpp" />
+    <ClCompile Include="d3d8_replay.cpp" />
+    <ClCompile Include="precompiled.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\dx\official\d3d8.h" />
+    <ClInclude Include="..\dx\official\d3d8caps.h" />
+    <ClInclude Include="..\dx\official\d3d8types.h" />
+    <ClInclude Include="..\dx\official\d3dcommon.h" />
+    <ClInclude Include="..\dx\official\d3dcompiler.h" />
+    <ClInclude Include="d3d8_common.h" />
+    <ClInclude Include="d3d8_debug.h" />
+    <ClInclude Include="d3d8_device.h" />
+    <ClInclude Include="precompiled.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj.filters
+++ b/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj.filters
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Hooks">
+      <UniqueIdentifier>{5CAAA42F-25FF-43DD-B545-E7ADB5135418}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="official">
+      <UniqueIdentifier>{87CAD3D6-BA09-4D6E-84CF-29B8DC5A5B0A}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Debug">
+      <UniqueIdentifier>{6056F6EB-A9BC-4B50-B205-461B7580977B}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{B9341B0E-2A54-415C-AF54-29D67D2325A2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Replay">
+      <UniqueIdentifier>{7D6E973E-947D-4EAA-AFB4-DA33987ED452}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="PCH">
+      <UniqueIdentifier>{74FA3D85-A524-442D-9682-BB832AB5E136}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="d3d8_hooks.cpp">
+      <Filter>Hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d8_debug.cpp">
+      <Filter>Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d8_device.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d8_common.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d8_replay.cpp">
+      <Filter>Replay</Filter>
+    </ClCompile>
+    <ClCompile Include="precompiled.cpp">
+      <Filter>PCH</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\dx\official\d3d8.h">
+      <Filter>official</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dx\official\d3dcommon.h">
+      <Filter>official</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dx\official\d3dcompiler.h">
+      <Filter>official</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dx\official\d3d8caps.h">
+      <Filter>official</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dx\official\d3d8types.h">
+      <Filter>official</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d8_debug.h">
+      <Filter>Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d8_device.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d8_common.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="precompiled.h">
+      <Filter>PCH</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/renderdoc/driver/dx/official/d3d8.h
+++ b/renderdoc/driver/dx/official/d3d8.h
@@ -1,0 +1,1279 @@
+/*==========================================================================;
+ *
+ *  Copyright (C) Microsoft Corporation.  All Rights Reserved.
+ *
+ *  File:   d3d8.h
+ *  Content:    Direct3D include file
+ *
+ ****************************************************************************/
+
+#ifndef _D3D8_H_
+#define _D3D8_H_
+
+#ifndef DIRECT3D_VERSION
+#define DIRECT3D_VERSION         0x0800
+#endif  //DIRECT3D_VERSION
+
+// include this file content only if compiling for DX8 interfaces
+#if(DIRECT3D_VERSION >= 0x0800)
+
+
+/* This identifier is passed to Direct3DCreate8 in order to ensure that an
+ * application was built against the correct header files. This number is
+ * incremented whenever a header (or other) change would require applications
+ * to be rebuilt. If the version doesn't match, Direct3DCreate8 will fail.
+ * (The number itself has no meaning.)*/
+
+#define D3D_SDK_VERSION 220
+
+
+#include <stdlib.h>
+
+#define COM_NO_WINDOWS_H
+#include <objbase.h>
+
+#include <windows.h>
+
+#if !defined(HMONITOR_DECLARED) && (WINVER < 0x0500)
+    #define HMONITOR_DECLARED
+    DECLARE_HANDLE(HMONITOR);
+#endif
+
+#define D3DAPI WINAPI
+
+/*
+ * Interface IID's
+ */
+#if defined( _WIN32 ) && !defined( _NO_COM)
+
+/* IID_IDirect3D8 */
+/* {1DD9E8DA-1C77-4d40-B0CF-98FEFDFF9512} */
+DEFINE_GUID(IID_IDirect3D8, 0x1dd9e8da, 0x1c77, 0x4d40, 0xb0, 0xcf, 0x98, 0xfe, 0xfd, 0xff, 0x95, 0x12);
+
+/* IID_IDirect3DDevice8 */
+/* {7385E5DF-8FE8-41D5-86B6-D7B48547B6CF} */
+DEFINE_GUID(IID_IDirect3DDevice8, 0x7385e5df, 0x8fe8, 0x41d5, 0x86, 0xb6, 0xd7, 0xb4, 0x85, 0x47, 0xb6, 0xcf);
+
+/* IID_IDirect3DResource8 */
+/* {1B36BB7B-09B7-410a-B445-7D1430D7B33F} */
+DEFINE_GUID(IID_IDirect3DResource8, 0x1b36bb7b, 0x9b7, 0x410a, 0xb4, 0x45, 0x7d, 0x14, 0x30, 0xd7, 0xb3, 0x3f);
+
+/* IID_IDirect3DBaseTexture8 */
+/* {B4211CFA-51B9-4a9f-AB78-DB99B2BB678E} */
+DEFINE_GUID(IID_IDirect3DBaseTexture8, 0xb4211cfa, 0x51b9, 0x4a9f, 0xab, 0x78, 0xdb, 0x99, 0xb2, 0xbb, 0x67, 0x8e);
+
+/* IID_IDirect3DTexture8 */
+/* {E4CDD575-2866-4f01-B12E-7EECE1EC9358} */
+DEFINE_GUID(IID_IDirect3DTexture8, 0xe4cdd575, 0x2866, 0x4f01, 0xb1, 0x2e, 0x7e, 0xec, 0xe1, 0xec, 0x93, 0x58);
+
+/* IID_IDirect3DCubeTexture8 */
+/* {3EE5B968-2ACA-4c34-8BB5-7E0C3D19B750} */
+DEFINE_GUID(IID_IDirect3DCubeTexture8, 0x3ee5b968, 0x2aca, 0x4c34, 0x8b, 0xb5, 0x7e, 0x0c, 0x3d, 0x19, 0xb7, 0x50);
+
+/* IID_IDirect3DVolumeTexture8 */
+/* {4B8AAAFA-140F-42ba-9131-597EAFAA2EAD} */
+DEFINE_GUID(IID_IDirect3DVolumeTexture8, 0x4b8aaafa, 0x140f, 0x42ba, 0x91, 0x31, 0x59, 0x7e, 0xaf, 0xaa, 0x2e, 0xad);
+
+/* IID_IDirect3DVertexBuffer8 */
+/* {8AEEEAC7-05F9-44d4-B591-000B0DF1CB95} */
+DEFINE_GUID(IID_IDirect3DVertexBuffer8, 0x8aeeeac7, 0x05f9, 0x44d4, 0xb5, 0x91, 0x00, 0x0b, 0x0d, 0xf1, 0xcb, 0x95);
+
+/* IID_IDirect3DIndexBuffer8 */
+/* {0E689C9A-053D-44a0-9D92-DB0E3D750F86} */
+DEFINE_GUID(IID_IDirect3DIndexBuffer8, 0x0e689c9a, 0x053d, 0x44a0, 0x9d, 0x92, 0xdb, 0x0e, 0x3d, 0x75, 0x0f, 0x86);
+
+/* IID_IDirect3DSurface8 */
+/* {B96EEBCA-B326-4ea5-882F-2FF5BAE021DD} */
+DEFINE_GUID(IID_IDirect3DSurface8, 0xb96eebca, 0xb326, 0x4ea5, 0x88, 0x2f, 0x2f, 0xf5, 0xba, 0xe0, 0x21, 0xdd);
+
+/* IID_IDirect3DVolume8 */
+/* {BD7349F5-14F1-42e4-9C79-972380DB40C0} */
+DEFINE_GUID(IID_IDirect3DVolume8, 0xbd7349f5, 0x14f1, 0x42e4, 0x9c, 0x79, 0x97, 0x23, 0x80, 0xdb, 0x40, 0xc0);
+
+/* IID_IDirect3DSwapChain8 */
+/* {928C088B-76B9-4C6B-A536-A590853876CD} */
+DEFINE_GUID(IID_IDirect3DSwapChain8, 0x928c088b, 0x76b9, 0x4c6b, 0xa5, 0x36, 0xa5, 0x90, 0x85, 0x38, 0x76, 0xcd);
+
+#endif
+
+#ifdef __cplusplus
+
+interface IDirect3D8;
+interface IDirect3DDevice8;
+
+interface IDirect3DResource8;
+interface IDirect3DBaseTexture8;
+interface IDirect3DTexture8;
+interface IDirect3DVolumeTexture8;
+interface IDirect3DCubeTexture8;
+
+interface IDirect3DVertexBuffer8;
+interface IDirect3DIndexBuffer8;
+
+interface IDirect3DSurface8;
+interface IDirect3DVolume8;
+
+interface IDirect3DSwapChain8;
+
+#endif
+
+
+typedef interface IDirect3D8                IDirect3D8;
+typedef interface IDirect3DDevice8          IDirect3DDevice8;
+typedef interface IDirect3DResource8        IDirect3DResource8;
+typedef interface IDirect3DBaseTexture8     IDirect3DBaseTexture8;
+typedef interface IDirect3DTexture8         IDirect3DTexture8;
+typedef interface IDirect3DVolumeTexture8   IDirect3DVolumeTexture8;
+typedef interface IDirect3DCubeTexture8     IDirect3DCubeTexture8;
+typedef interface IDirect3DVertexBuffer8    IDirect3DVertexBuffer8;
+typedef interface IDirect3DIndexBuffer8     IDirect3DIndexBuffer8;
+typedef interface IDirect3DSurface8         IDirect3DSurface8;
+typedef interface IDirect3DVolume8          IDirect3DVolume8;
+typedef interface IDirect3DSwapChain8       IDirect3DSwapChain8;
+
+#include "d3d8types.h"
+#include "d3d8caps.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * DLL Function for creating a Direct3D8 object. This object supports
+ * enumeration and allows the creation of Direct3DDevice8 objects.
+ * Pass the value of the constant D3D_SDK_VERSION to this function, so
+ * that the run-time can validate that your application was compiled
+ * against the right headers.
+ */
+
+IDirect3D8 * WINAPI Direct3DCreate8(UINT SDKVersion);
+
+
+/*
+ * Direct3D interfaces
+ */
+
+
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3D8
+
+DECLARE_INTERFACE_(IDirect3D8, IUnknown)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3D8 methods ***/
+    STDMETHOD(RegisterSoftwareDevice)(THIS_ void* pInitializeFunction) PURE;
+    STDMETHOD_(UINT, GetAdapterCount)(THIS) PURE;
+    STDMETHOD(GetAdapterIdentifier)(THIS_ UINT Adapter,DWORD Flags,D3DADAPTER_IDENTIFIER8* pIdentifier) PURE;
+    STDMETHOD_(UINT, GetAdapterModeCount)(THIS_ UINT Adapter) PURE;
+    STDMETHOD(EnumAdapterModes)(THIS_ UINT Adapter,UINT Mode,D3DDISPLAYMODE* pMode) PURE;
+    STDMETHOD(GetAdapterDisplayMode)(THIS_ UINT Adapter,D3DDISPLAYMODE* pMode) PURE;
+    STDMETHOD(CheckDeviceType)(THIS_ UINT Adapter,D3DDEVTYPE CheckType,D3DFORMAT DisplayFormat,D3DFORMAT BackBufferFormat,BOOL Windowed) PURE;
+    STDMETHOD(CheckDeviceFormat)(THIS_ UINT Adapter,D3DDEVTYPE DeviceType,D3DFORMAT AdapterFormat,DWORD Usage,D3DRESOURCETYPE RType,D3DFORMAT CheckFormat) PURE;
+    STDMETHOD(CheckDeviceMultiSampleType)(THIS_ UINT Adapter,D3DDEVTYPE DeviceType,D3DFORMAT SurfaceFormat,BOOL Windowed,D3DMULTISAMPLE_TYPE MultiSampleType) PURE;
+    STDMETHOD(CheckDepthStencilMatch)(THIS_ UINT Adapter,D3DDEVTYPE DeviceType,D3DFORMAT AdapterFormat,D3DFORMAT RenderTargetFormat,D3DFORMAT DepthStencilFormat) PURE;
+    STDMETHOD(GetDeviceCaps)(THIS_ UINT Adapter,D3DDEVTYPE DeviceType,D3DCAPS8* pCaps) PURE;
+    STDMETHOD_(HMONITOR, GetAdapterMonitor)(THIS_ UINT Adapter) PURE;
+    STDMETHOD(CreateDevice)(THIS_ UINT Adapter,D3DDEVTYPE DeviceType,HWND hFocusWindow,DWORD BehaviorFlags,D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DDevice8** ppReturnedDeviceInterface) PURE;
+};
+
+typedef struct IDirect3D8 *LPDIRECT3D8, *PDIRECT3D8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3D8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3D8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3D8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3D8_RegisterSoftwareDevice(p,a) (p)->lpVtbl->RegisterSoftwareDevice(p,a)
+#define IDirect3D8_GetAdapterCount(p) (p)->lpVtbl->GetAdapterCount(p)
+#define IDirect3D8_GetAdapterIdentifier(p,a,b,c) (p)->lpVtbl->GetAdapterIdentifier(p,a,b,c)
+#define IDirect3D8_GetAdapterModeCount(p,a) (p)->lpVtbl->GetAdapterModeCount(p,a)
+#define IDirect3D8_EnumAdapterModes(p,a,b,c) (p)->lpVtbl->EnumAdapterModes(p,a,b,c)
+#define IDirect3D8_GetAdapterDisplayMode(p,a,b) (p)->lpVtbl->GetAdapterDisplayMode(p,a,b)
+#define IDirect3D8_CheckDeviceType(p,a,b,c,d,e) (p)->lpVtbl->CheckDeviceType(p,a,b,c,d,e)
+#define IDirect3D8_CheckDeviceFormat(p,a,b,c,d,e,f) (p)->lpVtbl->CheckDeviceFormat(p,a,b,c,d,e,f)
+#define IDirect3D8_CheckDeviceMultiSampleType(p,a,b,c,d,e) (p)->lpVtbl->CheckDeviceMultiSampleType(p,a,b,c,d,e)
+#define IDirect3D8_CheckDepthStencilMatch(p,a,b,c,d,e) (p)->lpVtbl->CheckDepthStencilMatch(p,a,b,c,d,e)
+#define IDirect3D8_GetDeviceCaps(p,a,b,c) (p)->lpVtbl->GetDeviceCaps(p,a,b,c)
+#define IDirect3D8_GetAdapterMonitor(p,a) (p)->lpVtbl->GetAdapterMonitor(p,a)
+#define IDirect3D8_CreateDevice(p,a,b,c,d,e,f) (p)->lpVtbl->CreateDevice(p,a,b,c,d,e,f)
+#else
+#define IDirect3D8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3D8_AddRef(p) (p)->AddRef()
+#define IDirect3D8_Release(p) (p)->Release()
+#define IDirect3D8_RegisterSoftwareDevice(p,a) (p)->RegisterSoftwareDevice(a)
+#define IDirect3D8_GetAdapterCount(p) (p)->GetAdapterCount()
+#define IDirect3D8_GetAdapterIdentifier(p,a,b,c) (p)->GetAdapterIdentifier(a,b,c)
+#define IDirect3D8_GetAdapterModeCount(p,a) (p)->GetAdapterModeCount(a)
+#define IDirect3D8_EnumAdapterModes(p,a,b,c) (p)->EnumAdapterModes(a,b,c)
+#define IDirect3D8_GetAdapterDisplayMode(p,a,b) (p)->GetAdapterDisplayMode(a,b)
+#define IDirect3D8_CheckDeviceType(p,a,b,c,d,e) (p)->CheckDeviceType(a,b,c,d,e)
+#define IDirect3D8_CheckDeviceFormat(p,a,b,c,d,e,f) (p)->CheckDeviceFormat(a,b,c,d,e,f)
+#define IDirect3D8_CheckDeviceMultiSampleType(p,a,b,c,d,e) (p)->CheckDeviceMultiSampleType(a,b,c,d,e)
+#define IDirect3D8_CheckDepthStencilMatch(p,a,b,c,d,e) (p)->CheckDepthStencilMatch(a,b,c,d,e)
+#define IDirect3D8_GetDeviceCaps(p,a,b,c) (p)->GetDeviceCaps(a,b,c)
+#define IDirect3D8_GetAdapterMonitor(p,a) (p)->GetAdapterMonitor(a)
+#define IDirect3D8_CreateDevice(p,a,b,c,d,e,f) (p)->CreateDevice(a,b,c,d,e,f)
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DDevice8
+
+DECLARE_INTERFACE_(IDirect3DDevice8, IUnknown)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DDevice8 methods ***/
+    STDMETHOD(TestCooperativeLevel)(THIS) PURE;
+    STDMETHOD_(UINT, GetAvailableTextureMem)(THIS) PURE;
+    STDMETHOD(ResourceManagerDiscardBytes)(THIS_ DWORD Bytes) PURE;
+    STDMETHOD(GetDirect3D)(THIS_ IDirect3D8** ppD3D8) PURE;
+    STDMETHOD(GetDeviceCaps)(THIS_ D3DCAPS8* pCaps) PURE;
+    STDMETHOD(GetDisplayMode)(THIS_ D3DDISPLAYMODE* pMode) PURE;
+    STDMETHOD(GetCreationParameters)(THIS_ D3DDEVICE_CREATION_PARAMETERS *pParameters) PURE;
+    STDMETHOD(SetCursorProperties)(THIS_ UINT XHotSpot,UINT YHotSpot,IDirect3DSurface8* pCursorBitmap) PURE;
+    STDMETHOD_(void, SetCursorPosition)(THIS_ int X,int Y,DWORD Flags) PURE;
+    STDMETHOD_(BOOL, ShowCursor)(THIS_ BOOL bShow) PURE;
+    STDMETHOD(CreateAdditionalSwapChain)(THIS_ D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DSwapChain8** pSwapChain) PURE;
+    STDMETHOD(Reset)(THIS_ D3DPRESENT_PARAMETERS* pPresentationParameters) PURE;
+    STDMETHOD(Present)(THIS_ CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion) PURE;
+    STDMETHOD(GetBackBuffer)(THIS_ UINT BackBuffer,D3DBACKBUFFER_TYPE Type,IDirect3DSurface8** ppBackBuffer) PURE;
+    STDMETHOD(GetRasterStatus)(THIS_ D3DRASTER_STATUS* pRasterStatus) PURE;
+    STDMETHOD_(void, SetGammaRamp)(THIS_ DWORD Flags,CONST D3DGAMMARAMP* pRamp) PURE;
+    STDMETHOD_(void, GetGammaRamp)(THIS_ D3DGAMMARAMP* pRamp) PURE;
+    STDMETHOD(CreateTexture)(THIS_ UINT Width,UINT Height,UINT Levels,DWORD Usage,D3DFORMAT Format,D3DPOOL Pool,IDirect3DTexture8** ppTexture) PURE;
+    STDMETHOD(CreateVolumeTexture)(THIS_ UINT Width,UINT Height,UINT Depth,UINT Levels,DWORD Usage,D3DFORMAT Format,D3DPOOL Pool,IDirect3DVolumeTexture8** ppVolumeTexture) PURE;
+    STDMETHOD(CreateCubeTexture)(THIS_ UINT EdgeLength,UINT Levels,DWORD Usage,D3DFORMAT Format,D3DPOOL Pool,IDirect3DCubeTexture8** ppCubeTexture) PURE;
+    STDMETHOD(CreateVertexBuffer)(THIS_ UINT Length,DWORD Usage,DWORD FVF,D3DPOOL Pool,IDirect3DVertexBuffer8** ppVertexBuffer) PURE;
+    STDMETHOD(CreateIndexBuffer)(THIS_ UINT Length,DWORD Usage,D3DFORMAT Format,D3DPOOL Pool,IDirect3DIndexBuffer8** ppIndexBuffer) PURE;
+    STDMETHOD(CreateRenderTarget)(THIS_ UINT Width,UINT Height,D3DFORMAT Format,D3DMULTISAMPLE_TYPE MultiSample,BOOL Lockable,IDirect3DSurface8** ppSurface) PURE;
+    STDMETHOD(CreateDepthStencilSurface)(THIS_ UINT Width,UINT Height,D3DFORMAT Format,D3DMULTISAMPLE_TYPE MultiSample,IDirect3DSurface8** ppSurface) PURE;
+    STDMETHOD(CreateImageSurface)(THIS_ UINT Width,UINT Height,D3DFORMAT Format,IDirect3DSurface8** ppSurface) PURE;
+    STDMETHOD(CopyRects)(THIS_ IDirect3DSurface8* pSourceSurface,CONST RECT* pSourceRectsArray,UINT cRects,IDirect3DSurface8* pDestinationSurface,CONST POINT* pDestPointsArray) PURE;
+    STDMETHOD(UpdateTexture)(THIS_ IDirect3DBaseTexture8* pSourceTexture,IDirect3DBaseTexture8* pDestinationTexture) PURE;
+    STDMETHOD(GetFrontBuffer)(THIS_ IDirect3DSurface8* pDestSurface) PURE;
+    STDMETHOD(SetRenderTarget)(THIS_ IDirect3DSurface8* pRenderTarget,IDirect3DSurface8* pNewZStencil) PURE;
+    STDMETHOD(GetRenderTarget)(THIS_ IDirect3DSurface8** ppRenderTarget) PURE;
+    STDMETHOD(GetDepthStencilSurface)(THIS_ IDirect3DSurface8** ppZStencilSurface) PURE;
+    STDMETHOD(BeginScene)(THIS) PURE;
+    STDMETHOD(EndScene)(THIS) PURE;
+    STDMETHOD(Clear)(THIS_ DWORD Count,CONST D3DRECT* pRects,DWORD Flags,D3DCOLOR Color,float Z,DWORD Stencil) PURE;
+    STDMETHOD(SetTransform)(THIS_ D3DTRANSFORMSTATETYPE State,CONST D3DMATRIX* pMatrix) PURE;
+    STDMETHOD(GetTransform)(THIS_ D3DTRANSFORMSTATETYPE State,D3DMATRIX* pMatrix) PURE;
+    STDMETHOD(MultiplyTransform)(THIS_ D3DTRANSFORMSTATETYPE,CONST D3DMATRIX*) PURE;
+    STDMETHOD(SetViewport)(THIS_ CONST D3DVIEWPORT8* pViewport) PURE;
+    STDMETHOD(GetViewport)(THIS_ D3DVIEWPORT8* pViewport) PURE;
+    STDMETHOD(SetMaterial)(THIS_ CONST D3DMATERIAL8* pMaterial) PURE;
+    STDMETHOD(GetMaterial)(THIS_ D3DMATERIAL8* pMaterial) PURE;
+    STDMETHOD(SetLight)(THIS_ DWORD Index,CONST D3DLIGHT8*) PURE;
+    STDMETHOD(GetLight)(THIS_ DWORD Index,D3DLIGHT8*) PURE;
+    STDMETHOD(LightEnable)(THIS_ DWORD Index,BOOL Enable) PURE;
+    STDMETHOD(GetLightEnable)(THIS_ DWORD Index,BOOL* pEnable) PURE;
+    STDMETHOD(SetClipPlane)(THIS_ DWORD Index,CONST float* pPlane) PURE;
+    STDMETHOD(GetClipPlane)(THIS_ DWORD Index,float* pPlane) PURE;
+    STDMETHOD(SetRenderState)(THIS_ D3DRENDERSTATETYPE State,DWORD Value) PURE;
+    STDMETHOD(GetRenderState)(THIS_ D3DRENDERSTATETYPE State,DWORD* pValue) PURE;
+    STDMETHOD(BeginStateBlock)(THIS) PURE;
+    STDMETHOD(EndStateBlock)(THIS_ DWORD* pToken) PURE;
+    STDMETHOD(ApplyStateBlock)(THIS_ DWORD Token) PURE;
+    STDMETHOD(CaptureStateBlock)(THIS_ DWORD Token) PURE;
+    STDMETHOD(DeleteStateBlock)(THIS_ DWORD Token) PURE;
+    STDMETHOD(CreateStateBlock)(THIS_ D3DSTATEBLOCKTYPE Type,DWORD* pToken) PURE;
+    STDMETHOD(SetClipStatus)(THIS_ CONST D3DCLIPSTATUS8* pClipStatus) PURE;
+    STDMETHOD(GetClipStatus)(THIS_ D3DCLIPSTATUS8* pClipStatus) PURE;
+    STDMETHOD(GetTexture)(THIS_ DWORD Stage,IDirect3DBaseTexture8** ppTexture) PURE;
+    STDMETHOD(SetTexture)(THIS_ DWORD Stage,IDirect3DBaseTexture8* pTexture) PURE;
+    STDMETHOD(GetTextureStageState)(THIS_ DWORD Stage,D3DTEXTURESTAGESTATETYPE Type,DWORD* pValue) PURE;
+    STDMETHOD(SetTextureStageState)(THIS_ DWORD Stage,D3DTEXTURESTAGESTATETYPE Type,DWORD Value) PURE;
+    STDMETHOD(ValidateDevice)(THIS_ DWORD* pNumPasses) PURE;
+    STDMETHOD(GetInfo)(THIS_ DWORD DevInfoID,void* pDevInfoStruct,DWORD DevInfoStructSize) PURE;
+    STDMETHOD(SetPaletteEntries)(THIS_ UINT PaletteNumber,CONST PALETTEENTRY* pEntries) PURE;
+    STDMETHOD(GetPaletteEntries)(THIS_ UINT PaletteNumber,PALETTEENTRY* pEntries) PURE;
+    STDMETHOD(SetCurrentTexturePalette)(THIS_ UINT PaletteNumber) PURE;
+    STDMETHOD(GetCurrentTexturePalette)(THIS_ UINT *PaletteNumber) PURE;
+    STDMETHOD(DrawPrimitive)(THIS_ D3DPRIMITIVETYPE PrimitiveType,UINT StartVertex,UINT PrimitiveCount) PURE;
+    STDMETHOD(DrawIndexedPrimitive)(THIS_ D3DPRIMITIVETYPE,UINT minIndex,UINT NumVertices,UINT startIndex,UINT primCount) PURE;
+    STDMETHOD(DrawPrimitiveUP)(THIS_ D3DPRIMITIVETYPE PrimitiveType,UINT PrimitiveCount,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride) PURE;
+    STDMETHOD(DrawIndexedPrimitiveUP)(THIS_ D3DPRIMITIVETYPE PrimitiveType,UINT MinVertexIndex,UINT NumVertexIndices,UINT PrimitiveCount,CONST void* pIndexData,D3DFORMAT IndexDataFormat,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride) PURE;
+    STDMETHOD(ProcessVertices)(THIS_ UINT SrcStartIndex,UINT DestIndex,UINT VertexCount,IDirect3DVertexBuffer8* pDestBuffer,DWORD Flags) PURE;
+    STDMETHOD(CreateVertexShader)(THIS_ CONST DWORD* pDeclaration,CONST DWORD* pFunction,DWORD* pHandle,DWORD Usage) PURE;
+    STDMETHOD(SetVertexShader)(THIS_ DWORD Handle) PURE;
+    STDMETHOD(GetVertexShader)(THIS_ DWORD* pHandle) PURE;
+    STDMETHOD(DeleteVertexShader)(THIS_ DWORD Handle) PURE;
+    STDMETHOD(SetVertexShaderConstant)(THIS_ DWORD Register,CONST void* pConstantData,DWORD ConstantCount) PURE;
+    STDMETHOD(GetVertexShaderConstant)(THIS_ DWORD Register,void* pConstantData,DWORD ConstantCount) PURE;
+    STDMETHOD(GetVertexShaderDeclaration)(THIS_ DWORD Handle,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(GetVertexShaderFunction)(THIS_ DWORD Handle,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(SetStreamSource)(THIS_ UINT StreamNumber,IDirect3DVertexBuffer8* pStreamData,UINT Stride) PURE;
+    STDMETHOD(GetStreamSource)(THIS_ UINT StreamNumber,IDirect3DVertexBuffer8** ppStreamData,UINT* pStride) PURE;
+    STDMETHOD(SetIndices)(THIS_ IDirect3DIndexBuffer8* pIndexData,UINT BaseVertexIndex) PURE;
+    STDMETHOD(GetIndices)(THIS_ IDirect3DIndexBuffer8** ppIndexData,UINT* pBaseVertexIndex) PURE;
+    STDMETHOD(CreatePixelShader)(THIS_ CONST DWORD* pFunction,DWORD* pHandle) PURE;
+    STDMETHOD(SetPixelShader)(THIS_ DWORD Handle) PURE;
+    STDMETHOD(GetPixelShader)(THIS_ DWORD* pHandle) PURE;
+    STDMETHOD(DeletePixelShader)(THIS_ DWORD Handle) PURE;
+    STDMETHOD(SetPixelShaderConstant)(THIS_ DWORD Register,CONST void* pConstantData,DWORD ConstantCount) PURE;
+    STDMETHOD(GetPixelShaderConstant)(THIS_ DWORD Register,void* pConstantData,DWORD ConstantCount) PURE;
+    STDMETHOD(GetPixelShaderFunction)(THIS_ DWORD Handle,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(DrawRectPatch)(THIS_ UINT Handle,CONST float* pNumSegs,CONST D3DRECTPATCH_INFO* pRectPatchInfo) PURE;
+    STDMETHOD(DrawTriPatch)(THIS_ UINT Handle,CONST float* pNumSegs,CONST D3DTRIPATCH_INFO* pTriPatchInfo) PURE;
+    STDMETHOD(DeletePatch)(THIS_ UINT Handle) PURE;
+};
+
+typedef struct IDirect3DDevice8 *LPDIRECT3DDEVICE8, *PDIRECT3DDEVICE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DDevice8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DDevice8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DDevice8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DDevice8_TestCooperativeLevel(p) (p)->lpVtbl->TestCooperativeLevel(p)
+#define IDirect3DDevice8_GetAvailableTextureMem(p) (p)->lpVtbl->GetAvailableTextureMem(p)
+#define IDirect3DDevice8_ResourceManagerDiscardBytes(p,a) (p)->lpVtbl->ResourceManagerDiscardBytes(p,a)
+#define IDirect3DDevice8_GetDirect3D(p,a) (p)->lpVtbl->GetDirect3D(p,a)
+#define IDirect3DDevice8_GetDeviceCaps(p,a) (p)->lpVtbl->GetDeviceCaps(p,a)
+#define IDirect3DDevice8_GetDisplayMode(p,a) (p)->lpVtbl->GetDisplayMode(p,a)
+#define IDirect3DDevice8_GetCreationParameters(p,a) (p)->lpVtbl->GetCreationParameters(p,a)
+#define IDirect3DDevice8_SetCursorProperties(p,a,b,c) (p)->lpVtbl->SetCursorProperties(p,a,b,c)
+#define IDirect3DDevice8_SetCursorPosition(p,a,b,c) (p)->lpVtbl->SetCursorPosition(p,a,b,c)
+#define IDirect3DDevice8_ShowCursor(p,a) (p)->lpVtbl->ShowCursor(p,a)
+#define IDirect3DDevice8_CreateAdditionalSwapChain(p,a,b) (p)->lpVtbl->CreateAdditionalSwapChain(p,a,b)
+#define IDirect3DDevice8_Reset(p,a) (p)->lpVtbl->Reset(p,a)
+#define IDirect3DDevice8_Present(p,a,b,c,d) (p)->lpVtbl->Present(p,a,b,c,d)
+#define IDirect3DDevice8_GetBackBuffer(p,a,b,c) (p)->lpVtbl->GetBackBuffer(p,a,b,c)
+#define IDirect3DDevice8_GetRasterStatus(p,a) (p)->lpVtbl->GetRasterStatus(p,a)
+#define IDirect3DDevice8_SetGammaRamp(p,a,b) (p)->lpVtbl->SetGammaRamp(p,a,b)
+#define IDirect3DDevice8_GetGammaRamp(p,a) (p)->lpVtbl->GetGammaRamp(p,a)
+#define IDirect3DDevice8_CreateTexture(p,a,b,c,d,e,f,g) (p)->lpVtbl->CreateTexture(p,a,b,c,d,e,f,g)
+#define IDirect3DDevice8_CreateVolumeTexture(p,a,b,c,d,e,f,g,h) (p)->lpVtbl->CreateVolumeTexture(p,a,b,c,d,e,f,g,h)
+#define IDirect3DDevice8_CreateCubeTexture(p,a,b,c,d,e,f) (p)->lpVtbl->CreateCubeTexture(p,a,b,c,d,e,f)
+#define IDirect3DDevice8_CreateVertexBuffer(p,a,b,c,d,e) (p)->lpVtbl->CreateVertexBuffer(p,a,b,c,d,e)
+#define IDirect3DDevice8_CreateIndexBuffer(p,a,b,c,d,e) (p)->lpVtbl->CreateIndexBuffer(p,a,b,c,d,e)
+#define IDirect3DDevice8_CreateRenderTarget(p,a,b,c,d,e,f) (p)->lpVtbl->CreateRenderTarget(p,a,b,c,d,e,f)
+#define IDirect3DDevice8_CreateDepthStencilSurface(p,a,b,c,d,e) (p)->lpVtbl->CreateDepthStencilSurface(p,a,b,c,d,e)
+#define IDirect3DDevice8_CreateImageSurface(p,a,b,c,d) (p)->lpVtbl->CreateImageSurface(p,a,b,c,d)
+#define IDirect3DDevice8_CopyRects(p,a,b,c,d,e) (p)->lpVtbl->CopyRects(p,a,b,c,d,e)
+#define IDirect3DDevice8_UpdateTexture(p,a,b) (p)->lpVtbl->UpdateTexture(p,a,b)
+#define IDirect3DDevice8_GetFrontBuffer(p,a) (p)->lpVtbl->GetFrontBuffer(p,a)
+#define IDirect3DDevice8_SetRenderTarget(p,a,b) (p)->lpVtbl->SetRenderTarget(p,a,b)
+#define IDirect3DDevice8_GetRenderTarget(p,a) (p)->lpVtbl->GetRenderTarget(p,a)
+#define IDirect3DDevice8_GetDepthStencilSurface(p,a) (p)->lpVtbl->GetDepthStencilSurface(p,a)
+#define IDirect3DDevice8_BeginScene(p) (p)->lpVtbl->BeginScene(p)
+#define IDirect3DDevice8_EndScene(p) (p)->lpVtbl->EndScene(p)
+#define IDirect3DDevice8_Clear(p,a,b,c,d,e,f) (p)->lpVtbl->Clear(p,a,b,c,d,e,f)
+#define IDirect3DDevice8_SetTransform(p,a,b) (p)->lpVtbl->SetTransform(p,a,b)
+#define IDirect3DDevice8_GetTransform(p,a,b) (p)->lpVtbl->GetTransform(p,a,b)
+#define IDirect3DDevice8_MultiplyTransform(p,a,b) (p)->lpVtbl->MultiplyTransform(p,a,b)
+#define IDirect3DDevice8_SetViewport(p,a) (p)->lpVtbl->SetViewport(p,a)
+#define IDirect3DDevice8_GetViewport(p,a) (p)->lpVtbl->GetViewport(p,a)
+#define IDirect3DDevice8_SetMaterial(p,a) (p)->lpVtbl->SetMaterial(p,a)
+#define IDirect3DDevice8_GetMaterial(p,a) (p)->lpVtbl->GetMaterial(p,a)
+#define IDirect3DDevice8_SetLight(p,a,b) (p)->lpVtbl->SetLight(p,a,b)
+#define IDirect3DDevice8_GetLight(p,a,b) (p)->lpVtbl->GetLight(p,a,b)
+#define IDirect3DDevice8_LightEnable(p,a,b) (p)->lpVtbl->LightEnable(p,a,b)
+#define IDirect3DDevice8_GetLightEnable(p,a,b) (p)->lpVtbl->GetLightEnable(p,a,b)
+#define IDirect3DDevice8_SetClipPlane(p,a,b) (p)->lpVtbl->SetClipPlane(p,a,b)
+#define IDirect3DDevice8_GetClipPlane(p,a,b) (p)->lpVtbl->GetClipPlane(p,a,b)
+#define IDirect3DDevice8_SetRenderState(p,a,b) (p)->lpVtbl->SetRenderState(p,a,b)
+#define IDirect3DDevice8_GetRenderState(p,a,b) (p)->lpVtbl->GetRenderState(p,a,b)
+#define IDirect3DDevice8_BeginStateBlock(p) (p)->lpVtbl->BeginStateBlock(p)
+#define IDirect3DDevice8_EndStateBlock(p,a) (p)->lpVtbl->EndStateBlock(p,a)
+#define IDirect3DDevice8_ApplyStateBlock(p,a) (p)->lpVtbl->ApplyStateBlock(p,a)
+#define IDirect3DDevice8_CaptureStateBlock(p,a) (p)->lpVtbl->CaptureStateBlock(p,a)
+#define IDirect3DDevice8_DeleteStateBlock(p,a) (p)->lpVtbl->DeleteStateBlock(p,a)
+#define IDirect3DDevice8_CreateStateBlock(p,a,b) (p)->lpVtbl->CreateStateBlock(p,a,b)
+#define IDirect3DDevice8_SetClipStatus(p,a) (p)->lpVtbl->SetClipStatus(p,a)
+#define IDirect3DDevice8_GetClipStatus(p,a) (p)->lpVtbl->GetClipStatus(p,a)
+#define IDirect3DDevice8_GetTexture(p,a,b) (p)->lpVtbl->GetTexture(p,a,b)
+#define IDirect3DDevice8_SetTexture(p,a,b) (p)->lpVtbl->SetTexture(p,a,b)
+#define IDirect3DDevice8_GetTextureStageState(p,a,b,c) (p)->lpVtbl->GetTextureStageState(p,a,b,c)
+#define IDirect3DDevice8_SetTextureStageState(p,a,b,c) (p)->lpVtbl->SetTextureStageState(p,a,b,c)
+#define IDirect3DDevice8_ValidateDevice(p,a) (p)->lpVtbl->ValidateDevice(p,a)
+#define IDirect3DDevice8_GetInfo(p,a,b,c) (p)->lpVtbl->GetInfo(p,a,b,c)
+#define IDirect3DDevice8_SetPaletteEntries(p,a,b) (p)->lpVtbl->SetPaletteEntries(p,a,b)
+#define IDirect3DDevice8_GetPaletteEntries(p,a,b) (p)->lpVtbl->GetPaletteEntries(p,a,b)
+#define IDirect3DDevice8_SetCurrentTexturePalette(p,a) (p)->lpVtbl->SetCurrentTexturePalette(p,a)
+#define IDirect3DDevice8_GetCurrentTexturePalette(p,a) (p)->lpVtbl->GetCurrentTexturePalette(p,a)
+#define IDirect3DDevice8_DrawPrimitive(p,a,b,c) (p)->lpVtbl->DrawPrimitive(p,a,b,c)
+#define IDirect3DDevice8_DrawIndexedPrimitive(p,a,b,c,d,e) (p)->lpVtbl->DrawIndexedPrimitive(p,a,b,c,d,e)
+#define IDirect3DDevice8_DrawPrimitiveUP(p,a,b,c,d) (p)->lpVtbl->DrawPrimitiveUP(p,a,b,c,d)
+#define IDirect3DDevice8_DrawIndexedPrimitiveUP(p,a,b,c,d,e,f,g,h) (p)->lpVtbl->DrawIndexedPrimitiveUP(p,a,b,c,d,e,f,g,h)
+#define IDirect3DDevice8_ProcessVertices(p,a,b,c,d,e) (p)->lpVtbl->ProcessVertices(p,a,b,c,d,e)
+#define IDirect3DDevice8_CreateVertexShader(p,a,b,c,d) (p)->lpVtbl->CreateVertexShader(p,a,b,c,d)
+#define IDirect3DDevice8_SetVertexShader(p,a) (p)->lpVtbl->SetVertexShader(p,a)
+#define IDirect3DDevice8_GetVertexShader(p,a) (p)->lpVtbl->GetVertexShader(p,a)
+#define IDirect3DDevice8_DeleteVertexShader(p,a) (p)->lpVtbl->DeleteVertexShader(p,a)
+#define IDirect3DDevice8_SetVertexShaderConstant(p,a,b,c) (p)->lpVtbl->SetVertexShaderConstant(p,a,b,c)
+#define IDirect3DDevice8_GetVertexShaderConstant(p,a,b,c) (p)->lpVtbl->GetVertexShaderConstant(p,a,b,c)
+#define IDirect3DDevice8_GetVertexShaderDeclaration(p,a,b,c) (p)->lpVtbl->GetVertexShaderDeclaration(p,a,b,c)
+#define IDirect3DDevice8_GetVertexShaderFunction(p,a,b,c) (p)->lpVtbl->GetVertexShaderFunction(p,a,b,c)
+#define IDirect3DDevice8_SetStreamSource(p,a,b,c) (p)->lpVtbl->SetStreamSource(p,a,b,c)
+#define IDirect3DDevice8_GetStreamSource(p,a,b,c) (p)->lpVtbl->GetStreamSource(p,a,b,c)
+#define IDirect3DDevice8_SetIndices(p,a,b) (p)->lpVtbl->SetIndices(p,a,b)
+#define IDirect3DDevice8_GetIndices(p,a,b) (p)->lpVtbl->GetIndices(p,a,b)
+#define IDirect3DDevice8_CreatePixelShader(p,a,b) (p)->lpVtbl->CreatePixelShader(p,a,b)
+#define IDirect3DDevice8_SetPixelShader(p,a) (p)->lpVtbl->SetPixelShader(p,a)
+#define IDirect3DDevice8_GetPixelShader(p,a) (p)->lpVtbl->GetPixelShader(p,a)
+#define IDirect3DDevice8_DeletePixelShader(p,a) (p)->lpVtbl->DeletePixelShader(p,a)
+#define IDirect3DDevice8_SetPixelShaderConstant(p,a,b,c) (p)->lpVtbl->SetPixelShaderConstant(p,a,b,c)
+#define IDirect3DDevice8_GetPixelShaderConstant(p,a,b,c) (p)->lpVtbl->GetPixelShaderConstant(p,a,b,c)
+#define IDirect3DDevice8_GetPixelShaderFunction(p,a,b,c) (p)->lpVtbl->GetPixelShaderFunction(p,a,b,c)
+#define IDirect3DDevice8_DrawRectPatch(p,a,b,c) (p)->lpVtbl->DrawRectPatch(p,a,b,c)
+#define IDirect3DDevice8_DrawTriPatch(p,a,b,c) (p)->lpVtbl->DrawTriPatch(p,a,b,c)
+#define IDirect3DDevice8_DeletePatch(p,a) (p)->lpVtbl->DeletePatch(p,a)
+#else
+#define IDirect3DDevice8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DDevice8_AddRef(p) (p)->AddRef()
+#define IDirect3DDevice8_Release(p) (p)->Release()
+#define IDirect3DDevice8_TestCooperativeLevel(p) (p)->TestCooperativeLevel()
+#define IDirect3DDevice8_GetAvailableTextureMem(p) (p)->GetAvailableTextureMem()
+#define IDirect3DDevice8_ResourceManagerDiscardBytes(p,a) (p)->ResourceManagerDiscardBytes(a)
+#define IDirect3DDevice8_GetDirect3D(p,a) (p)->GetDirect3D(a)
+#define IDirect3DDevice8_GetDeviceCaps(p,a) (p)->GetDeviceCaps(a)
+#define IDirect3DDevice8_GetDisplayMode(p,a) (p)->GetDisplayMode(a)
+#define IDirect3DDevice8_GetCreationParameters(p,a) (p)->GetCreationParameters(a)
+#define IDirect3DDevice8_SetCursorProperties(p,a,b,c) (p)->SetCursorProperties(a,b,c)
+#define IDirect3DDevice8_SetCursorPosition(p,a,b,c) (p)->SetCursorPosition(a,b,c)
+#define IDirect3DDevice8_ShowCursor(p,a) (p)->ShowCursor(a)
+#define IDirect3DDevice8_CreateAdditionalSwapChain(p,a,b) (p)->CreateAdditionalSwapChain(a,b)
+#define IDirect3DDevice8_Reset(p,a) (p)->Reset(a)
+#define IDirect3DDevice8_Present(p,a,b,c,d) (p)->Present(a,b,c,d)
+#define IDirect3DDevice8_GetBackBuffer(p,a,b,c) (p)->GetBackBuffer(a,b,c)
+#define IDirect3DDevice8_GetRasterStatus(p,a) (p)->GetRasterStatus(a)
+#define IDirect3DDevice8_SetGammaRamp(p,a,b) (p)->SetGammaRamp(a,b)
+#define IDirect3DDevice8_GetGammaRamp(p,a) (p)->GetGammaRamp(a)
+#define IDirect3DDevice8_CreateTexture(p,a,b,c,d,e,f,g) (p)->CreateTexture(a,b,c,d,e,f,g)
+#define IDirect3DDevice8_CreateVolumeTexture(p,a,b,c,d,e,f,g,h) (p)->CreateVolumeTexture(a,b,c,d,e,f,g,h)
+#define IDirect3DDevice8_CreateCubeTexture(p,a,b,c,d,e,f) (p)->CreateCubeTexture(a,b,c,d,e,f)
+#define IDirect3DDevice8_CreateVertexBuffer(p,a,b,c,d,e) (p)->CreateVertexBuffer(a,b,c,d,e)
+#define IDirect3DDevice8_CreateIndexBuffer(p,a,b,c,d,e) (p)->CreateIndexBuffer(a,b,c,d,e)
+#define IDirect3DDevice8_CreateRenderTarget(p,a,b,c,d,e,f) (p)->CreateRenderTarget(a,b,c,d,e,f)
+#define IDirect3DDevice8_CreateDepthStencilSurface(p,a,b,c,d,e) (p)->CreateDepthStencilSurface(a,b,c,d,e)
+#define IDirect3DDevice8_CreateImageSurface(p,a,b,c,d) (p)->CreateImageSurface(a,b,c,d)
+#define IDirect3DDevice8_CopyRects(p,a,b,c,d,e) (p)->CopyRects(a,b,c,d,e)
+#define IDirect3DDevice8_UpdateTexture(p,a,b) (p)->UpdateTexture(a,b)
+#define IDirect3DDevice8_GetFrontBuffer(p,a) (p)->GetFrontBuffer(a)
+#define IDirect3DDevice8_SetRenderTarget(p,a,b) (p)->SetRenderTarget(a,b)
+#define IDirect3DDevice8_GetRenderTarget(p,a) (p)->GetRenderTarget(a)
+#define IDirect3DDevice8_GetDepthStencilSurface(p,a) (p)->GetDepthStencilSurface(a)
+#define IDirect3DDevice8_BeginScene(p) (p)->BeginScene()
+#define IDirect3DDevice8_EndScene(p) (p)->EndScene()
+#define IDirect3DDevice8_Clear(p,a,b,c,d,e,f) (p)->Clear(a,b,c,d,e,f)
+#define IDirect3DDevice8_SetTransform(p,a,b) (p)->SetTransform(a,b)
+#define IDirect3DDevice8_GetTransform(p,a,b) (p)->GetTransform(a,b)
+#define IDirect3DDevice8_MultiplyTransform(p,a,b) (p)->MultiplyTransform(a,b)
+#define IDirect3DDevice8_SetViewport(p,a) (p)->SetViewport(a)
+#define IDirect3DDevice8_GetViewport(p,a) (p)->GetViewport(a)
+#define IDirect3DDevice8_SetMaterial(p,a) (p)->SetMaterial(a)
+#define IDirect3DDevice8_GetMaterial(p,a) (p)->GetMaterial(a)
+#define IDirect3DDevice8_SetLight(p,a,b) (p)->SetLight(a,b)
+#define IDirect3DDevice8_GetLight(p,a,b) (p)->GetLight(a,b)
+#define IDirect3DDevice8_LightEnable(p,a,b) (p)->LightEnable(a,b)
+#define IDirect3DDevice8_GetLightEnable(p,a,b) (p)->GetLightEnable(a,b)
+#define IDirect3DDevice8_SetClipPlane(p,a,b) (p)->SetClipPlane(a,b)
+#define IDirect3DDevice8_GetClipPlane(p,a,b) (p)->GetClipPlane(a,b)
+#define IDirect3DDevice8_SetRenderState(p,a,b) (p)->SetRenderState(a,b)
+#define IDirect3DDevice8_GetRenderState(p,a,b) (p)->GetRenderState(a,b)
+#define IDirect3DDevice8_BeginStateBlock(p) (p)->BeginStateBlock()
+#define IDirect3DDevice8_EndStateBlock(p,a) (p)->EndStateBlock(a)
+#define IDirect3DDevice8_ApplyStateBlock(p,a) (p)->ApplyStateBlock(a)
+#define IDirect3DDevice8_CaptureStateBlock(p,a) (p)->CaptureStateBlock(a)
+#define IDirect3DDevice8_DeleteStateBlock(p,a) (p)->DeleteStateBlock(a)
+#define IDirect3DDevice8_CreateStateBlock(p,a,b) (p)->CreateStateBlock(a,b)
+#define IDirect3DDevice8_SetClipStatus(p,a) (p)->SetClipStatus(a)
+#define IDirect3DDevice8_GetClipStatus(p,a) (p)->GetClipStatus(a)
+#define IDirect3DDevice8_GetTexture(p,a,b) (p)->GetTexture(a,b)
+#define IDirect3DDevice8_SetTexture(p,a,b) (p)->SetTexture(a,b)
+#define IDirect3DDevice8_GetTextureStageState(p,a,b,c) (p)->GetTextureStageState(a,b,c)
+#define IDirect3DDevice8_SetTextureStageState(p,a,b,c) (p)->SetTextureStageState(a,b,c)
+#define IDirect3DDevice8_ValidateDevice(p,a) (p)->ValidateDevice(a)
+#define IDirect3DDevice8_GetInfo(p,a,b,c) (p)->GetInfo(a,b,c)
+#define IDirect3DDevice8_SetPaletteEntries(p,a,b) (p)->SetPaletteEntries(a,b)
+#define IDirect3DDevice8_GetPaletteEntries(p,a,b) (p)->GetPaletteEntries(a,b)
+#define IDirect3DDevice8_SetCurrentTexturePalette(p,a) (p)->SetCurrentTexturePalette(a)
+#define IDirect3DDevice8_GetCurrentTexturePalette(p,a) (p)->GetCurrentTexturePalette(a)
+#define IDirect3DDevice8_DrawPrimitive(p,a,b,c) (p)->DrawPrimitive(a,b,c)
+#define IDirect3DDevice8_DrawIndexedPrimitive(p,a,b,c,d,e) (p)->DrawIndexedPrimitive(a,b,c,d,e)
+#define IDirect3DDevice8_DrawPrimitiveUP(p,a,b,c,d) (p)->DrawPrimitiveUP(a,b,c,d)
+#define IDirect3DDevice8_DrawIndexedPrimitiveUP(p,a,b,c,d,e,f,g,h) (p)->DrawIndexedPrimitiveUP(a,b,c,d,e,f,g,h)
+#define IDirect3DDevice8_ProcessVertices(p,a,b,c,d,e) (p)->ProcessVertices(a,b,c,d,e)
+#define IDirect3DDevice8_CreateVertexShader(p,a,b,c,d) (p)->CreateVertexShader(a,b,c,d)
+#define IDirect3DDevice8_SetVertexShader(p,a) (p)->SetVertexShader(a)
+#define IDirect3DDevice8_GetVertexShader(p,a) (p)->GetVertexShader(a)
+#define IDirect3DDevice8_DeleteVertexShader(p,a) (p)->DeleteVertexShader(a)
+#define IDirect3DDevice8_SetVertexShaderConstant(p,a,b,c) (p)->SetVertexShaderConstant(a,b,c)
+#define IDirect3DDevice8_GetVertexShaderConstant(p,a,b,c) (p)->GetVertexShaderConstant(a,b,c)
+#define IDirect3DDevice8_GetVertexShaderDeclaration(p,a,b,c) (p)->GetVertexShaderDeclaration(a,b,c)
+#define IDirect3DDevice8_GetVertexShaderFunction(p,a,b,c) (p)->GetVertexShaderFunction(a,b,c)
+#define IDirect3DDevice8_SetStreamSource(p,a,b,c) (p)->SetStreamSource(a,b,c)
+#define IDirect3DDevice8_GetStreamSource(p,a,b,c) (p)->GetStreamSource(a,b,c)
+#define IDirect3DDevice8_SetIndices(p,a,b) (p)->SetIndices(a,b)
+#define IDirect3DDevice8_GetIndices(p,a,b) (p)->GetIndices(a,b)
+#define IDirect3DDevice8_CreatePixelShader(p,a,b) (p)->CreatePixelShader(a,b)
+#define IDirect3DDevice8_SetPixelShader(p,a) (p)->SetPixelShader(a)
+#define IDirect3DDevice8_GetPixelShader(p,a) (p)->GetPixelShader(a)
+#define IDirect3DDevice8_DeletePixelShader(p,a) (p)->DeletePixelShader(a)
+#define IDirect3DDevice8_SetPixelShaderConstant(p,a,b,c) (p)->SetPixelShaderConstant(a,b,c)
+#define IDirect3DDevice8_GetPixelShaderConstant(p,a,b,c) (p)->GetPixelShaderConstant(a,b,c)
+#define IDirect3DDevice8_GetPixelShaderFunction(p,a,b,c) (p)->GetPixelShaderFunction(a,b,c)
+#define IDirect3DDevice8_DrawRectPatch(p,a,b,c) (p)->DrawRectPatch(a,b,c)
+#define IDirect3DDevice8_DrawTriPatch(p,a,b,c) (p)->DrawTriPatch(a,b,c)
+#define IDirect3DDevice8_DeletePatch(p,a) (p)->DeletePatch(a)
+#endif
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DSwapChain8
+
+DECLARE_INTERFACE_(IDirect3DSwapChain8, IUnknown)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DSwapChain8 methods ***/
+    STDMETHOD(Present)(THIS_ CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion) PURE;
+    STDMETHOD(GetBackBuffer)(THIS_ UINT BackBuffer,D3DBACKBUFFER_TYPE Type,IDirect3DSurface8** ppBackBuffer) PURE;
+};
+
+typedef struct IDirect3DSwapChain8 *LPDIRECT3DSWAPCHAIN8, *PDIRECT3DSWAPCHAIN8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DSwapChain8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DSwapChain8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DSwapChain8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DSwapChain8_Present(p,a,b,c,d) (p)->lpVtbl->Present(p,a,b,c,d)
+#define IDirect3DSwapChain8_GetBackBuffer(p,a,b,c) (p)->lpVtbl->GetBackBuffer(p,a,b,c)
+#else
+#define IDirect3DSwapChain8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DSwapChain8_AddRef(p) (p)->AddRef()
+#define IDirect3DSwapChain8_Release(p) (p)->Release()
+#define IDirect3DSwapChain8_Present(p,a,b,c,d) (p)->Present(a,b,c,d)
+#define IDirect3DSwapChain8_GetBackBuffer(p,a,b,c) (p)->GetBackBuffer(a,b,c)
+#endif
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DResource8
+
+DECLARE_INTERFACE_(IDirect3DResource8, IUnknown)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DResource8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+};
+
+typedef struct IDirect3DResource8 *LPDIRECT3DRESOURCE8, *PDIRECT3DRESOURCE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DResource8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DResource8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DResource8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DResource8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DResource8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DResource8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DResource8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DResource8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DResource8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DResource8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DResource8_GetType(p) (p)->lpVtbl->GetType(p)
+#else
+#define IDirect3DResource8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DResource8_AddRef(p) (p)->AddRef()
+#define IDirect3DResource8_Release(p) (p)->Release()
+#define IDirect3DResource8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DResource8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DResource8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DResource8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DResource8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DResource8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DResource8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DResource8_GetType(p) (p)->GetType()
+#endif
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DBaseTexture8
+
+DECLARE_INTERFACE_(IDirect3DBaseTexture8, IDirect3DResource8)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DResource8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+    STDMETHOD_(DWORD, SetLOD)(THIS_ DWORD LODNew) PURE;
+    STDMETHOD_(DWORD, GetLOD)(THIS) PURE;
+    STDMETHOD_(DWORD, GetLevelCount)(THIS) PURE;
+};
+
+typedef struct IDirect3DBaseTexture8 *LPDIRECT3DBASETEXTURE8, *PDIRECT3DBASETEXTURE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DBaseTexture8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DBaseTexture8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DBaseTexture8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DBaseTexture8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DBaseTexture8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DBaseTexture8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DBaseTexture8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DBaseTexture8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DBaseTexture8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DBaseTexture8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DBaseTexture8_GetType(p) (p)->lpVtbl->GetType(p)
+#define IDirect3DBaseTexture8_SetLOD(p,a) (p)->lpVtbl->SetLOD(p,a)
+#define IDirect3DBaseTexture8_GetLOD(p) (p)->lpVtbl->GetLOD(p)
+#define IDirect3DBaseTexture8_GetLevelCount(p) (p)->lpVtbl->GetLevelCount(p)
+#else
+#define IDirect3DBaseTexture8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DBaseTexture8_AddRef(p) (p)->AddRef()
+#define IDirect3DBaseTexture8_Release(p) (p)->Release()
+#define IDirect3DBaseTexture8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DBaseTexture8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DBaseTexture8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DBaseTexture8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DBaseTexture8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DBaseTexture8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DBaseTexture8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DBaseTexture8_GetType(p) (p)->GetType()
+#define IDirect3DBaseTexture8_SetLOD(p,a) (p)->SetLOD(a)
+#define IDirect3DBaseTexture8_GetLOD(p) (p)->GetLOD()
+#define IDirect3DBaseTexture8_GetLevelCount(p) (p)->GetLevelCount()
+#endif
+
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DTexture8
+
+DECLARE_INTERFACE_(IDirect3DTexture8, IDirect3DBaseTexture8)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DBaseTexture8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+    STDMETHOD_(DWORD, SetLOD)(THIS_ DWORD LODNew) PURE;
+    STDMETHOD_(DWORD, GetLOD)(THIS) PURE;
+    STDMETHOD_(DWORD, GetLevelCount)(THIS) PURE;
+    STDMETHOD(GetLevelDesc)(THIS_ UINT Level,D3DSURFACE_DESC *pDesc) PURE;
+    STDMETHOD(GetSurfaceLevel)(THIS_ UINT Level,IDirect3DSurface8** ppSurfaceLevel) PURE;
+    STDMETHOD(LockRect)(THIS_ UINT Level,D3DLOCKED_RECT* pLockedRect,CONST RECT* pRect,DWORD Flags) PURE;
+    STDMETHOD(UnlockRect)(THIS_ UINT Level) PURE;
+    STDMETHOD(AddDirtyRect)(THIS_ CONST RECT* pDirtyRect) PURE;
+};
+
+typedef struct IDirect3DTexture8 *LPDIRECT3DTEXTURE8, *PDIRECT3DTEXTURE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DTexture8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DTexture8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DTexture8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DTexture8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DTexture8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DTexture8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DTexture8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DTexture8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DTexture8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DTexture8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DTexture8_GetType(p) (p)->lpVtbl->GetType(p)
+#define IDirect3DTexture8_SetLOD(p,a) (p)->lpVtbl->SetLOD(p,a)
+#define IDirect3DTexture8_GetLOD(p) (p)->lpVtbl->GetLOD(p)
+#define IDirect3DTexture8_GetLevelCount(p) (p)->lpVtbl->GetLevelCount(p)
+#define IDirect3DTexture8_GetLevelDesc(p,a,b) (p)->lpVtbl->GetLevelDesc(p,a,b)
+#define IDirect3DTexture8_GetSurfaceLevel(p,a,b) (p)->lpVtbl->GetSurfaceLevel(p,a,b)
+#define IDirect3DTexture8_LockRect(p,a,b,c,d) (p)->lpVtbl->LockRect(p,a,b,c,d)
+#define IDirect3DTexture8_UnlockRect(p,a) (p)->lpVtbl->UnlockRect(p,a)
+#define IDirect3DTexture8_AddDirtyRect(p,a) (p)->lpVtbl->AddDirtyRect(p,a)
+#else
+#define IDirect3DTexture8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DTexture8_AddRef(p) (p)->AddRef()
+#define IDirect3DTexture8_Release(p) (p)->Release()
+#define IDirect3DTexture8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DTexture8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DTexture8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DTexture8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DTexture8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DTexture8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DTexture8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DTexture8_GetType(p) (p)->GetType()
+#define IDirect3DTexture8_SetLOD(p,a) (p)->SetLOD(a)
+#define IDirect3DTexture8_GetLOD(p) (p)->GetLOD()
+#define IDirect3DTexture8_GetLevelCount(p) (p)->GetLevelCount()
+#define IDirect3DTexture8_GetLevelDesc(p,a,b) (p)->GetLevelDesc(a,b)
+#define IDirect3DTexture8_GetSurfaceLevel(p,a,b) (p)->GetSurfaceLevel(a,b)
+#define IDirect3DTexture8_LockRect(p,a,b,c,d) (p)->LockRect(a,b,c,d)
+#define IDirect3DTexture8_UnlockRect(p,a) (p)->UnlockRect(a)
+#define IDirect3DTexture8_AddDirtyRect(p,a) (p)->AddDirtyRect(a)
+#endif
+
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DVolumeTexture8
+
+DECLARE_INTERFACE_(IDirect3DVolumeTexture8, IDirect3DBaseTexture8)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DBaseTexture8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+    STDMETHOD_(DWORD, SetLOD)(THIS_ DWORD LODNew) PURE;
+    STDMETHOD_(DWORD, GetLOD)(THIS) PURE;
+    STDMETHOD_(DWORD, GetLevelCount)(THIS) PURE;
+    STDMETHOD(GetLevelDesc)(THIS_ UINT Level,D3DVOLUME_DESC *pDesc) PURE;
+    STDMETHOD(GetVolumeLevel)(THIS_ UINT Level,IDirect3DVolume8** ppVolumeLevel) PURE;
+    STDMETHOD(LockBox)(THIS_ UINT Level,D3DLOCKED_BOX* pLockedVolume,CONST D3DBOX* pBox,DWORD Flags) PURE;
+    STDMETHOD(UnlockBox)(THIS_ UINT Level) PURE;
+    STDMETHOD(AddDirtyBox)(THIS_ CONST D3DBOX* pDirtyBox) PURE;
+};
+
+typedef struct IDirect3DVolumeTexture8 *LPDIRECT3DVOLUMETEXTURE8, *PDIRECT3DVOLUMETEXTURE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DVolumeTexture8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DVolumeTexture8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DVolumeTexture8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DVolumeTexture8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DVolumeTexture8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DVolumeTexture8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DVolumeTexture8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DVolumeTexture8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DVolumeTexture8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DVolumeTexture8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DVolumeTexture8_GetType(p) (p)->lpVtbl->GetType(p)
+#define IDirect3DVolumeTexture8_SetLOD(p,a) (p)->lpVtbl->SetLOD(p,a)
+#define IDirect3DVolumeTexture8_GetLOD(p) (p)->lpVtbl->GetLOD(p)
+#define IDirect3DVolumeTexture8_GetLevelCount(p) (p)->lpVtbl->GetLevelCount(p)
+#define IDirect3DVolumeTexture8_GetLevelDesc(p,a,b) (p)->lpVtbl->GetLevelDesc(p,a,b)
+#define IDirect3DVolumeTexture8_GetVolumeLevel(p,a,b) (p)->lpVtbl->GetVolumeLevel(p,a,b)
+#define IDirect3DVolumeTexture8_LockBox(p,a,b,c,d) (p)->lpVtbl->LockBox(p,a,b,c,d)
+#define IDirect3DVolumeTexture8_UnlockBox(p,a) (p)->lpVtbl->UnlockBox(p,a)
+#define IDirect3DVolumeTexture8_AddDirtyBox(p,a) (p)->lpVtbl->AddDirtyBox(p,a)
+#else
+#define IDirect3DVolumeTexture8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DVolumeTexture8_AddRef(p) (p)->AddRef()
+#define IDirect3DVolumeTexture8_Release(p) (p)->Release()
+#define IDirect3DVolumeTexture8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DVolumeTexture8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DVolumeTexture8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DVolumeTexture8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DVolumeTexture8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DVolumeTexture8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DVolumeTexture8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DVolumeTexture8_GetType(p) (p)->GetType()
+#define IDirect3DVolumeTexture8_SetLOD(p,a) (p)->SetLOD(a)
+#define IDirect3DVolumeTexture8_GetLOD(p) (p)->GetLOD()
+#define IDirect3DVolumeTexture8_GetLevelCount(p) (p)->GetLevelCount()
+#define IDirect3DVolumeTexture8_GetLevelDesc(p,a,b) (p)->GetLevelDesc(a,b)
+#define IDirect3DVolumeTexture8_GetVolumeLevel(p,a,b) (p)->GetVolumeLevel(a,b)
+#define IDirect3DVolumeTexture8_LockBox(p,a,b,c,d) (p)->LockBox(a,b,c,d)
+#define IDirect3DVolumeTexture8_UnlockBox(p,a) (p)->UnlockBox(a)
+#define IDirect3DVolumeTexture8_AddDirtyBox(p,a) (p)->AddDirtyBox(a)
+#endif
+
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DCubeTexture8
+
+DECLARE_INTERFACE_(IDirect3DCubeTexture8, IDirect3DBaseTexture8)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DBaseTexture8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+    STDMETHOD_(DWORD, SetLOD)(THIS_ DWORD LODNew) PURE;
+    STDMETHOD_(DWORD, GetLOD)(THIS) PURE;
+    STDMETHOD_(DWORD, GetLevelCount)(THIS) PURE;
+    STDMETHOD(GetLevelDesc)(THIS_ UINT Level,D3DSURFACE_DESC *pDesc) PURE;
+    STDMETHOD(GetCubeMapSurface)(THIS_ D3DCUBEMAP_FACES FaceType,UINT Level,IDirect3DSurface8** ppCubeMapSurface) PURE;
+    STDMETHOD(LockRect)(THIS_ D3DCUBEMAP_FACES FaceType,UINT Level,D3DLOCKED_RECT* pLockedRect,CONST RECT* pRect,DWORD Flags) PURE;
+    STDMETHOD(UnlockRect)(THIS_ D3DCUBEMAP_FACES FaceType,UINT Level) PURE;
+    STDMETHOD(AddDirtyRect)(THIS_ D3DCUBEMAP_FACES FaceType,CONST RECT* pDirtyRect) PURE;
+};
+
+typedef struct IDirect3DCubeTexture8 *LPDIRECT3DCUBETEXTURE8, *PDIRECT3DCUBETEXTURE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DCubeTexture8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DCubeTexture8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DCubeTexture8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DCubeTexture8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DCubeTexture8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DCubeTexture8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DCubeTexture8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DCubeTexture8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DCubeTexture8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DCubeTexture8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DCubeTexture8_GetType(p) (p)->lpVtbl->GetType(p)
+#define IDirect3DCubeTexture8_SetLOD(p,a) (p)->lpVtbl->SetLOD(p,a)
+#define IDirect3DCubeTexture8_GetLOD(p) (p)->lpVtbl->GetLOD(p)
+#define IDirect3DCubeTexture8_GetLevelCount(p) (p)->lpVtbl->GetLevelCount(p)
+#define IDirect3DCubeTexture8_GetLevelDesc(p,a,b) (p)->lpVtbl->GetLevelDesc(p,a,b)
+#define IDirect3DCubeTexture8_GetCubeMapSurface(p,a,b,c) (p)->lpVtbl->GetCubeMapSurface(p,a,b,c)
+#define IDirect3DCubeTexture8_LockRect(p,a,b,c,d,e) (p)->lpVtbl->LockRect(p,a,b,c,d,e)
+#define IDirect3DCubeTexture8_UnlockRect(p,a,b) (p)->lpVtbl->UnlockRect(p,a,b)
+#define IDirect3DCubeTexture8_AddDirtyRect(p,a,b) (p)->lpVtbl->AddDirtyRect(p,a,b)
+#else
+#define IDirect3DCubeTexture8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DCubeTexture8_AddRef(p) (p)->AddRef()
+#define IDirect3DCubeTexture8_Release(p) (p)->Release()
+#define IDirect3DCubeTexture8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DCubeTexture8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DCubeTexture8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DCubeTexture8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DCubeTexture8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DCubeTexture8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DCubeTexture8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DCubeTexture8_GetType(p) (p)->GetType()
+#define IDirect3DCubeTexture8_SetLOD(p,a) (p)->SetLOD(a)
+#define IDirect3DCubeTexture8_GetLOD(p) (p)->GetLOD()
+#define IDirect3DCubeTexture8_GetLevelCount(p) (p)->GetLevelCount()
+#define IDirect3DCubeTexture8_GetLevelDesc(p,a,b) (p)->GetLevelDesc(a,b)
+#define IDirect3DCubeTexture8_GetCubeMapSurface(p,a,b,c) (p)->GetCubeMapSurface(a,b,c)
+#define IDirect3DCubeTexture8_LockRect(p,a,b,c,d,e) (p)->LockRect(a,b,c,d,e)
+#define IDirect3DCubeTexture8_UnlockRect(p,a,b) (p)->UnlockRect(a,b)
+#define IDirect3DCubeTexture8_AddDirtyRect(p,a,b) (p)->AddDirtyRect(a,b)
+#endif
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DVertexBuffer8
+
+DECLARE_INTERFACE_(IDirect3DVertexBuffer8, IDirect3DResource8)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DResource8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+    STDMETHOD(Lock)(THIS_ UINT OffsetToLock,UINT SizeToLock,BYTE** ppbData,DWORD Flags) PURE;
+    STDMETHOD(Unlock)(THIS) PURE;
+    STDMETHOD(GetDesc)(THIS_ D3DVERTEXBUFFER_DESC *pDesc) PURE;
+};
+
+typedef struct IDirect3DVertexBuffer8 *LPDIRECT3DVERTEXBUFFER8, *PDIRECT3DVERTEXBUFFER8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DVertexBuffer8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DVertexBuffer8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DVertexBuffer8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DVertexBuffer8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DVertexBuffer8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DVertexBuffer8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DVertexBuffer8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DVertexBuffer8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DVertexBuffer8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DVertexBuffer8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DVertexBuffer8_GetType(p) (p)->lpVtbl->GetType(p)
+#define IDirect3DVertexBuffer8_Lock(p,a,b,c,d) (p)->lpVtbl->Lock(p,a,b,c,d)
+#define IDirect3DVertexBuffer8_Unlock(p) (p)->lpVtbl->Unlock(p)
+#define IDirect3DVertexBuffer8_GetDesc(p,a) (p)->lpVtbl->GetDesc(p,a)
+#else
+#define IDirect3DVertexBuffer8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DVertexBuffer8_AddRef(p) (p)->AddRef()
+#define IDirect3DVertexBuffer8_Release(p) (p)->Release()
+#define IDirect3DVertexBuffer8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DVertexBuffer8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DVertexBuffer8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DVertexBuffer8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DVertexBuffer8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DVertexBuffer8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DVertexBuffer8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DVertexBuffer8_GetType(p) (p)->GetType()
+#define IDirect3DVertexBuffer8_Lock(p,a,b,c,d) (p)->Lock(a,b,c,d)
+#define IDirect3DVertexBuffer8_Unlock(p) (p)->Unlock()
+#define IDirect3DVertexBuffer8_GetDesc(p,a) (p)->GetDesc(a)
+#endif
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DIndexBuffer8
+
+DECLARE_INTERFACE_(IDirect3DIndexBuffer8, IDirect3DResource8)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DResource8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD_(DWORD, SetPriority)(THIS_ DWORD PriorityNew) PURE;
+    STDMETHOD_(DWORD, GetPriority)(THIS) PURE;
+    STDMETHOD_(void, PreLoad)(THIS) PURE;
+    STDMETHOD_(D3DRESOURCETYPE, GetType)(THIS) PURE;
+    STDMETHOD(Lock)(THIS_ UINT OffsetToLock,UINT SizeToLock,BYTE** ppbData,DWORD Flags) PURE;
+    STDMETHOD(Unlock)(THIS) PURE;
+    STDMETHOD(GetDesc)(THIS_ D3DINDEXBUFFER_DESC *pDesc) PURE;
+};
+
+typedef struct IDirect3DIndexBuffer8 *LPDIRECT3DINDEXBUFFER8, *PDIRECT3DINDEXBUFFER8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DIndexBuffer8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DIndexBuffer8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DIndexBuffer8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DIndexBuffer8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DIndexBuffer8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DIndexBuffer8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DIndexBuffer8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DIndexBuffer8_SetPriority(p,a) (p)->lpVtbl->SetPriority(p,a)
+#define IDirect3DIndexBuffer8_GetPriority(p) (p)->lpVtbl->GetPriority(p)
+#define IDirect3DIndexBuffer8_PreLoad(p) (p)->lpVtbl->PreLoad(p)
+#define IDirect3DIndexBuffer8_GetType(p) (p)->lpVtbl->GetType(p)
+#define IDirect3DIndexBuffer8_Lock(p,a,b,c,d) (p)->lpVtbl->Lock(p,a,b,c,d)
+#define IDirect3DIndexBuffer8_Unlock(p) (p)->lpVtbl->Unlock(p)
+#define IDirect3DIndexBuffer8_GetDesc(p,a) (p)->lpVtbl->GetDesc(p,a)
+#else
+#define IDirect3DIndexBuffer8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DIndexBuffer8_AddRef(p) (p)->AddRef()
+#define IDirect3DIndexBuffer8_Release(p) (p)->Release()
+#define IDirect3DIndexBuffer8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DIndexBuffer8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DIndexBuffer8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DIndexBuffer8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DIndexBuffer8_SetPriority(p,a) (p)->SetPriority(a)
+#define IDirect3DIndexBuffer8_GetPriority(p) (p)->GetPriority()
+#define IDirect3DIndexBuffer8_PreLoad(p) (p)->PreLoad()
+#define IDirect3DIndexBuffer8_GetType(p) (p)->GetType()
+#define IDirect3DIndexBuffer8_Lock(p,a,b,c,d) (p)->Lock(a,b,c,d)
+#define IDirect3DIndexBuffer8_Unlock(p) (p)->Unlock()
+#define IDirect3DIndexBuffer8_GetDesc(p,a) (p)->GetDesc(a)
+#endif
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DSurface8
+
+DECLARE_INTERFACE_(IDirect3DSurface8, IUnknown)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DSurface8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD(GetContainer)(THIS_ REFIID riid,void** ppContainer) PURE;
+    STDMETHOD(GetDesc)(THIS_ D3DSURFACE_DESC *pDesc) PURE;
+    STDMETHOD(LockRect)(THIS_ D3DLOCKED_RECT* pLockedRect,CONST RECT* pRect,DWORD Flags) PURE;
+    STDMETHOD(UnlockRect)(THIS) PURE;
+};
+
+typedef struct IDirect3DSurface8 *LPDIRECT3DSURFACE8, *PDIRECT3DSURFACE8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DSurface8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DSurface8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DSurface8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DSurface8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DSurface8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DSurface8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DSurface8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DSurface8_GetContainer(p,a,b) (p)->lpVtbl->GetContainer(p,a,b)
+#define IDirect3DSurface8_GetDesc(p,a) (p)->lpVtbl->GetDesc(p,a)
+#define IDirect3DSurface8_LockRect(p,a,b,c) (p)->lpVtbl->LockRect(p,a,b,c)
+#define IDirect3DSurface8_UnlockRect(p) (p)->lpVtbl->UnlockRect(p)
+#else
+#define IDirect3DSurface8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DSurface8_AddRef(p) (p)->AddRef()
+#define IDirect3DSurface8_Release(p) (p)->Release()
+#define IDirect3DSurface8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DSurface8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DSurface8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DSurface8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DSurface8_GetContainer(p,a,b) (p)->GetContainer(a,b)
+#define IDirect3DSurface8_GetDesc(p,a) (p)->GetDesc(a)
+#define IDirect3DSurface8_LockRect(p,a,b,c) (p)->LockRect(a,b,c)
+#define IDirect3DSurface8_UnlockRect(p) (p)->UnlockRect()
+#endif
+
+
+
+
+#undef INTERFACE
+#define INTERFACE IDirect3DVolume8
+
+DECLARE_INTERFACE_(IDirect3DVolume8, IUnknown)
+{
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
+    STDMETHOD_(ULONG,AddRef)(THIS) PURE;
+    STDMETHOD_(ULONG,Release)(THIS) PURE;
+
+    /*** IDirect3DVolume8 methods ***/
+    STDMETHOD(GetDevice)(THIS_ IDirect3DDevice8** ppDevice) PURE;
+    STDMETHOD(SetPrivateData)(THIS_ REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags) PURE;
+    STDMETHOD(GetPrivateData)(THIS_ REFGUID refguid,void* pData,DWORD* pSizeOfData) PURE;
+    STDMETHOD(FreePrivateData)(THIS_ REFGUID refguid) PURE;
+    STDMETHOD(GetContainer)(THIS_ REFIID riid,void** ppContainer) PURE;
+    STDMETHOD(GetDesc)(THIS_ D3DVOLUME_DESC *pDesc) PURE;
+    STDMETHOD(LockBox)(THIS_ D3DLOCKED_BOX * pLockedVolume,CONST D3DBOX* pBox,DWORD Flags) PURE;
+    STDMETHOD(UnlockBox)(THIS) PURE;
+};
+
+typedef struct IDirect3DVolume8 *LPDIRECT3DVOLUME8, *PDIRECT3DVOLUME8;
+
+#if !defined(__cplusplus) || defined(CINTERFACE)
+#define IDirect3DVolume8_QueryInterface(p,a,b) (p)->lpVtbl->QueryInterface(p,a,b)
+#define IDirect3DVolume8_AddRef(p) (p)->lpVtbl->AddRef(p)
+#define IDirect3DVolume8_Release(p) (p)->lpVtbl->Release(p)
+#define IDirect3DVolume8_GetDevice(p,a) (p)->lpVtbl->GetDevice(p,a)
+#define IDirect3DVolume8_SetPrivateData(p,a,b,c,d) (p)->lpVtbl->SetPrivateData(p,a,b,c,d)
+#define IDirect3DVolume8_GetPrivateData(p,a,b,c) (p)->lpVtbl->GetPrivateData(p,a,b,c)
+#define IDirect3DVolume8_FreePrivateData(p,a) (p)->lpVtbl->FreePrivateData(p,a)
+#define IDirect3DVolume8_GetContainer(p,a,b) (p)->lpVtbl->GetContainer(p,a,b)
+#define IDirect3DVolume8_GetDesc(p,a) (p)->lpVtbl->GetDesc(p,a)
+#define IDirect3DVolume8_LockBox(p,a,b,c) (p)->lpVtbl->LockBox(p,a,b,c)
+#define IDirect3DVolume8_UnlockBox(p) (p)->lpVtbl->UnlockBox(p)
+#else
+#define IDirect3DVolume8_QueryInterface(p,a,b) (p)->QueryInterface(a,b)
+#define IDirect3DVolume8_AddRef(p) (p)->AddRef()
+#define IDirect3DVolume8_Release(p) (p)->Release()
+#define IDirect3DVolume8_GetDevice(p,a) (p)->GetDevice(a)
+#define IDirect3DVolume8_SetPrivateData(p,a,b,c,d) (p)->SetPrivateData(a,b,c,d)
+#define IDirect3DVolume8_GetPrivateData(p,a,b,c) (p)->GetPrivateData(a,b,c)
+#define IDirect3DVolume8_FreePrivateData(p,a) (p)->FreePrivateData(a)
+#define IDirect3DVolume8_GetContainer(p,a,b) (p)->GetContainer(a,b)
+#define IDirect3DVolume8_GetDesc(p,a) (p)->GetDesc(a)
+#define IDirect3DVolume8_LockBox(p,a,b,c) (p)->LockBox(a,b,c)
+#define IDirect3DVolume8_UnlockBox(p) (p)->UnlockBox()
+#endif
+
+/****************************************************************************
+ * Flags for SetPrivateData method on all D3D8 interfaces
+ *
+ * The passed pointer is an IUnknown ptr. The SizeOfData argument to SetPrivateData
+ * must be set to sizeof(IUnknown*). Direct3D will call AddRef through this
+ * pointer and Release when the private data is destroyed. The data will be
+ * destroyed when another SetPrivateData with the same GUID is set, when
+ * FreePrivateData is called, or when the D3D8 object is freed.
+ ****************************************************************************/
+#define D3DSPD_IUNKNOWN                         0x00000001L
+
+/****************************************************************************
+ *
+ * Parameter for IDirect3D8 Enum and GetCaps8 functions to get the info for
+ * the current mode only.
+ *
+ ****************************************************************************/
+
+#define D3DCURRENT_DISPLAY_MODE                 0x00EFFFFFL
+
+/****************************************************************************
+ *
+ * Flags for IDirect3D8::CreateDevice's BehaviorFlags
+ *
+ ****************************************************************************/
+
+#define D3DCREATE_FPU_PRESERVE                  0x00000002L
+#define D3DCREATE_MULTITHREADED                 0x00000004L
+
+#define D3DCREATE_PUREDEVICE                    0x00000010L
+#define D3DCREATE_SOFTWARE_VERTEXPROCESSING     0x00000020L
+#define D3DCREATE_HARDWARE_VERTEXPROCESSING     0x00000040L
+#define D3DCREATE_MIXED_VERTEXPROCESSING        0x00000080L
+
+#define D3DCREATE_DISABLE_DRIVER_MANAGEMENT     0x00000100L
+
+
+/****************************************************************************
+ *
+ * Parameter for IDirect3D8::CreateDevice's iAdapter
+ *
+ ****************************************************************************/
+
+#define D3DADAPTER_DEFAULT                     0
+
+/****************************************************************************
+ *
+ * Flags for IDirect3D8::EnumAdapters
+ *
+ ****************************************************************************/
+
+#define D3DENUM_NO_WHQL_LEVEL                   0x00000002L
+
+/****************************************************************************
+ *
+ * Maximum number of back-buffers supported in DX8
+ *
+ ****************************************************************************/
+
+#define D3DPRESENT_BACK_BUFFERS_MAX             3L
+
+/****************************************************************************
+ *
+ * Flags for IDirect3DDevice8::SetGammaRamp
+ *
+ ****************************************************************************/
+
+#define D3DSGR_NO_CALIBRATION                  0x00000000L
+#define D3DSGR_CALIBRATE                       0x00000001L
+
+/****************************************************************************
+ *
+ * Flags for IDirect3DDevice8::SetCursorPosition
+ *
+ ****************************************************************************/
+
+#define D3DCURSOR_IMMEDIATE_UPDATE             0x00000001L
+
+/****************************************************************************
+ *
+ * Flags for DrawPrimitive/DrawIndexedPrimitive
+ *   Also valid for Begin/BeginIndexed
+ *   Also valid for VertexBuffer::CreateVertexBuffer
+ ****************************************************************************/
+
+
+/*
+ *  DirectDraw error codes
+ */
+#define _FACD3D  0x876
+#define MAKE_D3DHRESULT( code )  MAKE_HRESULT( 1, _FACD3D, code )
+
+/*
+ * Direct3D Errors
+ */
+#define D3D_OK                              S_OK
+
+#define D3DERR_WRONGTEXTUREFORMAT               MAKE_D3DHRESULT(2072)
+#define D3DERR_UNSUPPORTEDCOLOROPERATION        MAKE_D3DHRESULT(2073)
+#define D3DERR_UNSUPPORTEDCOLORARG              MAKE_D3DHRESULT(2074)
+#define D3DERR_UNSUPPORTEDALPHAOPERATION        MAKE_D3DHRESULT(2075)
+#define D3DERR_UNSUPPORTEDALPHAARG              MAKE_D3DHRESULT(2076)
+#define D3DERR_TOOMANYOPERATIONS                MAKE_D3DHRESULT(2077)
+#define D3DERR_CONFLICTINGTEXTUREFILTER         MAKE_D3DHRESULT(2078)
+#define D3DERR_UNSUPPORTEDFACTORVALUE           MAKE_D3DHRESULT(2079)
+#define D3DERR_CONFLICTINGRENDERSTATE           MAKE_D3DHRESULT(2081)
+#define D3DERR_UNSUPPORTEDTEXTUREFILTER         MAKE_D3DHRESULT(2082)
+#define D3DERR_CONFLICTINGTEXTUREPALETTE        MAKE_D3DHRESULT(2086)
+#define D3DERR_DRIVERINTERNALERROR              MAKE_D3DHRESULT(2087)
+
+#define D3DERR_NOTFOUND                         MAKE_D3DHRESULT(2150)
+#define D3DERR_MOREDATA                         MAKE_D3DHRESULT(2151)
+#define D3DERR_DEVICELOST                       MAKE_D3DHRESULT(2152)
+#define D3DERR_DEVICENOTRESET                   MAKE_D3DHRESULT(2153)
+#define D3DERR_NOTAVAILABLE                     MAKE_D3DHRESULT(2154)
+#define D3DERR_OUTOFVIDEOMEMORY                 MAKE_D3DHRESULT(380)
+#define D3DERR_INVALIDDEVICE                    MAKE_D3DHRESULT(2155)
+#define D3DERR_INVALIDCALL                      MAKE_D3DHRESULT(2156)
+#define D3DERR_DRIVERINVALIDCALL                MAKE_D3DHRESULT(2157)
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* (DIRECT3D_VERSION >= 0x0800) */
+#endif /* _D3D_H_ */
+

--- a/renderdoc/driver/dx/official/d3d8caps.h
+++ b/renderdoc/driver/dx/official/d3d8caps.h
@@ -1,0 +1,364 @@
+/*==========================================================================;
+ *
+ *  Copyright (C) Microsoft Corporation.  All Rights Reserved.
+ *
+ *  File:       d3d8caps.h
+ *  Content:    Direct3D capabilities include file
+ *
+ ***************************************************************************/
+
+#ifndef _D3D8CAPS_H
+#define _D3D8CAPS_H
+
+#ifndef DIRECT3D_VERSION
+#define DIRECT3D_VERSION         0x0800
+#endif  //DIRECT3D_VERSION
+
+// include this file content only if compiling for DX8 interfaces
+#if(DIRECT3D_VERSION >= 0x0800)
+
+#if defined(_X86_) || defined(_IA64_)
+#pragma pack(4)
+#endif
+
+typedef struct _D3DCAPS8
+{
+    /* Device Info */
+    D3DDEVTYPE  DeviceType;
+    UINT    AdapterOrdinal;
+
+    /* Caps from DX7 Draw */
+    DWORD   Caps;
+    DWORD   Caps2;
+    DWORD   Caps3;
+    DWORD   PresentationIntervals;
+
+    /* Cursor Caps */
+    DWORD   CursorCaps;
+
+    /* 3D Device Caps */
+    DWORD   DevCaps;
+
+    DWORD   PrimitiveMiscCaps;
+    DWORD   RasterCaps;
+    DWORD   ZCmpCaps;
+    DWORD   SrcBlendCaps;
+    DWORD   DestBlendCaps;
+    DWORD   AlphaCmpCaps;
+    DWORD   ShadeCaps;
+    DWORD   TextureCaps;
+    DWORD   TextureFilterCaps;          // D3DPTFILTERCAPS for IDirect3DTexture8's
+    DWORD   CubeTextureFilterCaps;      // D3DPTFILTERCAPS for IDirect3DCubeTexture8's
+    DWORD   VolumeTextureFilterCaps;    // D3DPTFILTERCAPS for IDirect3DVolumeTexture8's
+    DWORD   TextureAddressCaps;         // D3DPTADDRESSCAPS for IDirect3DTexture8's
+    DWORD   VolumeTextureAddressCaps;   // D3DPTADDRESSCAPS for IDirect3DVolumeTexture8's
+
+    DWORD   LineCaps;                   // D3DLINECAPS
+
+    DWORD   MaxTextureWidth, MaxTextureHeight;
+    DWORD   MaxVolumeExtent;
+
+    DWORD   MaxTextureRepeat;
+    DWORD   MaxTextureAspectRatio;
+    DWORD   MaxAnisotropy;
+    float   MaxVertexW;
+
+    float   GuardBandLeft;
+    float   GuardBandTop;
+    float   GuardBandRight;
+    float   GuardBandBottom;
+
+    float   ExtentsAdjust;
+    DWORD   StencilCaps;
+
+    DWORD   FVFCaps;
+    DWORD   TextureOpCaps;
+    DWORD   MaxTextureBlendStages;
+    DWORD   MaxSimultaneousTextures;
+
+    DWORD   VertexProcessingCaps;
+    DWORD   MaxActiveLights;
+    DWORD   MaxUserClipPlanes;
+    DWORD   MaxVertexBlendMatrices;
+    DWORD   MaxVertexBlendMatrixIndex;
+
+    float   MaxPointSize;
+
+    DWORD   MaxPrimitiveCount;          // max number of primitives per DrawPrimitive call
+    DWORD   MaxVertexIndex;
+    DWORD   MaxStreams;
+    DWORD   MaxStreamStride;            // max stride for SetStreamSource
+
+    DWORD   VertexShaderVersion;
+    DWORD   MaxVertexShaderConst;       // number of vertex shader constant registers
+
+    DWORD   PixelShaderVersion;
+    float   MaxPixelShaderValue;        // max value of pixel shader arithmetic component
+
+} D3DCAPS8;
+
+//
+// BIT DEFINES FOR D3DCAPS8 DWORD MEMBERS
+//
+
+//
+// Caps
+//
+#define D3DCAPS_READ_SCANLINE           0x00020000L
+
+//
+// Caps2
+//
+#define D3DCAPS2_NO2DDURING3DSCENE      0x00000002L
+#define D3DCAPS2_FULLSCREENGAMMA        0x00020000L
+#define D3DCAPS2_CANRENDERWINDOWED      0x00080000L
+#define D3DCAPS2_CANCALIBRATEGAMMA      0x00100000L
+#define D3DCAPS2_RESERVED               0x02000000L
+#define D3DCAPS2_CANMANAGERESOURCE      0x10000000L
+#define D3DCAPS2_DYNAMICTEXTURES        0x20000000L
+
+//
+// Caps3
+//
+#define D3DCAPS3_RESERVED               0x8000001fL
+
+// Indicates that the device can respect the ALPHABLENDENABLE render state
+// when fullscreen while using the FLIP or DISCARD swap effect.
+// COPY and COPYVSYNC swap effects work whether or not this flag is set.
+#define D3DCAPS3_ALPHA_FULLSCREEN_FLIP_OR_DISCARD   0x00000020L
+
+//
+// PresentationIntervals
+//
+#define D3DPRESENT_INTERVAL_DEFAULT     0x00000000L
+#define D3DPRESENT_INTERVAL_ONE         0x00000001L
+#define D3DPRESENT_INTERVAL_TWO         0x00000002L
+#define D3DPRESENT_INTERVAL_THREE       0x00000004L
+#define D3DPRESENT_INTERVAL_FOUR        0x00000008L
+#define D3DPRESENT_INTERVAL_IMMEDIATE   0x80000000L
+
+//
+// CursorCaps
+//
+// Driver supports HW color cursor in at least hi-res modes(height >=400)
+#define D3DCURSORCAPS_COLOR             0x00000001L
+// Driver supports HW cursor also in low-res modes(height < 400)
+#define D3DCURSORCAPS_LOWRES            0x00000002L
+
+//
+// DevCaps
+//
+#define D3DDEVCAPS_EXECUTESYSTEMMEMORY  0x00000010L /* Device can use execute buffers from system memory */
+#define D3DDEVCAPS_EXECUTEVIDEOMEMORY   0x00000020L /* Device can use execute buffers from video memory */
+#define D3DDEVCAPS_TLVERTEXSYSTEMMEMORY 0x00000040L /* Device can use TL buffers from system memory */
+#define D3DDEVCAPS_TLVERTEXVIDEOMEMORY  0x00000080L /* Device can use TL buffers from video memory */
+#define D3DDEVCAPS_TEXTURESYSTEMMEMORY  0x00000100L /* Device can texture from system memory */
+#define D3DDEVCAPS_TEXTUREVIDEOMEMORY   0x00000200L /* Device can texture from device memory */
+#define D3DDEVCAPS_DRAWPRIMTLVERTEX     0x00000400L /* Device can draw TLVERTEX primitives */
+#define D3DDEVCAPS_CANRENDERAFTERFLIP   0x00000800L /* Device can render without waiting for flip to complete */
+#define D3DDEVCAPS_TEXTURENONLOCALVIDMEM 0x00001000L /* Device can texture from nonlocal video memory */
+#define D3DDEVCAPS_DRAWPRIMITIVES2      0x00002000L /* Device can support DrawPrimitives2 */
+#define D3DDEVCAPS_SEPARATETEXTUREMEMORIES 0x00004000L /* Device is texturing from separate memory pools */
+#define D3DDEVCAPS_DRAWPRIMITIVES2EX    0x00008000L /* Device can support Extended DrawPrimitives2 i.e. DX7 compliant driver*/
+#define D3DDEVCAPS_HWTRANSFORMANDLIGHT  0x00010000L /* Device can support transformation and lighting in hardware and DRAWPRIMITIVES2EX must be also */
+#define D3DDEVCAPS_CANBLTSYSTONONLOCAL  0x00020000L /* Device supports a Tex Blt from system memory to non-local vidmem */
+#define D3DDEVCAPS_HWRASTERIZATION      0x00080000L /* Device has HW acceleration for rasterization */
+#define D3DDEVCAPS_PUREDEVICE           0x00100000L /* Device supports D3DCREATE_PUREDEVICE */
+#define D3DDEVCAPS_QUINTICRTPATCHES     0x00200000L /* Device supports quintic Beziers and BSplines */
+#define D3DDEVCAPS_RTPATCHES            0x00400000L /* Device supports Rect and Tri patches */
+#define D3DDEVCAPS_RTPATCHHANDLEZERO    0x00800000L /* Indicates that RT Patches may be drawn efficiently using handle 0 */
+#define D3DDEVCAPS_NPATCHES             0x01000000L /* Device supports N-Patches */
+
+//
+// PrimitiveMiscCaps
+//
+#define D3DPMISCCAPS_MASKZ              0x00000002L
+#define D3DPMISCCAPS_LINEPATTERNREP     0x00000004L
+#define D3DPMISCCAPS_CULLNONE           0x00000010L
+#define D3DPMISCCAPS_CULLCW             0x00000020L
+#define D3DPMISCCAPS_CULLCCW            0x00000040L
+#define D3DPMISCCAPS_COLORWRITEENABLE   0x00000080L
+#define D3DPMISCCAPS_CLIPPLANESCALEDPOINTS 0x00000100L /* Device correctly clips scaled points to clip planes */
+#define D3DPMISCCAPS_CLIPTLVERTS        0x00000200L /* device will clip post-transformed vertex primitives */
+#define D3DPMISCCAPS_TSSARGTEMP         0x00000400L /* device supports D3DTA_TEMP for temporary register */
+#define D3DPMISCCAPS_BLENDOP            0x00000800L /* device supports D3DRS_BLENDOP */
+#define D3DPMISCCAPS_NULLREFERENCE      0x00001000L /* Reference Device that doesnt render */
+
+//
+// LineCaps
+//
+#define D3DLINECAPS_TEXTURE             0x00000001L
+#define D3DLINECAPS_ZTEST               0x00000002L
+#define D3DLINECAPS_BLEND               0x00000004L
+#define D3DLINECAPS_ALPHACMP            0x00000008L
+#define D3DLINECAPS_FOG                 0x00000010L
+
+//
+// RasterCaps
+//
+#define D3DPRASTERCAPS_DITHER           0x00000001L
+#define D3DPRASTERCAPS_PAT              0x00000008L
+#define D3DPRASTERCAPS_ZTEST            0x00000010L
+#define D3DPRASTERCAPS_FOGVERTEX        0x00000080L
+#define D3DPRASTERCAPS_FOGTABLE         0x00000100L
+#define D3DPRASTERCAPS_ANTIALIASEDGES   0x00001000L
+#define D3DPRASTERCAPS_MIPMAPLODBIAS    0x00002000L
+#define D3DPRASTERCAPS_ZBIAS            0x00004000L
+#define D3DPRASTERCAPS_ZBUFFERLESSHSR   0x00008000L
+#define D3DPRASTERCAPS_FOGRANGE         0x00010000L
+#define D3DPRASTERCAPS_ANISOTROPY       0x00020000L
+#define D3DPRASTERCAPS_WBUFFER          0x00040000L
+#define D3DPRASTERCAPS_WFOG             0x00100000L
+#define D3DPRASTERCAPS_ZFOG             0x00200000L
+#define D3DPRASTERCAPS_COLORPERSPECTIVE 0x00400000L /* Device iterates colors perspective correct */
+#define D3DPRASTERCAPS_STRETCHBLTMULTISAMPLE  0x00800000L
+
+//
+// ZCmpCaps, AlphaCmpCaps
+//
+#define D3DPCMPCAPS_NEVER               0x00000001L
+#define D3DPCMPCAPS_LESS                0x00000002L
+#define D3DPCMPCAPS_EQUAL               0x00000004L
+#define D3DPCMPCAPS_LESSEQUAL           0x00000008L
+#define D3DPCMPCAPS_GREATER             0x00000010L
+#define D3DPCMPCAPS_NOTEQUAL            0x00000020L
+#define D3DPCMPCAPS_GREATEREQUAL        0x00000040L
+#define D3DPCMPCAPS_ALWAYS              0x00000080L
+
+//
+// SourceBlendCaps, DestBlendCaps
+//
+#define D3DPBLENDCAPS_ZERO              0x00000001L
+#define D3DPBLENDCAPS_ONE               0x00000002L
+#define D3DPBLENDCAPS_SRCCOLOR          0x00000004L
+#define D3DPBLENDCAPS_INVSRCCOLOR       0x00000008L
+#define D3DPBLENDCAPS_SRCALPHA          0x00000010L
+#define D3DPBLENDCAPS_INVSRCALPHA       0x00000020L
+#define D3DPBLENDCAPS_DESTALPHA         0x00000040L
+#define D3DPBLENDCAPS_INVDESTALPHA      0x00000080L
+#define D3DPBLENDCAPS_DESTCOLOR         0x00000100L
+#define D3DPBLENDCAPS_INVDESTCOLOR      0x00000200L
+#define D3DPBLENDCAPS_SRCALPHASAT       0x00000400L
+#define D3DPBLENDCAPS_BOTHSRCALPHA      0x00000800L
+#define D3DPBLENDCAPS_BOTHINVSRCALPHA   0x00001000L
+
+//
+// ShadeCaps
+//
+#define D3DPSHADECAPS_COLORGOURAUDRGB       0x00000008L
+#define D3DPSHADECAPS_SPECULARGOURAUDRGB    0x00000200L
+#define D3DPSHADECAPS_ALPHAGOURAUDBLEND     0x00004000L
+#define D3DPSHADECAPS_FOGGOURAUD            0x00080000L
+
+//
+// TextureCaps
+//
+#define D3DPTEXTURECAPS_PERSPECTIVE         0x00000001L /* Perspective-correct texturing is supported */
+#define D3DPTEXTURECAPS_POW2                0x00000002L /* Power-of-2 texture dimensions are required - applies to non-Cube/Volume textures only. */
+#define D3DPTEXTURECAPS_ALPHA               0x00000004L /* Alpha in texture pixels is supported */
+#define D3DPTEXTURECAPS_SQUAREONLY          0x00000020L /* Only square textures are supported */
+#define D3DPTEXTURECAPS_TEXREPEATNOTSCALEDBYSIZE 0x00000040L /* Texture indices are not scaled by the texture size prior to interpolation */
+#define D3DPTEXTURECAPS_ALPHAPALETTE        0x00000080L /* Device can draw alpha from texture palettes */
+// Device can use non-POW2 textures if:
+//  1) D3DTEXTURE_ADDRESS is set to CLAMP for this texture's stage
+//  2) D3DRS_WRAP(N) is zero for this texture's coordinates
+//  3) mip mapping is not enabled (use magnification filter only)
+#define D3DPTEXTURECAPS_NONPOW2CONDITIONAL  0x00000100L
+#define D3DPTEXTURECAPS_PROJECTED           0x00000400L /* Device can do D3DTTFF_PROJECTED */
+#define D3DPTEXTURECAPS_CUBEMAP             0x00000800L /* Device can do cubemap textures */
+#define D3DPTEXTURECAPS_VOLUMEMAP           0x00002000L /* Device can do volume textures */
+#define D3DPTEXTURECAPS_MIPMAP              0x00004000L /* Device can do mipmapped textures */
+#define D3DPTEXTURECAPS_MIPVOLUMEMAP        0x00008000L /* Device can do mipmapped volume textures */
+#define D3DPTEXTURECAPS_MIPCUBEMAP          0x00010000L /* Device can do mipmapped cube maps */
+#define D3DPTEXTURECAPS_CUBEMAP_POW2        0x00020000L /* Device requires that cubemaps be power-of-2 dimension */
+#define D3DPTEXTURECAPS_VOLUMEMAP_POW2      0x00040000L /* Device requires that volume maps be power-of-2 dimension */
+
+//
+// TextureFilterCaps
+//
+#define D3DPTFILTERCAPS_MINFPOINT           0x00000100L /* Min Filter */
+#define D3DPTFILTERCAPS_MINFLINEAR          0x00000200L
+#define D3DPTFILTERCAPS_MINFANISOTROPIC     0x00000400L
+#define D3DPTFILTERCAPS_MIPFPOINT           0x00010000L /* Mip Filter */
+#define D3DPTFILTERCAPS_MIPFLINEAR          0x00020000L
+#define D3DPTFILTERCAPS_MAGFPOINT           0x01000000L /* Mag Filter */
+#define D3DPTFILTERCAPS_MAGFLINEAR          0x02000000L
+#define D3DPTFILTERCAPS_MAGFANISOTROPIC     0x04000000L
+#define D3DPTFILTERCAPS_MAGFAFLATCUBIC      0x08000000L
+#define D3DPTFILTERCAPS_MAGFGAUSSIANCUBIC   0x10000000L
+
+//
+// TextureAddressCaps
+//
+#define D3DPTADDRESSCAPS_WRAP           0x00000001L
+#define D3DPTADDRESSCAPS_MIRROR         0x00000002L
+#define D3DPTADDRESSCAPS_CLAMP          0x00000004L
+#define D3DPTADDRESSCAPS_BORDER         0x00000008L
+#define D3DPTADDRESSCAPS_INDEPENDENTUV  0x00000010L
+#define D3DPTADDRESSCAPS_MIRRORONCE     0x00000020L
+
+//
+// StencilCaps
+//
+#define D3DSTENCILCAPS_KEEP             0x00000001L
+#define D3DSTENCILCAPS_ZERO             0x00000002L
+#define D3DSTENCILCAPS_REPLACE          0x00000004L
+#define D3DSTENCILCAPS_INCRSAT          0x00000008L
+#define D3DSTENCILCAPS_DECRSAT          0x00000010L
+#define D3DSTENCILCAPS_INVERT           0x00000020L
+#define D3DSTENCILCAPS_INCR             0x00000040L
+#define D3DSTENCILCAPS_DECR             0x00000080L
+
+//
+// TextureOpCaps
+//
+#define D3DTEXOPCAPS_DISABLE                    0x00000001L
+#define D3DTEXOPCAPS_SELECTARG1                 0x00000002L
+#define D3DTEXOPCAPS_SELECTARG2                 0x00000004L
+#define D3DTEXOPCAPS_MODULATE                   0x00000008L
+#define D3DTEXOPCAPS_MODULATE2X                 0x00000010L
+#define D3DTEXOPCAPS_MODULATE4X                 0x00000020L
+#define D3DTEXOPCAPS_ADD                        0x00000040L
+#define D3DTEXOPCAPS_ADDSIGNED                  0x00000080L
+#define D3DTEXOPCAPS_ADDSIGNED2X                0x00000100L
+#define D3DTEXOPCAPS_SUBTRACT                   0x00000200L
+#define D3DTEXOPCAPS_ADDSMOOTH                  0x00000400L
+#define D3DTEXOPCAPS_BLENDDIFFUSEALPHA          0x00000800L
+#define D3DTEXOPCAPS_BLENDTEXTUREALPHA          0x00001000L
+#define D3DTEXOPCAPS_BLENDFACTORALPHA           0x00002000L
+#define D3DTEXOPCAPS_BLENDTEXTUREALPHAPM        0x00004000L
+#define D3DTEXOPCAPS_BLENDCURRENTALPHA          0x00008000L
+#define D3DTEXOPCAPS_PREMODULATE                0x00010000L
+#define D3DTEXOPCAPS_MODULATEALPHA_ADDCOLOR     0x00020000L
+#define D3DTEXOPCAPS_MODULATECOLOR_ADDALPHA     0x00040000L
+#define D3DTEXOPCAPS_MODULATEINVALPHA_ADDCOLOR  0x00080000L
+#define D3DTEXOPCAPS_MODULATEINVCOLOR_ADDALPHA  0x00100000L
+#define D3DTEXOPCAPS_BUMPENVMAP                 0x00200000L
+#define D3DTEXOPCAPS_BUMPENVMAPLUMINANCE        0x00400000L
+#define D3DTEXOPCAPS_DOTPRODUCT3                0x00800000L
+#define D3DTEXOPCAPS_MULTIPLYADD                0x01000000L
+#define D3DTEXOPCAPS_LERP                       0x02000000L
+
+//
+// FVFCaps
+//
+#define D3DFVFCAPS_TEXCOORDCOUNTMASK    0x0000ffffL /* mask for texture coordinate count field */
+#define D3DFVFCAPS_DONOTSTRIPELEMENTS   0x00080000L /* Device prefers that vertex elements not be stripped */
+#define D3DFVFCAPS_PSIZE                0x00100000L /* Device can receive point size */
+
+//
+// VertexProcessingCaps
+//
+#define D3DVTXPCAPS_TEXGEN              0x00000001L /* device can do texgen */
+#define D3DVTXPCAPS_MATERIALSOURCE7     0x00000002L /* device can do DX7-level colormaterialsource ops */
+#define D3DVTXPCAPS_DIRECTIONALLIGHTS   0x00000008L /* device can do directional lights */
+#define D3DVTXPCAPS_POSITIONALLIGHTS    0x00000010L /* device can do positional lights (includes point and spot) */
+#define D3DVTXPCAPS_LOCALVIEWER         0x00000020L /* device can do local viewer */
+#define D3DVTXPCAPS_TWEENING            0x00000040L /* device can do vertex tweening */
+#define D3DVTXPCAPS_NO_VSDT_UBYTE4      0x00000080L /* device does not support D3DVSDT_UBYTE4 */
+
+#pragma pack()
+
+#endif /* (DIRECT3D_VERSION >= 0x0800) */
+#endif /* _D3D8CAPS_H_ */
+

--- a/renderdoc/driver/dx/official/d3d8types.h
+++ b/renderdoc/driver/dx/official/d3d8types.h
@@ -1,0 +1,1684 @@
+/*==========================================================================;
+ *
+ *  Copyright (C) Microsoft Corporation.  All Rights Reserved.
+ *
+ *  File:       d3d8types.h
+ *  Content:    Direct3D capabilities include file
+ *
+ ***************************************************************************/
+
+#ifndef _D3D8TYPES_H_
+#define _D3D8TYPES_H_
+
+#ifndef DIRECT3D_VERSION
+#define DIRECT3D_VERSION         0x0800
+#endif  //DIRECT3D_VERSION
+
+// include this file content only if compiling for DX8 interfaces
+#if(DIRECT3D_VERSION >= 0x0800)
+
+#include <float.h>
+
+#if _MSC_VER >= 1200
+#pragma warning(push)
+#endif
+#pragma warning(disable:4201) // anonymous unions warning
+#if defined(_X86_) || defined(_IA64_)
+#pragma pack(4)
+#endif
+
+// D3DCOLOR is equivalent to D3DFMT_A8R8G8B8
+#ifndef D3DCOLOR_DEFINED
+typedef DWORD D3DCOLOR;
+#define D3DCOLOR_DEFINED
+#endif
+
+// maps unsigned 8 bits/channel to D3DCOLOR
+#define D3DCOLOR_ARGB(a,r,g,b) \
+    ((D3DCOLOR)((((a)&0xff)<<24)|(((r)&0xff)<<16)|(((g)&0xff)<<8)|((b)&0xff)))
+#define D3DCOLOR_RGBA(r,g,b,a) D3DCOLOR_ARGB(a,r,g,b)
+#define D3DCOLOR_XRGB(r,g,b)   D3DCOLOR_ARGB(0xff,r,g,b)
+
+// maps floating point channels (0.f to 1.f range) to D3DCOLOR
+#define D3DCOLOR_COLORVALUE(r,g,b,a) \
+    D3DCOLOR_RGBA((DWORD)((r)*255.f),(DWORD)((g)*255.f),(DWORD)((b)*255.f),(DWORD)((a)*255.f))
+
+
+#ifndef D3DVECTOR_DEFINED
+typedef struct _D3DVECTOR {
+    float x;
+    float y;
+    float z;
+} D3DVECTOR;
+#define D3DVECTOR_DEFINED
+#endif
+
+#ifndef D3DCOLORVALUE_DEFINED
+typedef struct _D3DCOLORVALUE {
+    float r;
+    float g;
+    float b;
+    float a;
+} D3DCOLORVALUE;
+#define D3DCOLORVALUE_DEFINED
+#endif
+
+#ifndef D3DRECT_DEFINED
+typedef struct _D3DRECT {
+    LONG x1;
+    LONG y1;
+    LONG x2;
+    LONG y2;
+} D3DRECT;
+#define D3DRECT_DEFINED
+#endif
+
+#ifndef D3DMATRIX_DEFINED
+typedef struct _D3DMATRIX {
+    union {
+        struct {
+            float        _11, _12, _13, _14;
+            float        _21, _22, _23, _24;
+            float        _31, _32, _33, _34;
+            float        _41, _42, _43, _44;
+
+        };
+        float m[4][4];
+    };
+} D3DMATRIX;
+#define D3DMATRIX_DEFINED
+#endif
+
+typedef struct _D3DVIEWPORT8 {
+    DWORD       X;
+    DWORD       Y;            /* Viewport Top left */
+    DWORD       Width;
+    DWORD       Height;       /* Viewport Dimensions */
+    float       MinZ;         /* Min/max of clip Volume */
+    float       MaxZ;
+} D3DVIEWPORT8;
+
+/*
+ * Values for clip fields.
+ */
+
+// Max number of user clipping planes, supported in D3D.
+#define D3DMAXUSERCLIPPLANES 32
+
+// These bits could be ORed together to use with D3DRS_CLIPPLANEENABLE
+//
+#define D3DCLIPPLANE0 (1 << 0)
+#define D3DCLIPPLANE1 (1 << 1)
+#define D3DCLIPPLANE2 (1 << 2)
+#define D3DCLIPPLANE3 (1 << 3)
+#define D3DCLIPPLANE4 (1 << 4)
+#define D3DCLIPPLANE5 (1 << 5)
+
+// The following bits are used in the ClipUnion and ClipIntersection
+// members of the D3DCLIPSTATUS8
+//
+
+#define D3DCS_LEFT        0x00000001L
+#define D3DCS_RIGHT       0x00000002L
+#define D3DCS_TOP         0x00000004L
+#define D3DCS_BOTTOM      0x00000008L
+#define D3DCS_FRONT       0x00000010L
+#define D3DCS_BACK        0x00000020L
+#define D3DCS_PLANE0      0x00000040L
+#define D3DCS_PLANE1      0x00000080L
+#define D3DCS_PLANE2      0x00000100L
+#define D3DCS_PLANE3      0x00000200L
+#define D3DCS_PLANE4      0x00000400L
+#define D3DCS_PLANE5      0x00000800L
+
+#define D3DCS_ALL (D3DCS_LEFT   | \
+                   D3DCS_RIGHT  | \
+                   D3DCS_TOP    | \
+                   D3DCS_BOTTOM | \
+                   D3DCS_FRONT  | \
+                   D3DCS_BACK   | \
+                   D3DCS_PLANE0 | \
+                   D3DCS_PLANE1 | \
+                   D3DCS_PLANE2 | \
+                   D3DCS_PLANE3 | \
+                   D3DCS_PLANE4 | \
+                   D3DCS_PLANE5)
+
+typedef struct _D3DCLIPSTATUS8 {
+    DWORD ClipUnion;
+    DWORD ClipIntersection;
+} D3DCLIPSTATUS8;
+
+typedef struct _D3DMATERIAL8 {
+    D3DCOLORVALUE   Diffuse;        /* Diffuse color RGBA */
+    D3DCOLORVALUE   Ambient;        /* Ambient color RGB */
+    D3DCOLORVALUE   Specular;       /* Specular 'shininess' */
+    D3DCOLORVALUE   Emissive;       /* Emissive color RGB */
+    float           Power;          /* Sharpness if specular highlight */
+} D3DMATERIAL8;
+
+typedef enum _D3DLIGHTTYPE {
+    D3DLIGHT_POINT          = 1,
+    D3DLIGHT_SPOT           = 2,
+    D3DLIGHT_DIRECTIONAL    = 3,
+    D3DLIGHT_FORCE_DWORD    = 0x7fffffff, /* force 32-bit size enum */
+} D3DLIGHTTYPE;
+
+typedef struct _D3DLIGHT8 {
+    D3DLIGHTTYPE    Type;            /* Type of light source */
+    D3DCOLORVALUE   Diffuse;         /* Diffuse color of light */
+    D3DCOLORVALUE   Specular;        /* Specular color of light */
+    D3DCOLORVALUE   Ambient;         /* Ambient color of light */
+    D3DVECTOR       Position;         /* Position in world space */
+    D3DVECTOR       Direction;        /* Direction in world space */
+    float           Range;            /* Cutoff range */
+    float           Falloff;          /* Falloff */
+    float           Attenuation0;     /* Constant attenuation */
+    float           Attenuation1;     /* Linear attenuation */
+    float           Attenuation2;     /* Quadratic attenuation */
+    float           Theta;            /* Inner angle of spotlight cone */
+    float           Phi;              /* Outer angle of spotlight cone */
+} D3DLIGHT8;
+
+/*
+ * Options for clearing
+ */
+#define D3DCLEAR_TARGET            0x00000001l  /* Clear target surface */
+#define D3DCLEAR_ZBUFFER           0x00000002l  /* Clear target z buffer */
+#define D3DCLEAR_STENCIL           0x00000004l  /* Clear stencil planes */
+
+/*
+ * The following defines the rendering states
+ */
+
+typedef enum _D3DSHADEMODE {
+    D3DSHADE_FLAT               = 1,
+    D3DSHADE_GOURAUD            = 2,
+    D3DSHADE_PHONG              = 3,
+    D3DSHADE_FORCE_DWORD        = 0x7fffffff, /* force 32-bit size enum */
+} D3DSHADEMODE;
+
+typedef enum _D3DFILLMODE {
+    D3DFILL_POINT               = 1,
+    D3DFILL_WIREFRAME           = 2,
+    D3DFILL_SOLID               = 3,
+    D3DFILL_FORCE_DWORD         = 0x7fffffff, /* force 32-bit size enum */
+} D3DFILLMODE;
+
+typedef struct _D3DLINEPATTERN {
+    WORD    wRepeatFactor;
+    WORD    wLinePattern;
+} D3DLINEPATTERN;
+
+typedef enum _D3DBLEND {
+    D3DBLEND_ZERO               = 1,
+    D3DBLEND_ONE                = 2,
+    D3DBLEND_SRCCOLOR           = 3,
+    D3DBLEND_INVSRCCOLOR        = 4,
+    D3DBLEND_SRCALPHA           = 5,
+    D3DBLEND_INVSRCALPHA        = 6,
+    D3DBLEND_DESTALPHA          = 7,
+    D3DBLEND_INVDESTALPHA       = 8,
+    D3DBLEND_DESTCOLOR          = 9,
+    D3DBLEND_INVDESTCOLOR       = 10,
+    D3DBLEND_SRCALPHASAT        = 11,
+    D3DBLEND_BOTHSRCALPHA       = 12,
+    D3DBLEND_BOTHINVSRCALPHA    = 13,
+    D3DBLEND_FORCE_DWORD        = 0x7fffffff, /* force 32-bit size enum */
+} D3DBLEND;
+
+typedef enum _D3DBLENDOP {
+    D3DBLENDOP_ADD              = 1,
+    D3DBLENDOP_SUBTRACT         = 2,
+    D3DBLENDOP_REVSUBTRACT      = 3,
+    D3DBLENDOP_MIN              = 4,
+    D3DBLENDOP_MAX              = 5,
+    D3DBLENDOP_FORCE_DWORD      = 0x7fffffff, /* force 32-bit size enum */
+} D3DBLENDOP;
+
+typedef enum _D3DTEXTUREADDRESS {
+    D3DTADDRESS_WRAP            = 1,
+    D3DTADDRESS_MIRROR          = 2,
+    D3DTADDRESS_CLAMP           = 3,
+    D3DTADDRESS_BORDER          = 4,
+    D3DTADDRESS_MIRRORONCE      = 5,
+    D3DTADDRESS_FORCE_DWORD     = 0x7fffffff, /* force 32-bit size enum */
+} D3DTEXTUREADDRESS;
+
+typedef enum _D3DCULL {
+    D3DCULL_NONE                = 1,
+    D3DCULL_CW                  = 2,
+    D3DCULL_CCW                 = 3,
+    D3DCULL_FORCE_DWORD         = 0x7fffffff, /* force 32-bit size enum */
+} D3DCULL;
+
+typedef enum _D3DCMPFUNC {
+    D3DCMP_NEVER                = 1,
+    D3DCMP_LESS                 = 2,
+    D3DCMP_EQUAL                = 3,
+    D3DCMP_LESSEQUAL            = 4,
+    D3DCMP_GREATER              = 5,
+    D3DCMP_NOTEQUAL             = 6,
+    D3DCMP_GREATEREQUAL         = 7,
+    D3DCMP_ALWAYS               = 8,
+    D3DCMP_FORCE_DWORD          = 0x7fffffff, /* force 32-bit size enum */
+} D3DCMPFUNC;
+
+typedef enum _D3DSTENCILOP {
+    D3DSTENCILOP_KEEP           = 1,
+    D3DSTENCILOP_ZERO           = 2,
+    D3DSTENCILOP_REPLACE        = 3,
+    D3DSTENCILOP_INCRSAT        = 4,
+    D3DSTENCILOP_DECRSAT        = 5,
+    D3DSTENCILOP_INVERT         = 6,
+    D3DSTENCILOP_INCR           = 7,
+    D3DSTENCILOP_DECR           = 8,
+    D3DSTENCILOP_FORCE_DWORD    = 0x7fffffff, /* force 32-bit size enum */
+} D3DSTENCILOP;
+
+typedef enum _D3DFOGMODE {
+    D3DFOG_NONE                 = 0,
+    D3DFOG_EXP                  = 1,
+    D3DFOG_EXP2                 = 2,
+    D3DFOG_LINEAR               = 3,
+    D3DFOG_FORCE_DWORD          = 0x7fffffff, /* force 32-bit size enum */
+} D3DFOGMODE;
+
+typedef enum _D3DZBUFFERTYPE {
+    D3DZB_FALSE                 = 0,
+    D3DZB_TRUE                  = 1, // Z buffering
+    D3DZB_USEW                  = 2, // W buffering
+    D3DZB_FORCE_DWORD           = 0x7fffffff, /* force 32-bit size enum */
+} D3DZBUFFERTYPE;
+
+// Primitives supported by draw-primitive API
+typedef enum _D3DPRIMITIVETYPE {
+    D3DPT_POINTLIST             = 1,
+    D3DPT_LINELIST              = 2,
+    D3DPT_LINESTRIP             = 3,
+    D3DPT_TRIANGLELIST          = 4,
+    D3DPT_TRIANGLESTRIP         = 5,
+    D3DPT_TRIANGLEFAN           = 6,
+    D3DPT_FORCE_DWORD           = 0x7fffffff, /* force 32-bit size enum */
+} D3DPRIMITIVETYPE;
+
+typedef enum _D3DTRANSFORMSTATETYPE {
+    D3DTS_VIEW          = 2,
+    D3DTS_PROJECTION    = 3,
+    D3DTS_TEXTURE0      = 16,
+    D3DTS_TEXTURE1      = 17,
+    D3DTS_TEXTURE2      = 18,
+    D3DTS_TEXTURE3      = 19,
+    D3DTS_TEXTURE4      = 20,
+    D3DTS_TEXTURE5      = 21,
+    D3DTS_TEXTURE6      = 22,
+    D3DTS_TEXTURE7      = 23,
+    D3DTS_FORCE_DWORD     = 0x7fffffff, /* force 32-bit size enum */
+} D3DTRANSFORMSTATETYPE;
+
+#define D3DTS_WORLDMATRIX(index) (D3DTRANSFORMSTATETYPE)(index + 256)
+#define D3DTS_WORLD  D3DTS_WORLDMATRIX(0)
+#define D3DTS_WORLD1 D3DTS_WORLDMATRIX(1)
+#define D3DTS_WORLD2 D3DTS_WORLDMATRIX(2)
+#define D3DTS_WORLD3 D3DTS_WORLDMATRIX(3)
+
+typedef enum _D3DRENDERSTATETYPE {
+    D3DRS_ZENABLE                   = 7,    /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
+    D3DRS_FILLMODE                  = 8,    /* D3DFILLMODE */
+    D3DRS_SHADEMODE                 = 9,    /* D3DSHADEMODE */
+    D3DRS_LINEPATTERN               = 10,   /* D3DLINEPATTERN */
+    D3DRS_ZWRITEENABLE              = 14,   /* TRUE to enable z writes */
+    D3DRS_ALPHATESTENABLE           = 15,   /* TRUE to enable alpha tests */
+    D3DRS_LASTPIXEL                 = 16,   /* TRUE for last-pixel on lines */
+    D3DRS_SRCBLEND                  = 19,   /* D3DBLEND */
+    D3DRS_DESTBLEND                 = 20,   /* D3DBLEND */
+    D3DRS_CULLMODE                  = 22,   /* D3DCULL */
+    D3DRS_ZFUNC                     = 23,   /* D3DCMPFUNC */
+    D3DRS_ALPHAREF                  = 24,   /* D3DFIXED */
+    D3DRS_ALPHAFUNC                 = 25,   /* D3DCMPFUNC */
+    D3DRS_DITHERENABLE              = 26,   /* TRUE to enable dithering */
+    D3DRS_ALPHABLENDENABLE          = 27,   /* TRUE to enable alpha blending */
+    D3DRS_FOGENABLE                 = 28,   /* TRUE to enable fog blending */
+    D3DRS_SPECULARENABLE            = 29,   /* TRUE to enable specular */
+    D3DRS_ZVISIBLE                  = 30,   /* TRUE to enable z checking */
+    D3DRS_FOGCOLOR                  = 34,   /* D3DCOLOR */
+    D3DRS_FOGTABLEMODE              = 35,   /* D3DFOGMODE */
+    D3DRS_FOGSTART                  = 36,   /* Fog start (for both vertex and pixel fog) */
+    D3DRS_FOGEND                    = 37,   /* Fog end      */
+    D3DRS_FOGDENSITY                = 38,   /* Fog density  */
+    D3DRS_EDGEANTIALIAS             = 40,   /* TRUE to enable edge antialiasing */
+    D3DRS_ZBIAS                     = 47,   /* LONG Z bias */
+    D3DRS_RANGEFOGENABLE            = 48,   /* Enables range-based fog */
+    D3DRS_STENCILENABLE             = 52,   /* BOOL enable/disable stenciling */
+    D3DRS_STENCILFAIL               = 53,   /* D3DSTENCILOP to do if stencil test fails */
+    D3DRS_STENCILZFAIL              = 54,   /* D3DSTENCILOP to do if stencil test passes and Z test fails */
+    D3DRS_STENCILPASS               = 55,   /* D3DSTENCILOP to do if both stencil and Z tests pass */
+    D3DRS_STENCILFUNC               = 56,   /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
+    D3DRS_STENCILREF                = 57,   /* Reference value used in stencil test */
+    D3DRS_STENCILMASK               = 58,   /* Mask value used in stencil test */
+    D3DRS_STENCILWRITEMASK          = 59,   /* Write mask applied to values written to stencil buffer */
+    D3DRS_TEXTUREFACTOR             = 60,   /* D3DCOLOR used for multi-texture blend */
+    D3DRS_WRAP0                     = 128,  /* wrap for 1st texture coord. set */
+    D3DRS_WRAP1                     = 129,  /* wrap for 2nd texture coord. set */
+    D3DRS_WRAP2                     = 130,  /* wrap for 3rd texture coord. set */
+    D3DRS_WRAP3                     = 131,  /* wrap for 4th texture coord. set */
+    D3DRS_WRAP4                     = 132,  /* wrap for 5th texture coord. set */
+    D3DRS_WRAP5                     = 133,  /* wrap for 6th texture coord. set */
+    D3DRS_WRAP6                     = 134,  /* wrap for 7th texture coord. set */
+    D3DRS_WRAP7                     = 135,  /* wrap for 8th texture coord. set */
+    D3DRS_CLIPPING                  = 136,
+    D3DRS_LIGHTING                  = 137,
+    D3DRS_AMBIENT                   = 139,
+    D3DRS_FOGVERTEXMODE             = 140,
+    D3DRS_COLORVERTEX               = 141,
+    D3DRS_LOCALVIEWER               = 142,
+    D3DRS_NORMALIZENORMALS          = 143,
+    D3DRS_DIFFUSEMATERIALSOURCE     = 145,
+    D3DRS_SPECULARMATERIALSOURCE    = 146,
+    D3DRS_AMBIENTMATERIALSOURCE     = 147,
+    D3DRS_EMISSIVEMATERIALSOURCE    = 148,
+    D3DRS_VERTEXBLEND               = 151,
+    D3DRS_CLIPPLANEENABLE           = 152,
+    D3DRS_SOFTWAREVERTEXPROCESSING  = 153,
+    D3DRS_POINTSIZE                 = 154,   /* float point size */
+    D3DRS_POINTSIZE_MIN             = 155,   /* float point size min threshold */
+    D3DRS_POINTSPRITEENABLE         = 156,   /* BOOL point texture coord control */
+    D3DRS_POINTSCALEENABLE          = 157,   /* BOOL point size scale enable */
+    D3DRS_POINTSCALE_A              = 158,   /* float point attenuation A value */
+    D3DRS_POINTSCALE_B              = 159,   /* float point attenuation B value */
+    D3DRS_POINTSCALE_C              = 160,   /* float point attenuation C value */
+    D3DRS_MULTISAMPLEANTIALIAS      = 161,  // BOOL - set to do FSAA with multisample buffer
+    D3DRS_MULTISAMPLEMASK           = 162,  // DWORD - per-sample enable/disable
+    D3DRS_PATCHEDGESTYLE            = 163,  // Sets whether patch edges will use float style tessellation
+    D3DRS_PATCHSEGMENTS             = 164,  // Number of segments per edge when drawing patches
+    D3DRS_DEBUGMONITORTOKEN         = 165,  // DEBUG ONLY - token to debug monitor
+    D3DRS_POINTSIZE_MAX             = 166,   /* float point size max threshold */
+    D3DRS_INDEXEDVERTEXBLENDENABLE  = 167,
+    D3DRS_COLORWRITEENABLE          = 168,  // per-channel write enable
+    D3DRS_TWEENFACTOR               = 170,   // float tween factor
+    D3DRS_BLENDOP                   = 171,   // D3DBLENDOP setting
+    D3DRS_POSITIONORDER             = 172,   // NPatch position interpolation order. D3DORDER_LINEAR or D3DORDER_CUBIC (default)
+    D3DRS_NORMALORDER               = 173,   // NPatch normal interpolation order. D3DORDER_LINEAR (default) or D3DORDER_QUADRATIC
+
+    D3DRS_FORCE_DWORD               = 0x7fffffff, /* force 32-bit size enum */
+} D3DRENDERSTATETYPE;
+
+// Values for material source
+typedef enum _D3DMATERIALCOLORSOURCE
+{
+    D3DMCS_MATERIAL         = 0,            // Color from material is used
+    D3DMCS_COLOR1           = 1,            // Diffuse vertex color is used
+    D3DMCS_COLOR2           = 2,            // Specular vertex color is used
+    D3DMCS_FORCE_DWORD      = 0x7fffffff,   // force 32-bit size enum
+} D3DMATERIALCOLORSOURCE;
+
+// Bias to apply to the texture coordinate set to apply a wrap to.
+#define D3DRENDERSTATE_WRAPBIAS                 128UL
+
+/* Flags to construct the WRAP render states */
+#define D3DWRAP_U   0x00000001L
+#define D3DWRAP_V   0x00000002L
+#define D3DWRAP_W   0x00000004L
+
+/* Flags to construct the WRAP render states for 1D thru 4D texture coordinates */
+#define D3DWRAPCOORD_0   0x00000001L    // same as D3DWRAP_U
+#define D3DWRAPCOORD_1   0x00000002L    // same as D3DWRAP_V
+#define D3DWRAPCOORD_2   0x00000004L    // same as D3DWRAP_W
+#define D3DWRAPCOORD_3   0x00000008L
+
+/* Flags to construct D3DRS_COLORWRITEENABLE */
+#define D3DCOLORWRITEENABLE_RED     (1L<<0)
+#define D3DCOLORWRITEENABLE_GREEN   (1L<<1)
+#define D3DCOLORWRITEENABLE_BLUE    (1L<<2)
+#define D3DCOLORWRITEENABLE_ALPHA   (1L<<3)
+
+/*
+ * State enumerants for per-stage texture processing.
+ */
+typedef enum _D3DTEXTURESTAGESTATETYPE
+{
+    D3DTSS_COLOROP        =  1, /* D3DTEXTUREOP - per-stage blending controls for color channels */
+    D3DTSS_COLORARG1      =  2, /* D3DTA_* (texture arg) */
+    D3DTSS_COLORARG2      =  3, /* D3DTA_* (texture arg) */
+    D3DTSS_ALPHAOP        =  4, /* D3DTEXTUREOP - per-stage blending controls for alpha channel */
+    D3DTSS_ALPHAARG1      =  5, /* D3DTA_* (texture arg) */
+    D3DTSS_ALPHAARG2      =  6, /* D3DTA_* (texture arg) */
+    D3DTSS_BUMPENVMAT00   =  7, /* float (bump mapping matrix) */
+    D3DTSS_BUMPENVMAT01   =  8, /* float (bump mapping matrix) */
+    D3DTSS_BUMPENVMAT10   =  9, /* float (bump mapping matrix) */
+    D3DTSS_BUMPENVMAT11   = 10, /* float (bump mapping matrix) */
+    D3DTSS_TEXCOORDINDEX  = 11, /* identifies which set of texture coordinates index this texture */
+    D3DTSS_ADDRESSU       = 13, /* D3DTEXTUREADDRESS for U coordinate */
+    D3DTSS_ADDRESSV       = 14, /* D3DTEXTUREADDRESS for V coordinate */
+    D3DTSS_BORDERCOLOR    = 15, /* D3DCOLOR */
+    D3DTSS_MAGFILTER      = 16, /* D3DTEXTUREFILTER filter to use for magnification */
+    D3DTSS_MINFILTER      = 17, /* D3DTEXTUREFILTER filter to use for minification */
+    D3DTSS_MIPFILTER      = 18, /* D3DTEXTUREFILTER filter to use between mipmaps during minification */
+    D3DTSS_MIPMAPLODBIAS  = 19, /* float Mipmap LOD bias */
+    D3DTSS_MAXMIPLEVEL    = 20, /* DWORD 0..(n-1) LOD index of largest map to use (0 == largest) */
+    D3DTSS_MAXANISOTROPY  = 21, /* DWORD maximum anisotropy */
+    D3DTSS_BUMPENVLSCALE  = 22, /* float scale for bump map luminance */
+    D3DTSS_BUMPENVLOFFSET = 23, /* float offset for bump map luminance */
+    D3DTSS_TEXTURETRANSFORMFLAGS = 24, /* D3DTEXTURETRANSFORMFLAGS controls texture transform */
+    D3DTSS_ADDRESSW       = 25, /* D3DTEXTUREADDRESS for W coordinate */
+    D3DTSS_COLORARG0      = 26, /* D3DTA_* third arg for triadic ops */
+    D3DTSS_ALPHAARG0      = 27, /* D3DTA_* third arg for triadic ops */
+    D3DTSS_RESULTARG      = 28, /* D3DTA_* arg for result (CURRENT or TEMP) */
+    D3DTSS_FORCE_DWORD   = 0x7fffffff, /* force 32-bit size enum */
+} D3DTEXTURESTAGESTATETYPE;
+
+// Values, used with D3DTSS_TEXCOORDINDEX, to specify that the vertex data(position
+// and normal in the camera space) should be taken as texture coordinates
+// Low 16 bits are used to specify texture coordinate index, to take the WRAP mode from
+//
+#define D3DTSS_TCI_PASSTHRU                             0x00000000
+#define D3DTSS_TCI_CAMERASPACENORMAL                    0x00010000
+#define D3DTSS_TCI_CAMERASPACEPOSITION                  0x00020000
+#define D3DTSS_TCI_CAMERASPACEREFLECTIONVECTOR          0x00030000
+
+/*
+ * Enumerations for COLOROP and ALPHAOP texture blending operations set in
+ * texture processing stage controls in D3DTSS.
+ */
+typedef enum _D3DTEXTUREOP
+{
+    // Control
+    D3DTOP_DISABLE              = 1,      // disables stage
+    D3DTOP_SELECTARG1           = 2,      // the default
+    D3DTOP_SELECTARG2           = 3,
+
+    // Modulate
+    D3DTOP_MODULATE             = 4,      // multiply args together
+    D3DTOP_MODULATE2X           = 5,      // multiply and  1 bit
+    D3DTOP_MODULATE4X           = 6,      // multiply and  2 bits
+
+    // Add
+    D3DTOP_ADD                  =  7,   // add arguments together
+    D3DTOP_ADDSIGNED            =  8,   // add with -0.5 bias
+    D3DTOP_ADDSIGNED2X          =  9,   // as above but left  1 bit
+    D3DTOP_SUBTRACT             = 10,   // Arg1 - Arg2, with no saturation
+    D3DTOP_ADDSMOOTH            = 11,   // add 2 args, subtract product
+                                        // Arg1 + Arg2 - Arg1*Arg2
+                                        // = Arg1 + (1-Arg1)*Arg2
+
+    // Linear alpha blend: Arg1*(Alpha) + Arg2*(1-Alpha)
+    D3DTOP_BLENDDIFFUSEALPHA    = 12, // iterated alpha
+    D3DTOP_BLENDTEXTUREALPHA    = 13, // texture alpha
+    D3DTOP_BLENDFACTORALPHA     = 14, // alpha from D3DRS_TEXTUREFACTOR
+
+    // Linear alpha blend with pre-multiplied arg1 input: Arg1 + Arg2*(1-Alpha)
+    D3DTOP_BLENDTEXTUREALPHAPM  = 15, // texture alpha
+    D3DTOP_BLENDCURRENTALPHA    = 16, // by alpha of current color
+
+    // Specular mapping
+    D3DTOP_PREMODULATE            = 17,     // modulate with next texture before use
+    D3DTOP_MODULATEALPHA_ADDCOLOR = 18,     // Arg1.RGB + Arg1.A*Arg2.RGB
+                                            // COLOROP only
+    D3DTOP_MODULATECOLOR_ADDALPHA = 19,     // Arg1.RGB*Arg2.RGB + Arg1.A
+                                            // COLOROP only
+    D3DTOP_MODULATEINVALPHA_ADDCOLOR = 20,  // (1-Arg1.A)*Arg2.RGB + Arg1.RGB
+                                            // COLOROP only
+    D3DTOP_MODULATEINVCOLOR_ADDALPHA = 21,  // (1-Arg1.RGB)*Arg2.RGB + Arg1.A
+                                            // COLOROP only
+
+    // Bump mapping
+    D3DTOP_BUMPENVMAP           = 22, // per pixel env map perturbation
+    D3DTOP_BUMPENVMAPLUMINANCE  = 23, // with luminance channel
+
+    // This can do either diffuse or specular bump mapping with correct input.
+    // Performs the function (Arg1.R*Arg2.R + Arg1.G*Arg2.G + Arg1.B*Arg2.B)
+    // where each component has been scaled and offset to make it signed.
+    // The result is replicated into all four (including alpha) channels.
+    // This is a valid COLOROP only.
+    D3DTOP_DOTPRODUCT3          = 24,
+
+    // Triadic ops
+    D3DTOP_MULTIPLYADD          = 25, // Arg0 + Arg1*Arg2
+    D3DTOP_LERP                 = 26, // (Arg0)*Arg1 + (1-Arg0)*Arg2
+
+    D3DTOP_FORCE_DWORD = 0x7fffffff,
+} D3DTEXTUREOP;
+
+/*
+ * Values for COLORARG0,1,2, ALPHAARG0,1,2, and RESULTARG texture blending
+ * operations set in texture processing stage controls in D3DRENDERSTATE.
+ */
+#define D3DTA_SELECTMASK        0x0000000f  // mask for arg selector
+#define D3DTA_DIFFUSE           0x00000000  // select diffuse color (read only)
+#define D3DTA_CURRENT           0x00000001  // select stage destination register (read/write)
+#define D3DTA_TEXTURE           0x00000002  // select texture color (read only)
+#define D3DTA_TFACTOR           0x00000003  // select D3DRS_TEXTUREFACTOR (read only)
+#define D3DTA_SPECULAR          0x00000004  // select specular color (read only)
+#define D3DTA_TEMP              0x00000005  // select temporary register color (read/write)
+#define D3DTA_COMPLEMENT        0x00000010  // take 1.0 - x (read modifier)
+#define D3DTA_ALPHAREPLICATE    0x00000020  // replicate alpha to color components (read modifier)
+
+//
+// Values for D3DTSS_***FILTER texture stage states
+//
+typedef enum _D3DTEXTUREFILTERTYPE
+{
+    D3DTEXF_NONE            = 0,    // filtering disabled (valid for mip filter only)
+    D3DTEXF_POINT           = 1,    // nearest
+    D3DTEXF_LINEAR          = 2,    // linear interpolation
+    D3DTEXF_ANISOTROPIC     = 3,    // anisotropic
+    D3DTEXF_FLATCUBIC       = 4,    // cubic
+    D3DTEXF_GAUSSIANCUBIC   = 5,    // different cubic kernel
+    D3DTEXF_FORCE_DWORD     = 0x7fffffff,   // force 32-bit size enum
+} D3DTEXTUREFILTERTYPE;
+
+/* Bits for Flags in ProcessVertices call */
+
+#define D3DPV_DONOTCOPYDATA     (1 << 0)
+
+//-------------------------------------------------------------------
+
+// Flexible vertex format bits
+//
+#define D3DFVF_RESERVED0        0x001
+#define D3DFVF_POSITION_MASK    0x00E
+#define D3DFVF_XYZ              0x002
+#define D3DFVF_XYZRHW           0x004
+#define D3DFVF_XYZB1            0x006
+#define D3DFVF_XYZB2            0x008
+#define D3DFVF_XYZB3            0x00a
+#define D3DFVF_XYZB4            0x00c
+#define D3DFVF_XYZB5            0x00e
+
+#define D3DFVF_NORMAL           0x010
+#define D3DFVF_PSIZE            0x020
+#define D3DFVF_DIFFUSE          0x040
+#define D3DFVF_SPECULAR         0x080
+
+#define D3DFVF_TEXCOUNT_MASK    0xf00
+#define D3DFVF_TEXCOUNT_SHIFT   8
+#define D3DFVF_TEX0             0x000
+#define D3DFVF_TEX1             0x100
+#define D3DFVF_TEX2             0x200
+#define D3DFVF_TEX3             0x300
+#define D3DFVF_TEX4             0x400
+#define D3DFVF_TEX5             0x500
+#define D3DFVF_TEX6             0x600
+#define D3DFVF_TEX7             0x700
+#define D3DFVF_TEX8             0x800
+
+#define D3DFVF_LASTBETA_UBYTE4  0x1000
+
+#define D3DFVF_RESERVED2        0xE000  // 4 reserved bits
+
+//---------------------------------------------------------------------
+// Vertex Shaders
+//
+
+/*
+
+Vertex Shader Declaration
+
+The declaration portion of a vertex shader defines the static external
+interface of the shader.  The information in the declaration includes:
+
+- Assignments of vertex shader input registers to data streams.  These
+assignments bind a specific vertex register to a single component within a
+vertex stream.  A vertex stream element is identified by a byte offset
+within the stream and a type.  The type specifies the arithmetic data type
+plus the dimensionality (1, 2, 3, or 4 values).  Stream data which is
+less than 4 values are always expanded out to 4 values with zero or more
+0.F values and one 1.F value.
+
+- Assignment of vertex shader input registers to implicit data from the
+primitive tessellator.  This controls the loading of vertex data which is
+not loaded from a stream, but rather is generated during primitive
+tessellation prior to the vertex shader.
+
+- Loading data into the constant memory at the time a shader is set as the
+current shader.  Each token specifies values for one or more contiguous 4
+DWORD constant registers.  This allows the shader to update an arbitrary
+subset of the constant memory, overwriting the device state (which
+contains the current values of the constant memory).  Note that these
+values can be subsequently overwritten (between DrawPrimitive calls)
+during the time a shader is bound to a device via the
+SetVertexShaderConstant method.
+
+
+Declaration arrays are single-dimensional arrays of DWORDs composed of
+multiple tokens each of which is one or more DWORDs.  The single-DWORD
+token value 0xFFFFFFFF is a special token used to indicate the end of the
+declaration array.  The single DWORD token value 0x00000000 is a NOP token
+with is ignored during the declaration parsing.  Note that 0x00000000 is a
+valid value for DWORDs following the first DWORD for multiple word tokens.
+
+[31:29] TokenType
+    0x0 - NOP (requires all DWORD bits to be zero)
+    0x1 - stream selector
+    0x2 - stream data definition (map to vertex input memory)
+    0x3 - vertex input memory from tessellator
+    0x4 - constant memory from shader
+    0x5 - extension
+    0x6 - reserved
+    0x7 - end-of-array (requires all DWORD bits to be 1)
+
+NOP Token (single DWORD token)
+    [31:29] 0x0
+    [28:00] 0x0
+
+Stream Selector (single DWORD token)
+    [31:29] 0x1
+    [28]    indicates whether this is a tessellator stream
+    [27:04] 0x0
+    [03:00] stream selector (0..15)
+
+Stream Data Definition (single DWORD token)
+    Vertex Input Register Load
+      [31:29] 0x2
+      [28]    0x0
+      [27:20] 0x0
+      [19:16] type (dimensionality and data type)
+      [15:04] 0x0
+      [03:00] vertex register address (0..15)
+    Data Skip (no register load)
+      [31:29] 0x2
+      [28]    0x1
+      [27:20] 0x0
+      [19:16] count of DWORDS to skip over (0..15)
+      [15:00] 0x0
+    Vertex Input Memory from Tessellator Data (single DWORD token)
+      [31:29] 0x3
+      [28]    indicates whether data is normals or u/v
+      [27:24] 0x0
+      [23:20] vertex register address (0..15)
+      [19:16] type (dimensionality)
+      [15:04] 0x0
+      [03:00] vertex register address (0..15)
+
+Constant Memory from Shader (multiple DWORD token)
+    [31:29] 0x4
+    [28:25] count of 4*DWORD constants to load (0..15)
+    [24:07] 0x0
+    [06:00] constant memory address (0..95)
+
+Extension Token (single or multiple DWORD token)
+    [31:29] 0x5
+    [28:24] count of additional DWORDs in token (0..31)
+    [23:00] extension-specific information
+
+End-of-array token (single DWORD token)
+    [31:29] 0x7
+    [28:00] 0x1fffffff
+
+The stream selector token must be immediately followed by a contiguous set of stream data definition tokens.  This token sequence fully defines that stream, including the set of elements within the stream, the order in which the elements appear, the type of each element, and the vertex register into which to load an element.
+Streams are allowed to include data which is not loaded into a vertex register, thus allowing data which is not used for this shader to exist in the vertex stream.  This skipped data is defined only by a count of DWORDs to skip over, since the type information is irrelevant.
+The token sequence:
+Stream Select: stream=0
+Stream Data Definition (Load): type=FLOAT3; register=3
+Stream Data Definition (Load): type=FLOAT3; register=4
+Stream Data Definition (Skip): count=2
+Stream Data Definition (Load): type=FLOAT2; register=7
+
+defines stream zero to consist of 4 elements, 3 of which are loaded into registers and the fourth skipped over.  Register 3 is loaded with the first three DWORDs in each vertex interpreted as FLOAT data.  Register 4 is loaded with the 4th, 5th, and 6th DWORDs interpreted as FLOAT data.  The next two DWORDs (7th and 8th) are skipped over and not loaded into any vertex input register.   Register 7 is loaded with the 9th and 10th DWORDS interpreted as FLOAT data.
+Placing of tokens other than NOPs between the Stream Selector and Stream Data Definition tokens is disallowed.
+
+*/
+
+typedef enum _D3DVSD_TOKENTYPE
+{
+    D3DVSD_TOKEN_NOP        = 0,    // NOP or extension
+    D3DVSD_TOKEN_STREAM,            // stream selector
+    D3DVSD_TOKEN_STREAMDATA,        // stream data definition (map to vertex input memory)
+    D3DVSD_TOKEN_TESSELLATOR,       // vertex input memory from tessellator
+    D3DVSD_TOKEN_CONSTMEM,          // constant memory from shader
+    D3DVSD_TOKEN_EXT,               // extension
+    D3DVSD_TOKEN_END = 7,           // end-of-array (requires all DWORD bits to be 1)
+    D3DVSD_FORCE_DWORD = 0x7fffffff,// force 32-bit size enum
+} D3DVSD_TOKENTYPE;
+
+#define D3DVSD_TOKENTYPESHIFT   29
+#define D3DVSD_TOKENTYPEMASK    (7 << D3DVSD_TOKENTYPESHIFT)
+
+#define D3DVSD_STREAMNUMBERSHIFT 0
+#define D3DVSD_STREAMNUMBERMASK (0xF << D3DVSD_STREAMNUMBERSHIFT)
+
+#define D3DVSD_DATALOADTYPESHIFT 28
+#define D3DVSD_DATALOADTYPEMASK (0x1 << D3DVSD_DATALOADTYPESHIFT)
+
+#define D3DVSD_DATATYPESHIFT 16
+#define D3DVSD_DATATYPEMASK (0xF << D3DVSD_DATATYPESHIFT)
+
+#define D3DVSD_SKIPCOUNTSHIFT 16
+#define D3DVSD_SKIPCOUNTMASK (0xF << D3DVSD_SKIPCOUNTSHIFT)
+
+#define D3DVSD_VERTEXREGSHIFT 0
+#define D3DVSD_VERTEXREGMASK (0x1F << D3DVSD_VERTEXREGSHIFT)
+
+#define D3DVSD_VERTEXREGINSHIFT 20
+#define D3DVSD_VERTEXREGINMASK (0xF << D3DVSD_VERTEXREGINSHIFT)
+
+#define D3DVSD_CONSTCOUNTSHIFT 25
+#define D3DVSD_CONSTCOUNTMASK (0xF << D3DVSD_CONSTCOUNTSHIFT)
+
+#define D3DVSD_CONSTADDRESSSHIFT 0
+#define D3DVSD_CONSTADDRESSMASK (0x7F << D3DVSD_CONSTADDRESSSHIFT)
+
+#define D3DVSD_CONSTRSSHIFT 16
+#define D3DVSD_CONSTRSMASK (0x1FFF << D3DVSD_CONSTRSSHIFT)
+
+#define D3DVSD_EXTCOUNTSHIFT 24
+#define D3DVSD_EXTCOUNTMASK (0x1F << D3DVSD_EXTCOUNTSHIFT)
+
+#define D3DVSD_EXTINFOSHIFT 0
+#define D3DVSD_EXTINFOMASK (0xFFFFFF << D3DVSD_EXTINFOSHIFT)
+
+#define D3DVSD_MAKETOKENTYPE(tokenType) ((tokenType << D3DVSD_TOKENTYPESHIFT) & D3DVSD_TOKENTYPEMASK)
+
+// macros for generation of CreateVertexShader Declaration token array
+
+// Set current stream
+// _StreamNumber [0..(MaxStreams-1)] stream to get data from
+//
+#define D3DVSD_STREAM( _StreamNumber ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_STREAM) | (_StreamNumber))
+
+// Set tessellator stream
+//
+#define D3DVSD_STREAMTESSSHIFT 28
+#define D3DVSD_STREAMTESSMASK (1 << D3DVSD_STREAMTESSSHIFT)
+#define D3DVSD_STREAM_TESS( ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_STREAM) | (D3DVSD_STREAMTESSMASK))
+
+// bind single vertex register to vertex element from vertex stream
+//
+// _VertexRegister [0..15] address of the vertex register
+// _Type [D3DVSDT_*] dimensionality and arithmetic data type
+
+#define D3DVSD_REG( _VertexRegister, _Type ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_STREAMDATA) |            \
+     ((_Type) << D3DVSD_DATATYPESHIFT) | (_VertexRegister))
+
+// Skip _DWORDCount DWORDs in vertex
+//
+#define D3DVSD_SKIP( _DWORDCount ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_STREAMDATA) | 0x10000000 | \
+     ((_DWORDCount) << D3DVSD_SKIPCOUNTSHIFT))
+
+// load data into vertex shader constant memory
+//
+// _ConstantAddress [0..95] - address of constant array to begin filling data
+// _Count [0..15] - number of constant vectors to load (4 DWORDs each)
+// followed by 4*_Count DWORDS of data
+//
+#define D3DVSD_CONST( _ConstantAddress, _Count ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_CONSTMEM) | \
+     ((_Count) << D3DVSD_CONSTCOUNTSHIFT) | (_ConstantAddress))
+
+// enable tessellator generated normals
+//
+// _VertexRegisterIn  [0..15] address of vertex register whose input stream
+//                            will be used in normal computation
+// _VertexRegisterOut [0..15] address of vertex register to output the normal to
+//
+#define D3DVSD_TESSNORMAL( _VertexRegisterIn, _VertexRegisterOut ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_TESSELLATOR) | \
+     ((_VertexRegisterIn) << D3DVSD_VERTEXREGINSHIFT) | \
+     ((0x02) << D3DVSD_DATATYPESHIFT) | (_VertexRegisterOut))
+
+// enable tessellator generated surface parameters
+//
+// _VertexRegister [0..15] address of vertex register to output parameters
+//
+#define D3DVSD_TESSUV( _VertexRegister ) \
+    (D3DVSD_MAKETOKENTYPE(D3DVSD_TOKEN_TESSELLATOR) | 0x10000000 | \
+     ((0x01) << D3DVSD_DATATYPESHIFT) | (_VertexRegister))
+
+// Generates END token
+//
+#define D3DVSD_END() 0xFFFFFFFF
+
+// Generates NOP token
+#define D3DVSD_NOP() 0x00000000
+
+// bit declarations for _Type fields
+#define D3DVSDT_FLOAT1      0x00    // 1D float expanded to (value, 0., 0., 1.)
+#define D3DVSDT_FLOAT2      0x01    // 2D float expanded to (value, value, 0., 1.)
+#define D3DVSDT_FLOAT3      0x02    // 3D float expanded to (value, value, value, 1.)
+#define D3DVSDT_FLOAT4      0x03    // 4D float
+#define D3DVSDT_D3DCOLOR    0x04    // 4D packed unsigned bytes mapped to 0. to 1. range
+                                    // Input is in D3DCOLOR format (ARGB) expanded to (R, G, B, A)
+#define D3DVSDT_UBYTE4      0x05    // 4D unsigned byte
+#define D3DVSDT_SHORT2      0x06    // 2D signed short expanded to (value, value, 0., 1.)
+#define D3DVSDT_SHORT4      0x07    // 4D signed short
+
+// assignments of vertex input registers for fixed function vertex shader
+//
+#define D3DVSDE_POSITION        0
+#define D3DVSDE_BLENDWEIGHT     1
+#define D3DVSDE_BLENDINDICES    2
+#define D3DVSDE_NORMAL          3
+#define D3DVSDE_PSIZE           4
+#define D3DVSDE_DIFFUSE         5
+#define D3DVSDE_SPECULAR        6
+#define D3DVSDE_TEXCOORD0       7
+#define D3DVSDE_TEXCOORD1       8
+#define D3DVSDE_TEXCOORD2       9
+#define D3DVSDE_TEXCOORD3       10
+#define D3DVSDE_TEXCOORD4       11
+#define D3DVSDE_TEXCOORD5       12
+#define D3DVSDE_TEXCOORD6       13
+#define D3DVSDE_TEXCOORD7       14
+#define D3DVSDE_POSITION2       15
+#define D3DVSDE_NORMAL2         16
+
+// Maximum supported number of texture coordinate sets
+#define D3DDP_MAXTEXCOORD   8
+
+
+//
+// Instruction Token Bit Definitions
+//
+#define D3DSI_OPCODE_MASK       0x0000FFFF
+
+typedef enum _D3DSHADER_INSTRUCTION_OPCODE_TYPE
+{
+    D3DSIO_NOP          = 0,    // PS/VS
+    D3DSIO_MOV          ,       // PS/VS
+    D3DSIO_ADD          ,       // PS/VS
+    D3DSIO_SUB          ,       // PS
+    D3DSIO_MAD          ,       // PS/VS
+    D3DSIO_MUL          ,       // PS/VS
+    D3DSIO_RCP          ,       // VS
+    D3DSIO_RSQ          ,       // VS
+    D3DSIO_DP3          ,       // PS/VS
+    D3DSIO_DP4          ,       // PS/VS
+    D3DSIO_MIN          ,       // VS
+    D3DSIO_MAX          ,       // VS
+    D3DSIO_SLT          ,       // VS
+    D3DSIO_SGE          ,       // VS
+    D3DSIO_EXP          ,       // VS
+    D3DSIO_LOG          ,       // VS
+    D3DSIO_LIT          ,       // VS
+    D3DSIO_DST          ,       // VS
+    D3DSIO_LRP          ,       // PS
+    D3DSIO_FRC          ,       // VS
+    D3DSIO_M4x4         ,       // VS
+    D3DSIO_M4x3         ,       // VS
+    D3DSIO_M3x4         ,       // VS
+    D3DSIO_M3x3         ,       // VS
+    D3DSIO_M3x2         ,       // VS
+
+    D3DSIO_TEXCOORD     = 64,   // PS
+    D3DSIO_TEXKILL      ,       // PS
+    D3DSIO_TEX          ,       // PS
+    D3DSIO_TEXBEM       ,       // PS
+    D3DSIO_TEXBEML      ,       // PS
+    D3DSIO_TEXREG2AR    ,       // PS
+    D3DSIO_TEXREG2GB    ,       // PS
+    D3DSIO_TEXM3x2PAD   ,       // PS
+    D3DSIO_TEXM3x2TEX   ,       // PS
+    D3DSIO_TEXM3x3PAD   ,       // PS
+    D3DSIO_TEXM3x3TEX   ,       // PS
+    D3DSIO_TEXM3x3DIFF  ,       // PS
+    D3DSIO_TEXM3x3SPEC  ,       // PS
+    D3DSIO_TEXM3x3VSPEC ,       // PS
+    D3DSIO_EXPP         ,       // VS
+    D3DSIO_LOGP         ,       // VS
+    D3DSIO_CND          ,       // PS
+    D3DSIO_DEF          ,       // PS
+    D3DSIO_TEXREG2RGB   ,       // PS
+    D3DSIO_TEXDP3TEX    ,       // PS
+    D3DSIO_TEXM3x2DEPTH ,       // PS
+    D3DSIO_TEXDP3       ,       // PS
+    D3DSIO_TEXM3x3      ,       // PS
+    D3DSIO_TEXDEPTH     ,       // PS
+    D3DSIO_CMP          ,       // PS
+    D3DSIO_BEM          ,       // PS
+
+    D3DSIO_PHASE        = 0xFFFD,
+    D3DSIO_COMMENT      = 0xFFFE,
+    D3DSIO_END          = 0xFFFF,
+
+    D3DSIO_FORCE_DWORD  = 0x7fffffff,   // force 32-bit size enum
+} D3DSHADER_INSTRUCTION_OPCODE_TYPE;
+
+//
+// Co-Issue Instruction Modifier - if set then this instruction is to be
+// issued in parallel with the previous instruction(s) for which this bit
+// is not set.
+//
+#define D3DSI_COISSUE           0x40000000
+
+//
+// Parameter Token Bit Definitions
+//
+#define D3DSP_REGNUM_MASK       0x00001FFF
+
+// destination parameter write mask
+#define D3DSP_WRITEMASK_0       0x00010000  // Component 0 (X;Red)
+#define D3DSP_WRITEMASK_1       0x00020000  // Component 1 (Y;Green)
+#define D3DSP_WRITEMASK_2       0x00040000  // Component 2 (Z;Blue)
+#define D3DSP_WRITEMASK_3       0x00080000  // Component 3 (W;Alpha)
+#define D3DSP_WRITEMASK_ALL     0x000F0000  // All Components
+
+// destination parameter modifiers
+#define D3DSP_DSTMOD_SHIFT      20
+#define D3DSP_DSTMOD_MASK       0x00F00000
+
+typedef enum _D3DSHADER_PARAM_DSTMOD_TYPE
+{
+    D3DSPDM_NONE    = 0<<D3DSP_DSTMOD_SHIFT, // nop
+    D3DSPDM_SATURATE= 1<<D3DSP_DSTMOD_SHIFT, // clamp to 0. to 1. range
+    D3DSPDM_FORCE_DWORD  = 0x7fffffff,      // force 32-bit size enum
+} D3DSHADER_PARAM_DSTMOD_TYPE;
+
+// destination parameter 
+#define D3DSP_DSTSHIFT_SHIFT    24
+#define D3DSP_DSTSHIFT_MASK     0x0F000000
+
+// destination/source parameter register type
+#define D3DSP_REGTYPE_SHIFT     28
+#define D3DSP_REGTYPE_MASK      0x70000000
+
+typedef enum _D3DSHADER_PARAM_REGISTER_TYPE
+{
+    D3DSPR_TEMP     = 0<<D3DSP_REGTYPE_SHIFT, // Temporary Register File
+    D3DSPR_INPUT    = 1<<D3DSP_REGTYPE_SHIFT, // Input Register File
+    D3DSPR_CONST    = 2<<D3DSP_REGTYPE_SHIFT, // Constant Register File
+    D3DSPR_ADDR     = 3<<D3DSP_REGTYPE_SHIFT, // Address Register (VS)
+    D3DSPR_TEXTURE  = 3<<D3DSP_REGTYPE_SHIFT, // Texture Register File (PS)
+    D3DSPR_RASTOUT  = 4<<D3DSP_REGTYPE_SHIFT, // Rasterizer Register File
+    D3DSPR_ATTROUT  = 5<<D3DSP_REGTYPE_SHIFT, // Attribute Output Register File
+    D3DSPR_TEXCRDOUT= 6<<D3DSP_REGTYPE_SHIFT, // Texture Coordinate Output Register File
+    D3DSPR_FORCE_DWORD  = 0x7fffffff,         // force 32-bit size enum
+} D3DSHADER_PARAM_REGISTER_TYPE;
+
+// Register offsets in the Rasterizer Register File
+//
+typedef enum _D3DVS_RASTOUT_OFFSETS
+{
+    D3DSRO_POSITION = 0,
+    D3DSRO_FOG,
+    D3DSRO_POINT_SIZE,
+    D3DSRO_FORCE_DWORD  = 0x7fffffff,         // force 32-bit size enum
+} D3DVS_RASTOUT_OFFSETS;
+
+// Source operand addressing modes
+
+#define D3DVS_ADDRESSMODE_SHIFT 13
+#define D3DVS_ADDRESSMODE_MASK  (1 << D3DVS_ADDRESSMODE_SHIFT)
+
+typedef enum _D3DVS_ADDRESSMODE_TYPE
+{
+    D3DVS_ADDRMODE_ABSOLUTE  = (0 << D3DVS_ADDRESSMODE_SHIFT),
+    D3DVS_ADDRMODE_RELATIVE  = (1 << D3DVS_ADDRESSMODE_SHIFT),   // Relative to register A0
+    D3DVS_ADDRMODE_FORCE_DWORD = 0x7fffffff, // force 32-bit size enum
+} D3DVS_ADDRESSMODE_TYPE;
+
+// Source operand swizzle definitions
+//
+#define D3DVS_SWIZZLE_SHIFT     16
+#define D3DVS_SWIZZLE_MASK      0x00FF0000
+
+// The following bits define where to take component X from:
+
+#define D3DVS_X_X       (0 << D3DVS_SWIZZLE_SHIFT)
+#define D3DVS_X_Y       (1 << D3DVS_SWIZZLE_SHIFT)
+#define D3DVS_X_Z       (2 << D3DVS_SWIZZLE_SHIFT)
+#define D3DVS_X_W       (3 << D3DVS_SWIZZLE_SHIFT)
+
+// The following bits define where to take component Y from:
+
+#define D3DVS_Y_X       (0 << (D3DVS_SWIZZLE_SHIFT + 2))
+#define D3DVS_Y_Y       (1 << (D3DVS_SWIZZLE_SHIFT + 2))
+#define D3DVS_Y_Z       (2 << (D3DVS_SWIZZLE_SHIFT + 2))
+#define D3DVS_Y_W       (3 << (D3DVS_SWIZZLE_SHIFT + 2))
+
+// The following bits define where to take component Z from:
+
+#define D3DVS_Z_X       (0 << (D3DVS_SWIZZLE_SHIFT + 4))
+#define D3DVS_Z_Y       (1 << (D3DVS_SWIZZLE_SHIFT + 4))
+#define D3DVS_Z_Z       (2 << (D3DVS_SWIZZLE_SHIFT + 4))
+#define D3DVS_Z_W       (3 << (D3DVS_SWIZZLE_SHIFT + 4))
+
+// The following bits define where to take component W from:
+
+#define D3DVS_W_X       (0 << (D3DVS_SWIZZLE_SHIFT + 6))
+#define D3DVS_W_Y       (1 << (D3DVS_SWIZZLE_SHIFT + 6))
+#define D3DVS_W_Z       (2 << (D3DVS_SWIZZLE_SHIFT + 6))
+#define D3DVS_W_W       (3 << (D3DVS_SWIZZLE_SHIFT + 6))
+
+// Value when there is no swizzle (X is taken from X, Y is taken from Y,
+// Z is taken from Z, W is taken from W
+//
+#define D3DVS_NOSWIZZLE (D3DVS_X_X | D3DVS_Y_Y | D3DVS_Z_Z | D3DVS_W_W)
+
+// source parameter swizzle
+#define D3DSP_SWIZZLE_SHIFT     16
+#define D3DSP_SWIZZLE_MASK      0x00FF0000
+
+#define D3DSP_NOSWIZZLE \
+    ( (0 << (D3DSP_SWIZZLE_SHIFT + 0)) | \
+      (1 << (D3DSP_SWIZZLE_SHIFT + 2)) | \
+      (2 << (D3DSP_SWIZZLE_SHIFT + 4)) | \
+      (3 << (D3DSP_SWIZZLE_SHIFT + 6)) )
+
+// pixel-shader swizzle ops
+#define D3DSP_REPLICATERED \
+    ( (0 << (D3DSP_SWIZZLE_SHIFT + 0)) | \
+      (0 << (D3DSP_SWIZZLE_SHIFT + 2)) | \
+      (0 << (D3DSP_SWIZZLE_SHIFT + 4)) | \
+      (0 << (D3DSP_SWIZZLE_SHIFT + 6)) )
+
+#define D3DSP_REPLICATEGREEN \
+    ( (1 << (D3DSP_SWIZZLE_SHIFT + 0)) | \
+      (1 << (D3DSP_SWIZZLE_SHIFT + 2)) | \
+      (1 << (D3DSP_SWIZZLE_SHIFT + 4)) | \
+      (1 << (D3DSP_SWIZZLE_SHIFT + 6)) )
+
+#define D3DSP_REPLICATEBLUE \
+    ( (2 << (D3DSP_SWIZZLE_SHIFT + 0)) | \
+      (2 << (D3DSP_SWIZZLE_SHIFT + 2)) | \
+      (2 << (D3DSP_SWIZZLE_SHIFT + 4)) | \
+      (2 << (D3DSP_SWIZZLE_SHIFT + 6)) )
+
+#define D3DSP_REPLICATEALPHA \
+    ( (3 << (D3DSP_SWIZZLE_SHIFT + 0)) | \
+      (3 << (D3DSP_SWIZZLE_SHIFT + 2)) | \
+      (3 << (D3DSP_SWIZZLE_SHIFT + 4)) | \
+      (3 << (D3DSP_SWIZZLE_SHIFT + 6)) )
+
+// source parameter modifiers
+#define D3DSP_SRCMOD_SHIFT      24
+#define D3DSP_SRCMOD_MASK       0x0F000000
+
+typedef enum _D3DSHADER_PARAM_SRCMOD_TYPE
+{
+    D3DSPSM_NONE    = 0<<D3DSP_SRCMOD_SHIFT, // nop
+    D3DSPSM_NEG     = 1<<D3DSP_SRCMOD_SHIFT, // negate
+    D3DSPSM_BIAS    = 2<<D3DSP_SRCMOD_SHIFT, // bias
+    D3DSPSM_BIASNEG = 3<<D3DSP_SRCMOD_SHIFT, // bias and negate
+    D3DSPSM_SIGN    = 4<<D3DSP_SRCMOD_SHIFT, // sign
+    D3DSPSM_SIGNNEG = 5<<D3DSP_SRCMOD_SHIFT, // sign and negate
+    D3DSPSM_COMP    = 6<<D3DSP_SRCMOD_SHIFT, // complement
+    D3DSPSM_X2      = 7<<D3DSP_SRCMOD_SHIFT, // *2
+    D3DSPSM_X2NEG   = 8<<D3DSP_SRCMOD_SHIFT, // *2 and negate
+    D3DSPSM_DZ      = 9<<D3DSP_SRCMOD_SHIFT, // divide through by z component 
+    D3DSPSM_DW      = 10<<D3DSP_SRCMOD_SHIFT, // divide through by w component
+    D3DSPSM_FORCE_DWORD = 0x7fffffff,        // force 32-bit size enum
+} D3DSHADER_PARAM_SRCMOD_TYPE;
+
+// pixel shader version token
+#define D3DPS_VERSION(_Major,_Minor) (0xFFFF0000|((_Major)<<8)|(_Minor))
+
+// vertex shader version token
+#define D3DVS_VERSION(_Major,_Minor) (0xFFFE0000|((_Major)<<8)|(_Minor))
+
+// extract major/minor from version cap
+#define D3DSHADER_VERSION_MAJOR(_Version) (((_Version)>>8)&0xFF)
+#define D3DSHADER_VERSION_MINOR(_Version) (((_Version)>>0)&0xFF)
+
+// destination/source parameter register type
+#define D3DSI_COMMENTSIZE_SHIFT     16
+#define D3DSI_COMMENTSIZE_MASK      0x7FFF0000
+#define D3DSHADER_COMMENT(_DWordSize) \
+    ((((_DWordSize)<<D3DSI_COMMENTSIZE_SHIFT)&D3DSI_COMMENTSIZE_MASK)|D3DSIO_COMMENT)
+
+// pixel/vertex shader end token
+#define D3DPS_END()  0x0000FFFF
+#define D3DVS_END()  0x0000FFFF
+
+//---------------------------------------------------------------------
+
+// High order surfaces
+//
+typedef enum _D3DBASISTYPE
+{
+   D3DBASIS_BEZIER      = 0,
+   D3DBASIS_BSPLINE     = 1,
+   D3DBASIS_INTERPOLATE = 2,
+   D3DBASIS_FORCE_DWORD = 0x7fffffff,
+} D3DBASISTYPE;
+
+typedef enum _D3DORDERTYPE
+{
+   D3DORDER_LINEAR      = 1,
+   D3DORDER_QUADRATIC   = 2,
+   D3DORDER_CUBIC       = 3,
+   D3DORDER_QUINTIC     = 5,
+   D3DORDER_FORCE_DWORD = 0x7fffffff,
+} D3DORDERTYPE;
+
+typedef enum _D3DPATCHEDGESTYLE
+{
+   D3DPATCHEDGE_DISCRETE    = 0,
+   D3DPATCHEDGE_CONTINUOUS  = 1,
+   D3DPATCHEDGE_FORCE_DWORD = 0x7fffffff,
+} D3DPATCHEDGESTYLE;
+
+typedef enum _D3DSTATEBLOCKTYPE
+{
+    D3DSBT_ALL           = 1, // capture all state
+    D3DSBT_PIXELSTATE    = 2, // capture pixel state
+    D3DSBT_VERTEXSTATE   = 3, // capture vertex state
+    D3DSBT_FORCE_DWORD   = 0x7fffffff,
+} D3DSTATEBLOCKTYPE;
+
+// The D3DVERTEXBLENDFLAGS type is used with D3DRS_VERTEXBLEND state.
+//
+typedef enum _D3DVERTEXBLENDFLAGS
+{
+    D3DVBF_DISABLE  = 0,     // Disable vertex blending
+    D3DVBF_1WEIGHTS = 1,     // 2 matrix blending
+    D3DVBF_2WEIGHTS = 2,     // 3 matrix blending
+    D3DVBF_3WEIGHTS = 3,     // 4 matrix blending
+    D3DVBF_TWEENING = 255,   // blending using D3DRS_TWEENFACTOR
+    D3DVBF_0WEIGHTS = 256,   // one matrix is used with weight 1.0
+    D3DVBF_FORCE_DWORD = 0x7fffffff, // force 32-bit size enum
+} D3DVERTEXBLENDFLAGS;
+
+typedef enum _D3DTEXTURETRANSFORMFLAGS {
+    D3DTTFF_DISABLE         = 0,    // texture coordinates are passed directly
+    D3DTTFF_COUNT1          = 1,    // rasterizer should expect 1-D texture coords
+    D3DTTFF_COUNT2          = 2,    // rasterizer should expect 2-D texture coords
+    D3DTTFF_COUNT3          = 3,    // rasterizer should expect 3-D texture coords
+    D3DTTFF_COUNT4          = 4,    // rasterizer should expect 4-D texture coords
+    D3DTTFF_PROJECTED       = 256,  // texcoords to be divided by COUNTth element
+    D3DTTFF_FORCE_DWORD     = 0x7fffffff,
+} D3DTEXTURETRANSFORMFLAGS;
+
+// Macros to set texture coordinate format bits in the FVF id
+
+#define D3DFVF_TEXTUREFORMAT2 0         // Two floating point values
+#define D3DFVF_TEXTUREFORMAT1 3         // One floating point value
+#define D3DFVF_TEXTUREFORMAT3 1         // Three floating point values
+#define D3DFVF_TEXTUREFORMAT4 2         // Four floating point values
+
+#define D3DFVF_TEXCOORDSIZE3(CoordIndex) (D3DFVF_TEXTUREFORMAT3 << (CoordIndex*2 + 16))
+#define D3DFVF_TEXCOORDSIZE2(CoordIndex) (D3DFVF_TEXTUREFORMAT2)
+#define D3DFVF_TEXCOORDSIZE4(CoordIndex) (D3DFVF_TEXTUREFORMAT4 << (CoordIndex*2 + 16))
+#define D3DFVF_TEXCOORDSIZE1(CoordIndex) (D3DFVF_TEXTUREFORMAT1 << (CoordIndex*2 + 16))
+
+
+//---------------------------------------------------------------------
+
+/* Direct3D8 Device types */
+typedef enum _D3DDEVTYPE
+{
+    D3DDEVTYPE_HAL         = 1,
+    D3DDEVTYPE_REF         = 2,
+    D3DDEVTYPE_SW          = 3,
+
+    D3DDEVTYPE_FORCE_DWORD  = 0x7fffffff
+} D3DDEVTYPE;
+
+/* Multi-Sample buffer types */
+typedef enum _D3DMULTISAMPLE_TYPE
+{
+    D3DMULTISAMPLE_NONE            =  0,
+    D3DMULTISAMPLE_2_SAMPLES       =  2,
+    D3DMULTISAMPLE_3_SAMPLES       =  3,
+    D3DMULTISAMPLE_4_SAMPLES       =  4,
+    D3DMULTISAMPLE_5_SAMPLES       =  5,
+    D3DMULTISAMPLE_6_SAMPLES       =  6,
+    D3DMULTISAMPLE_7_SAMPLES       =  7,
+    D3DMULTISAMPLE_8_SAMPLES       =  8,
+    D3DMULTISAMPLE_9_SAMPLES       =  9,
+    D3DMULTISAMPLE_10_SAMPLES      = 10,
+    D3DMULTISAMPLE_11_SAMPLES      = 11,
+    D3DMULTISAMPLE_12_SAMPLES      = 12,
+    D3DMULTISAMPLE_13_SAMPLES      = 13,
+    D3DMULTISAMPLE_14_SAMPLES      = 14,
+    D3DMULTISAMPLE_15_SAMPLES      = 15,
+    D3DMULTISAMPLE_16_SAMPLES      = 16,
+
+    D3DMULTISAMPLE_FORCE_DWORD     = 0x7fffffff
+} D3DMULTISAMPLE_TYPE;
+
+/* Formats
+ * Most of these names have the following convention:
+ *      A = Alpha
+ *      R = Red
+ *      G = Green
+ *      B = Blue
+ *      X = Unused Bits
+ *      P = Palette
+ *      L = Luminance
+ *      U = dU coordinate for BumpMap
+ *      V = dV coordinate for BumpMap
+ *      S = Stencil
+ *      D = Depth (e.g. Z or W buffer)
+ *
+ *      Further, the order of the pieces are from MSB first; hence
+ *      D3DFMT_A8L8 indicates that the high byte of this two byte
+ *      format is alpha.
+ *
+ *      D16 indicates:
+ *           - An integer 16-bit value.
+ *           - An app-lockable surface.
+ *
+ *      All Depth/Stencil formats except D3DFMT_D16_LOCKABLE indicate:
+ *          - no particular bit ordering per pixel, and
+ *          - are not app lockable, and
+ *          - the driver is allowed to consume more than the indicated
+ *            number of bits per Depth channel (but not Stencil channel).
+ */
+#ifndef MAKEFOURCC
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
+                ((DWORD)(BYTE)(ch0) | ((DWORD)(BYTE)(ch1) << 8) |       \
+                ((DWORD)(BYTE)(ch2) << 16) | ((DWORD)(BYTE)(ch3) << 24 ))
+#endif /* defined(MAKEFOURCC) */
+
+
+typedef enum _D3DFORMAT
+{
+    D3DFMT_UNKNOWN              =  0,
+
+    D3DFMT_R8G8B8               = 20,
+    D3DFMT_A8R8G8B8             = 21,
+    D3DFMT_X8R8G8B8             = 22,
+    D3DFMT_R5G6B5               = 23,
+    D3DFMT_X1R5G5B5             = 24,
+    D3DFMT_A1R5G5B5             = 25,
+    D3DFMT_A4R4G4B4             = 26,
+    D3DFMT_R3G3B2               = 27,
+    D3DFMT_A8                   = 28,
+    D3DFMT_A8R3G3B2             = 29,
+    D3DFMT_X4R4G4B4             = 30,
+    D3DFMT_A2B10G10R10          = 31,
+    D3DFMT_G16R16               = 34,
+
+    D3DFMT_A8P8                 = 40,
+    D3DFMT_P8                   = 41,
+
+    D3DFMT_L8                   = 50,
+    D3DFMT_A8L8                 = 51,
+    D3DFMT_A4L4                 = 52,
+
+    D3DFMT_V8U8                 = 60,
+    D3DFMT_L6V5U5               = 61,
+    D3DFMT_X8L8V8U8             = 62,
+    D3DFMT_Q8W8V8U8             = 63,
+    D3DFMT_V16U16               = 64,
+    D3DFMT_W11V11U10            = 65,
+    D3DFMT_A2W10V10U10          = 67,
+
+    D3DFMT_UYVY                 = MAKEFOURCC('U', 'Y', 'V', 'Y'),
+    D3DFMT_YUY2                 = MAKEFOURCC('Y', 'U', 'Y', '2'),
+    D3DFMT_DXT1                 = MAKEFOURCC('D', 'X', 'T', '1'),
+    D3DFMT_DXT2                 = MAKEFOURCC('D', 'X', 'T', '2'),
+    D3DFMT_DXT3                 = MAKEFOURCC('D', 'X', 'T', '3'),
+    D3DFMT_DXT4                 = MAKEFOURCC('D', 'X', 'T', '4'),
+    D3DFMT_DXT5                 = MAKEFOURCC('D', 'X', 'T', '5'),
+
+    D3DFMT_D16_LOCKABLE         = 70,
+    D3DFMT_D32                  = 71,
+    D3DFMT_D15S1                = 73,
+    D3DFMT_D24S8                = 75,
+    D3DFMT_D16                  = 80,
+    D3DFMT_D24X8                = 77,
+    D3DFMT_D24X4S4              = 79,
+
+
+    D3DFMT_VERTEXDATA           =100,
+    D3DFMT_INDEX16              =101,
+    D3DFMT_INDEX32              =102,
+
+    D3DFMT_FORCE_DWORD          =0x7fffffff
+} D3DFORMAT;
+
+/* Display Modes */
+typedef struct _D3DDISPLAYMODE
+{
+    UINT            Width;
+    UINT            Height;
+    UINT            RefreshRate;
+    D3DFORMAT       Format;
+} D3DDISPLAYMODE;
+
+/* Creation Parameters */
+typedef struct _D3DDEVICE_CREATION_PARAMETERS
+{
+    UINT            AdapterOrdinal;
+    D3DDEVTYPE      DeviceType;
+    HWND            hFocusWindow;
+    DWORD           BehaviorFlags;
+} D3DDEVICE_CREATION_PARAMETERS;
+
+
+/* SwapEffects */
+typedef enum _D3DSWAPEFFECT
+{
+    D3DSWAPEFFECT_DISCARD           = 1,
+    D3DSWAPEFFECT_FLIP              = 2,
+    D3DSWAPEFFECT_COPY              = 3,
+    D3DSWAPEFFECT_COPY_VSYNC        = 4,
+
+    D3DSWAPEFFECT_FORCE_DWORD       = 0x7fffffff
+} D3DSWAPEFFECT;
+
+/* Pool types */
+typedef enum _D3DPOOL {
+    D3DPOOL_DEFAULT                 = 0,
+    D3DPOOL_MANAGED                 = 1,
+    D3DPOOL_SYSTEMMEM               = 2,
+    D3DPOOL_SCRATCH                 = 3,
+
+    D3DPOOL_FORCE_DWORD             = 0x7fffffff
+} D3DPOOL;
+
+
+/* RefreshRate pre-defines */
+#define D3DPRESENT_RATE_DEFAULT         0x00000000
+#define D3DPRESENT_RATE_UNLIMITED       0x7fffffff
+
+
+/* Resize Optional Parameters */
+typedef struct _D3DPRESENT_PARAMETERS_
+{
+    UINT                BackBufferWidth;
+    UINT                BackBufferHeight;
+    D3DFORMAT           BackBufferFormat;
+    UINT                BackBufferCount;
+
+    D3DMULTISAMPLE_TYPE MultiSampleType;
+
+    D3DSWAPEFFECT       SwapEffect;
+    HWND                hDeviceWindow;
+    BOOL                Windowed;
+    BOOL                EnableAutoDepthStencil;
+    D3DFORMAT           AutoDepthStencilFormat;
+    DWORD               Flags;
+
+    /* Following elements must be zero for Windowed mode */
+    UINT                FullScreen_RefreshRateInHz;
+    UINT                FullScreen_PresentationInterval;
+
+} D3DPRESENT_PARAMETERS;
+
+// Values for D3DPRESENT_PARAMETERS.Flags
+
+#define D3DPRESENTFLAG_LOCKABLE_BACKBUFFER  0x00000001
+
+
+/* Gamma Ramp: Same as DX7 */
+
+typedef struct _D3DGAMMARAMP
+{
+    WORD                red  [256];
+    WORD                green[256];
+    WORD                blue [256];
+} D3DGAMMARAMP;
+
+/* Back buffer types */
+typedef enum _D3DBACKBUFFER_TYPE
+{
+    D3DBACKBUFFER_TYPE_MONO         = 0,
+    D3DBACKBUFFER_TYPE_LEFT         = 1,
+    D3DBACKBUFFER_TYPE_RIGHT        = 2,
+
+    D3DBACKBUFFER_TYPE_FORCE_DWORD  = 0x7fffffff
+} D3DBACKBUFFER_TYPE;
+
+
+/* Types */
+typedef enum _D3DRESOURCETYPE {
+    D3DRTYPE_SURFACE                =  1,
+    D3DRTYPE_VOLUME                 =  2,
+    D3DRTYPE_TEXTURE                =  3,
+    D3DRTYPE_VOLUMETEXTURE          =  4,
+    D3DRTYPE_CUBETEXTURE            =  5,
+    D3DRTYPE_VERTEXBUFFER           =  6,
+    D3DRTYPE_INDEXBUFFER            =  7,
+
+
+    D3DRTYPE_FORCE_DWORD            = 0x7fffffff
+} D3DRESOURCETYPE;
+
+/* Usages */
+#define D3DUSAGE_RENDERTARGET       (0x00000001L)
+#define D3DUSAGE_DEPTHSTENCIL       (0x00000002L)
+
+/* Usages for Vertex/Index buffers */
+#define D3DUSAGE_WRITEONLY          (0x00000008L)
+#define D3DUSAGE_SOFTWAREPROCESSING (0x00000010L)
+#define D3DUSAGE_DONOTCLIP          (0x00000020L)
+#define D3DUSAGE_POINTS             (0x00000040L)
+#define D3DUSAGE_RTPATCHES          (0x00000080L)
+#define D3DUSAGE_NPATCHES           (0x00000100L)
+#define D3DUSAGE_DYNAMIC            (0x00000200L)
+
+
+
+
+
+
+
+
+
+/* CubeMap Face identifiers */
+typedef enum _D3DCUBEMAP_FACES
+{
+    D3DCUBEMAP_FACE_POSITIVE_X     = 0,
+    D3DCUBEMAP_FACE_NEGATIVE_X     = 1,
+    D3DCUBEMAP_FACE_POSITIVE_Y     = 2,
+    D3DCUBEMAP_FACE_NEGATIVE_Y     = 3,
+    D3DCUBEMAP_FACE_POSITIVE_Z     = 4,
+    D3DCUBEMAP_FACE_NEGATIVE_Z     = 5,
+
+    D3DCUBEMAP_FACE_FORCE_DWORD    = 0x7fffffff
+} D3DCUBEMAP_FACES;
+
+
+/* Lock flags */
+
+#define D3DLOCK_READONLY           0x00000010L
+#define D3DLOCK_DISCARD             0x00002000L
+#define D3DLOCK_NOOVERWRITE        0x00001000L
+#define D3DLOCK_NOSYSLOCK          0x00000800L
+
+#define D3DLOCK_NO_DIRTY_UPDATE     0x00008000L
+
+
+
+
+
+
+/* Vertex Buffer Description */
+typedef struct _D3DVERTEXBUFFER_DESC
+{
+    D3DFORMAT           Format;
+    D3DRESOURCETYPE     Type;
+    DWORD               Usage;
+    D3DPOOL             Pool;
+    UINT                Size;
+
+    DWORD               FVF;
+
+} D3DVERTEXBUFFER_DESC;
+
+/* Index Buffer Description */
+typedef struct _D3DINDEXBUFFER_DESC
+{
+    D3DFORMAT           Format;
+    D3DRESOURCETYPE     Type;
+    DWORD               Usage;
+    D3DPOOL             Pool;
+    UINT                Size;
+} D3DINDEXBUFFER_DESC;
+
+
+/* Surface Description */
+typedef struct _D3DSURFACE_DESC
+{
+    D3DFORMAT           Format;
+    D3DRESOURCETYPE     Type;
+    DWORD               Usage;
+    D3DPOOL             Pool;
+    UINT                Size;
+
+    D3DMULTISAMPLE_TYPE MultiSampleType;
+    UINT                Width;
+    UINT                Height;
+} D3DSURFACE_DESC;
+
+typedef struct _D3DVOLUME_DESC
+{
+    D3DFORMAT           Format;
+    D3DRESOURCETYPE     Type;
+    DWORD               Usage;
+    D3DPOOL             Pool;
+    UINT                Size;
+
+    UINT                Width;
+    UINT                Height;
+    UINT                Depth;
+} D3DVOLUME_DESC;
+
+/* Structure for LockRect */
+typedef struct _D3DLOCKED_RECT
+{
+    INT                 Pitch;
+    void*               pBits;
+} D3DLOCKED_RECT;
+
+/* Structures for LockBox */
+typedef struct _D3DBOX
+{
+    UINT                Left;
+    UINT                Top;
+    UINT                Right;
+    UINT                Bottom;
+    UINT                Front;
+    UINT                Back;
+} D3DBOX;
+
+typedef struct _D3DLOCKED_BOX
+{
+    INT                 RowPitch;
+    INT                 SlicePitch;
+    void*               pBits;
+} D3DLOCKED_BOX;
+
+/* Structures for LockRange */
+typedef struct _D3DRANGE
+{
+    UINT                Offset;
+    UINT                Size;
+} D3DRANGE;
+
+/* Structures for high order primitives */
+typedef struct _D3DRECTPATCH_INFO
+{
+    UINT                StartVertexOffsetWidth;
+    UINT                StartVertexOffsetHeight;
+    UINT                Width;
+    UINT                Height;
+    UINT                Stride;
+    D3DBASISTYPE        Basis;
+    D3DORDERTYPE        Order;
+} D3DRECTPATCH_INFO;
+
+typedef struct _D3DTRIPATCH_INFO
+{
+    UINT                StartVertexOffset;
+    UINT                NumVertices;
+    D3DBASISTYPE        Basis;
+    D3DORDERTYPE        Order;
+} D3DTRIPATCH_INFO;
+
+/* Adapter Identifier */
+
+#define MAX_DEVICE_IDENTIFIER_STRING        512
+typedef struct _D3DADAPTER_IDENTIFIER8
+{
+    char            Driver[MAX_DEVICE_IDENTIFIER_STRING];
+    char            Description[MAX_DEVICE_IDENTIFIER_STRING];
+
+#ifdef _WIN32
+    LARGE_INTEGER   DriverVersion;            /* Defined for 32 bit components */
+#else
+    DWORD           DriverVersionLowPart;     /* Defined for 16 bit driver components */
+    DWORD           DriverVersionHighPart;
+#endif
+
+    DWORD           VendorId;
+    DWORD           DeviceId;
+    DWORD           SubSysId;
+    DWORD           Revision;
+
+    GUID            DeviceIdentifier;
+
+    DWORD           WHQLLevel;
+
+} D3DADAPTER_IDENTIFIER8;
+
+
+/* Raster Status structure returned by GetRasterStatus */
+typedef struct _D3DRASTER_STATUS
+{
+    BOOL            InVBlank;
+    UINT            ScanLine;
+} D3DRASTER_STATUS;
+
+
+
+/* Debug monitor tokens (DEBUG only)
+
+   Note that if D3DRS_DEBUGMONITORTOKEN is set, the call is treated as
+   passing a token to the debug monitor.  For example, if, after passing
+   D3DDMT_ENABLE/DISABLE to D3DRS_DEBUGMONITORTOKEN other token values
+   are passed in, the enabled/disabled state of the debug
+   monitor will still persist.
+
+   The debug monitor defaults to enabled.
+
+   Calling GetRenderState on D3DRS_DEBUGMONITORTOKEN is not of any use.
+*/
+typedef enum _D3DDEBUGMONITORTOKENS {
+    D3DDMT_ENABLE            = 0,    // enable debug monitor
+    D3DDMT_DISABLE           = 1,    // disable debug monitor
+    D3DDMT_FORCE_DWORD     = 0x7fffffff,
+} D3DDEBUGMONITORTOKENS;
+
+// GetInfo IDs
+
+#define D3DDEVINFOID_RESOURCEMANAGER    5           /* Used with D3DDEVINFO_RESOURCEMANAGER */
+#define D3DDEVINFOID_VERTEXSTATS        6           /* Used with D3DDEVINFO_D3DVERTEXSTATS */
+
+typedef struct _D3DRESOURCESTATS
+{
+// Data collected since last Present()
+    BOOL    bThrashing;             /* indicates if thrashing */
+    DWORD   ApproxBytesDownloaded;  /* Approximate number of bytes downloaded by resource manager */
+    DWORD   NumEvicts;              /* number of objects evicted */
+    DWORD   NumVidCreates;          /* number of objects created in video memory */
+    DWORD   LastPri;                /* priority of last object evicted */
+    DWORD   NumUsed;                /* number of objects set to the device */
+    DWORD   NumUsedInVidMem;        /* number of objects set to the device, which are already in video memory */
+// Persistent data
+    DWORD   WorkingSet;             /* number of objects in video memory */
+    DWORD   WorkingSetBytes;        /* number of bytes in video memory */
+    DWORD   TotalManaged;           /* total number of managed objects */
+    DWORD   TotalBytes;             /* total number of bytes of managed objects */
+} D3DRESOURCESTATS;
+
+#define D3DRTYPECOUNT (D3DRTYPE_INDEXBUFFER+1)
+
+typedef struct _D3DDEVINFO_RESOURCEMANAGER
+{
+    D3DRESOURCESTATS    stats[D3DRTYPECOUNT];
+} D3DDEVINFO_RESOURCEMANAGER, *LPD3DDEVINFO_RESOURCEMANAGER;
+
+typedef struct _D3DDEVINFO_D3DVERTEXSTATS
+{
+    DWORD   NumRenderedTriangles;       /* total number of triangles that are not clipped in this frame */
+    DWORD   NumExtraClippingTriangles;  /* Number of new triangles generated by clipping */
+} D3DDEVINFO_D3DVERTEXSTATS, *LPD3DDEVINFO_D3DVERTEXSTATS;
+
+
+#pragma pack()
+#if _MSC_VER >= 1200
+#pragma warning(pop)
+#else
+#pragma warning(default:4201)
+#endif
+
+#endif /* (DIRECT3D_VERSION >= 0x0800) */
+#endif /* _D3D8TYPES(P)_H_ */
+

--- a/renderdoc/renderdoc.vcxproj
+++ b/renderdoc/renderdoc.vcxproj
@@ -355,6 +355,14 @@
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
     </ProjectReference>
+    <ProjectReference Include="driver\d3d8\renderdoc_d3d8.vcxproj">
+      <Project>{9c4487e8-eeb0-4a7f-bd81-23f81cd24e22}</Project>
+      <Private>false</Private>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+      <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
+    </ProjectReference>
     <ProjectReference Include="driver\d3d9\renderdoc_d3d9.vcxproj">
       <Project>{44044776-9469-4079-b587-abfff6574aa4}</Project>
       <Private>false</Private>


### PR DESCRIPTION
So far, I've implemented (err, copied from the D3D9 driver) the basic driver skeleton and overlay renderer. I've obviously adjusted the COM interfaces to match the D3D8 header files.

It works well enough to draw the overlay text on top of C&C Generals (a D3D8 game), so it's not completely broken :)

This relates to #663.