### PR TITLE
Automatic Install of RenderDocCmd APK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(BUILD_VERSION_STABLE "If this is a stable build. See RENDERDOC_STABLE_BUI
 set(BUILD_VERSION_DIST_NAME "" CACHE STRING "The name of the distribution. See DISTRIBUTION_NAME in renderdoc/api/replay/version.h")
 set(BUILD_VERSION_DIST_VER "" CACHE STRING "The distribution-specific version number. See DISTRIBUTION_VERSION in renderdoc/api/replay/version.h")
 set(BUILD_VERSION_DIST_CONTACT "" CACHE STRING "The URL or email to contact with issues. See DISTRIBUTION_CONTACT in renderdoc/api/replay/version.h")
+set(RENDERDOC_APK_PATH "" CACHE STRING "Path to RenderDocCmd.apk after installation of RenderDoc on host (either absolute or relative to binary)")
 
 if(BUILD_VERSION_STABLE)
     add_definitions(-DRENDERDOC_STABLE_BUILD=1)
@@ -51,6 +52,11 @@ endif()
 
 if(NOT BUILD_VERSION_DIST_CONTACT STREQUAL "")
     add_definitions(-DDISTRIBUTION_CONTACT="${BUILD_VERSION_DIST_CONTACT}")
+endif()
+
+if(NOT RENDERDOC_APK_PATH STREQUAL "")
+    message(STATUS "Detected custom path to RenderDocCmd.apk: ${RENDERDOC_APK}")
+    add_definitions(-DRENDERDOC_APK_PATH="${RENDERDOC_APK_PATH}")
 endif()
 
 function(get_git_hash _git_hash)

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -237,6 +237,7 @@ string GetReplayAppFilename();
 
 void CreateParentDirectory(const string &filename);
 
+bool IsRelativePath(const string &path);
 string GetFullPathname(const string &filename);
 
 void GetExecutableFilename(string &selfName);

--- a/renderdoc/os/posix/posix_stringio.cpp
+++ b/renderdoc/os/posix/posix_stringio.cpp
@@ -83,6 +83,14 @@ void CreateParentDirectory(const string &filename)
   }
 }
 
+bool IsRelativePath(const string &path)
+{
+  if(path.empty())
+    return false;
+
+  return path.front() != '/';
+}
+
 string GetFullPathname(const string &filename)
 {
   char path[PATH_MAX + 1] = {0};

--- a/renderdoc/os/win32/win32_stringio.cpp
+++ b/renderdoc/os/win32/win32_stringio.cpp
@@ -24,6 +24,7 @@
  ******************************************************************************/
 
 #include <shlobj.h>
+#include <shlwapi.h>
 #include <stdio.h>
 #include <string.h>
 #include <tchar.h>
@@ -164,6 +165,15 @@ void GetExecutableFilename(string &selfName)
   GetModuleFileNameW(NULL, curFile, 511);
 
   selfName = StringFormat::Wide2UTF8(wstring(curFile));
+}
+
+bool IsRelativePath(const string &path)
+{
+  if(path.empty())
+    return false;
+
+  wstring wpath = StringFormat::UTF82Wide(path.c_str());
+  return PathIsRelativeW(wpath.c_str()) != 0;
 }
 
 string GetFullPathname(const string &filename)

--- a/renderdoc/renderdoc.vcxproj
+++ b/renderdoc/renderdoc.vcxproj
@@ -77,7 +77,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>ws2_32.lib;kernel32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;kernel32.lib;user32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(ProjectDir)os\win32\comexport.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -608,6 +608,8 @@ string adbExecCommand(const string &device, const string &args)
   if(result.strStdout.length())
     // This could be an error (i.e. no package), or just regular output from adb devices.
     RDCLOG("STDOUT:\n%s", result.strStdout.c_str());
+  if(result.strStderror.length())
+    RDCLOG("STDERR:\n%s", result.strStderror.c_str());
   return result.strStdout;
 }
 string adbGetDeviceList()

--- a/renderdoc/serialise/string_utils.cpp
+++ b/renderdoc/serialise/string_utils.cpp
@@ -99,3 +99,11 @@ std::string trim(const std::string &str)
   // searching from the start found something, so searching from the end must have too.
   return str.substr(start, end - start + 1);
 }
+
+bool endswith(const std::string &value, const std::string &ending)
+{
+  if(ending.length() > value.length())
+    return false;
+
+  return (0 == value.compare(value.length() - ending.length(), ending.length(), ending));
+}

--- a/renderdoc/serialise/string_utils.h
+++ b/renderdoc/serialise/string_utils.h
@@ -41,6 +41,8 @@ std::string trim(const std::string &str);
 
 uint32_t strhash(const char *str, uint32_t existingHash = 5381);
 
+bool endswith(const std::string &value, const std::string &ending);
+
 template <class strType>
 strType basename(const strType &path)
 {


### PR DESCRIPTION
This series adds the ability to have the RenderDocCmd APK automatically installed on devices that don't already have it, improving the workflow for Android.

- It detects whether the server is present on the device and, if not, searches known locations for the APK (for distributions or local builds), installing the version that matches your target device.
- You can also specify a custom location in cmake using -DRENDERDOC_APK_PATH

I can follow this up with a progress box while the install is happening, if folks like the direction.