### PR TITLE
Wrap D3D8 vertex and index buffers

### DIFF
--- a/renderdoc/driver/d3d8/d3d8_common.h
+++ b/renderdoc/driver/d3d8/d3d8_common.h
@@ -77,3 +77,7 @@ public:
   unsigned int SoftRef(WrappedD3DDevice8 *device);
   unsigned int SoftRelease(WrappedD3DDevice8 *device);
 };
+
+#define IMPLEMENT_FUNCTION_SERIALISED(ret, func) \
+  ret func;                                      \
+  bool CONCAT(Serialise_, func);

--- a/renderdoc/driver/d3d8/d3d8_device.h
+++ b/renderdoc/driver/d3d8/d3d8_device.h
@@ -25,6 +25,7 @@
 #pragma once
 #include "common/timing.h"
 #include "d3d8_common.h"
+#include "d3d8_manager.h"
 
 class D3D8DebugManager;
 
@@ -50,6 +51,10 @@ public:
   }
 
   D3D8DebugManager *GetDebugManager() { return m_DebugManager; }
+  D3D8ResourceManager *GetResourceManager() { return m_ResourceManager; }
+  Threading::CriticalSection &D3DLock() { return m_D3DLock; }
+  IMPLEMENT_FUNCTION_SERIALISED(void, ReleaseResource(IDirect3DResource8 *res));
+
   /*** IUnknown methods ***/
   ULONG STDMETHODCALLTYPE AddRef() { return m_RefCounter.AddRef(); }
   ULONG STDMETHODCALLTYPE Release()
@@ -205,10 +210,18 @@ private:
 
   IDirect3DDevice8 *m_device;
   D3D8DebugManager *m_DebugManager;
+  D3D8ResourceManager *m_ResourceManager;
 
   D3DPRESENT_PARAMETERS m_PresentParameters;
 
   HWND m_Wnd;
+
+  // ensure all calls in via the D3D wrapped interface are thread safe
+  // protects wrapped resource creation and serialiser access
+  Threading::CriticalSection m_D3DLock;
+
+  Serialiser *m_pSerialiser;
+  LogState m_State;
 
   unsigned int m_InternalRefcount;
   RefCounter8 m_RefCounter;

--- a/renderdoc/driver/d3d8/d3d8_manager.cpp
+++ b/renderdoc/driver/d3d8/d3d8_manager.cpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "d3d8_manager.h"
+#include "d3d8_resources.h"
+
+bool D3D8ResourceManager::SerialisableResource(ResourceId id, D3D8ResourceRecord *record)
+{
+  return true;
+}
+
+ResourceId D3D8ResourceManager::GetID(IUnknown *res)
+{
+  return GetResID(res);
+}
+
+bool D3D8ResourceManager::ResourceTypeRelease(IUnknown *res)
+{
+  if(res)
+    res->Release();
+
+  return true;
+}
+
+bool D3D8ResourceManager::Force_InitialState(IUnknown *res, bool prepare)
+{
+  return false;
+}
+
+bool D3D8ResourceManager::Need_InitialStateChunk(IUnknown *res)
+{
+  return true;
+}
+
+bool D3D8ResourceManager::Prepare_InitialState(IUnknown *res)
+{
+  // TODO
+  return false;
+}
+
+bool D3D8ResourceManager::Serialise_InitialState(ResourceId id, IUnknown *res)
+{
+  // TODO
+  return false;
+}
+
+void D3D8ResourceManager::Create_InitialState(ResourceId id, IUnknown *live, bool hasData)
+{
+}
+
+void D3D8ResourceManager::Apply_InitialState(IUnknown *live, InitialContentData data)
+{
+  // TODO
+}

--- a/renderdoc/driver/d3d8/d3d8_manager.h
+++ b/renderdoc/driver/d3d8/d3d8_manager.h
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "api/replay/renderdoc_replay.h"
+#include "common/wrapped_pool.h"
+#include "core/core.h"
+#include "core/resource_manager.h"
+#include "serialise/serialiser.h"
+#include "d3d8_common.h"
+
+enum D3D8ResourceType
+{
+  Resource_Unknown = 0,
+  Resource_VertexBuffer,
+  Resource_IndexBuffer,
+};
+
+struct D3D8ResourceRecord : public ResourceRecord
+{
+  enum
+  {
+    NullResource = NULL
+  };
+
+  D3D8ResourceRecord(ResourceId id) : ResourceRecord(id, true) {}
+};
+
+class D3D8ResourceManager : public ResourceManager<IUnknown *, IUnknown *, D3D8ResourceRecord>
+{
+public:
+  D3D8ResourceManager(LogState state, Serialiser *ser, WrappedD3DDevice8 *dev)
+      : ResourceManager(state, ser), m_Device(dev)
+  {
+  }
+
+private:
+  bool SerialisableResource(ResourceId id, D3D8ResourceRecord *record);
+  ResourceId GetID(IUnknown *res);
+
+  bool ResourceTypeRelease(IUnknown *res);
+
+  bool Force_InitialState(IUnknown *res, bool prepare);
+  bool Need_InitialStateChunk(IUnknown *res);
+  bool Prepare_InitialState(IUnknown *res);
+  bool Serialise_InitialState(ResourceId resid, IUnknown *res);
+  void Create_InitialState(ResourceId id, IUnknown *live, bool hasData);
+  void Apply_InitialState(IUnknown *live, InitialContentData data);
+
+  WrappedD3DDevice8 *m_Device;
+};

--- a/renderdoc/driver/d3d8/d3d8_resources.cpp
+++ b/renderdoc/driver/d3d8/d3d8_resources.cpp
@@ -1,0 +1,121 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "d3d8_resources.h"
+
+#undef D3D8_TYPE_MACRO
+#define D3D8_TYPE_MACRO(iface) WRAPPED_POOL_INST(CONCAT(Wrapped, iface));
+
+ALL_D3D8_TYPES;
+
+map<ResourceId, WrappedIDirect3DVertexBuffer8::BufferEntry>
+    WrappedD3DBuffer8<IDirect3DVertexBuffer8, D3DVERTEXBUFFER_DESC>::m_BufferList;
+map<ResourceId, WrappedIDirect3DIndexBuffer8::BufferEntry>
+    WrappedD3DBuffer8<IDirect3DIndexBuffer8, D3DINDEXBUFFER_DESC>::m_BufferList;
+
+D3D8ResourceType IdentifyTypeByPtr(IUnknown *ptr)
+{
+  if(ptr == NULL)
+    return Resource_Unknown;
+
+#undef D3D8_TYPE_MACRO
+#define D3D8_TYPE_MACRO(iface)          \
+  if(UnwrapHelper<iface>::IsAlloc(ptr)) \
+    return UnwrapHelper<iface>::GetTypeEnum();
+
+  ALL_D3D8_TYPES;
+
+  RDCERR("Unknown type for ptr 0x%p", ptr);
+
+  return Resource_Unknown;
+}
+
+TrackedResource8 *GetTracked(IUnknown *ptr)
+{
+  if(ptr == NULL)
+    return NULL;
+
+#undef D3D8_TYPE_MACRO
+#define D3D8_TYPE_MACRO(iface)          \
+  if(UnwrapHelper<iface>::IsAlloc(ptr)) \
+    return (TrackedResource8 *)GetWrapped((iface *)ptr);
+
+  ALL_D3D8_TYPES;
+
+  return NULL;
+}
+
+template <>
+IUnknown *Unwrap(IUnknown *ptr)
+{
+  if(ptr == NULL)
+    return NULL;
+
+#undef D3D8_TYPE_MACRO
+#define D3D8_TYPE_MACRO(iface)          \
+  if(UnwrapHelper<iface>::IsAlloc(ptr)) \
+    return (IUnknown *)GetWrapped((iface *)ptr)->GetReal();
+
+  ALL_D3D8_TYPES;
+
+  RDCERR("Unknown type of ptr 0x%p", ptr);
+
+  return NULL;
+}
+
+template <>
+ResourceId GetResID(IUnknown *ptr)
+{
+  if(ptr == NULL)
+    return ResourceId();
+
+  TrackedResource8 *res = GetTracked(ptr);
+
+  if(res == NULL)
+  {
+    RDCERR("Unknown type of ptr 0x%p", ptr);
+
+    return ResourceId();
+  }
+
+  return res->GetResourceID();
+}
+
+template <>
+D3D8ResourceRecord *GetRecord(IUnknown *ptr)
+{
+  if(ptr == NULL)
+    return NULL;
+
+  TrackedResource8 *res = GetTracked(ptr);
+
+  if(res == NULL)
+  {
+    RDCERR("Unknown type of ptr 0x%p", ptr);
+
+    return NULL;
+  }
+
+  return res->GetResourceRecord();
+}

--- a/renderdoc/driver/d3d8/d3d8_resources.h
+++ b/renderdoc/driver/d3d8/d3d8_resources.h
@@ -1,0 +1,332 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "d3d8_device.h"
+#include "d3d8_manager.h"
+
+class TrackedResource8
+{
+public:
+  TrackedResource8() { m_ID = ResourceIDGen::GetNewUniqueID(); }
+  ResourceId GetResourceID() { return m_ID; }
+  D3D8ResourceRecord *GetResourceRecord() { return m_pRecord; }
+  void SetResourceRecord(D3D8ResourceRecord *record) { m_pRecord = record; }
+private:
+  TrackedResource8(const TrackedResource8 &);
+  TrackedResource8 &operator=(const TrackedResource8 &);
+
+  ResourceId m_ID;
+  D3D8ResourceRecord *m_pRecord;
+};
+
+template <typename NestedType>
+class WrappedIDirect3DResource8 : public RefCounter8, public NestedType, public TrackedResource8
+{
+protected:
+  WrappedD3DDevice8 *m_pDevice;
+  NestedType *m_pReal;
+  unsigned int m_PipelineRefs;
+
+  WrappedIDirect3DResource8(NestedType *real, WrappedD3DDevice8 *device)
+      : RefCounter8(real), m_pDevice(device), m_pReal(real), m_PipelineRefs(0)
+  {
+    m_pDevice->SoftRef();
+
+    bool ret = m_pDevice->GetResourceManager()->AddWrapper(this, real);
+    if(!ret)
+      RDCERR("Error adding wrapper for type %s", ToStr::Get(__uuidof(NestedType)).c_str());
+
+    m_pDevice->GetResourceManager()->AddCurrentResource(GetResourceID(), this);
+  }
+
+  virtual void Shutdown()
+  {
+    m_pDevice->GetResourceManager()->RemoveWrapper(m_pReal);
+    m_pDevice->GetResourceManager()->ReleaseCurrentResource(GetResourceID());
+    m_pDevice->ReleaseResource((NestedType *)this);
+    SAFE_RELEASE(m_pReal);
+    m_pDevice = NULL;
+  }
+
+  virtual ~WrappedIDirect3DResource8()
+  {
+    // should have already called shutdown (needs to be called from child class to ensure
+    // vtables are still in place when we call ReleaseResource)
+    RDCASSERT(m_pDevice == NULL && m_pReal == NULL);
+  }
+
+public:
+  typedef NestedType InnerType;
+
+  NestedType *GetReal() { return m_pReal; }
+  ULONG STDMETHODCALLTYPE AddRef() { return RefCounter8::SoftRef(m_pDevice) - m_PipelineRefs; }
+  ULONG STDMETHODCALLTYPE Release()
+  {
+    unsigned int piperefs = m_PipelineRefs;
+    return RefCounter8::SoftRelease(m_pDevice) - piperefs;
+  }
+
+  void PipelineAddRef() { InterlockedIncrement(&m_PipelineRefs); }
+  void PipelineRelease() { InterlockedDecrement(&m_PipelineRefs); }
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject)
+  {
+    if(riid == __uuidof(IUnknown))
+    {
+      *ppvObject = (IUnknown *)(NestedType *)this;
+      AddRef();
+      return S_OK;
+    }
+    if(riid == __uuidof(NestedType))
+    {
+      *ppvObject = (NestedType *)this;
+      AddRef();
+      return S_OK;
+    }
+    if(riid == __uuidof(IDirect3DResource8))
+    {
+      *ppvObject = (IDirect3DResource8 *)this;
+      AddRef();
+      return S_OK;
+    }
+
+    return RefCounter8::QueryInterface(riid, ppvObject);
+  }
+
+  //////////////////////////////
+  // implement IDirect3DResource8
+
+  HRESULT STDMETHODCALLTYPE GetDevice(__out IDirect3DDevice8 **ppDevice)
+  {
+    if(ppDevice)
+    {
+      *ppDevice = m_pDevice;
+      m_pDevice->AddRef();
+      return S_OK;
+    }
+    return E_INVALIDARG;
+  }
+
+  HRESULT STDMETHODCALLTYPE GetPrivateData(REFGUID guid, void *pData, DWORD *pSizeOfData)
+  {
+    return m_pReal->GetPrivateData(guid, pData, pSizeOfData);
+  }
+
+  HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID guid, const void *pData, DWORD SizeOfData,
+                                           DWORD Flags)
+  {
+    return m_pReal->SetPrivateData(guid, pData, SizeOfData, Flags);
+  }
+
+  HRESULT STDMETHODCALLTYPE FreePrivateData(REFGUID guid) { return m_pReal->FreePrivateData(guid); }
+  DWORD STDMETHODCALLTYPE SetPriority(DWORD PriorityNew)
+  {
+    return m_pReal->SetPriority(PriorityNew);
+  }
+
+  DWORD STDMETHODCALLTYPE GetPriority() { return m_pReal->GetPriority(); }
+  void STDMETHODCALLTYPE PreLoad() { return m_pReal->PreLoad(); }
+  D3DRESOURCETYPE STDMETHODCALLTYPE GetType() { return m_pReal->GetType(); }
+};
+
+template <typename NestedType, typename DescType>
+class WrappedD3DBuffer8 : public WrappedIDirect3DResource8<NestedType>
+{
+protected:
+#if ENABLED(RDOC_DEVEL)
+  DescType m_Desc;
+#endif
+
+public:
+  struct BufferEntry
+  {
+    BufferEntry(WrappedD3DBuffer8 *b = NULL, uint32_t l = 0) : m_Buffer(b), length(l) {}
+    WrappedD3DBuffer8 *m_Buffer;
+    uint32_t length;
+  };
+
+  static map<ResourceId, BufferEntry> m_BufferList;
+
+  WrappedD3DBuffer8(NestedType *real, uint32_t byteLength, WrappedD3DDevice8 *device)
+      : WrappedIDirect3DResource8(real, device)
+  {
+#if ENABLED(RDOC_DEVEL)
+    real->GetDesc(&m_Desc);
+#endif
+    SCOPED_LOCK(m_pDevice->D3DLock());
+
+    RDCASSERT(m_BufferList.find(GetResourceID()) == m_BufferList.end());
+    m_BufferList[GetResourceID()] = BufferEntry(this, byteLength);
+  }
+
+  virtual ~WrappedD3DBuffer8()
+  {
+    SCOPED_LOCK(m_pDevice->D3DLock());
+
+    if(m_BufferList.find(GetResourceID()) != m_BufferList.end())
+      m_BufferList.erase(GetResourceID());
+
+    Shutdown();
+  }
+
+  HRESULT STDMETHODCALLTYPE Lock(UINT OffsetToLock, UINT SizeToLock, BYTE **ppbData, DWORD Flags)
+  {
+    // TODO
+    return m_pReal->Lock(OffsetToLock, SizeToLock, ppbData, Flags);
+  }
+
+  HRESULT STDMETHODCALLTYPE Unlock()
+  {
+    // TODO
+    return m_pReal->Unlock();
+  }
+
+  HRESULT STDMETHODCALLTYPE GetDesc(DescType *pDesc) { return m_pReal->GetDesc(pDesc); }
+};
+
+class WrappedIDirect3DVertexBuffer8
+    : public WrappedD3DBuffer8<IDirect3DVertexBuffer8, D3DVERTEXBUFFER_DESC>
+{
+public:
+  ALLOCATE_WITH_WRAPPED_POOL(WrappedIDirect3DVertexBuffer8);
+
+  enum
+  {
+    TypeEnum = Resource_VertexBuffer,
+  };
+
+  WrappedIDirect3DVertexBuffer8(IDirect3DVertexBuffer8 *real, uint32_t byteLength,
+                                WrappedD3DDevice8 *device)
+      : WrappedD3DBuffer8(real, byteLength, device)
+  {
+  }
+};
+
+class WrappedIDirect3DIndexBuffer8
+    : public WrappedD3DBuffer8<IDirect3DIndexBuffer8, D3DINDEXBUFFER_DESC>
+{
+public:
+  ALLOCATE_WITH_WRAPPED_POOL(WrappedIDirect3DIndexBuffer8);
+
+  enum
+  {
+    TypeEnum = Resource_IndexBuffer,
+  };
+
+  WrappedIDirect3DIndexBuffer8(IDirect3DIndexBuffer8 *real, uint32_t byteLength,
+                               WrappedD3DDevice8 *device)
+      : WrappedD3DBuffer8(real, byteLength, device)
+  {
+  }
+};
+
+#define ALL_D3D8_TYPES                     \
+  D3D8_TYPE_MACRO(IDirect3DVertexBuffer8); \
+  D3D8_TYPE_MACRO(IDirect3DIndexBuffer8);
+
+// template magic voodoo to unwrap types
+template <typename inner>
+struct UnwrapHelper
+{
+};
+
+#undef D3D8_TYPE_MACRO
+#define D3D8_TYPE_MACRO(iface)                                                          \
+  template <>                                                                           \
+  struct UnwrapHelper<iface>                                                            \
+  {                                                                                     \
+    typedef CONCAT(Wrapped, iface) Outer;                                               \
+    static bool IsAlloc(void *ptr) { return Outer::IsAlloc(ptr); }                      \
+    static D3D8ResourceType GetTypeEnum() { return (D3D8ResourceType)Outer::TypeEnum; } \
+    static Outer *FromHandle(iface *wrapped) { return (Outer *)wrapped; }               \
+  };                                                                                    \
+  template <>                                                                           \
+  struct UnwrapHelper<CONCAT(Wrapped, iface)>                                           \
+  {                                                                                     \
+    typedef CONCAT(Wrapped, iface) Outer;                                               \
+    static bool IsAlloc(void *ptr) { return Outer::IsAlloc(ptr); }                      \
+    static D3D8ResourceType GetTypeEnum() { return (D3D8ResourceType)Outer::TypeEnum; } \
+    static Outer *FromHandle(iface *wrapped) { return (Outer *)wrapped; }               \
+  };
+
+ALL_D3D8_TYPES;
+
+D3D8ResourceType IdentifyTypeByPtr(IUnknown *ptr);
+
+#define WRAPPING_DEBUG 0
+
+template <typename iface>
+typename UnwrapHelper<iface>::Outer *GetWrapped(iface *obj)
+{
+  if(obj == NULL)
+    return NULL;
+
+  typename UnwrapHelper<iface>::Outer *wrapped = UnwrapHelper<iface>::FromHandle(obj);
+
+#if WRAPPING_DEBUG
+  if(obj != NULL && !wrapped->IsAlloc(wrapped))
+  {
+    RDCERR("Trying to unwrap invalid type");
+    return NULL;
+  }
+#endif
+
+  return wrapped;
+}
+
+template <typename ifaceptr>
+ifaceptr Unwrap(ifaceptr obj)
+{
+  if(obj == NULL)
+    return NULL;
+
+  return GetWrapped(obj)->GetReal();
+}
+
+template <typename ifaceptr>
+ResourceId GetResID(ifaceptr obj)
+{
+  if(obj == NULL)
+    return ResourceId();
+
+  return GetWrapped(obj)->GetResourceID();
+}
+
+template <typename ifaceptr>
+D3D8ResourceRecord *GetRecord(ifaceptr obj)
+{
+  if(obj == NULL)
+    return NULL;
+
+  return GetWrapped(obj)->GetResourceRecord();
+}
+
+// specialisations that use the IsAlloc() function to identify the real type
+template <>
+ResourceId GetResID(IUnknown *ptr);
+template <>
+IUnknown *Unwrap(IUnknown *ptr);
+template <>
+D3D8ResourceRecord *GetRecord(IUnknown *ptr);

--- a/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj
+++ b/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj
@@ -102,7 +102,9 @@
     <ClCompile Include="d3d8_debug.cpp" />
     <ClCompile Include="d3d8_device.cpp" />
     <ClCompile Include="d3d8_hooks.cpp" />
+    <ClCompile Include="d3d8_manager.cpp" />
     <ClCompile Include="d3d8_replay.cpp" />
+    <ClCompile Include="d3d8_resources.cpp" />
     <ClCompile Include="precompiled.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -116,6 +118,8 @@
     <ClInclude Include="d3d8_common.h" />
     <ClInclude Include="d3d8_debug.h" />
     <ClInclude Include="d3d8_device.h" />
+    <ClInclude Include="d3d8_manager.h" />
+    <ClInclude Include="d3d8_resources.h" />
     <ClInclude Include="precompiled.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj.filters
+++ b/renderdoc/driver/d3d8/renderdoc_d3d8.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="PCH">
       <UniqueIdentifier>{74FA3D85-A524-442D-9682-BB832AB5E136}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Util">
+      <UniqueIdentifier>{025d23be-15d8-4d7d-bcbb-5899d5984f30}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="d3d8_hooks.cpp">
@@ -38,6 +41,12 @@
     </ClCompile>
     <ClCompile Include="precompiled.cpp">
       <Filter>PCH</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d8_manager.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="d3d8_resources.cpp">
+      <Filter>Util</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -67,6 +76,12 @@
     </ClInclude>
     <ClInclude Include="precompiled.h">
       <Filter>PCH</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d8_resources.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="d3d8_manager.h">
+      <Filter>Util</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/renderdoc/driver/dx/official/d3d8.h
+++ b/renderdoc/driver/dx/official/d3d8.h
@@ -162,7 +162,7 @@ IDirect3D8 * WINAPI Direct3DCreate8(UINT SDKVersion);
 #undef INTERFACE
 #define INTERFACE IDirect3D8
 
-DECLARE_INTERFACE_(IDirect3D8, IUnknown)
+DECLARE_INTERFACE_IID_(IDirect3D8, IUnknown, "1DD9E8DA-1C77-4d40-B0CF-98FEFDFF9512")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -244,7 +244,7 @@ typedef struct IDirect3D8 *LPDIRECT3D8, *PDIRECT3D8;
 #undef INTERFACE
 #define INTERFACE IDirect3DDevice8
 
-DECLARE_INTERFACE_(IDirect3DDevice8, IUnknown)
+DECLARE_INTERFACE_IID_(IDirect3DDevice8, IUnknown, "7385E5DF-8FE8-41D5-86B6-D7B48547B6CF")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -553,7 +553,7 @@ typedef struct IDirect3DDevice8 *LPDIRECT3DDEVICE8, *PDIRECT3DDEVICE8;
 #undef INTERFACE
 #define INTERFACE IDirect3DSwapChain8
 
-DECLARE_INTERFACE_(IDirect3DSwapChain8, IUnknown)
+DECLARE_INTERFACE_IID_(IDirect3DSwapChain8, IUnknown, "928C088B-76B9-4C6B-A536-A590853876CD")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -586,7 +586,7 @@ typedef struct IDirect3DSwapChain8 *LPDIRECT3DSWAPCHAIN8, *PDIRECT3DSWAPCHAIN8;
 #undef INTERFACE
 #define INTERFACE IDirect3DResource8
 
-DECLARE_INTERFACE_(IDirect3DResource8, IUnknown)
+DECLARE_INTERFACE_IID_(IDirect3DResource8, IUnknown, "1B36BB7B-09B7-410a-B445-7D1430D7B33F")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -638,7 +638,7 @@ typedef struct IDirect3DResource8 *LPDIRECT3DRESOURCE8, *PDIRECT3DRESOURCE8;
 #undef INTERFACE
 #define INTERFACE IDirect3DBaseTexture8
 
-DECLARE_INTERFACE_(IDirect3DBaseTexture8, IDirect3DResource8)
+DECLARE_INTERFACE_IID_(IDirect3DBaseTexture8, IDirect3DResource8, "B4211CFA-51B9-4a9f-AB78-DB99B2BB678E")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -700,7 +700,7 @@ typedef struct IDirect3DBaseTexture8 *LPDIRECT3DBASETEXTURE8, *PDIRECT3DBASETEXT
 #undef INTERFACE
 #define INTERFACE IDirect3DTexture8
 
-DECLARE_INTERFACE_(IDirect3DTexture8, IDirect3DBaseTexture8)
+DECLARE_INTERFACE_IID_(IDirect3DTexture8, IDirect3DBaseTexture8, "E4CDD575-2866-4f01-B12E-7EECE1EC9358")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -777,7 +777,7 @@ typedef struct IDirect3DTexture8 *LPDIRECT3DTEXTURE8, *PDIRECT3DTEXTURE8;
 #undef INTERFACE
 #define INTERFACE IDirect3DVolumeTexture8
 
-DECLARE_INTERFACE_(IDirect3DVolumeTexture8, IDirect3DBaseTexture8)
+DECLARE_INTERFACE_IID_(IDirect3DVolumeTexture8, IDirect3DBaseTexture8, "4B8AAAFA-140F-42ba-9131-597EAFAA2EAD")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -854,7 +854,7 @@ typedef struct IDirect3DVolumeTexture8 *LPDIRECT3DVOLUMETEXTURE8, *PDIRECT3DVOLU
 #undef INTERFACE
 #define INTERFACE IDirect3DCubeTexture8
 
-DECLARE_INTERFACE_(IDirect3DCubeTexture8, IDirect3DBaseTexture8)
+DECLARE_INTERFACE_IID_(IDirect3DCubeTexture8, IDirect3DBaseTexture8, "3EE5B968-2ACA-4c34-8BB5-7E0C3D19B750")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -930,7 +930,7 @@ typedef struct IDirect3DCubeTexture8 *LPDIRECT3DCUBETEXTURE8, *PDIRECT3DCUBETEXT
 #undef INTERFACE
 #define INTERFACE IDirect3DVertexBuffer8
 
-DECLARE_INTERFACE_(IDirect3DVertexBuffer8, IDirect3DResource8)
+DECLARE_INTERFACE_IID_(IDirect3DVertexBuffer8, IDirect3DResource8, "8AEEEAC7-05F9-44d4-B591-000B0DF1CB95")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -991,7 +991,7 @@ typedef struct IDirect3DVertexBuffer8 *LPDIRECT3DVERTEXBUFFER8, *PDIRECT3DVERTEX
 #undef INTERFACE
 #define INTERFACE IDirect3DIndexBuffer8
 
-DECLARE_INTERFACE_(IDirect3DIndexBuffer8, IDirect3DResource8)
+DECLARE_INTERFACE_IID_(IDirect3DIndexBuffer8, IDirect3DResource8, "0E689C9A-053D-44a0-9D92-DB0E3D750F86")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -1052,7 +1052,7 @@ typedef struct IDirect3DIndexBuffer8 *LPDIRECT3DINDEXBUFFER8, *PDIRECT3DINDEXBUF
 #undef INTERFACE
 #define INTERFACE IDirect3DSurface8
 
-DECLARE_INTERFACE_(IDirect3DSurface8, IUnknown)
+DECLARE_INTERFACE_IID_(IDirect3DSurface8, IUnknown, "B96EEBCA-B326-4ea5-882F-2FF5BAE021DD")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;
@@ -1104,7 +1104,7 @@ typedef struct IDirect3DSurface8 *LPDIRECT3DSURFACE8, *PDIRECT3DSURFACE8;
 #undef INTERFACE
 #define INTERFACE IDirect3DVolume8
 
-DECLARE_INTERFACE_(IDirect3DVolume8, IUnknown)
+DECLARE_INTERFACE_IID_(IDirect3DVolume8, IUnknown, "BD7349F5-14F1-42e4-9C79-972380DB40C0")
 {
     /*** IUnknown methods ***/
     STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) PURE;


### PR DESCRIPTION
Next round of D3D8 driver changes - this time, wrapping vertex and index buffers, and the associated boilerplate code that goes along with that. There's definitely some cargo-culting here, because I don't yet fully understand the resource manager, or serialisation. So please let me know if you spot anything that looks wrong, or was only necessary in D3D11 but shouldn't be necessary here, etc.

I wanted to keep this PR to a reasonable size, so there are plenty of TODOs that I'll get to after this PR is merged.

I'm starting to get a handle on how drivers work, but I do have an initial question. On the [How RenderDoc works](https://renderdoc.org/docs/behind_scenes/how_works.html) page, I found this:

> As a general rule, creation and deletion type actions are always serialised, and data-upload calls can sometimes be serialised. In some cases the driver might choose to optimise out some of the data-upload calls and lazy initialise the contents of some resources to save on idle overhead.

How do those 2 sentences map to these functions?

``` cpp
bool D3D8ResourceManager::Force_InitialState(IDirect3DResource8 *res, bool prepare);
bool D3D8ResourceManager::Need_InitialStateChunk(IDirect3DResource8 *res);
bool D3D8ResourceManager::Prepare_InitialState(IDirect3DResource8 *res);
bool D3D8ResourceManager::Serialise_InitialState(ResourceId id, IDirect3DResource8 *res);
void D3D8ResourceManager::Create_InitialState(ResourceId id, IDirect3DResource8 *live, bool hasData);
void D3D8ResourceManager::Apply_InitialState(IDirect3DResource8 *live, InitialContentData data);
```

If your answer is "read the code", then no problem :) But I'm struggling a bit when looking at the resource manager code to get the overall picture in my head.