### PR TITLE
Expose a set of GL ES extensions

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -727,11 +727,16 @@ void WrappedOpenGL::BuildGLESExtensions()
 {
   m_GLESExtensions.push_back("GL_ARM_rgba8");
   m_GLESExtensions.push_back("GL_EXT_base_instance");
+  m_GLESExtensions.push_back("GL_EXT_clip_cull_distance");
   m_GLESExtensions.push_back("GL_EXT_color_buffer_float");
   m_GLESExtensions.push_back("GL_EXT_color_buffer_half_float");
   m_GLESExtensions.push_back("GL_EXT_copy_image");
+  m_GLESExtensions.push_back("GL_EXT_debug_label");
+  m_GLESExtensions.push_back("GL_EXT_debug_marker");
   m_GLESExtensions.push_back("GL_EXT_disjoint_timer_query");
+  m_GLESExtensions.push_back("GL_EXT_blend_minmax");
   m_GLESExtensions.push_back("GL_EXT_draw_buffers");
+  m_GLESExtensions.push_back("GL_EXT_draw_elements_base_vertex");
   m_GLESExtensions.push_back("GL_EXT_draw_buffers_indexed");
   m_GLESExtensions.push_back("GL_EXT_geometry_point_size");
   m_GLESExtensions.push_back("GL_EXT_geometry_shader");
@@ -767,6 +772,7 @@ void WrappedOpenGL::BuildGLESExtensions()
   m_GLESExtensions.push_back("GL_EXT_texture_sRGB_R8");
   m_GLESExtensions.push_back("GL_EXT_texture_sRGB_RG8");
   m_GLESExtensions.push_back("GL_EXT_texture_storage");
+  m_GLESExtensions.push_back("GL_EXT_texture_type_2_10_10_10_REV");
   m_GLESExtensions.push_back("GL_KHR_blend_equation_advanced");
   m_GLESExtensions.push_back("GL_KHR_blend_equation_advanced_coherent");
   m_GLESExtensions.push_back("GL_KHR_context_flush_control");
@@ -777,6 +783,7 @@ void WrappedOpenGL::BuildGLESExtensions()
   m_GLESExtensions.push_back("GL_KHR_texture_compression_astc_ldr");
   m_GLESExtensions.push_back("GL_KHR_texture_compression_astc_sliced_3d");
   m_GLESExtensions.push_back("GL_OES_copy_image");
+  m_GLESExtensions.push_back("GL_OES_draw_elements_base_vertex");
   m_GLESExtensions.push_back("GL_OES_geometry_shader");
   m_GLESExtensions.push_back("GL_OES_gpu_shader5");
   m_GLESExtensions.push_back("GL_OES_mapbuffer");

--- a/renderdoc/driver/gl/gl_hookset.h
+++ b/renderdoc/driver/gl/gl_hookset.h
@@ -586,17 +586,17 @@ struct GLHookSet
   PFNGLPROGRAMUNIFORMMATRIX4X2DVPROC glProgramUniformMatrix4x2dv;    // aliases glProgramUniformMatrix4x2dvEXT
   PFNGLPROGRAMUNIFORMMATRIX4X3DVPROC glProgramUniformMatrix4x3dv;                       // aliases glProgramUniformMatrix4x3dvEXT
   PFNGLDRAWRANGEELEMENTSPROC glDrawRangeElements;    // aliases glDrawRangeElementsEXT
-  PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC glDrawRangeElementsBaseVertex;
+  PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC glDrawRangeElementsBaseVertex;   // aliases glDrawRangeElementsBaseVertexEXT, glDrawRangeElementsBaseVertexOES
   PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEPROC glDrawArraysInstancedBaseInstance;    // aliases glDrawArraysInstancedBaseInstanceEXT
   PFNGLDRAWARRAYSINSTANCEDPROC glDrawArraysInstanced;    // aliases glDrawArraysInstancedARB, glDrawArraysInstancedEXT
   PFNGLDRAWELEMENTSINSTANCEDPROC glDrawElementsInstanced;    // aliases glDrawElementsInstancedARB, glDrawElementsInstancedEXT
   PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEPROC glDrawElementsInstancedBaseInstance;    // aliases glDrawElementsInstancedBaseInstanceEXT
-  PFNGLDRAWELEMENTSBASEVERTEXPROC glDrawElementsBaseVertex;
-  PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXPROC glDrawElementsInstancedBaseVertex;
+  PFNGLDRAWELEMENTSBASEVERTEXPROC glDrawElementsBaseVertex;     // aliases glDrawElementsBaseVertexEXT, glDrawElementsBaseVertexOES
+  PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXPROC glDrawElementsInstancedBaseVertex;   // aliases glDrawElementsInstancedBaseVertexEXT, DrawElementsInstancedBaseVertexOES
   PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEPROC glDrawElementsInstancedBaseVertexBaseInstance;    // aliases glDrawElementsInstancedBaseVertexBaseInstanceEXT
   PFNGLMULTIDRAWARRAYSPROC glMultiDrawArrays;    // aliases glMultiDrawArraysEXT
   PFNGLMULTIDRAWELEMENTSPROC glMultiDrawElements;
-  PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC glMultiDrawElementsBaseVertex;
+  PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC glMultiDrawElementsBaseVertex;   // aliases glMultiDrawElementsBaseVertexEXT, glMultiDrawElementsBaseVertexOES
   PFNGLMULTIDRAWARRAYSINDIRECTPROC glMultiDrawArraysIndirect;
   PFNGLMULTIDRAWELEMENTSINDIRECTPROC glMultiDrawElementsIndirect;
   PFNGLDRAWARRAYSINDIRECTPROC glDrawArraysIndirect;

--- a/renderdoc/driver/gl/gl_hookset_defs.h
+++ b/renderdoc/driver/gl/gl_hookset_defs.h
@@ -519,9 +519,17 @@
   HookExtension(PFNGLGETACTIVEUNIFORMBLOCKNAMEPROC, glGetActiveUniformBlockName); \
   HookExtension(PFNGLUNIFORMBLOCKBINDINGPROC, glUniformBlockBinding); \
   HookExtension(PFNGLDRAWELEMENTSBASEVERTEXPROC, glDrawElementsBaseVertex); \
+  HookExtensionAlias(PFNGLDRAWELEMENTSBASEVERTEXPROC, glDrawElementsBaseVertex, glDrawElementsBaseVertexEXT); \
+  HookExtensionAlias(PFNGLDRAWELEMENTSBASEVERTEXPROC, glDrawElementsBaseVertex, glDrawElementsBaseVertexOES); \
   HookExtension(PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC, glDrawRangeElementsBaseVertex); \
+  HookExtensionAlias(PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC, glDrawRangeElementsBaseVertex, glDrawRangeElementsBaseVertexEXT); \
+  HookExtensionAlias(PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC, glDrawRangeElementsBaseVertex, glDrawRangeElementsBaseVertexOES); \
   HookExtension(PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXPROC, glDrawElementsInstancedBaseVertex); \
+  HookExtensionAlias(PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXPROC, glDrawElementsInstancedBaseVertex, glDrawElementsInstancedBaseVertexEXT); \
+  HookExtensionAlias(PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXPROC, glDrawElementsInstancedBaseVertex, DrawElementsInstancedBaseVertexOES); \
   HookExtension(PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC, glMultiDrawElementsBaseVertex); \
+  HookExtensionAlias(PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC, glMultiDrawElementsBaseVertex, glMultiDrawElementsBaseVertexEXT); \
+  HookExtensionAlias(PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC, glMultiDrawElementsBaseVertex, glMultiDrawElementsBaseVertexOES); \
   HookExtension(PFNGLPROVOKINGVERTEXPROC, glProvokingVertex); \
   HookExtensionAlias(PFNGLPROVOKINGVERTEXPROC, glProvokingVertex, glProvokingVertexEXT); \
   HookExtension(PFNGLFENCESYNCPROC, glFenceSync); \
@@ -3563,10 +3571,7 @@
     HookWrapper5(void, glblendfuncseparateioes, GLuint, buf, GLenum, srcRGB, GLenum, dstRGB, GLenum, srcAlpha, GLenum, dstAlpha); \
     HookWrapper5(void, glcolormaskioes, GLuint, index, GLboolean, r, GLboolean, g, GLboolean, b, GLboolean, a); \
     HookWrapper2(GLboolean, glisenabledioes, GLenum, target, GLuint, index); \
-    HookWrapper5(void, gldrawelementsbasevertexoes, GLenum, mode, GLsizei, count, GLenum, type, const void *, indices, GLint, basevertex); \
-    HookWrapper7(void, gldrawrangeelementsbasevertexoes, GLenum, mode, GLuint, start, GLuint, end, GLsizei, count, GLenum, type, const void *, indices, GLint, basevertex); \
     HookWrapper6(void, gldrawelementsinstancedbasevertexoes, GLenum, mode, GLsizei, count, GLenum, type, const void *, indices, GLsizei, instancecount, GLint, basevertex); \
-    HookWrapper6(void, glmultidrawelementsbasevertexoes, GLenum, mode, const GLsizei *, count, GLenum, type, const void *const*, indices, GLsizei, primcount, const GLint *, basevertex); \
     HookWrapper5(void, glgetprogrambinaryoes, GLuint, program, GLsizei, bufSize, GLsizei *, length, GLenum *, binaryFormat, void *, binary); \
     HookWrapper4(void, glprogrambinaryoes, GLuint, program, GLenum, binaryFormat, const void *, binary, GLint, length); \
     HookWrapper10(void, glteximage3does, GLenum, target, GLint, level, GLenum, internalformat, GLsizei, width, GLsizei, height, GLsizei, depth, GLint, border, GLenum, format, GLenum, type, const void *, pixels); \
@@ -3608,10 +3613,6 @@
     HookWrapper5(void, glclearteximageext, GLuint, texture, GLint, level, GLenum, format, GLenum, type, const void *, data); \
     HookWrapper11(void, glcleartexsubimageext, GLuint, texture, GLint, level, GLint, xoffset, GLint, yoffset, GLint, zoffset, GLsizei, width, GLsizei, height, GLsizei, depth, GLenum, format, GLenum, type, const void *, data); \
     HookWrapper3(void, gldiscardframebufferext, GLenum, target, GLsizei, numAttachments, const GLenum *, attachments); \
-    HookWrapper5(void, gldrawelementsbasevertexext, GLenum, mode, GLsizei, count, GLenum, type, const void *, indices, GLint, basevertex); \
-    HookWrapper7(void, gldrawrangeelementsbasevertexext, GLenum, mode, GLuint, start, GLuint, end, GLsizei, count, GLenum, type, const void *, indices, GLint, basevertex); \
-    HookWrapper6(void, gldrawelementsinstancedbasevertexext, GLenum, mode, GLsizei, count, GLenum, type, const void *, indices, GLsizei, instancecount, GLint, basevertex); \
-    HookWrapper6(void, glmultidrawelementsbasevertexext, GLenum, mode, const GLsizei *, count, GLenum, type, const void *const*, indices, GLsizei, primcount, const GLint *, basevertex); \
     HookWrapper2(void, gldrawtransformfeedbackext, GLenum, mode, GLuint, id); \
     HookWrapper3(void, gldrawtransformfeedbackinstancedext, GLenum, mode, GLuint, id, GLsizei, instancecount); \
     HookWrapper2(void, glvertexattribdivisorext, GLuint, index, GLuint, divisor); \
@@ -5542,10 +5543,7 @@
     HandleUnsupported(PFNGLBLENDFUNCSEPARATEIOESPROC, glblendfuncseparateioes); \
     HandleUnsupported(PFNGLCOLORMASKIOESPROC, glcolormaskioes); \
     HandleUnsupported(PFNGLISENABLEDIOESPROC, glisenabledioes); \
-    HandleUnsupported(PFNGLDRAWELEMENTSBASEVERTEXOESPROC, gldrawelementsbasevertexoes); \
-    HandleUnsupported(PFNGLDRAWRANGEELEMENTSBASEVERTEXOESPROC, gldrawrangeelementsbasevertexoes); \
     HandleUnsupported(PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXOESPROC, gldrawelementsinstancedbasevertexoes); \
-    HandleUnsupported(PFNGLMULTIDRAWELEMENTSBASEVERTEXOESPROC, glmultidrawelementsbasevertexoes); \
     HandleUnsupported(PFNGLGETPROGRAMBINARYOESPROC, glgetprogrambinaryoes); \
     HandleUnsupported(PFNGLPROGRAMBINARYOESPROC, glprogrambinaryoes); \
     HandleUnsupported(PFNGLTEXIMAGE3DOESPROC, glteximage3does); \
@@ -5587,10 +5585,6 @@
     HandleUnsupported(PFNGLCLEARTEXIMAGEEXTPROC, glclearteximageext); \
     HandleUnsupported(PFNGLCLEARTEXSUBIMAGEEXTPROC, glcleartexsubimageext); \
     HandleUnsupported(PFNGLDISCARDFRAMEBUFFEREXTPROC, gldiscardframebufferext); \
-    HandleUnsupported(PFNGLDRAWELEMENTSBASEVERTEXEXTPROC, gldrawelementsbasevertexext); \
-    HandleUnsupported(PFNGLDRAWRANGEELEMENTSBASEVERTEXEXTPROC, gldrawrangeelementsbasevertexext); \
-    HandleUnsupported(PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXEXTPROC, gldrawelementsinstancedbasevertexext); \
-    HandleUnsupported(PFNGLMULTIDRAWELEMENTSBASEVERTEXEXTPROC, glmultidrawelementsbasevertexext); \
     HandleUnsupported(PFNGLDRAWTRANSFORMFEEDBACKEXTPROC, gldrawtransformfeedbackext); \
     HandleUnsupported(PFNGLDRAWTRANSFORMFEEDBACKINSTANCEDEXTPROC, gldrawtransformfeedbackinstancedext); \
     HandleUnsupported(PFNGLVERTEXATTRIBDIVISOREXTPROC, glvertexattribdivisorext); \


### PR DESCRIPTION
List of exposed GL ES extensions:
* GL_EXT_clip_cull_distance
* GL_EXT_debug_label
* GL_EXT_debug_marker
* GL_EXT_blend_minmax
* GL_EXT_draw_elements_base_vertex
* GL_OES_draw_elements_base_vertex
* GL_EXT_texture_type_2_10_10_10_REV

All of these extensions already have implementations in RenderDoc
there was just missing entries in the allowed extensions list.