### PR TITLE
Android - Warn and Patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(BUILD_VERSION_DIST_VER "" CACHE STRING "The distribution-specific version nu
 set(BUILD_VERSION_DIST_CONTACT "" CACHE STRING "The URL or email to contact with issues. See DISTRIBUTION_CONTACT in renderdoc/api/replay/version.h")
 set(RENDERDOC_PLUGINS_PATH "" CACHE STRING "Path to RenderDoc plugins folder after installation of RenderDoc (either absolute or relative to binary)")
 set(RENDERDOC_APK_PATH "" CACHE STRING "Path to RenderDocCmd.apk after installation of RenderDoc on host (either absolute or relative to binary)")
+set(RENDERDOC_LAYER_PATH "" CACHE STRING "Path to ABI directories (i.e. lib in lib/armeabi-v7a/libVkLayer_GLES_RenderDoc.so) after installation of RenderDoc on host (either absolute or relative to dir)")
 
 if(BUILD_VERSION_STABLE)
     add_definitions(-DRENDERDOC_STABLE_BUILD=1)
@@ -61,8 +62,13 @@ if(NOT RENDERDOC_PLUGINS_PATH STREQUAL "")
 endif()
 
 if(NOT RENDERDOC_APK_PATH STREQUAL "")
-    message(STATUS "Detected custom path to RenderDocCmd.apk: ${RENDERDOC_APK}")
+    message(STATUS "Detected custom path to RenderDocCmd.apk: ${RENDERDOC_APK_PATH}")
     add_definitions(-DRENDERDOC_APK_PATH="${RENDERDOC_APK_PATH}")
+endif()
+
+if(NOT RENDERDOC_LAYER_PATH STREQUAL "")
+	message(STATUS "Detected custom path to libVkLayer_GLES_RenderDoc.so: ${RENDERDOC_LAYER_PATH}")
+    add_definitions(-DRENDERDOC_LAYER_PATH="${RENDERDOC_LAYER_PATH}")
 endif()
 
 function(get_git_hash _git_hash)

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.h
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.h
@@ -35,6 +35,7 @@ class CaptureDialog;
 
 class QStandardItemModel;
 class LiveCapture;
+class RDLabel;
 
 class CaptureDialog : public QFrame, public ICaptureDialog
 {
@@ -97,6 +98,7 @@ private slots:
 
   // manual slots
   void vulkanLayerWarn_mouseClick();
+  void androidWarn_mouseClick();
 
 private:
   Ui::CaptureDialog *ui;
@@ -110,4 +112,8 @@ private:
   QList<EnvironmentModification> m_EnvModifications;
   bool m_Inject;
   void fillProcessList();
+  void initWarning(RDLabel *label);
+
+  void CheckAndroidSetup(QString &filename);
+  AndroidFlags m_AndroidFlags;
 };

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
@@ -313,6 +313,50 @@
     </widget>
    </item>
    <item>
+    <widget class="RDLabel" name="androidScan">
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table&gt;&lt;tr&gt;&lt;td valign=&quot;middle&quot;&gt;&lt;img src=&quot;:/information.png&quot;/&gt;&lt;/td&gt;&lt;td valign=&quot;middle&quot;&gt;&lt;p&gt;Scanning Android application for RenderDoc support...&lt;br/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../Resources/resources.qrc">:/information.png</pixmap>
+     </property>
+     <property name="margin">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="RDLabel" name="androidWarn">
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table&gt;&lt;tr&gt;&lt;td valign=&quot;middle&quot;&gt;&lt;img src=&quot;:/information.png&quot;/&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;Warning: Android application not set up for RenderDoc capture.&lt;br/&gt;Click here for ways to fix this.&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="pixmap">
+      <pixmap resource="../../Resources/resources.qrc">:/information.png</pixmap>
+     </property>
+     <property name="margin">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="optionsGroup">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -1557,3 +1557,13 @@ extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_EnumerateAndroidDevices(rdc
 
 DOCUMENT("Internal function for starting an android remote server.");
 extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_StartAndroidRemoteServer(const char *device);
+
+DOCUMENT("Internal function for checking remote Android package for requirements");
+extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const char *host,
+                                                                         const char *exe,
+                                                                         AndroidFlags *flags);
+
+DOCUMENT("Internal function that attempts to modify APK contents, adding Vulkan layer.");
+extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_AddLayerToAndroidPackage(const char *host,
+                                                                              const char *exe,
+                                                                              float *progress);

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -3302,3 +3302,40 @@ enum class VulkanLayerFlags : uint32_t
 };
 
 BITMASK_OPERATORS(VulkanLayerFlags);
+
+DOCUMENT(R"(A set of flags giving details of the current status of Android tracability.
+
+.. data:: NoFlags
+
+  There are no problems with the Android application setup.
+
+.. data:: MissingLibrary
+
+  The RenderDoc library (whether Vulkan layer or OpenGLES library) could not be found in the
+  application or system locations.
+
+.. data:: MissingPermissions
+
+  The application being checked does not have the requesite permission:
+
+  android.permission.WRITE_EXTERNAL_STORAGE
+  android.permission.INTERNET
+
+.. data:: NotDebuggable
+
+  The application is not debuggable.
+
+.. data:: Unfixable
+
+  The current situation is not fixable automatically and requires user intervention/disambiguation.
+)");
+enum class AndroidFlags : uint32_t
+{
+  NoFlags = 0x0,
+  MissingLibrary = 0x1,
+  MissingPermissions = 0x2,
+  NotDebuggable = 0x4,
+  Unfixable = 0x8,
+};
+
+BITMASK_OPERATORS(AndroidFlags);

--- a/renderdoc/core/remote_server.cpp
+++ b/renderdoc/core/remote_server.cpp
@@ -833,7 +833,7 @@ public:
       std::string deviceID;
       Android::extractDeviceIDAndIndex(m_hostname, index, deviceID);
 
-      string adbStdout = Android::adbExecCommand(deviceID, "shell pm list packages -3");
+      string adbStdout = Android::adbExecCommand(deviceID, "shell pm list packages -3").strStdout;
       using namespace std;
       istringstream stdoutStream(adbStdout);
       string line;

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -244,6 +244,7 @@ void CreateParentDirectory(const string &filename);
 
 bool IsRelativePath(const string &path);
 string GetFullPathname(const string &filename);
+string FindFileInPath(const string &fileName);
 
 void GetExecutableFilename(string &selfName);
 

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -417,6 +417,6 @@ namespace Android
 {
 bool IsHostADB(const char *hostname);
 uint32_t StartAndroidPackageForCapture(const char *host, const char *package);
-string adbExecCommand(const string &deviceID, const string &args);
+Process::ProcessResult adbExecCommand(const string &deviceID, const string &args);
 void extractDeviceIDAndIndex(const string &hostname, int &index, string &deviceID);
 }

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -66,6 +66,8 @@ struct ProcessResult
 };
 uint32_t LaunchProcess(const char *app, const char *workingDir, const char *cmdLine,
                        ProcessResult *result = NULL);
+uint32_t LaunchScript(const char *script, const char *workingDir, const char *args,
+                      ProcessResult *result = NULL);
 uint32_t LaunchAndInjectIntoProcess(const char *app, const char *workingDir, const char *cmdLine,
                                     const rdctype::array<EnvironmentModification> &env,
                                     const char *logfile, const CaptureOptions &opts,

--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -456,6 +456,15 @@ uint32_t Process::LaunchProcess(const char *app, const char *workingDir, const c
   return ret;
 }
 
+uint32_t Process::LaunchScript(const char *script, const char *workingDir, const char *argList,
+                               ProcessResult *result)
+{
+  // Change parameters to invoke command interpreter
+  string args = "-lc \"" + string(script) + " " + string(argList) + "\"";
+
+  return LaunchProcess("bash", workingDir, args.c_str(), result);
+}
+
 uint32_t Process::LaunchAndInjectIntoProcess(const char *app, const char *workingDir,
                                              const char *cmdLine,
                                              const rdctype::array<EnvironmentModification> &envList,

--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -455,18 +455,21 @@ uint32_t Process::LaunchProcess(const char *app, const char *workingDir, const c
     result->strStderror = "";
 
     ssize_t stdoutRead, stderrRead;
+    char chBuf[4096];
     do
     {
-      char chBuf[1000];
       stdoutRead = read(stdoutPipe[0], chBuf, sizeof(chBuf));
       if(stdoutRead > 0)
         result->strStdout += string(chBuf, stdoutRead);
+    } while(stdoutRead > 0);
 
+    do
+    {
       stderrRead = read(stderrPipe[0], chBuf, sizeof(chBuf));
       if(stderrRead > 0)
         result->strStderror += string(chBuf, stderrRead);
 
-    } while(stdoutRead > 0 || stderrRead > 0);
+    } while(stderrRead > 0);
 
     // Close read ends.
     close(stdoutPipe[0]);

--- a/renderdoc/os/posix/posix_stringio.cpp
+++ b/renderdoc/os/posix/posix_stringio.cpp
@@ -104,6 +104,38 @@ string GetFullPathname(const string &filename)
   return string(path);
 }
 
+string FindFileInPath(const string &fileName)
+{
+  string filePath;
+
+  // Search the PATH directory list for the application (like shell which) to get the absolute path
+  // Return "" if no exectuable found in the PATH list
+  char *pathEnvVar = getenv("PATH");
+  if(!pathEnvVar)
+    return filePath;
+
+  // Make a copy of our PATH so strtok can insert NULL without actually changing env
+  char *localPath = new char[strlen(pathEnvVar) + 1];
+  strcpy(localPath, pathEnvVar);
+
+  const char *pathSeparator = ":";
+  const char *path = strtok(localPath, pathSeparator);
+  while(path)
+  {
+    string testPath(path);
+    testPath += "/" + fileName;
+    if(!access(testPath.c_str(), X_OK))
+    {
+      filePath = testPath;
+      break;
+    }
+    path = strtok(NULL, pathSeparator);
+  }
+
+  delete[] localPath;
+  return filePath;
+}
+
 string GetReplayAppFilename()
 {
   // look up the shared object's path via dladdr

--- a/renderdoc/os/win32/win32_process.cpp
+++ b/renderdoc/os/win32/win32_process.cpp
@@ -963,6 +963,15 @@ uint32_t Process::LaunchProcess(const char *app, const char *workingDir, const c
   return pi.dwProcessId;
 }
 
+uint32_t Process::LaunchScript(const char *script, const char *workingDir, const char *argList,
+                               ProcessResult *result)
+{
+  // Change parameters to invoke command interpreter
+  string args = "/C " + string(script) + " " + string(argList);
+
+  return LaunchProcess("cmd.exe", workingDir, args.c_str(), result);
+}
+
 uint32_t Process::LaunchAndInjectIntoProcess(const char *app, const char *workingDir,
                                              const char *cmdLine,
                                              const rdctype::array<EnvironmentModification> &env,

--- a/renderdoc/os/win32/win32_process.cpp
+++ b/renderdoc/os/win32/win32_process.cpp
@@ -925,20 +925,28 @@ uint32_t Process::LaunchProcess(const char *app, const char *workingDir, const c
   {
     result->strStdout = "";
     result->strStderror = "";
+
+    char chBuf[4096];
+    DWORD dwOutputRead, dwErrorRead;
+    BOOL success = FALSE;
+    string s;
     for(;;)
     {
-      char chBuf[1000];
-      DWORD dwOutputRead, dwErrorRead;
-
-      BOOL success = ReadFile(hChildStdOutput_Rd, chBuf, sizeof(chBuf), &dwOutputRead, NULL);
-      string s(chBuf, dwOutputRead);
+      success = ReadFile(hChildStdOutput_Rd, chBuf, sizeof(chBuf), &dwOutputRead, NULL);
+      s = string(chBuf, dwOutputRead);
       result->strStdout += s;
 
+      if(!success && !dwOutputRead)
+        break;
+    }
+
+    for(;;)
+    {
       success = ReadFile(hChildStdError_Rd, chBuf, sizeof(chBuf), &dwErrorRead, NULL);
       s = string(chBuf, dwErrorRead);
       result->strStderror += s;
 
-      if(!success && !dwOutputRead && !dwErrorRead)
+      if(!success && !dwErrorRead)
         break;
     }
 

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -687,7 +687,323 @@ uint32_t StartAndroidPackageForCapture(const char *host, const char *package)
 
   return ret;
 }
+
+bool SearchForAndroidLayer(const string &deviceID, const string &location, const string &layerName)
+{
+  RDCLOG("Checking for layers in: %s", location.c_str());
+  string findLayer =
+      adbExecCommand(deviceID, "shell find " + location + " -name " + layerName).strStdout;
+  if(!findLayer.empty())
+  {
+    RDCLOG("Found RenderDoc layer in %s", location.c_str());
+    return true;
+  }
+  return false;
 }
+
+bool RemoveAPKSignature(const string &apk)
+{
+  RDCLOG("Checking for existing signature");
+
+  // Get the list of files in META-INF
+  string fileList = execCommand("aapt list " + apk).strStdout;
+  if(fileList.empty())
+    return false;
+
+  // Walk through the output.  If it starts with META-INF, remove it.
+  uint32_t fileCount = 0;
+  uint32_t matchCount = 0;
+  std::istringstream contents(fileList);
+  string line;
+  string prefix("META-INF");
+  while(std::getline(contents, line))
+  {
+    line = trim(line);
+    fileCount++;
+    if(line.compare(0, prefix.size(), prefix) == 0)
+    {
+      RDCDEBUG("Match found, removing  %s", line.c_str());
+      execCommand("aapt remove " + apk + " " + line);
+      matchCount++;
+    }
+  }
+  RDCLOG("%d files searched, %d removed", fileCount, matchCount);
+
+  // Ensure no hits on second pass through
+  RDCDEBUG("Walk through file list again, ensure signature removed");
+  fileList = execCommand("aapt list " + apk).strStdout;
+  std::istringstream recheck(fileList);
+  while(std::getline(recheck, line))
+  {
+    if(line.compare(0, prefix.size(), prefix) == 0)
+    {
+      RDCERR("Match found, that means removal failed! %s", line.c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AddLayerToAPK(const string &apk, const string &layerPath, const string &layerName,
+                   const string &abi, const string &tmpDir)
+{
+  RDCLOG("Adding RenderDoc layer");
+
+  // Run aapt from the directory containing "lib" so the relative paths are good
+  string relativeLayer("lib/" + abi + "/" + layerName);
+  string workDir = removeFromEnd(layerPath, relativeLayer);
+  Process::ProcessResult result = execCommand("aapt add " + apk + " " + relativeLayer, workDir);
+
+  if(result.strStdout.empty())
+  {
+    RDCERR("Failed to add layer to APK. STDERR: %s", result.strStderror.c_str());
+    return false;
+  }
+
+  return true;
+}
+
+bool RealignAPK(const string &apk, string &alignedAPK, const string &tmpDir)
+{
+  // Re-align the APK for performance
+  RDCLOG("Realigning APK");
+  string errOut = execCommand("zipalign -f 4 " + apk + " " + alignedAPK, tmpDir).strStderror;
+
+  if(!errOut.empty())
+    return false;
+
+  // Wait until the aligned version exists to proceed
+  uint32_t elapsed = 0;
+  uint32_t timeout = 10000;    // 10 seconds
+  while(elapsed < timeout)
+  {
+    if(FileIO::exists(alignedAPK.c_str()))
+    {
+      RDCLOG("Aligned APK ready to go, continuing...");
+      return true;
+    }
+
+    Threading::Sleep(1000);
+    elapsed += 1000;
+  }
+
+  RDCERR("Timeout reached aligning APK");
+  return false;
+}
+
+string GetAndroidDebugKey()
+{
+  string key = FileIO::GetTempFolderFilename() + "debug.keystore";
+
+  if(FileIO::exists(key.c_str()))
+    return key;
+
+  string create = "keytool";
+  create += " -genkey";
+  create += " -keystore " + key;
+  create += " -storepass android";
+  create += " -alias androiddebugkey";
+  create += " -keypass android";
+  create += " -keyalg RSA";
+  create += " -keysize 2048";
+  create += " -validity 10000";
+  create += " -dname \"CN=, OU=, O=, L=, S=, C=\"";
+
+  Process::ProcessResult result = execCommand(create);
+
+  if(!result.strStderror.empty())
+    RDCERR("Failed to create debug key");
+
+  return key;
+}
+bool DebugSignAPK(const string &apk, const string &workDir)
+{
+  RDCLOG("Signing with debug key");
+
+  string debugKey = GetAndroidDebugKey();
+
+  string args;
+  args += " sign ";
+  args += " --ks " + debugKey + " ";
+  args += " --ks-pass pass:android ";
+  args += " --key-pass pass:android ";
+  args += " --ks-key-alias androiddebugkey ";
+  args += apk;
+  execScript("apksigner", args.c_str(), workDir.c_str());
+
+  // Check for signature
+  string list = execCommand("aapt list " + apk).strStdout;
+
+  // Walk through the output.  If it starts with META-INF, we're good
+  std::istringstream contents(list);
+  string line;
+  string prefix("META-INF");
+  while(std::getline(contents, line))
+  {
+    if(line.compare(0, prefix.size(), prefix) == 0)
+    {
+      RDCLOG("Signature found, continuing...");
+      return true;
+    }
+  }
+
+  RDCERR("re-sign of APK failed!");
+  return false;
+}
+
+bool UninstallOriginalAPK(const string &deviceID, const string &packageName, const string &workDir)
+{
+  RDCLOG("Uninstalling previous version of application");
+
+  execCommand("adb uninstall " + packageName, workDir);
+
+  // Wait until uninstall completes
+  string uninstallResult;
+  uint32_t elapsed = 0;
+  uint32_t timeout = 10000;    // 10 seconds
+  while(elapsed < timeout)
+  {
+    uninstallResult = adbExecCommand(deviceID, "shell pm path " + packageName).strStdout;
+    if(uninstallResult.empty())
+    {
+      RDCLOG("Package removed");
+      return true;
+    }
+
+    Threading::Sleep(1000);
+    elapsed += 1000;
+  }
+
+  RDCERR("Uninstallation of APK failed!");
+  return false;
+}
+
+bool ReinstallPatchedAPK(const string &deviceID, const string &apk, const string &abi,
+                         const string &packageName, const string &workDir)
+{
+  RDCLOG("Reinstalling APK");
+
+  execCommand("adb install --abi " + abi + " " + apk, workDir);
+
+  // Wait until re-install completes
+  string reinstallResult;
+  uint32_t elapsed = 0;
+  uint32_t timeout = 10000;    // 10 seconds
+  while(elapsed < timeout)
+  {
+    reinstallResult = adbExecCommand(deviceID, "shell pm path " + packageName).strStdout;
+    if(!reinstallResult.empty())
+    {
+      RDCLOG("Patched APK reinstalled, continuing...");
+      return true;
+    }
+
+    Threading::Sleep(1000);
+    elapsed += 1000;
+  }
+
+  RDCERR("Reinstallation of APK failed!");
+  return false;
+}
+
+bool CheckPatchingRequirements()
+{
+  // check for aapt, zipalign, apksigner, debug key
+  vector<string> requirements;
+  vector<string> missingTools;
+  requirements.push_back("aapt");
+  requirements.push_back("zipalign");
+  requirements.push_back("keytool");
+  requirements.push_back("apksigner");
+  requirements.push_back("java");
+
+  for(uint32_t i = 0; i < requirements.size(); i++)
+  {
+    if(FileIO::FindFileInPath(requirements[i]).empty())
+      missingTools.push_back(requirements[i]);
+  }
+
+  if(missingTools.size() > 0)
+  {
+    for(uint32_t i = 0; i < missingTools.size(); i++)
+      RDCERR("Missing %s", missingTools[i].c_str());
+    return false;
+  }
+
+  return true;
+}
+
+bool PullAPK(const string &deviceID, const string &pkgPath, const string &apk)
+{
+  RDCLOG("Pulling APK to patch");
+
+  adbExecCommand(deviceID, "pull " + pkgPath + " " + apk);
+
+  // Wait until the apk lands
+  uint32_t elapsed = 0;
+  uint32_t timeout = 10000;    // 10 seconds
+  while(elapsed < timeout)
+  {
+    if(FileIO::exists(apk.c_str()))
+    {
+      RDCLOG("Original APK ready to go, continuing...");
+      return true;
+    }
+
+    Threading::Sleep(1000);
+    elapsed += 1000;
+  }
+
+  RDCERR("Failed to pull APK");
+  return false;
+}
+
+bool CheckPermissions(const string &dump)
+{
+  if(dump.find("android.permission.WRITE_EXTERNAL_STORAGE") == string::npos)
+  {
+    RDCWARN("APK missing WRITE_EXTERNAL_STORAGE permission");
+    return false;
+  }
+
+  if(dump.find("android.permission.INTERNET") == string::npos)
+  {
+    RDCWARN("APK missing INTERNET permission");
+    return false;
+  }
+
+  return true;
+}
+
+bool CheckAPKPermissions(const string &apk)
+{
+  RDCLOG("Checking that APK can be can write to sdcard");
+
+  string badging = execCommand("aapt dump badging " + apk).strStdout;
+
+  if(badging.empty())
+  {
+    RDCERR("Unable to aapt dump %s", apk.c_str());
+    return false;
+  }
+
+  return CheckPermissions(badging);
+}
+bool CheckDebuggable(const string &apk)
+{
+  RDCLOG("Checking that APK s debuggable");
+
+  string badging = execCommand("aapt dump badging " + apk).strStdout;
+
+  if(badging.find("application-debuggable"))
+  {
+    RDCERR("APK is not debuggable");
+    return false;
+  }
+
+  return true;
+}
+}    // namespace Android
 
 using namespace Android;
 extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_GetAndroidFriendlyName(const rdctype::str &device,
@@ -863,7 +1179,8 @@ bool installRenderDocServer(const string &deviceID)
   }
 
   // Ensure installation succeeded
-  string adbCheck = adbExecCommand(deviceID, "shell pm list packages org.renderdoc.renderdoccmd").strStdout;
+  string adbCheck =
+      adbExecCommand(deviceID, "shell pm list packages org.renderdoc.renderdoccmd").strStdout;
   if(adbCheck.empty())
   {
     RDCERR("Installation of RenderDocCmd.apk failed!");
@@ -884,7 +1201,8 @@ extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_StartAndroidRemoteServer(co
 
   // We should hook up versioning of the server, then re-install if the version is old or mismatched
   // But for now, just install it, if not already present
-  string adbPackage = adbExecCommand(deviceID, "shell pm list packages org.renderdoc.renderdoccmd").strStdout;
+  string adbPackage =
+      adbExecCommand(deviceID, "shell pm list packages org.renderdoc.renderdoccmd").strStdout;
   if(adbPackage.empty())
   {
     if(!installRenderDocServer(deviceID))
@@ -897,6 +1215,242 @@ extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_StartAndroidRemoteServer(co
   adbExecCommand(
       deviceID,
       "shell am start -n org.renderdoc.renderdoccmd/.Loader -e renderdoccmd remoteserver");
+}
+
+bool CheckInstalledPermissions(const string &deviceID, const string &packageName)
+{
+  RDCLOG("Checking installed permissions for %s", packageName.c_str());
+
+  string dump = adbExecCommand(deviceID, "shell pm dump " + packageName).strStdout;
+  if(dump.empty())
+    RDCERR("Unable to pm dump %s", packageName.c_str());
+
+  return CheckPermissions(dump);
+}
+
+extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const char *host,
+                                                                         const char *exe,
+                                                                         AndroidFlags *flags)
+{
+  string packageName(basename(string(exe)));
+
+  int index = 0;
+  std::string deviceID;
+  Android::extractDeviceIDAndIndex(host, index, deviceID);
+
+  // Find the path to package
+  string pkgPath = trim(adbExecCommand(deviceID, "shell pm path " + packageName).strStdout);
+  pkgPath.erase(pkgPath.begin(), pkgPath.begin() + strlen("package:"));
+  pkgPath.erase(pkgPath.end() - strlen("base.apk"), pkgPath.end());
+  pkgPath += "lib";
+
+  string layerName = "libVkLayer_GLES_RenderDoc.so";
+
+  // Reset the flags each time we check
+  *flags = AndroidFlags::NoFlags;
+
+  bool found = false;
+
+  // First, see if the application contains the layer
+  if(SearchForAndroidLayer(deviceID, pkgPath, layerName))
+    found = true;
+
+  // Next, check a debug location only usable by rooted devices
+  if(!found && SearchForAndroidLayer(deviceID, "/data/local/debug/vulkan", layerName))
+    found = true;
+
+  // TODO: Add any future layer locations
+
+  if(!found)
+  {
+    RDCWARN("No RenderDoc layer for Vulkan or GLES was found");
+    *flags |= AndroidFlags::MissingLibrary;
+  }
+
+  // Next check permissions of the installed application (without pulling the APK)
+  if(!CheckInstalledPermissions(deviceID, packageName))
+  {
+    RDCWARN("Android application does not have required permissions");
+    *flags |= AndroidFlags::MissingPermissions;
+  }
+
+  return;
+}
+
+string DetermineInstalledABI(const string &deviceID, const string &packageName)
+{
+  RDCLOG("Checking installed ABI for %s", packageName.c_str());
+  string abi;
+
+  string dump = adbExecCommand(deviceID, "shell pm dump " + packageName).strStdout;
+  if(dump.empty())
+    RDCERR("Unable to pm dump %s", packageName.c_str());
+
+  // Walk through the output and look for primaryCpuAbi
+  std::istringstream contents(dump);
+  string line;
+  string prefix("primaryCpuAbi=");
+  while(std::getline(contents, line))
+  {
+    line = trim(line);
+    if(line.compare(0, prefix.size(), prefix) == 0)
+    {
+      // Extract the abi
+      abi = line.substr(line.find_last_of("=") + 1);
+      RDCLOG("primaryCpuAbi found: %s", abi.c_str());
+      break;
+    }
+  }
+
+  if(abi.empty())
+    RDCERR("Unable to determine installed abi for: %s", packageName.c_str());
+
+  return abi;
+}
+
+string FindAndroidLayer(const string &abi, const string &layerName)
+{
+  string layer;
+
+  // Check known paths for RenderDoc layer
+  string exePath;
+  FileIO::GetExecutableFilename(exePath);
+  string exeDir = dirname(FileIO::GetFullPathname(exePath));
+
+  std::vector<std::string> paths;
+
+#if defined(RENDERDOC_LAYER_PATH)
+  string customPath(RENDERDOC_LAYER_PATH);
+  RDCLOG("Custom layer path: %s", customPath.c_str());
+
+  if(FileIO::IsRelativePath(customPath))
+    customPath = exeDir + "/" + customPath;
+
+  if(!endswith(customPath, "/"))
+    customPath += "/";
+
+  // Custom path must point to directory containing ABI folders
+  customPath += abi;
+  if(!FileIO::exists(customPath.c_str()))
+  {
+    RDCWARN("Custom layer path does not contain required ABI");
+  }
+  paths.push_back(customPath + "/" + layerName);
+#endif
+
+  string windows = "/android/lib/";
+  string linux = "/../share/renderdoc/android/lib/";
+  string local = "/../../build-android/renderdoccmd/libs/lib/";
+  string macOS = "/../../../../../build-android/renderdoccmd/libs/lib/";
+
+  paths.push_back(exeDir + windows + abi + "/" + layerName);
+  paths.push_back(exeDir + linux + abi + "/" + layerName);
+  paths.push_back(exeDir + local + abi + "/" + layerName);
+  paths.push_back(exeDir + macOS + abi + "/" + layerName);
+
+  for(uint32_t i = 0; i < paths.size(); i++)
+  {
+    RDCLOG("Checking for layer in %s", paths[i].c_str());
+    if(FileIO::exists(paths[i].c_str()))
+    {
+      layer = paths[i];
+      RDCLOG("Layer found!: %s", layer.c_str());
+      break;
+    }
+  }
+
+  if(layer.empty())
+  {
+    RDCERR(
+        "%s missing! RenderDoc for Android will not work without it. "
+        "Build your Android ABI in build-android in the root to have it "
+        "automatically found and installed.",
+        layer.c_str());
+  }
+
+  return layer;
+}
+
+extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_AddLayerToAndroidPackage(const char *host,
+                                                                              const char *exe,
+                                                                              float *progress)
+{
+  Process::ProcessResult result = {};
+  string packageName(basename(string(exe)));
+
+  int index = 0;
+  std::string deviceID;
+  Android::extractDeviceIDAndIndex(host, index, deviceID);
+
+  *progress = 0.0f;
+
+  if(!CheckPatchingRequirements())
+    return false;
+
+  *progress = 0.11f;
+
+  // Detect which ABI was installed on the device
+  string abi = DetermineInstalledABI(deviceID, packageName);
+
+  // Find the layer on host
+  string layerName("libVkLayer_GLES_RenderDoc.so");
+  string layerPath = FindAndroidLayer(abi, layerName);
+  if(layerPath.empty())
+    return false;
+
+  // Find the APK on the device
+  string pkgPath = trim(adbExecCommand(deviceID, "shell pm path " + packageName).strStdout);
+  pkgPath.erase(pkgPath.begin(), pkgPath.begin() + strlen("package:"));
+
+  string tmpDir = FileIO::GetTempFolderFilename();
+  string origAPK(tmpDir + packageName + ".orig.apk");
+  string alignedAPK(origAPK + ".aligned.apk");
+
+  *progress = 0.21f;
+
+  // Try the following steps, bailing if anything fails
+  if(!PullAPK(deviceID, pkgPath, origAPK))
+    return false;
+
+  *progress = 0.31f;
+
+  if(!CheckAPKPermissions(origAPK))
+    return false;
+
+  *progress = 0.41f;
+
+  if(!RemoveAPKSignature(origAPK))
+    return false;
+
+  *progress = 0.51f;
+
+  if(!AddLayerToAPK(origAPK, layerPath, layerName, abi, tmpDir))
+    return false;
+
+  *progress = 0.61f;
+
+  if(!RealignAPK(origAPK, alignedAPK, tmpDir))
+    return false;
+
+  *progress = 0.71f;
+
+  if(!DebugSignAPK(alignedAPK, tmpDir))
+    return false;
+
+  *progress = 0.81f;
+
+  if(!UninstallOriginalAPK(deviceID, packageName, tmpDir))
+    return false;
+
+  *progress = 0.91f;
+
+  if(!ReinstallPatchedAPK(deviceID, alignedAPK, abi, packageName, tmpDir))
+    return false;
+
+  *progress = 1.0f;
+
+  // All clean!
+  return true;
 }
 
 extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_NeedVulkanLayerRegistration(

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -577,6 +577,15 @@ void extractDeviceIDAndIndex(const string &hostname, int &index, string &deviceI
 
   deviceID = c;
 }
+Process::ProcessResult execScript(const string &script, const string &args,
+                                  const string &workDir = ".")
+{
+  RDCLOG("SCRIPT: %s", script.c_str());
+
+  Process::ProcessResult result;
+  Process::LaunchScript(script.c_str(), workDir.c_str(), args.c_str(), &result);
+  return result;
+}
 Process::ProcessResult execCommand(const string &cmd, const string &workDir = ".")
 {
   RDCLOG("COMMAND: %s", cmd.c_str());

--- a/renderdoc/serialise/string_utils.cpp
+++ b/renderdoc/serialise/string_utils.cpp
@@ -107,3 +107,16 @@ bool endswith(const std::string &value, const std::string &ending)
 
   return (0 == value.compare(value.length() - ending.length(), ending.length(), ending));
 }
+
+std::string removeFromEnd(const std::string &value, const std::string &ending)
+{
+  string::size_type pos;
+  pos = value.rfind(ending);
+
+  // Create new string from beginning to pattern
+  if(string::npos != pos)
+    return value.substr(0, pos);
+
+  // If pattern not found, just return original string
+  return value;
+}

--- a/renderdoc/serialise/string_utils.h
+++ b/renderdoc/serialise/string_utils.h
@@ -38,6 +38,7 @@ std::string strupper(const std::string &str);
 std::wstring strupper(const std::wstring &str);
 
 std::string trim(const std::string &str);
+std::string removeFromEnd(const std::string &value, const std::string &ending);
 
 uint32_t strhash(const char *str, uint32_t existingHash = 5381);
 

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -72,5 +72,8 @@ if(ANDROID)
                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoccmd> libs/${ANDROID_ABI}/$<TARGET_FILE_NAME:renderdoccmd>
                        COMMAND android update project --path . --name RenderDocCmd --target ${APK_TARGET_ID}
                        COMMAND ant debug
-                       COMMAND ${CMAKE_COMMAND} -E copy bin/RenderDocCmd-debug.apk ${APK_FILE})
+                       COMMAND ${CMAKE_COMMAND} -E copy bin/RenderDocCmd-debug.apk ${APK_FILE}
+                       COMMAND ${CMAKE_COMMAND} -E make_directory libs/lib
+                       COMMAND ${CMAKE_COMMAND} -E copy_directory libs/${ANDROID_ABI} libs/lib/${ANDROID_ABI}
+                       COMMAND ${CMAKE_COMMAND} -E remove_directory libs/${ANDROID_ABI})
 endif()

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -68,7 +68,7 @@ if(ANDROID)
                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/android ${CMAKE_CURRENT_BINARY_DIR}
                        COMMAND ${CMAKE_COMMAND} -E make_directory libs/${ANDROID_ABI}
-                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoc> libs/${ANDROID_ABI}/$<TARGET_FILE_NAME:renderdoc>
+                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoc> libs/${ANDROID_ABI}/libVkLayer_GLES_RenderDoc.so
                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoccmd> libs/${ANDROID_ABI}/$<TARGET_FILE_NAME:renderdoccmd>
                        COMMAND android update project --path . --name RenderDocCmd --target ${APK_TARGET_ID}
                        COMMAND ant debug

--- a/renderdoccmd/android/src/org/renderdoc/renderdoccmd/Loader.java
+++ b/renderdoccmd/android/src/org/renderdoc/renderdoccmd/Loader.java
@@ -5,7 +5,7 @@ public class Loader extends android.app.NativeActivity
 {
     /* load our native library */
     static {
-        System.loadLibrary("renderdoc");
+        System.loadLibrary("VkLayer_GLES_RenderDoc");
     }
 
     @Override

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -65,7 +65,7 @@ if [ -f bin-android32/RenderDocCmd.apk ]; then
 	mkdir -p dist/Release64/android/apk dist/Release64/android/lib/armeabi-v7a
 
 	cp bin-android32/RenderDocCmd.apk dist/Release64/android/apk
-	cp bin-android32/librenderdoc.so dist/Release64/android/lib/armeabi-v7a/libVkLayer_RenderDoc.so
+	cp bin-android32/libVkLayer_GLES_RenderDoc.so dist/Release64/android/lib/armeabi-v7a/libVkLayer_GLES_RenderDoc.so
 fi
 
 if [ -f bin-android64/RenderDocCmd.apk ]; then
@@ -75,7 +75,7 @@ if [ -f bin-android64/RenderDocCmd.apk ]; then
 	mkdir -p dist/Release64/android/lib/arm64-v8a
 
 	#cp bin-android64/RenderDocCmd.apk dist/Release64/android/apk/64
-	cp bin-android64/librenderdoc.so dist/Release64/android/lib/arm64-v8a/libVkLayer_RenderDoc.so
+	cp bin-android64/libVkLayer_GLES_RenderDoc.so dist/Release64/android/lib/arm64-v8a/libVkLayer_GLES_RenderDoc.so
 fi
 
 # try to copy adb.exe in as well, with its dll dependencies


### PR DESCRIPTION
Okay, I think this is ready for initial review.  +@michaelrgb for Android coverage.

This series does two things:
1. Add a warning when the selected Android application does not contain the RenderDoc layer
2. When clicked, attempt to pull, patch, and reinstall the target application

The warning is modeled after the desktop version.  Both are displayed on my systems (I haven't registered the desktop layer).

![warning](https://user-images.githubusercontent.com/6932500/27716734-a03650f4-5cfd-11e7-9322-33dab5830f9f.png)

For now, the patch offer has a giant disclaimer and suggestion to use Android Studio to get required components.  We can change this as we figure out the right way to do it.  I need to list dependencies (and how to get them) on the wiki.  The patch sequence checks for dependencies first.  I may have missed some, needs to be tested on clean systems.

![patch](https://user-images.githubusercontent.com/6932500/27716736-a5f65c6e-5cfd-11e7-9b73-9737ef02d734.png)

I'm not worried about the components that are available in AOSP (we can ship those with RenderDoc).  But apksigner uses java.  Need to figure out if shipping a JRE is the answer, or direct people to install it via Android Studio.

One big change is renaming `librenderdoc.so `to `libVkLayer_GLES_RenderDoc.so.`  This allows it to be used with Vulkan and GLES, without renaming (by hand) for local builds.

I haven't tested the series with a GLES app, but with the layer rename, the warning should fire.

I'm sure there is some polishing to be done, and I'm certainly flexible on the text of the popups, but things are functioning well on Windows (with Qt UI), Linux and macOS.

Let me know what you think!