### PR TITLE
Export the egl* symbols via linker script

### DIFF
--- a/renderdoc/renderdoc.version
+++ b/renderdoc/renderdoc.version
@@ -3,6 +3,7 @@
                 _init;
                 _fini;
                 gl[A-Z]*;
+                egl[A-Z]*;
                 dlopen;
                 _exit;
                 RENDERDOC_*;


### PR DESCRIPTION
The egl symbols should be exported so applications
using it can correctly run with RenderDoc.