### PR TITLE
android: Update packaging to work with latest SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ cd build-android
 cmake -DBUILD_ANDROID=On -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=23 ..
 make
 ```
+On Windows, you need to specify the 'generator' type to the cmake invocation. The exact parameter will depend on your bash shell, but options are e.g. -G "MSYS Makefiles" or -G "MinGW Makefiles", i.e.:
+```
+cmake -DBUILD_ANDROID=On -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=23 -G"MSYS Makefiles" ..
+```
 
 # Code of Conduct
 
@@ -169,8 +173,8 @@ export ANDROID_SDK=<path_to_sdk_root>
 export ANDROID_NDK=<path_to_ndk_root>
 export JAVA_HOME=<path_to_jdk_root>
 ```
-Otherwise, below are steps to acquire the tools for Ubuntu.
-
+Otherwise, below are steps to acquire the tools for each platform.
+#### Ubuntu
 The Java Development Kit can be installed with:
 ```
 sudo apt-get install openjdk-8-jdk
@@ -178,8 +182,12 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ```
 
 The Android SDK and NDK can be set up with the following steps.  They are also mirrored in our Travis-CI [setup script](scripts/travis/android_setup.sh) for Android.  We are currently targeting build-tools 26.0.1 and NDK r14b.
+
+SDK links are pulled from [here](https://developer.android.com/studio/index.html).
+
+NDK links are pulled from [here](https://developer.android.com/ndk/downloads/older_releases.html).
 ```
-# Set up Android SDK and NDK
+# Set up Android SDK
 export ANDROID_SDK=<path_to_desired_setup>
 pushd $ANDROID_SDK
 wget http://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
@@ -193,6 +201,51 @@ pushd $ANDROID_SDK
 wget http://dl.google.com/android/repository/android-ndk-r14b-linux-x86_64.zip
 unzip android-ndk-r14b-linux-x86_64.zip
 export ANDROID_NDK=$ANDROID_SDK/android-ndk-r14b
+```
+#### macOS
+JDK can be installed with brew:
+```
+brew cask install java
+export JAVA_HOME="$(/usr/libexec/java_home)"
+```
+Android NDK and SDK:
+```
+# Set up Android SDK
+export ANDROID_SDK=<path_to_desired_setup>
+pushd $ANDROID_SDK
+wget https://dl.google.com/android/repository/sdk-tools-darwin-3859397.zip
+unzip sdk-tools-darwin-3859397.zip
+cd tools/bin/
+./sdkmanager --sdk_root=$ANDROID_SDK "build-tools;26.0.1" "platforms;android-23"
+# Accept the license
+
+# Set up Android NDK
+pushd $ANDROID_SDK
+wget https://dl.google.com/android/repository/android-ndk-r14b-darwin-x86_64.zip
+unzip android-ndk-r14b-darwin-x86_64.zip
+export ANDROID_NDK=$ANDROID_SDK/android-ndk-r14b
+```
+#### Windows
+JDK can be installed from the following [link](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+```
+set JAVA_HOME=<path_to_jdk_root>
+```
+Android NDK and SDK:
+```
+# Set up the Android SDK
+set ANDROID_SDK=<path_to_desired_setup>
+cd %ANDROID_SDK%
+wget https://dl.google.com/android/repository/sdk-tools-windows-3859397.zip
+unzip sdk-tools-windows-3859397.zip
+cd tools\bin
+sdkmanager --sdk_root=%ANDROID_SDK% "build-tools;26.0.1" "platforms;android-23"
+# Accept the license
+
+# Set up the Android NDK
+cd %ANDROID_SDK%
+wget http://dl.google.com/android/repository/android-ndk-r14b-windows-x86_64.zip
+unzip android-ndk-r14b-windows-x86_64.zip
+set ANDROID_NDK=%ANDROID_SDK%\android-ndk-r14b
 ```
 
 # Where to Start

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@ Configuration is available for cmake, [documented elsewhere](https://cmake.org/d
 
 Mac support is pretty early and while it will compile, it's not usable for debugging yet. Builds happen with cmake the same way as Linux.
 
+### Android
+
+To build the components required to debug an Android target, first gather everything from [Dependencies](#dependencies) below, then run:
+```
+mkdir build-android
+cd build-android
+cmake -DBUILD_ANDROID=On -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=23 ..
+make
+```
+
 # Code of Conduct
 
 I want to ensure that anyone can contribute to RenderDoc with only the next bug to worry about. For that reason the project has adopted the [contributor covenent](CODE_OF_CONDUCT.md) as a code of conduct to be enforced for anyone taking part in RenderDoc development. If you have any queries in this regard you can get in touch with me [directly over email](mailto:baldurk@baldurk.org).
@@ -147,6 +157,42 @@ Mac requires a recent version of CMake, and the same Qt version as the other pla
 ```
 brew install cmake qt5
 brew link qt5 --force
+```
+
+### Android
+
+To build for Android, you must download components of the Android SDK, the Android NDK, and Java Development Kit.
+
+If you've already got the tools required, simply set the following three environment variables:
+```
+export ANDROID_SDK=<path_to_sdk_root>
+export ANDROID_NDK=<path_to_ndk_root>
+export JAVA_HOME=<path_to_jdk_root>
+```
+Otherwise, below are steps to acquire the tools for Ubuntu.
+
+The Java Development Kit can be installed with:
+```
+sudo apt-get install openjdk-8-jdk
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+```
+
+The Android SDK and NDK can be set up with the following steps.  They are also mirrored in our Travis-CI [setup script](scripts/travis/android_setup.sh) for Android.  We are currently targeting build-tools 26.0.1 and NDK r14b.
+```
+# Set up Android SDK and NDK
+export ANDROID_SDK=<path_to_desired_setup>
+pushd $ANDROID_SDK
+wget http://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+unzip sdk-tools-linux-3859397.zip
+cd tools/bin/
+./sdkmanager --sdk_root=$ANDROID_SDK "build-tools;26.0.1" "platforms;android-23"
+# Accept the license
+
+# Set up Android NDK
+pushd $ANDROID_SDK
+wget http://dl.google.com/android/repository/android-ndk-r14b-linux-x86_64.zip
+unzip android-ndk-r14b-linux-x86_64.zip
+export ANDROID_NDK=$ANDROID_SDK/android-ndk-r14b
 ```
 
 # Where to Start

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -57,23 +57,45 @@ target_link_libraries(renderdoccmd ${libraries})
 install (TARGETS renderdoccmd DESTINATION bin)
 
 if(ANDROID)
+    if(NOT DEFINED ENV{JAVA_HOME})
+        message(FATAL_ERROR "JAVA_HOME environment variable must be defined for Android build")
+    endif()
+    if(NOT DEFINED ENV{ANDROID_SDK})
+        message(FATAL_ERROR "ANDROID_SDK environment variable must be defined for Android build")
+    endif()
+
+    set(BUILD_TOOLS "$ENV{ANDROID_SDK}/build-tools/26.0.1")
+    set(ANDROID_JAR "$ENV{ANDROID_SDK}/platforms/android-23/android.jar")
+    set(RT_JAR "$ENV{JAVA_HOME}/jre/lib/rt.jar")
+    set(JAVA_BIN "$ENV{JAVA_HOME}/bin")
+
     set(APK_TARGET_ID "android-23" CACHE STRING "The Target ID to build the APK for, use <android list targets> to choose another one.")
+    set(KEYSTORE ${CMAKE_CURRENT_BINARY_DIR}/debug.keystore)
+    add_custom_command(OUTPUT ${KEYSTORE}
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                       COMMAND ${JAVA_BIN}/keytool -genkey -keystore ${KEYSTORE} -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=, OU=, O=, L=, S=, C=")
 
     set(APK_FILE ${CMAKE_BINARY_DIR}/bin/RenderDocCmd.apk)
     add_custom_target(apk ALL
-                      DEPENDS ${APK_FILE})
+                      DEPENDS ${APK_FILE}
+                      DEPENDS ${KEYSTORE})
+
     add_custom_command(OUTPUT ${APK_FILE}
                        DEPENDS renderdoc
                        DEPENDS renderdoccmd
                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/android ${CMAKE_CURRENT_BINARY_DIR}
-                       COMMAND ${CMAKE_COMMAND} -E make_directory libs/${ANDROID_ABI}
-                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoc> libs/${ANDROID_ABI}/libVkLayer_GLES_RenderDoc.so
-                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoccmd> libs/${ANDROID_ABI}/$<TARGET_FILE_NAME:renderdoccmd>
-                       COMMAND android update project --path . --name RenderDocCmd --target ${APK_TARGET_ID}
-                       COMMAND ant debug
-                       COMMAND ${CMAKE_COMMAND} -E copy bin/RenderDocCmd-debug.apk ${APK_FILE}
-                       COMMAND ${CMAKE_COMMAND} -E make_directory libs/lib
-                       COMMAND ${CMAKE_COMMAND} -E copy_directory libs/${ANDROID_ABI} libs/lib/${ANDROID_ABI}
-                       COMMAND ${CMAKE_COMMAND} -E remove_directory libs/${ANDROID_ABI})
+                       COMMAND ${CMAKE_COMMAND} -E make_directory libs/lib/${ANDROID_ABI}
+                       COMMAND ${CMAKE_COMMAND} -E make_directory obj
+                       COMMAND ${CMAKE_COMMAND} -E make_directory bin
+                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoc> libs/lib/${ANDROID_ABI}/libVkLayer_GLES_RenderDoc.so
+                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoccmd> libs/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:renderdoccmd>
+                       COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
+                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath ${ANDROID_JAR}:obj -sourcepath src src/org/renderdoc/renderdoccmd/*.java
+                       COMMAND ${BUILD_TOOLS}/dx --dex --output=bin/classes.dex ./obj
+                       COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml -S res -I ${ANDROID_JAR} -F RenderDocCmd-unaligned.apk bin libs
+                       COMMAND ${BUILD_TOOLS}/zipalign -f 4 RenderDocCmd-unaligned.apk RenderDocCmd.apk
+                       COMMAND ${BUILD_TOOLS}/apksigner sign --ks ${KEYSTORE} --ks-pass pass:android --key-pass pass:android --ks-key-alias androiddebugkey RenderDocCmd.apk
+                       COMMAND ${CMAKE_COMMAND} -E copy RenderDocCmd.apk ${APK_FILE})
+
 endif()

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -64,12 +64,18 @@ if(ANDROID)
         message(FATAL_ERROR "ANDROID_SDK environment variable must be defined for Android build")
     endif()
 
-    set(BUILD_TOOLS "$ENV{ANDROID_SDK}/build-tools/26.0.1")
-    set(ANDROID_JAR "$ENV{ANDROID_SDK}/platforms/android-23/android.jar")
+    set(ANDROID_BUILD_TOOLS_VERSION "" CACHE STRING "Version of Android build-tools to use instead of the default")
+    if(ANDROID_BUILD_TOOLS_VERSION STREQUAL "")
+        set(ANDROID_BUILD_TOOLS_VERSION "26.0.1")
+    endif()
+    message(STATUS "Using Android build-tools version ${ANDROID_BUILD_TOOLS_VERSION}")
+
+    set(BUILD_TOOLS "$ENV{ANDROID_SDK}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}")
     set(RT_JAR "$ENV{JAVA_HOME}/jre/lib/rt.jar")
     set(JAVA_BIN "$ENV{JAVA_HOME}/bin")
 
     set(APK_TARGET_ID "android-23" CACHE STRING "The Target ID to build the APK for, use <android list targets> to choose another one.")
+    set(ANDROID_JAR "$ENV{ANDROID_SDK}/platforms/${APK_TARGET_ID}/android.jar")
     set(KEYSTORE ${CMAKE_CURRENT_BINARY_DIR}/debug.keystore)
     add_custom_command(OUTPUT ${KEYSTORE}
                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -76,6 +76,11 @@ if(ANDROID)
 
     set(APK_TARGET_ID "android-23" CACHE STRING "The Target ID to build the APK for, use <android list targets> to choose another one.")
     set(ANDROID_JAR "$ENV{ANDROID_SDK}/platforms/${APK_TARGET_ID}/android.jar")
+    if(CMAKE_HOST_WIN32)
+        set(CLASS_PATH "${ANDROID_JAR}\;obj")
+    else()
+        set(CLASS_PATH "${ANDROID_JAR}:obj")
+    endif()
     set(KEYSTORE ${CMAKE_CURRENT_BINARY_DIR}/debug.keystore)
     add_custom_command(OUTPUT ${KEYSTORE}
                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -97,7 +102,7 @@ if(ANDROID)
                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoc> libs/lib/${ANDROID_ABI}/libVkLayer_GLES_RenderDoc.so
                        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:renderdoccmd> libs/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:renderdoccmd>
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
-                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath ${ANDROID_JAR}:obj -sourcepath src src/org/renderdoc/renderdoccmd/*.java
+                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/org/renderdoc/renderdoccmd/*.java
                        COMMAND ${BUILD_TOOLS}/dx --dex --output=bin/classes.dex ./obj
                        COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml -S res -I ${ANDROID_JAR} -F RenderDocCmd-unaligned.apk bin libs
                        COMMAND ${BUILD_TOOLS}/zipalign -f 4 RenderDocCmd-unaligned.apk RenderDocCmd.apk

--- a/scripts/travis/android_setup.sh
+++ b/scripts/travis/android_setup.sh
@@ -6,28 +6,17 @@ sudo apt-get install -y cmake
 
 export ARCH=`uname -m`
 
-# Pull known working tools toward the end of 2016
-wget http://dl.google.com/android/repository/android-ndk-r13b-linux-${ARCH}.zip
-wget https://dl.google.com/android/repository/tools_r25.2.5-linux.zip
-wget https://dl.google.com/android/repository/platform-tools_r25.0.3-linux.zip
-wget https://dl.google.com/android/repository/build-tools_r25.0.2-linux.zip
-unzip -u -q android-ndk-r13b-linux-${ARCH}.zip
-unzip -u -q tools_r25.2.5-linux.zip
-unzip -u -q platform-tools_r25.0.3-linux.zip
-unzip -u -q build-tools_r25.0.2-linux.zip
+# Pull known working tools August 2017
+wget http://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+wget http://dl.google.com/android/repository/android-ndk-r14b-linux-${ARCH}.zip
+unzip -u -q android-ndk-r14b-linux-${ARCH}.zip
+unzip -u -q sdk-tools-linux-3859397.zip
 
-# Munge the build-tools layout
-mkdir -p build-tools/25.0.2
-mv android-7.1.1/* build-tools/25.0.2/
-
-export ANDROID_HOME=`pwd`/tools
 export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
-export ANDROID_NDK=`pwd`/android-ndk-r13b
-export ANDROID_SDK=`pwd`
-export PATH=`pwd`/android-ndk-r13b:$PATH
-export PATH=`pwd`/tools:$PATH
-export PATH=`pwd`/platform-tools:$PATH
-export PATH=`pwd`/build-tools/25.0.2:$PATH
+export ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r14b
+export ANDROID_SDK=$TRAVIS_BUILD_DIR
 
 # Answer "yes" to any license acceptance requests
-(while sleep 3; do echo "y"; done) | android update sdk --no-ui -s -t android-23
+pushd tools/bin
+(while sleep 3; do echo "y"; done) | ./sdkmanager --sdk_root=$TRAVIS_BUILD_DIR "build-tools;26.0.1" "platforms;android-23"
+popd

--- a/scripts/travis/android_setup.sh
+++ b/scripts/travis/android_setup.sh
@@ -23,6 +23,7 @@ mv android-7.1.1/* build-tools/25.0.2/
 export ANDROID_HOME=`pwd`/tools
 export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
 export ANDROID_NDK=`pwd`/android-ndk-r13b
+export ANDROID_SDK=`pwd`
 export PATH=`pwd`/android-ndk-r13b:$PATH
 export PATH=`pwd`/tools:$PATH
 export PATH=`pwd`/platform-tools:$PATH


### PR DESCRIPTION
This changes our Android build process to call directly into the tools that create it, rather than use ant and "android project" which have been removed from the SDK.

The end result is the same APK, just signed differently, but equivalently.

Contents before:

```
$ aapt list ./bin/RenderDocCmd.apk
AndroidManifest.xml
res/drawable/icon.png
resources.arsc
classes.dex
lib/armeabi-v7a/librenderdoccmd.so
lib/armeabi-v7a/libVkLayer_GLES_RenderDoc.so
META-INF/MANIFEST.MF
META-INF/CERT.SF
META-INF/CERT.RSA
```

Contents after:

```
$ aapt list ./bin/RenderDocCmd.apk 
AndroidManifest.xml
classes.dex
lib/armeabi-v7a/libVkLayer_GLES_RenderDoc.so
lib/armeabi-v7a/librenderdoccmd.so
res/drawable/icon.png
resources.arsc
META-INF/ANDROIDD.SF
META-INF/ANDROIDD.RSA
META-INF/MANIFEST.MF
```

With this, developers can safely update their Android SDK components to latest.

Most of the tools in use come from the Android SDK, with the exception of **keytool**, which may need to be installed and added to PATH.

The following two env vars are needed and CMake will error out cleanly if they are not found: 
- **ANDROID_SDK**
- **JAVA_HOME**

libVkLayer_GLES_RenderDoc.so resides in the same place, so RenderDoc can continue to find it.

This also generates a debug.keystore that we can use with patching process, potentially ship.

Tested on Ubuntu and macOS.