### PR TITLE
Detect root and push Vulkan layer to Android application

### DIFF
--- a/qrenderdoc/Code/Interface/PersistantConfig.cpp
+++ b/qrenderdoc/Code/Interface/PersistantConfig.cpp
@@ -188,6 +188,9 @@ void PersistantConfig::AddAndroidHosts()
 
   SetConfigSetting(lit("MaxConnectTimeout"), QString::number(Android_MaxConnectTimeout));
 
+  SetConfigSetting(lit("Android_AutoPushLayerToApp"),
+                   Android_AutoPushLayerToApp ? lit("1") : lit("0"));
+
   rdctype::str androidHosts;
   RENDERDOC_EnumerateAndroidDevices(&androidHosts);
   for(const QString &hostName : ToQStr(androidHosts).split(QLatin1Char(','), QString::SkipEmptyParts))

--- a/qrenderdoc/Code/Interface/PersistantConfig.h
+++ b/qrenderdoc/Code/Interface/PersistantConfig.h
@@ -109,6 +109,8 @@ DECLARE_REFLECTION_STRUCT(SPIRVDisassembler);
                                                                                            \
   CONFIG_SETTING_VAL(public, int, int, Android_MaxConnectTimeout, 30)                      \
                                                                                            \
+  CONFIG_SETTING_VAL(public, bool, bool, Android_AutoPushLayerToApp, false)                \
+                                                                                           \
   CONFIG_SETTING_VAL(public, bool, bool, CheckUpdate_AllowChecks, true)                    \
                                                                                            \
   CONFIG_SETTING_VAL(public, bool, bool, CheckUpdate_UpdateAvailable, false)               \
@@ -346,6 +348,12 @@ For more information about some of these settings that are user-facing see
   The maximum timeout in seconds to wait when launching an Android package.
 
   Defaults to ``30``.
+
+.. data:: Android_AutoPushLayerToApp
+
+  Whether to automatically push the RenderDoc layer to the application's lib directory when running
+  on a device with root access.  This can enable debugging of Vulkan applications that didn't already
+  package the layer in the APK.
 
 .. data:: CheckUpdate_AllowChecks
 

--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -448,7 +448,6 @@ QMessageBox::StandardButton RDDialog::messageBoxChecked(QMessageBox::Icon icon, 
                                                         QMessageBox::StandardButtons buttons,
                                                         QMessageBox::StandardButton defaultButton)
 {
-  bool isChecked = checked;
   QMessageBox::StandardButton ret = defaultButton;
 
   // if we're already on the right thread, this boils down to a function call
@@ -457,11 +456,10 @@ QMessageBox::StandardButton RDDialog::messageBoxChecked(QMessageBox::Icon icon, 
     mb.setDefaultButton(defaultButton);
     mb.setCheckBox(checkBox);
     show(&mb);
-    isChecked = mb.checkBox()->isChecked();
+    checked = mb.checkBox()->isChecked();
     ret = mb.standardButton(mb.clickedButton());
   });
 
-  checked = isChecked;
   return ret;
 }
 

--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -442,6 +442,29 @@ QMessageBox::StandardButton RDDialog::messageBox(QMessageBox::Icon icon, QWidget
   return ret;
 }
 
+QMessageBox::StandardButton RDDialog::messageBoxChecked(QMessageBox::Icon icon, QWidget *parent,
+                                                        const QString &title, const QString &text,
+                                                        QCheckBox *checkBox, bool &checked,
+                                                        QMessageBox::StandardButtons buttons,
+                                                        QMessageBox::StandardButton defaultButton)
+{
+  bool isChecked = checked;
+  QMessageBox::StandardButton ret = defaultButton;
+
+  // if we're already on the right thread, this boils down to a function call
+  GUIInvoke::blockcall([&]() {
+    QMessageBox mb(icon, title, text, buttons, parent);
+    mb.setDefaultButton(defaultButton);
+    mb.setCheckBox(checkBox);
+    show(&mb);
+    isChecked = mb.checkBox()->isChecked();
+    ret = mb.standardButton(mb.clickedButton());
+  });
+
+  checked = isChecked;
+  return ret;
+}
+
 QString RDDialog::getExistingDirectory(QWidget *parent, const QString &caption, const QString &dir,
                                        QFileDialog::Options options)
 {

--- a/qrenderdoc/Code/QRDUtils.h
+++ b/qrenderdoc/Code/QRDUtils.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <QCheckBox>
 #include <QCoreApplication>
 #include <QDebug>
 #include <QFileDialog>
@@ -818,6 +819,10 @@ struct RDDialog
       QMessageBox::Icon, QWidget *parent, const QString &title, const QString &text,
       QMessageBox::StandardButtons buttons = QMessageBox::Ok,
       QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
+  static QMessageBox::StandardButton messageBoxChecked(
+      QMessageBox::Icon, QWidget *parent, const QString &title, const QString &text,
+      QCheckBox *checkBox, bool &checked, QMessageBox::StandardButtons buttons = QMessageBox::Ok,
+      QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
 
   static QMessageBox::StandardButton information(
       QWidget *parent, const QString &title, const QString &text,
@@ -834,6 +839,16 @@ struct RDDialog
       QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
   {
     return messageBox(QMessageBox::Question, parent, title, text, buttons, defaultButton);
+  }
+
+  static QMessageBox::StandardButton questionChecked(
+      QWidget *parent, const QString &title, const QString &text, QCheckBox *checkBox, bool &checked,
+      QMessageBox::StandardButtons buttons = QMessageBox::StandardButtons(QMessageBox::Yes |
+                                                                          QMessageBox::No),
+      QMessageBox::StandardButton defaultButton = QMessageBox::NoButton)
+  {
+    return messageBoxChecked(QMessageBox::Question, parent, title, text, checkBox, checked, buttons,
+                             defaultButton);
   }
 
   static QMessageBox::StandardButton warning(

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -517,7 +517,7 @@ void CaptureDialog::androidWarn_mouseClick()
              "RenderDoc can try to push the layer directly to your application.<br><br>"
              "Would you like RenderDoc to push the layer?<br>");
 
-      QString checkMsg(lit("Automatically push the layer on rooted devices"));
+      QString checkMsg(tr("Automatically push the layer on rooted devices"));
       QCheckBox *cb = new QCheckBox(checkMsg, this);
       cb->setChecked(autoPushCheckBox);
       prompt = RDDialog::questionChecked(this, caption, rootmsg, cb, autoPushCheckBox,
@@ -546,7 +546,7 @@ void CaptureDialog::androidWarn_mouseClick()
 
           RDDialog::information(
               this, tr("Push succeeded!"),
-              tr("The push attempt succeeded and %1 now contains the RenderDoc layer").arg(exe));
+              tr("The push attempt succeeded and<br>%1 now contains the RenderDoc layer").arg(exe));
         }
       });
 
@@ -611,7 +611,7 @@ void CaptureDialog::androidWarn_mouseClick()
 
           RDDialog::information(
               this, tr("Patch succeeded!"),
-              tr("The patch process succeeded and %1 now contains the RenderDoc layer").arg(exe));
+              tr("The patch process succeeded and<br>%1 now contains the RenderDoc layer").arg(exe));
         }
         else
         {

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -423,8 +423,8 @@ void CaptureDialog::vulkanLayerWarn_mouseClick()
 
 void CaptureDialog::CheckAndroidSetup(QString &filename)
 {
-  ui->androidWarn->setVisible(false);
   ui->androidScan->setVisible(true);
+  ui->androidWarn->setVisible(false);
 
   LambdaThread *scan = new LambdaThread([this, filename]() {
 
@@ -466,6 +466,7 @@ void CaptureDialog::androidWarn_mouseClick()
 
   bool missingPermissions = bool(m_AndroidFlags & AndroidFlags::MissingPermissions);
   bool missingLibrary = bool(m_AndroidFlags & AndroidFlags::MissingLibrary);
+  bool rootAccess = bool(m_AndroidFlags & AndroidFlags::RootAccess);
 
   if(missingPermissions)
   {
@@ -481,21 +482,107 @@ void CaptureDialog::androidWarn_mouseClick()
     msg +=
         tr("<b>Missing library</b><br>"
            "The RenderDoc library must be present in the "
-           "installed application.<br><br>"
-           "To fix this, you should repackage the APK following guidelines on the "
-           "<a href='http://github.com/baldurk/renderdoc/wiki/Android-Support'>"
-           "RenderDoc Wiki</a><br><br>");
+           "installed application.<br><br>");
   }
 
   if(missingPermissions)
   {
-    // Don't prompt for patching if anything other than library is missing
+    // Don't prompt for patching if permissions are wrong - we can't fix that
     RDDialog::critical(this, caption, msg);
+    return;
   }
-  else
+
+  // Track whether we tried to push layer directly, to influence text
+  bool triedPush = false;
+
+  // Track whether to continue with push suggestion dialogue, in case user clicked Cancel
+  bool suggestPatch = true;
+
+  if(rootAccess)
   {
+    // Check whether user has requested automatic pushing
+    bool autoPushConfig = m_Ctx.Config().Android_AutoPushLayerToApp;
+
+    // Separately, track whether the persistent checkBox is selected
+    bool autoPushCheckBox = autoPushConfig;
+
+    QMessageBox::StandardButton prompt = QMessageBox::No;
+
+    // Only display initial prompt if user has not chosen to push automatically
+    if(!autoPushConfig)
+    {
+      QString rootmsg = msg;
+      rootmsg +=
+          tr("Your device appears to have <b>root access</b>. If you are only targeting Vulkan, "
+             "RenderDoc can try to push the layer directly to your application.<br><br>"
+             "Would you like RenderDoc to push the layer?<br>");
+
+      QString checkMsg(lit("Automatically push the layer on rooted devices"));
+      QCheckBox *cb = new QCheckBox(checkMsg, this);
+      cb->setChecked(autoPushCheckBox);
+      prompt = RDDialog::questionChecked(this, caption, rootmsg, cb, autoPushCheckBox,
+                                         RDDialog::YesNoCancel);
+    }
+
+    if(autoPushConfig || prompt == QMessageBox::Yes)
+    {
+      bool pushSucceeded = false;
+      triedPush = true;
+
+      // Only update the autoPush setting if Yes was clicked
+      if(autoPushCheckBox != m_Ctx.Config().Android_AutoPushLayerToApp)
+      {
+        m_Ctx.Config().Android_AutoPushLayerToApp = autoPushCheckBox;
+        m_Ctx.Config().Save();
+      }
+
+      // Call into layer push routine, then continue
+      LambdaThread *push = new LambdaThread([this, exe, &pushSucceeded]() {
+        QByteArray hostnameBytes = m_Ctx.Replay().CurrentRemote()->Hostname.toUtf8();
+        if(RENDERDOC_PushLayerToAndroidApp(hostnameBytes.data(), exe.toUtf8().data()))
+        {
+          // Sucess!
+          pushSucceeded = true;
+
+          RDDialog::information(
+              this, tr("Push succeeded!"),
+              tr("The push attempt succeeded and %1 now contains the RenderDoc layer").arg(exe));
+        }
+      });
+
+      push->start();
+      if(push->isRunning())
+      {
+        ShowProgressDialog(this, tr("Pushing layer to %1, please wait...").arg(exe),
+                           [push]() { return !push->isRunning(); });
+      }
+      push->deleteLater();
+
+      if(pushSucceeded)
+      {
+        // We should be good from here, no futher prompts
+        suggestPatch = false;
+        ui->androidWarn->setVisible(false);
+      }
+    }
+    else if(prompt == QMessageBox::Cancel)
+    {
+      // Cancel skips any other fix prompts
+      suggestPatch = false;
+    }
+  }
+
+  if(suggestPatch)
+  {
+    if(triedPush)
+      msg.insert(0, tr("The push attempt failed, so other methods must be used to fix the missing "
+                       "layer.<br><br>"));
+
     msg +=
-        tr("If you are only targeting Vulkan, RenderDoc can try to add the layer for you, "
+        tr("To fix this, you should repackage the APK following guidelines on the "
+           "<a href='http://github.com/baldurk/renderdoc/wiki/Android-Support'>"
+           "RenderDoc Wiki</a><br><br>"
+           "If you are only targeting Vulkan, RenderDoc can try to <b>add the layer for you</b>, "
            "which requires pulling the APK, patching it, uninstalling the original, and "
            "installing the modified version with a debug key. "
            "This works for many debuggable applications, but not all, especially those that "
@@ -506,7 +593,8 @@ void CaptureDialog::androidWarn_mouseClick()
            "</a> to get them.<br><br>"
            "Would you like RenderDoc to try patching your APK?");
 
-    QMessageBox::StandardButton prompt = RDDialog::question(this, caption, msg);
+    QMessageBox::StandardButton prompt =
+        RDDialog::question(this, caption, msg, RDDialog::YesNoCancel);
 
     if(prompt == QMessageBox::Yes)
     {

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -539,7 +539,7 @@ void CaptureDialog::androidWarn_mouseClick()
       // Call into layer push routine, then continue
       LambdaThread *push = new LambdaThread([this, exe, &pushSucceeded]() {
         QByteArray hostnameBytes = m_Ctx.Replay().CurrentRemote()->Hostname.toUtf8();
-        if(RENDERDOC_PushLayerToAndroidApp(hostnameBytes.data(), exe.toUtf8().data()))
+        if(RENDERDOC_PushLayerToInstalledAndroidApp(hostnameBytes.data(), exe.toUtf8().data()))
         {
           // Sucess!
           pushSucceeded = true;

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
@@ -63,6 +63,7 @@ SettingsDialog::SettingsDialog(ICaptureContext &ctx, QWidget *parent)
   }
   ui->Android_AdbExecutablePath->setText(m_Ctx.Config().Android_AdbExecutablePath);
   ui->Android_MaxConnectTimeout->setValue(m_Ctx.Config().Android_MaxConnectTimeout);
+  ui->Android_AutoPushLayerToApp->setChecked(m_Ctx.Config().Android_AutoPushLayerToApp);
 
   ui->TextureViewer_ResetRange->setChecked(m_Ctx.Config().TextureViewer_ResetRange);
   ui->TextureViewer_PerTexSettings->setChecked(m_Ctx.Config().TextureViewer_PerTexSettings);
@@ -375,6 +376,13 @@ void SettingsDialog::on_Android_AdbExecutablePath_textEdited(const QString &adb)
 {
   if(QFileInfo::exists(adb) || adb.isEmpty())
     m_Ctx.Config().Android_AdbExecutablePath = adb;
+
+  m_Ctx.Config().Save();
+}
+
+void SettingsDialog::on_Android_AutoPushLayerToApp_toggled(bool checked)
+{
+  m_Ctx.Config().Android_AutoPushLayerToApp = ui->Android_AutoPushLayerToApp->isChecked();
 
   m_Ctx.Config().Save();
 }

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.h
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.h
@@ -86,6 +86,7 @@ private slots:
   void on_browseAdbPath_clicked();
   void on_Android_MaxConnectTimeout_valueChanged(double timeout);
   void on_Android_AdbExecutablePath_textEdited(const QString &path);
+  void on_Android_AutoPushLayerToApp_toggled(bool checked);
 
   // manual slots
   void formatter_valueChanged(int value);

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -874,7 +874,7 @@ If {spv_disas} is not used, the tool is expected to output the disassembly on st
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <spacer name="verticalSpacer_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -886,6 +886,25 @@ If {spv_disas} is not used, the tool is expected to output the disassembly on st
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_26">
+            <property name="toolTip">
+             <string>Automatically push the RenderDoc layer to applications that need it when running on a device with root access.
+This can enable debugging of Vulkan apps that don't already contain the layer.</string>
+            </property>
+            <property name="text">
+             <string>Automatically push RenderDoc layer for Vulkan on devices with root access.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="Android_AutoPushLayerToApp">
+            <property name="toolTip">
+              <string>Automatically push the RenderDoc layer to applications that need it when running on a device with root access.
+This can enable debugging of Vulkan apps that don't already contain the layer.</string>
+            </property>
+           </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_25">

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -1580,8 +1580,8 @@ extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const c
                                                                          AndroidFlags *flags);
 
 DOCUMENT("Internal function that attempts to push Vulkan layer to Android application.");
-extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_PushLayerToAndroidApp(const char *host,
-                                                                           const char *exe);
+extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_PushLayerToInstalledAndroidApp(const char *host,
+                                                                                    const char *exe);
 
 DOCUMENT("Internal function that attempts to modify APK contents, adding Vulkan layer.");
 extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_AddLayerToAndroidPackage(const char *host,

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -1579,6 +1579,10 @@ extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const c
                                                                          const char *exe,
                                                                          AndroidFlags *flags);
 
+DOCUMENT("Internal function that attempts to push Vulkan layer to Android application.");
+extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_PushLayerToAndroidApp(const char *host,
+                                                                           const char *exe);
+
 DOCUMENT("Internal function that attempts to modify APK contents, adding Vulkan layer.");
 extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_AddLayerToAndroidPackage(const char *host,
                                                                               const char *exe,

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -3325,6 +3325,10 @@ DOCUMENT(R"(A set of flags giving details of the current status of Android traca
 
   The application is not debuggable.
 
+.. data:: RootAccess
+
+   The device being targeted has root access.
+
 .. data:: Unfixable
 
   The current situation is not fixable automatically and requires user intervention/disambiguation.
@@ -3335,7 +3339,8 @@ enum class AndroidFlags : uint32_t
   MissingLibrary = 0x1,
   MissingPermissions = 0x2,
   NotDebuggable = 0x4,
-  Unfixable = 0x8,
+  RootAccess = 0x8,
+  Unfixable = 0x10,
 };
 
 BITMASK_OPERATORS(AndroidFlags);

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -1298,6 +1298,12 @@ extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const c
     *flags |= AndroidFlags::MissingPermissions;
   }
 
+  if(CheckRootAccess(deviceID))
+  {
+    RDCLOG("Root access detected");
+    *flags |= AndroidFlags::RootAccess;
+  }
+
   return;
 }
 

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -1228,6 +1228,30 @@ bool CheckInstalledPermissions(const string &deviceID, const string &packageName
   return CheckPermissions(dump);
 }
 
+bool CheckRootAccess(const string &deviceID)
+{
+  RDCLOG("Checking for root access on %s", deviceID.c_str());
+
+  Process::ProcessResult result = {};
+
+  // Try switching adb to root and check a few indicators for success
+  // Nothing will fall over if we get a false positive here, it just enables
+  // additional methods of getting things set up.
+
+  result = adbExecCommand(deviceID, "root");
+
+  string whoami = trim(adbExecCommand(deviceID, "shell whoami").strStdout);
+  if(whoami == "root")
+    return true;
+
+  string checksu =
+      trim(adbExecCommand(deviceID, "shell test -e /system/xbin/su && echo found").strStdout);
+  if(checksu == "found")
+    return true;
+
+  return false;
+}
+
 extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const char *host,
                                                                          const char *exe,
                                                                          AndroidFlags *flags)

--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -1401,8 +1401,8 @@ string FindAndroidLayer(const string &abi, const string &layerName)
   return layer;
 }
 
-extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_PushLayerToAndroidApp(const char *host,
-                                                                           const char *exe)
+extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_PushLayerToInstalledAndroidApp(const char *host,
+                                                                                    const char *exe)
 {
   Process::ProcessResult result = {};
   string packageName(basename(string(exe)));


### PR DESCRIPTION
This series updates the Android workflow to detect when the device has root access and allows pushing the layer directly to the application's lib folder.

To accomplish this:

During initial scan of the selected Android application, detect if root access is available, track it in flags.  The methods used to detect root are imperfect, but false positives are okay, as failure to push directly will fall back to the production path.

When user selects "Click here for ways to fix this" and has root access, display new dialogue window with slightly different text:

![root_access_dialogue](https://user-images.githubusercontent.com/6932500/29046990-0cee88ea-7b87-11e7-9105-f26de76c8dd7.png)

If that fails, fall back to existing workflow with slightly modified text, reflecting failure to push the layer.

There is also a new entry for Android under Settings, which is synchronized with the dialogue checkBox:

![root_access_setting](https://user-images.githubusercontent.com/6932500/29047390-d0411f0a-7b88-11e7-8865-dd9314876201.png)

Changes include:
- Add function to detect root access (`CheckRootAccess`)
- Add function to push layer to application's lib folder (`RENDERDOC_PushLayerToAndroidApp`)
- Add new dialogue window (and helpers) that prompts user to push the layer directly, if root detected.
- Add persistent setting to always push the layer on rooted devices (`Android_AutoPushLayerToApp`).  Accessible via dialogue checkbox and through Android Settings menu.