### PR TITLE
Fix tracking of dynamic offsets when binding multiple descriptor sets

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1333,6 +1333,7 @@ bool WrappedVulkan::Serialise_vkCmdBindDescriptorSets(
         descsets[first + i].descSet = descriptorIDs[i];
         uint32_t dynCount = m_CreationInfo.m_DescSetLayout[descSetLayouts[first + i]].dynamicCount;
         descsets[first + i].offsets.assign(offsIter, offsIter + dynCount);
+        offsIter += dynCount;
         dynConsumed += dynCount;
         RDCASSERT(dynConsumed <= offsCount);
       }


### PR DESCRIPTION
Before this, when binding multiple sets that use dynamic offsets, the wrong offsets would be stored for all sets other than the first. This caused the wrong offsets to be used when replaying individual draws.