### PR TITLE
Fixed a problem which prevents opening capture files larger than 2gb on windows

### DIFF
--- a/renderdoc/os/win32/win32_stringio.cpp
+++ b/renderdoc/os/win32/win32_stringio.cpp
@@ -531,8 +531,8 @@ bool exists(const char *filename)
 {
   wstring wfn = StringFormat::UTF82Wide(filename);
 
-  struct _stat st;
-  int res = _wstat(wfn.c_str(), &st);
+  struct __stat64 st;
+  int res = _wstat64(wfn.c_str(), &st);
 
   return (res == 0);
 }


### PR DESCRIPTION
_wstat returns -1 for files larger than 2gb