### PR TITLE
Check Android server version

### DIFF
--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -86,6 +86,17 @@ if(ANDROID)
                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                        COMMAND ${JAVA_BIN}/keytool -genkey -keystore ${KEYSTORE} -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=, OU=, O=, L=, S=, C=")
 
+    # APK_VERSION_CODE corresponds to android:versionCode, an internal integer value that can be queried. Higher numbers indicate more recent versions.
+    # APK_VERSION_NAME corresponds to android:versionName, a string value that is displayed to the user.
+    set(APK_VERSION_CODE "${RENDERDOC_VERSION_MAJOR}${RENDERDOC_VERSION_MINOR}")
+    if(BUILD_VERSION_STABLE)
+        set(APK_VERSION_NAME "${RENDERDOC_VERSION}")
+    else()
+        set(APK_VERSION_NAME ${GIT_COMMIT_HASH})
+    endif()
+    message(STATUS "Building APK versionCode ${APK_VERSION_CODE}, versionName ${APK_VERSION_NAME}")
+
+
     set(APK_FILE ${CMAKE_BINARY_DIR}/bin/RenderDocCmd.apk)
     add_custom_target(apk ALL
                       DEPENDS ${APK_FILE}
@@ -104,7 +115,7 @@ if(ANDROID)
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
                        COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/org/renderdoc/renderdoccmd/*.java
                        COMMAND ${BUILD_TOOLS}/dx --dex --output=bin/classes.dex ./obj
-                       COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml -S res -I ${ANDROID_JAR} -F RenderDocCmd-unaligned.apk bin libs
+                       COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml --version-code ${APK_VERSION_CODE} --version-name ${APK_VERSION_NAME} -S res -I ${ANDROID_JAR} -F RenderDocCmd-unaligned.apk bin libs
                        COMMAND ${BUILD_TOOLS}/zipalign -f 4 RenderDocCmd-unaligned.apk RenderDocCmd.apk
                        COMMAND ${BUILD_TOOLS}/apksigner sign --ks ${KEYSTORE} --ks-pass pass:android --key-pass pass:android --ks-key-alias androiddebugkey RenderDocCmd.apk
                        COMMAND ${CMAKE_COMMAND} -E copy RenderDocCmd.apk ${APK_FILE})

--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- BEGIN_INCLUDE(manifest) -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.renderdoc.renderdoccmd" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.renderdoc.renderdoccmd">
 
   <!-- This is the platform API where NativeActivity was introduced. -->
   <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>


### PR DESCRIPTION
These commits replace the RenderDoc server if it doesn't match the version of the RenderDoc host.

* The first commit changes the `versionCode` and `versionName` of the `RenderDocCmd.apk`.  Rather than hard code them in `AndroidManifest.xml`, assign them as part of the build process.  The `versionCode` must be an integer that increments for newer versions, so it becomes `${RENDERDOC_VERSION_MAJOR}${RENDERDOC_VERSION_MINOR}` .  The `versionName` is a string, so for development builds, it becomes a matching hash of the RenderDoc build, `${GIT_COMMIT_HASH}`.  For stable builds, it becomes the `${RENDERDOC_VERSION}`.  These values match what the host components are assigning.

* The second commit checks the value at runtime to determine if the server is compatible with the host.  If it doesn't, uninstall and allow the clean install logic to kick in.

This prevents one of the common crashes I get when working on RenderDoc.

We also need to check the layer's `implementationVersion`, but I'd like to bounce some ideas around before I work on that.