### PR TITLE
Android arm64

### DIFF
--- a/renderdoc/core/android.cpp
+++ b/renderdoc/core/android.cpp
@@ -968,8 +968,16 @@ extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_PushLayerToInstalledAndroid
   if(layerPath.empty())
     return false;
 
-  string layerDst = "/data/data/" + packageName + "/lib/";
+  // Determine where to push the layer
+  string pkgPath = trim(adbExecCommand(deviceID, "shell pm path " + packageName).strStdout);
 
+  // Isolate the app's lib dir
+  pkgPath.erase(pkgPath.begin(), pkgPath.begin() + strlen("package:"));
+  string libDir = removeFromEnd(pkgPath, "base.apk") + "lib/";
+
+  // There will only be one ABI in the lib dir
+  string libsAbi = trim(adbExecCommand(deviceID, "shell ls " + libDir).strStdout);
+  string layerDst = libDir + libsAbi + "/";
   result = adbExecCommand(deviceID, "push " + layerPath + " " + layerDst);
 
   // Ensure the push succeeded

--- a/renderdoc/core/android.cpp
+++ b/renderdoc/core/android.cpp
@@ -553,7 +553,10 @@ bool installRenderDocServer(const string &deviceID)
   abi_string_map["mips64"]      = Android_mips64;
   // clang-format on
 
-  // 32-bit server works for 32 and 64 bit apps, so install 32-bit matching ABI
+  // 32-bit server works for 32 and 64 bit apps
+  // For stable builds of the server, only 32-bit libs will be packaged into APK
+  // For local builds, whatever was specified as single ABI will be packaged into APK
+
   string adbAbi = trim(adbExecCommand(deviceID, "shell getprop ro.product.cpu.abi").strStdout);
 
   string adbInstall;
@@ -561,7 +564,7 @@ bool installRenderDocServer(const string &deviceID)
   {
     case Android_armeabi_v7a:
     case Android_arm64_v8a:
-      adbInstall = adbExecCommand(deviceID, "install -r --abi armeabi-v7a " + serverApk).strStdout;
+      adbInstall = adbExecCommand(deviceID, "install -r -g " + serverApk).strStdout;
       break;
     case Android_armeabi:
     case Android_x86:


### PR DESCRIPTION
These changes get local builds working for arm64 server and layer, as pointed out by @michaelrgb in #747.  Tested with local builds of arm32 and arm64 targeting both eng and prod devices.  This could use more testing with a nightly or stable release to make sure all combinations still work.

I was unable to clean up the code as much as I wanted because ARM binaries will happily install on x86 devices, which doesn't work for a number of reasons.  So we can't rely on simply failing the install on unsupported ABIs.

Also small change to grant requested runtime permissions for the server, removing one manual step for users (clicking to allow reading from external storage).