### PR TITLE
Create uniform translation table from live prog instead of initial prog.

### DIFF
--- a/renderdoc/driver/gl/gl_manager.cpp
+++ b/renderdoc/driver/gl/gl_manager.cpp
@@ -1181,7 +1181,9 @@ bool GLResourceManager::Serialise_InitialState(ResourceId resid, GLResource res)
         gl.glLinkProgram(initProg);
       }
 
-      SerialiseProgramUniforms(gl, m_pSerialiser, initProg, &details.locationTranslate, false);
+      GLuint live = GetLiveResource(Id).name;
+      SerialiseProgramUniforms(gl, m_pSerialiser, live, &details.locationTranslate, false);
+      CopyProgramUniforms(gl, live, initProg);
 
       SetInitialContents(
           Id, InitialContentData(res.Namespace, ProgramRes(m_GL->GetCtx(), initProg), 0, NULL));


### PR DESCRIPTION
The table is used on the live program, and the driver is free to create it
with different locations to the initial state program.