### PR TITLE
Improve save file handling

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -714,7 +714,7 @@ ICaptureDialog *CaptureContext::GetCaptureDialog()
              CaptureOptions opts, std::function<void(LiveCapture *)> callback) {
         return m_MainWindow->OnInjectTrigger(PID, env, name, opts, callback);
       },
-      m_MainWindow);
+      m_MainWindow, m_MainWindow);
   m_CaptureDialog->setObjectName(lit("capDialog"));
   m_CaptureDialog->setWindowIcon(*m_Icon);
 

--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -537,11 +537,12 @@ QString RDDialog::getExecutableFileName(QWidget *parent, const QString &caption,
 }
 
 QString RDDialog::getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
-                                  const QString &filter, QString *selectedFilter,
-                                  QFileDialog::Options options)
+                                  const QString &filter, const QString &defaultExt,
+                                  QString *selectedFilter, QFileDialog::Options options)
 {
   QFileDialog fd(parent, caption, dir, filter);
   fd.setAcceptMode(QFileDialog::AcceptSave);
+  fd.setDefaultSuffix(defaultExt);
   fd.setOptions(options);
   show(&fd);
 

--- a/qrenderdoc/Code/QRDUtils.h
+++ b/qrenderdoc/Code/QRDUtils.h
@@ -877,6 +877,7 @@ struct RDDialog
 
   static QString getSaveFileName(QWidget *parent = NULL, const QString &caption = QString(),
                                  const QString &dir = QString(), const QString &filter = QString(),
+                                 const QString &defaultExt = QString(),
                                  QString *selectedFilter = NULL,
                                  QFileDialog::Options options = QFileDialog::Options());
 };

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -856,7 +856,7 @@ void CaptureDialog::on_toggleGlobal_clicked()
 void CaptureDialog::on_saveSettings_clicked()
 {
   QString filename = RDDialog::getSaveFileName(this, tr("Save Settings As"), QString(),
-                                               tr("Capture settings (*.cap)"));
+                                               tr("Capture settings (*.cap)"), lit("cap"));
 
   if(!filename.isEmpty())
   {

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -32,6 +32,7 @@
 #include "Code/qprocessinfo.h"
 #include "Windows/Dialogs/EnvironmentEditor.h"
 #include "Windows/Dialogs/VirtualFileDialog.h"
+#include "Windows/MainWindow.h"
 #include "LiveCapture.h"
 #include "ui_CaptureDialog.h"
 
@@ -91,8 +92,8 @@ void CaptureDialog::initWarning(RDLabel *warning)
 }
 
 CaptureDialog::CaptureDialog(ICaptureContext &ctx, OnCaptureMethod captureCallback,
-                             OnInjectMethod injectCallback, QWidget *parent)
-    : QFrame(parent), ui(new Ui::CaptureDialog), m_Ctx(ctx)
+                             OnInjectMethod injectCallback, MainWindow *main, QWidget *parent)
+    : QFrame(parent), ui(new Ui::CaptureDialog), m_Ctx(ctx), m_Main(main)
 {
   ui->setupUi(this);
 
@@ -865,6 +866,7 @@ void CaptureDialog::on_saveSettings_clicked()
     {
       SaveSettings(filename);
       AddRecentFile(m_Ctx.Config().RecentCaptureSettings, filename, 10);
+      m_Main->PopulateRecentCaptures();
     }
   }
 }

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.h
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.h
@@ -35,6 +35,7 @@ class CaptureDialog;
 
 class QStandardItemModel;
 class LiveCapture;
+class MainWindow;
 class RDLabel;
 
 class CaptureDialog : public QFrame, public ICaptureDialog
@@ -51,7 +52,7 @@ public:
       OnInjectMethod;
 
   explicit CaptureDialog(ICaptureContext &ctx, OnCaptureMethod captureCallback,
-                         OnInjectMethod injectCallback, QWidget *parent = 0);
+                         OnInjectMethod injectCallback, MainWindow *main, QWidget *parent = 0);
   ~CaptureDialog();
 
   // ICaptureDialog
@@ -103,6 +104,7 @@ private slots:
 private:
   Ui::CaptureDialog *ui;
   ICaptureContext &m_Ctx;
+  MainWindow *m_Main;
 
   QStandardItemModel *m_ProcessModel;
 

--- a/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
+++ b/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
@@ -353,8 +353,9 @@ void PerformanceCounterSelection::SetSelectedCounters(const QList<GPUCounter> &c
 
 void PerformanceCounterSelection::Save()
 {
-  QString filename = RDDialog::getSaveFileName(this, tr("Save File"), QDir::homePath(),
-                                               tr("Performance Counter Settings (*.json)"));
+  QString filename =
+      RDDialog::getSaveFileName(this, tr("Save File"), QDir::homePath(),
+                                tr("Performance Counter Settings (*.json)"), lit("json"));
 
   if(filename.isEmpty())
     return;

--- a/qrenderdoc/Windows/Dialogs/TextureSaveDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/TextureSaveDialog.cpp
@@ -526,8 +526,8 @@ void TextureSaveDialog::on_browse_clicked()
 
   QString *selectedFilter = NULL;
 
-  QString filename =
-      RDDialog::getSaveFileName(this, tr("Save Texture As"), QString(), filter, selectedFilter);
+  QString filename = RDDialog::getSaveFileName(this, tr("Save Texture As"), QString(), filter,
+                                               QString(), selectedFilter);
 
   QFileInfo checkFile(filename);
   if(!filename.isEmpty())

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -98,6 +98,11 @@ MainWindow::MainWindow(ICaptureContext &ctx) : QMainWindow(NULL), ui(new Ui::Mai
   QObject::connect(ui->action_Launch_Application_Window, &QAction::triggered, this,
                    &MainWindow::on_action_Launch_Application_triggered);
 
+  QObject::connect(ui->action_Clear_Capture_History, &QAction::triggered, this,
+                   &MainWindow::ClearRecentCaptures);
+  QObject::connect(ui->action_Clear_Log_History, &QAction::triggered, this,
+                   &MainWindow::ClearRecentFiles);
+
   contextChooserMenu = new QMenu(this);
 
   FillRemotesMenu(contextChooserMenu, true);
@@ -727,6 +732,12 @@ void MainWindow::SetTitle()
   SetTitle(m_Ctx.LogFilename());
 }
 
+void MainWindow::ClearRecentFiles()
+{
+  m_Ctx.Config().RecentLogFiles.clear();
+  PopulateRecentFiles();
+}
+
 void MainWindow::PopulateRecentFiles()
 {
   ui->menu_Recent_Logs->clear();
@@ -748,6 +759,12 @@ void MainWindow::PopulateRecentFiles()
   ui->menu_Recent_Logs->addAction(ui->action_Clear_Log_History);
 }
 
+void MainWindow::ClearRecentCaptures()
+{
+  m_Ctx.Config().RecentCaptureSettings.clear();
+  PopulateRecentCaptures();
+}
+
 void MainWindow::PopulateRecentCaptures()
 {
   ui->menu_Recent_Capture_Settings->clear();
@@ -766,7 +783,7 @@ void MainWindow::PopulateRecentCaptures()
   }
 
   ui->menu_Recent_Capture_Settings->addSeparator();
-  ui->menu_Recent_Capture_Settings->addAction(ui->action_Clear_Log_History);
+  ui->menu_Recent_Capture_Settings->addAction(ui->action_Clear_Capture_History);
 }
 
 void MainWindow::ShowLiveCapture(LiveCapture *live)
@@ -914,9 +931,9 @@ void MainWindow::recentCapture(const QString &filename)
 
     if(res == QMessageBox::Yes)
     {
-      m_Ctx.Config().RecentLogFiles.removeOne(filename);
+      m_Ctx.Config().RecentCaptureSettings.removeOne(filename);
 
-      PopulateRecentFiles();
+      PopulateRecentCaptures();
     }
   }
 }

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -566,8 +566,8 @@ QString MainWindow::GetSavePath()
       dir = m_LastSaveCapturePath;
   }
 
-  QString filename =
-      RDDialog::getSaveFileName(this, tr("Save Capture As"), dir, tr("Capture Files (*.rdc)"));
+  QString filename = RDDialog::getSaveFileName(this, tr("Save Capture As"), dir,
+                                               tr("Capture Files (*.rdc)"), lit("rdc"));
 
   if(!filename.isEmpty())
   {

--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -79,8 +79,6 @@ public:
   void OnInjectTrigger(uint32_t PID, const QList<EnvironmentModification> &env, const QString &name,
                        CaptureOptions opts, std::function<void(LiveCapture *)> callback);
 
-  void PopulateRecentFiles();
-
   void ShowLiveCapture(LiveCapture *live);
   void LiveCaptureClosed(LiveCapture *live);
 
@@ -95,6 +93,9 @@ public:
   void showTimelineBar() { on_action_Timeline_triggered(); }
   void showPythonShell() { on_action_Python_Shell_triggered(); }
   void showPerformanceCounterViewer() { on_action_Counter_Viewer_triggered(); }
+public slots:
+  void ClearRecentFiles();
+  void PopulateRecentFiles();
 private slots:
   // automatic slots
   void on_action_Exit_triggered();
@@ -133,6 +134,9 @@ private slots:
   void statusDoubleClicked(QMouseEvent *event);
   void switchContext();
   void contextChooser_menuShowing();
+
+  void PopulateRecentCaptures();
+  void ClearRecentCaptures();
 
 private:
   void closeEvent(QCloseEvent *event) override;
@@ -174,8 +178,6 @@ private:
 
   void SetTitle(const QString &filename);
   void SetTitle();
-
-  void PopulateRecentCaptures();
 
   void recentLog(const QString &filename);
   void recentCapture(const QString &filename);

--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -93,9 +93,8 @@ public:
   void showTimelineBar() { on_action_Timeline_triggered(); }
   void showPythonShell() { on_action_Python_Shell_triggered(); }
   void showPerformanceCounterViewer() { on_action_Counter_Viewer_triggered(); }
-public slots:
-  void ClearRecentFiles();
   void PopulateRecentFiles();
+  void PopulateRecentCaptures();
 private slots:
   // automatic slots
   void on_action_Exit_triggered();
@@ -135,7 +134,7 @@ private slots:
   void switchContext();
   void contextChooser_menuShowing();
 
-  void PopulateRecentCaptures();
+  void ClearRecentFiles();
   void ClearRecentCaptures();
 
 private:

--- a/qrenderdoc/Windows/PythonShell.cpp
+++ b/qrenderdoc/Windows/PythonShell.cpp
@@ -511,7 +511,7 @@ void PythonShell::on_openScript_clicked()
 void PythonShell::on_saveScript_clicked()
 {
   QString filename = RDDialog::getSaveFileName(this, tr("Save Python Script"), QString(),
-                                               tr("Python scripts (*.py)"));
+                                               tr("Python scripts (*.py)"), lit("py"));
 
   if(!filename.isEmpty())
   {


### PR DESCRIPTION
I was a little confused when I saved my capture settings and then couldn't find them again. After realizing that the file was getting filtered out because I didn't write out the extension, I figured I would just add a bit of code to automatically append the file extension if necessary.

When I started doing that, I realized that other files had the same problem. I made extension appending a generic feature in getSaveFileName and updated saving for all the other file types I could identify that required a particular extension.

Then I noticed that there was a recent list for capture files. I wanted to be sure the extension appending wouldn't screw that up, so I tried playing around with it a bit. The recent files menu turned out to have a few bugs, so I fixed them. It now updates as expected and "Clear History" works.

I tried to match your style, though it feels a little weird. I also created the branch [cgmb/fix-save-file-handling-2](https://github.com/cgmb/renderdoc/compare/950c27719bd149c2195748e6d592fd6ea1d8453c...fix-save-file-handling-2) with an implementation that feels a slightly cleaner to me, but doesn't match your style as closely. If you prefer that version, I can force-push it over this branch to update the PR. If not, then merge away... or code review, or whatever.