### PR TITLE
Resample thumbnails to fix JPEG shear distortion if(width % 4 != 0)

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -2981,15 +2981,17 @@ WrappedOpenGL::BackbufferImage *WrappedOpenGL::SaveBackbufferImage()
     m_Real.glPixelStorei(eGL_PACK_ALIGNMENT, prevPackAlignment);
 
     // scale down if necessary using simple point sampling
-    if(thwidth > maxSize)
+    uint32_t resample_width = RDCMIN(maxSize, thwidth);
+    resample_width &= ~3;    // JPEG encoder gives shear distortion if width is not divisible by 4.
+    if(thwidth != resample_width)
     {
       float widthf = float(thwidth);
       float heightf = float(thheight);
 
       float aspect = widthf / heightf;
 
-      // clamp dimensions to a width of maxSize
-      thwidth = maxSize;
+      // clamp dimensions to a width of resample_width
+      thwidth = resample_width;
       thheight = uint32_t(float(thwidth) / aspect);
 
       byte *src = thpixels;


### PR DESCRIPTION
This can be reproduced if you simply run es2gears (or whatever) on desktop and resize the width from 300 to 301.

The distorted image after decoding also causes the GUI to crash half the time.

This is a suggested fix, perhaps you can update the encoder instead (your version is from 2014)? Otherwise the Vulkan etc code probably also needs to be changed.