### PR TITLE
Improve save dialog file extension handling and misc cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ This is the apt-get line you'd need to install the requirements bar Qt on Ubuntu
 sudo apt-get install libx11-dev libx11-xcb-dev mesa-common-dev libgl1-mesa-dev libxcb-keysyms1-dev cmake python3-dev bison autoconf automake libpcre3-dev
 ```
 
-Your version of Ubuntu might not include a recent enough Qt version, so you can use [Stephan Binner's ppas](https://launchpad.net/~beineri) to install a more recent version of Qt. At least 5.6.2 is required.
+Your version of Ubuntu might not include a recent enough Qt version, so you can use [Stephan Binner's ppas](https://launchpad.net/~beineri) to install a more recent version of Qt. At least 5.6.2 is required. If you choose to instead install an [official Qt release](https://download.qt.io/official_releases/qt/) or build Qt from source, add `-DQMAKE_QT5_COMMAND=/path/to/qmake` to your cmake arguments to specify where to find it.
 
 For Archlinux (as of 2017.04.18) you'll need:
 

--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -514,7 +514,7 @@ QString RDDialog::getExecutableFileName(QWidget *parent, const QString &caption,
 
 #if defined(Q_OS_WIN32)
   // can't filter by executable bit on windows, but we have extensions
-  filter = QApplication::translate("RDDialog", "Executables (*.exe);;All Files (*.*)");
+  filter = QApplication::translate("RDDialog", "Executables (*.exe);;All Files (*)");
 #endif
 
   QFileDialog fd(parent, caption, dir, filter);

--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -537,12 +537,11 @@ QString RDDialog::getExecutableFileName(QWidget *parent, const QString &caption,
 }
 
 QString RDDialog::getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
-                                  const QString &filter, const QString &defaultExt,
-                                  QString *selectedFilter, QFileDialog::Options options)
+                                  const QString &filter, QString *selectedFilter,
+                                  QFileDialog::Options options)
 {
   QFileDialog fd(parent, caption, dir, filter);
   fd.setAcceptMode(QFileDialog::AcceptSave);
-  fd.setDefaultSuffix(defaultExt);
   fd.setOptions(options);
   show(&fd);
 

--- a/qrenderdoc/Code/QRDUtils.h
+++ b/qrenderdoc/Code/QRDUtils.h
@@ -877,7 +877,6 @@ struct RDDialog
 
   static QString getSaveFileName(QWidget *parent = NULL, const QString &caption = QString(),
                                  const QString &dir = QString(), const QString &filter = QString(),
-                                 const QString &defaultExt = QString(),
                                  QString *selectedFilter = NULL,
                                  QFileDialog::Options options = QFileDialog::Options());
 };

--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -2894,7 +2894,7 @@ void BufferViewer::exportData(const BufferExport &params)
     filter = tr("Binary Files (*.bin)");
 
   QString filename = RDDialog::getSaveFileName(this, tr("Export buffer to bytes"), QString(),
-                                               tr("%1;;All files (*.*)").arg(filter));
+                                               tr("%1;;All files (*)").arg(filter));
 
   if(filename.isEmpty())
     return;

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -857,7 +857,7 @@ void CaptureDialog::on_toggleGlobal_clicked()
 void CaptureDialog::on_saveSettings_clicked()
 {
   QString filename = RDDialog::getSaveFileName(this, tr("Save Settings As"), QString(),
-                                               tr("Capture settings (*.cap)"), lit("cap"));
+                                               tr("Capture settings (*.cap)"));
 
   if(!filename.isEmpty())
   {

--- a/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
+++ b/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
@@ -353,9 +353,8 @@ void PerformanceCounterSelection::SetSelectedCounters(const QList<GPUCounter> &c
 
 void PerformanceCounterSelection::Save()
 {
-  QString filename =
-      RDDialog::getSaveFileName(this, tr("Save File"), QDir::homePath(),
-                                tr("Performance Counter Settings (*.json)"), lit("json"));
+  QString filename = RDDialog::getSaveFileName(this, tr("Save File"), QDir::homePath(),
+                                               tr("Performance Counter Settings (*.json)"));
 
   if(filename.isEmpty())
     return;

--- a/qrenderdoc/Windows/Dialogs/TextureSaveDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/TextureSaveDialog.cpp
@@ -526,8 +526,8 @@ void TextureSaveDialog::on_browse_clicked()
 
   QString *selectedFilter = NULL;
 
-  QString filename = RDDialog::getSaveFileName(this, tr("Save Texture As"), QString(), filter,
-                                               QString(), selectedFilter);
+  QString filename =
+      RDDialog::getSaveFileName(this, tr("Save Texture As"), QString(), filter, selectedFilter);
 
   QFileInfo checkFile(filename);
   if(!filename.isEmpty())

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -268,7 +268,7 @@ void MainWindow::on_action_Open_Log_triggered()
   QString filename = RDDialog::getOpenFileName(
       this, tr("Select Logfile to open"), m_Ctx.Config().LastLogPath,
       tr("Capture Files (*.rdc);;Image Files (*.dds *.hdr *.exr *.bmp *.jpg "
-         "*.jpeg *.png *.tga *.gif *.psd;;All Files (*.*)"));
+         "*.jpeg *.png *.tga *.gif *.psd;;All Files (*)"));
 
   if(!filename.isEmpty())
     LoadFromFilename(filename, false);

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -1645,17 +1645,17 @@ void MainWindow::on_action_View_Diagnostic_Log_File_triggered()
     QDesktopServices::openUrl(QUrl::fromLocalFile(logPath));
 }
 
-void MainWindow::on_action_Source_on_github_triggered()
+void MainWindow::on_action_Source_on_GitHub_triggered()
 {
   QDesktopServices::openUrl(QUrl::fromUserInput(lit("https://github.com/baldurk/renderdoc")));
 }
 
-void MainWindow::on_action_Build_Release_downloads_triggered()
+void MainWindow::on_action_Build_Release_Downloads_triggered()
 {
   QDesktopServices::openUrl(QUrl::fromUserInput(lit("https://renderdoc.org/builds")));
 }
 
-void MainWindow::on_actionShow_Tips_triggered()
+void MainWindow::on_action_Show_Tips_triggered()
 {
   TipsDialog tipsDialog(m_Ctx, this);
   RDDialog::show(&tipsDialog);

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -571,8 +571,8 @@ QString MainWindow::GetSavePath()
       dir = m_LastSaveCapturePath;
   }
 
-  QString filename = RDDialog::getSaveFileName(this, tr("Save Capture As"), dir,
-                                               tr("Capture Files (*.rdc)"), lit("rdc"));
+  QString filename =
+      RDDialog::getSaveFileName(this, tr("Save Capture As"), dir, tr("Capture Files (*.rdc)"));
 
   if(!filename.isEmpty())
   {

--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -120,9 +120,9 @@ private slots:
   void on_action_Settings_triggered();
   void on_action_View_Documentation_triggered();
   void on_action_View_Diagnostic_Log_File_triggered();
-  void on_action_Source_on_github_triggered();
-  void on_action_Build_Release_downloads_triggered();
-  void on_actionShow_Tips_triggered();
+  void on_action_Source_on_GitHub_triggered();
+  void on_action_Build_Release_Downloads_triggered();
+  void on_action_Show_Tips_triggered();
   void on_action_Counter_Viewer_triggered();
 
   // manual slots

--- a/qrenderdoc/Windows/MainWindow.ui
+++ b/qrenderdoc/Windows/MainWindow.ui
@@ -138,14 +138,14 @@
     </property>
     <addaction name="action_View_Documentation"/>
     <addaction name="action_View_Diagnostic_Log_File"/>
-    <addaction name="actionShow_Tips"/>
+    <addaction name="action_Show_Tips"/>
     <addaction name="separator"/>
     <addaction name="action_Send_Error_Report"/>
     <addaction name="separator"/>
-    <addaction name="actionUpdate_available"/>
+    <addaction name="action_Update_Available"/>
     <addaction name="separator"/>
-    <addaction name="action_Source_on_github"/>
-    <addaction name="action_Build_Release_downloads"/>
+    <addaction name="action_Source_on_GitHub"/>
+    <addaction name="action_Build_Release_Downloads"/>
     <addaction name="action_About"/>
    </widget>
    <addaction name="menu_File"/>
@@ -356,19 +356,19 @@
     <string>Send &amp;Error Report</string>
    </property>
   </action>
-  <action name="actionUpdate_available">
+  <action name="action_Update_Available">
    <property name="text">
-    <string>Update available</string>
+    <string>Update Available</string>
    </property>
   </action>
-  <action name="action_Source_on_github">
+  <action name="action_Source_on_GitHub">
    <property name="text">
-    <string>Source on github</string>
+    <string>Source on GitHub</string>
    </property>
   </action>
-  <action name="action_Build_Release_downloads">
+  <action name="action_Build_Release_Downloads">
    <property name="text">
-    <string>Build/Release downloads</string>
+    <string>Build/Release Downloads</string>
    </property>
   </action>
   <action name="action_About">
@@ -391,7 +391,7 @@
     <string>Statisti&amp;cs Viewer</string>
    </property>
   </action>
-  <action name="actionShow_Tips">
+  <action name="action_Show_Tips">
    <property name="text">
     <string>Show Tips</string>
    </property>

--- a/qrenderdoc/Windows/PythonShell.cpp
+++ b/qrenderdoc/Windows/PythonShell.cpp
@@ -511,7 +511,7 @@ void PythonShell::on_openScript_clicked()
 void PythonShell::on_saveScript_clicked()
 {
   QString filename = RDDialog::getSaveFileName(this, tr("Save Python Script"), QString(),
-                                               tr("Python scripts (*.py)"), lit("py"));
+                                               tr("Python scripts (*.py)"));
 
   if(!filename.isEmpty())
   {

--- a/qrenderdoc/qrenderdoc.pro
+++ b/qrenderdoc/qrenderdoc.pro
@@ -8,9 +8,9 @@ QT       += core gui widgets svg
 
 CONFIG   += silent
 
-lessThan(QT_MAJOR_VERSION, 5): error("requires Qt 5")
+lessThan(QT_MAJOR_VERSION, 5): error("requires Qt 5.6; found $$[QT_VERSION]")
 
-equals(QT_MAJOR_VERSION, 5): lessThan(QT_MINOR_VERSION, 6): error("requires Qt 5.6")
+equals(QT_MAJOR_VERSION, 5): lessThan(QT_MINOR_VERSION, 6): error("requires Qt 5.6; found $$[QT_VERSION]")
 
 TARGET = qrenderdoc
 TEMPLATE = app


### PR DESCRIPTION
Turns out I did have a chance to do a little more.

From #768:

> > However, I'm not thrilled about the prospect of parsing the filter string to further improve that behaviour. I'd like to call that out of scope for this change.

> I was thinking that since we already have our own getSaveFileName we can just change the interface. Instead of taking a single opaque concatenated filter string, we could take a list of string-pairs, one with the description and one with the extension. Then getSaveFileName can build up the filter strings and it doesn't need to do any string parsing to identify which filter is which, and get the extension from the filter.

Actually, parsing wasn't so bad. I just go through each filter, regex match the first `*.` and take the following word. If you specify a bunch of file extensions within a single filter, it will just take the first one. That means that it works without changing from the original `getSaveFileName` signature. Seems easier than manually picking the default extension. You should definitely check that it works on Windows with the native dialog, though. Especially with multiple filters, like with textures.

I bundled in a few cleanup items in here, too. Added a little bit more help for picking your Qt version on Linux, made the error message more helpful for those who screw up, made All Files more Linux-friendly, and made the help menu a bit more consistently capitalized.