### PR TITLE
Set shader stage in reflection for compute shaders

### DIFF
--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -376,6 +376,7 @@ void VulkanCreationInfo::Pipeline::Init(VulkanResourceManager *resourceMan, Vulk
     if(reflData.entryPoint.empty())
     {
       reflData.entryPoint = shad.entryPoint;
+      reflData.stage = StageIndex(pCreateInfo->stage.stage);
       SPVModule &spv = info.m_ShaderModule[id].spirv;
       spv.MakeReflection(ShaderStage::Compute, reflData.entryPoint, reflData.refl, reflData.mapping,
                          reflData.patchData);


### PR DESCRIPTION
Missing this meant an incorrect stage flag would be passed to vkGetShaderInfoAMD for compute shaders when getting a disassembly.