### PR TITLE
[GL/GLES] Fix incorrect chunk type serialization

### DIFF
--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -1754,7 +1754,19 @@ enum class GLChunk : uint32_t
   Max,
 };
 
+class GLChunkPreserver
+{
+public:
+  GLChunkPreserver(GLChunk &original) : m_original(original), m_value(original) {}
+  ~GLChunkPreserver() { m_original = m_value; }
+private:
+  GLChunk &m_original;
+  GLChunk m_value;
+};
+
 // set at the point of each hooked entry point, so we know precisely which function was called
 extern GLChunk gl_CurChunk;
+
+#define PUSH_CURRENT_CHUNK GLChunkPreserver _chunk_restore(gl_CurChunk)
 
 DECLARE_REFLECTION_ENUM(GLChunk);

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1212,17 +1212,27 @@ void WrappedOpenGL::ActivateContext(GLWindowingData winData)
 
       if(IsCaptureMode(m_State))
       {
+        PUSH_CURRENT_CHUNK;
         GLuint prevArrayBuffer = 0;
         glGetIntegerv(eGL_ARRAY_BUFFER_BINDING, (GLint *)&prevArrayBuffer);
 
         // Initialize VBOs used in case we copy from client memory.
+        gl_CurChunk = GLChunk::glGenBuffers;
         glGenBuffers(ARRAY_COUNT(ctxdata.m_ClientMemoryVBOs), ctxdata.m_ClientMemoryVBOs);
+
         for(size_t i = 0; i < ARRAY_COUNT(ctxdata.m_ClientMemoryVBOs); i++)
         {
+          gl_CurChunk = GLChunk::glBindBuffer;
           glBindBuffer(eGL_ARRAY_BUFFER, ctxdata.m_ClientMemoryVBOs[i]);
+
+          gl_CurChunk = GLChunk::glBufferData;
           glBufferData(eGL_ARRAY_BUFFER, 64, NULL, eGL_DYNAMIC_DRAW);
         }
+
+        gl_CurChunk = GLChunk::glBindBuffer;
         glBindBuffer(eGL_ARRAY_BUFFER, prevArrayBuffer);
+
+        gl_CurChunk = GLChunk::glGenBuffers;
         glGenBuffers(1, &ctxdata.m_ClientMemoryIBO);
       }
     }


### PR DESCRIPTION
In some cases a few GL wrapper methods are called
with incorrect gl_CurChunk during serialization.

This can happen if the capturing application calls
a GL method - for which the gl_CurChunk will be set correctly -
and the wrapped method calls another wrapped GL method
but for that the gl_CurChunk will be incorrect.

Also during the ActivateContext call the gl_CurChunk
was not set.

For now do a hotfix for glDrawArrays and initial context.