### PR TITLE
[EGL] Rework the function pointer loading and context creation

### DIFF
--- a/renderdoc/driver/gl/CMakeLists.txt
+++ b/renderdoc/driver/gl/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
         list(APPEND sources
             gl_hooks_egl.cpp
             gl_hooks_egl_pass.cpp
+            gl_library_egl.cpp
             gl_replay_egl.cpp)
     endif()
 endif()

--- a/renderdoc/driver/gl/gl_hooks_egl.cpp
+++ b/renderdoc/driver/gl/gl_hooks_egl.cpp
@@ -103,36 +103,7 @@ public:
 
     if(real.CreateContext && real.ChooseConfig && real.CreatePbufferSurface)
     {
-      const EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_CONTEXT_FLAGS_KHR,
-                                   EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR, EGL_NONE};
-
-      const EGLint attribs[] = {EGL_RED_SIZE,
-                                8,
-                                EGL_GREEN_SIZE,
-                                8,
-                                EGL_BLUE_SIZE,
-                                8,
-                                EGL_SURFACE_TYPE,
-                                EGL_PBUFFER_BIT,
-                                EGL_RENDERABLE_TYPE,
-                                EGL_OPENGL_ES3_BIT,
-                                EGL_CONFORMANT,
-                                EGL_OPENGL_ES3_BIT,
-                                EGL_COLOR_BUFFER_TYPE,
-                                EGL_RGB_BUFFER,
-                                EGL_NONE};
-
-      EGLConfig config;
-      EGLint numConfigs;
-      EGLBoolean configFound = real.ChooseConfig(share.egl_dpy, attribs, &config, 1, &numConfigs);
-
-      if(configFound)
-      {
-        const EGLint pbAttribs[] = {EGL_WIDTH, 32, EGL_HEIGHT, 32, EGL_NONE};
-        ret.egl_wnd = real.CreatePbufferSurface(share.egl_dpy, config, pbAttribs);
-        ret.egl_dpy = share.egl_dpy;
-        ret.egl_ctx = real.CreateContext(share.egl_dpy, config, share.ctx, ctxAttribs);
-      }
+      ret = CreateWindowingData(real, share.egl_dpy, share.ctx, 0);
     }
 
     return ret;
@@ -186,7 +157,6 @@ public:
   GLWindowingData MakeOutputWindow(WindowingSystem system, void *data, bool depth,
                                    GLWindowingData share_context)
   {
-    GLWindowingData ret;
     EGLNativeWindowType window = 0;
 
     switch(system)
@@ -210,54 +180,7 @@ public:
     EGLDisplay eglDisplay = real.GetDisplay(EGL_DEFAULT_DISPLAY);
     RDCASSERT(eglDisplay);
 
-    static const EGLint configAttribs[] = {EGL_RED_SIZE,
-                                           8,
-                                           EGL_GREEN_SIZE,
-                                           8,
-                                           EGL_BLUE_SIZE,
-                                           8,
-                                           EGL_RENDERABLE_TYPE,
-                                           EGL_OPENGL_ES3_BIT,
-                                           EGL_SURFACE_TYPE,
-                                           EGL_PBUFFER_BIT | EGL_WINDOW_BIT,
-                                           EGL_NONE};
-
-    EGLint numConfigs;
-    EGLConfig config;
-    if(!real.ChooseConfig(eglDisplay, configAttribs, &config, 1, &numConfigs))
-    {
-      RDCERR("Couldn't find a suitable EGL config");
-      return ret;
-    }
-
-    static const EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_CONTEXT_FLAGS_KHR,
-                                        EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR, EGL_NONE};
-
-    EGLContext ctx = real.CreateContext(eglDisplay, config, share_context.ctx, ctxAttribs);
-
-    if(ctx == NULL)
-    {
-      RDCERR("Couldn't create GL ES context");
-      return ret;
-    }
-
-    EGLSurface surface = 0;
-
-    if(window != 0)
-    {
-      surface = real.CreateWindowSurface(eglDisplay, config, window, NULL);
-    }
-    else
-    {
-      static const EGLint pbAttribs[] = {EGL_WIDTH, 32, EGL_HEIGHT, 32, EGL_NONE};
-      surface = real.CreatePbufferSurface(eglDisplay, config, pbAttribs);
-    }
-
-    ret.egl_dpy = eglDisplay;
-    ret.egl_ctx = ctx;
-    ret.egl_wnd = surface;
-
-    return ret;
+    return CreateWindowingData(real, eglDisplay, share_context.ctx, window);
   }
 
   bool DrawQuads(float width, float height, const std::vector<Vec4f> &vertices);

--- a/renderdoc/driver/gl/gl_library_egl.cpp
+++ b/renderdoc/driver/gl/gl_library_egl.cpp
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "gl_library_egl.h"
+#include <dlfcn.h>
+
+bool EGLPointers::LoadSymbolsFrom(void *lib_handle)
+{
+  if(m_initialized)
+  {
+    RDCDEBUG("EGL function pointers already loaded, skipping");
+    return m_initialized;
+  }
+
+  bool symbols_ok = true;
+#define LOAD_SYM(SYMBOL_NAME)                                                        \
+  do                                                                                 \
+  {                                                                                  \
+    this->SYMBOL_NAME = (PFN_egl##SYMBOL_NAME)dlsym(lib_handle, "egl" #SYMBOL_NAME); \
+    if(this->SYMBOL_NAME == NULL)                                                    \
+    {                                                                                \
+      symbols_ok = false;                                                            \
+      RDCWARN("Unable to load symbol: %s", #SYMBOL_NAME);                            \
+    }                                                                                \
+  } while(0)
+
+  EGL_SYMBOLS(LOAD_SYM)
+
+#undef LOAD_SYM
+  m_initialized = symbols_ok;
+  return symbols_ok;
+}

--- a/renderdoc/driver/gl/gl_library_egl.h
+++ b/renderdoc/driver/gl/gl_library_egl.h
@@ -1,0 +1,89 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "gl_common.h"
+
+typedef EGLBoolean (*PFN_eglBindAPI)(EGLenum api);
+typedef EGLDisplay (*PFN_eglGetDisplay)(EGLNativeDisplayType display_id);
+typedef EGLContext (*PFN_eglCreateContext)(EGLDisplay dpy, EGLConfig config,
+                                           EGLContext share_context, const EGLint *attrib_list);
+typedef EGLBoolean (*PFN_eglMakeCurrent)(EGLDisplay dpy, EGLSurface draw, EGLSurface read,
+                                         EGLContext ctx);
+typedef EGLBoolean (*PFN_eglSwapBuffers)(EGLDisplay dpy, EGLSurface surface);
+typedef EGLBoolean (*PFN_eglDestroyContext)(EGLDisplay dpy, EGLContext ctx);
+typedef EGLBoolean (*PFN_eglQuerySurface)(EGLDisplay dpy, EGLSurface surface, EGLint attribute,
+                                          EGLint *value);
+typedef EGLBoolean (*PFN_eglDestroySurface)(EGLDisplay dpy, EGLSurface surface);
+typedef EGLSurface (*PFN_eglCreatePbufferSurface)(EGLDisplay dpy, EGLConfig config,
+                                                  const EGLint *attrib_list);
+typedef EGLSurface (*PFN_eglCreateWindowSurface)(EGLDisplay dpy, EGLConfig config,
+                                                 EGLNativeWindowType win, const EGLint *attrib_list);
+typedef EGLBoolean (*PFN_eglChooseConfig)(EGLDisplay dpy, const EGLint *attrib_list,
+                                          EGLConfig *configs, EGLint config_size, EGLint *num_config);
+typedef __eglMustCastToProperFunctionPointerType (*PFN_eglGetProcAddress)(const char *procname);
+typedef EGLBoolean (*PFN_eglInitialize)(EGLDisplay dpy, EGLint *major, EGLint *minor);
+typedef EGLContext (*PFN_eglGetCurrentContext)(void);
+typedef EGLDisplay (*PFN_eglGetCurrentDisplay)(void);
+typedef EGLSurface (*PFN_eglGetCurrentSurface)(EGLint readdraw);
+typedef EGLint (*PFN_eglGetError)(void);
+typedef EGLBoolean (*PFN_eglGetConfigAttrib)(EGLDisplay dpy, EGLConfig config, EGLint attribute,
+                                             EGLint *value);
+
+#define EGL_SYMBOLS(FUNC)     \
+  FUNC(BindAPI);              \
+  FUNC(ChooseConfig);         \
+  FUNC(CreateContext);        \
+  FUNC(CreatePbufferSurface); \
+  FUNC(CreateWindowSurface);  \
+  FUNC(DestroyContext);       \
+  FUNC(DestroySurface);       \
+  FUNC(GetConfigAttrib);      \
+  FUNC(GetCurrentContext);    \
+  FUNC(GetCurrentDisplay);    \
+  FUNC(GetCurrentSurface);    \
+  FUNC(GetDisplay);           \
+  FUNC(GetError);             \
+  FUNC(GetProcAddress);       \
+  FUNC(Initialize);           \
+  FUNC(MakeCurrent);          \
+  FUNC(QuerySurface);         \
+  FUNC(SwapBuffers);
+
+class EGLPointers
+{
+public:
+  EGLPointers() : m_initialized(false) {}
+  bool IsInitialized() const { return m_initialized; }
+  bool LoadSymbolsFrom(void *lib_handle);
+
+// Generate the EGL function pointers
+#define EGL_PTR_GEN(SYMBOL_NAME) PFN_egl##SYMBOL_NAME SYMBOL_NAME = NULL;
+  EGL_SYMBOLS(EGL_PTR_GEN)
+#undef EGL_PTR_GEN
+
+private:
+  bool m_initialized;
+};

--- a/renderdoc/driver/gl/gl_library_egl.h
+++ b/renderdoc/driver/gl/gl_library_egl.h
@@ -87,3 +87,6 @@ public:
 private:
   bool m_initialized;
 };
+
+GLWindowingData CreateWindowingData(const EGLPointers &egl, EGLDisplay eglDisplay,
+                                    EGLContext share_ctx, EGLNativeWindowType window);


### PR DESCRIPTION
EGL function pointers were loaded at multiple places via dlsym (in gl_hooks_egl and gl_replay_egl) however they basically did the same thing. This PR adds a common place where the function pointers are loaded and managed.

Additionally the EGL context/surface creation code parts was moved to a common place.