### PR TITLE
Fix sampler slot extraction on gather4_po_c when debugging dxbc shader

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
@@ -4049,8 +4049,12 @@ State State::GetNext(GlobalState &global, State quad[4]) const
       UINT texSlot = (UINT)op.operands[2].indices[0].index;
       UINT sampSlot = 0;
 
-      if(op.operands.size() >= 4 && !op.operands[3].indices.empty())
-        sampSlot = (UINT)op.operands[3].indices[0].index;
+      for(size_t i = 0; i < op.operands.size(); i++)
+      {
+        const ASMOperand &operand = op.operands[i];
+        if(operand.type == OperandType::TYPE_SAMPLER)
+          sampSlot = (UINT)operand.indices[0].index;
+      }
 
       if(op.operation == OPCODE_SAMPLE || op.operation == OPCODE_SAMPLE_B ||
          op.operation == OPCODE_SAMPLE_D)


### PR DESCRIPTION
gather4_po_c has 6 operands and offset of sampler should be 4 instead of 3.