### PR TITLE
Android abstract socket

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -197,7 +197,9 @@ if(ANDROID)
         os/posix/android/android_process.cpp
         os/posix/android/android_threading.cpp
         os/posix/android/android_hook.cpp
+        os/posix/android/android_network.cpp
         os/posix/posix_hook.h
+        os/posix/posix_network.h
         os/posix/posix_network.cpp
         os/posix/posix_process.cpp
         os/posix/posix_stringio.cpp
@@ -214,7 +216,9 @@ elseif(APPLE)
         os/posix/apple/apple_process.cpp
         os/posix/apple/apple_threading.cpp
         os/posix/apple/apple_hook.cpp
+        os/posix/apple/apple_network.cpp
         os/posix/posix_hook.h
+        os/posix/posix_network.h
         os/posix/posix_network.cpp
         os/posix/posix_process.cpp
         os/posix/posix_stringio.cpp
@@ -231,9 +235,11 @@ elseif(UNIX)
         os/posix/linux/linux_process.cpp
         os/posix/linux/linux_threading.cpp
         os/posix/linux/linux_hook.cpp
+        os/posix/linux/linux_network.cpp
         3rdparty/plthook/plthook.h
         3rdparty/plthook/plthook_elf.c
         os/posix/posix_hook.h
+        os/posix/posix_network.h
         os/posix/posix_network.cpp
         os/posix/posix_process.cpp
         os/posix/posix_stringio.cpp

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -3496,9 +3496,8 @@ DOCUMENT(R"(A set of flags giving details of the current status of Android traca
 
 .. data:: MissingPermissions
 
-  The application being checked does not have the requesite permission:
-
-  android.permission.INTERNET
+  The application being checked does not have the requesite permission. Currently there
+  are no required permissions.
 
 .. data:: NotDebuggable
 

--- a/renderdoc/core/android.cpp
+++ b/renderdoc/core/android.cpp
@@ -112,13 +112,13 @@ string adbGetDeviceList()
 }
 void adbForwardPorts(int index, const std::string &deviceID)
 {
+  const char *forwardCommand = "forward tcp:%i localabstract:renderdoc_%i";
   int offs = RenderDoc_AndroidPortOffset * (index + 1);
-  adbExecCommand(deviceID,
-                 StringFormat::Fmt("forward tcp:%i tcp:%i", RenderDoc_RemoteServerPort + offs,
-                                   RenderDoc_RemoteServerPort));
-  adbExecCommand(deviceID,
-                 StringFormat::Fmt("forward tcp:%i tcp:%i", RenderDoc_FirstTargetControlPort + offs,
-                                   RenderDoc_FirstTargetControlPort));
+
+  adbExecCommand(deviceID, StringFormat::Fmt(forwardCommand, RenderDoc_RemoteServerPort + offs,
+                                             RenderDoc_RemoteServerPort));
+  adbExecCommand(deviceID, StringFormat::Fmt(forwardCommand, RenderDoc_FirstTargetControlPort + offs,
+                                             RenderDoc_FirstTargetControlPort));
 }
 uint32_t StartAndroidPackageForCapture(const char *host, const char *package)
 {
@@ -430,12 +430,7 @@ bool PullAPK(const string &deviceID, const string &pkgPath, const string &apk)
 
 bool CheckPermissions(const string &dump)
 {
-  if(dump.find("android.permission.INTERNET") == string::npos)
-  {
-    RDCWARN("APK missing INTERNET permission");
-    return false;
-  }
-
+  // TODO: remove this if we are sure that there are no permissions to check.
   return true;
 }
 

--- a/renderdoc/os/posix/android/android_network.cpp
+++ b/renderdoc/os/posix/android/android_network.cpp
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include <arpa/inet.h>
+#include "os/os_specific.h"
+#include "os/posix/posix_network.h"
+
+namespace Network
+{
+uint32_t Socket::GetRemoteIP() const
+{
+  // Android uses abstract sockets which are only "localhost" accessible
+  return ntohl(MakeIP(127, 0, 0, 1));
+}
+
+Socket *CreateServerSocket(const char * /* bindaddr */, uint16_t port, int queuesize)
+{
+  return CreateAbstractServerSocket(port, queuesize);
+}
+};

--- a/renderdoc/os/posix/android/android_process.cpp
+++ b/renderdoc/os/posix/android/android_process.cpp
@@ -36,7 +36,7 @@ int GetIdentPort(pid_t childPid)
 {
   int ret = 0;
 
-  string procfile = StringFormat::Fmt("/proc/%d/net/tcp", (int)childPid);
+  string procfile = StringFormat::Fmt("/proc/%d/net/unix", (int)childPid);
 
   // try for a little while for the /proc entry to appear
   for(int retry = 0; retry < 10; retry++)
@@ -60,19 +60,34 @@ int GetIdentPort(pid_t childPid)
       line[sz - 1] = 0;
       fgets(line, sz - 1, f);
 
-      int socketnum = 0, hexip = 0, hexport = 0;
-      int num = sscanf(line, " %d: %x:%x", &socketnum, &hexip, &hexport);
+      int port = 0;
+      char *startpos = strstr(line, "@renderdoc_");
 
-      // find open listen socket on 0.0.0.0:port
-      if(num == 3 && hexip == 0 && hexport >= RenderDoc_FirstTargetControlPort &&
-         hexport <= RenderDoc_LastTargetControlPort)
+      if (startpos == NULL)
       {
-        ret = hexport;
+        // This is not the line we are looking for, continue the processing.
+        continue;
+      }
+
+      int num = sscanf(startpos, "@renderdoc_%d", &port);
+
+      // find open listen abstract socket on 'renderdoc_<port>'
+      if(num == 1 && port >= RenderDoc_FirstTargetControlPort &&
+         port <= RenderDoc_LastTargetControlPort)
+      {
+        ret = port;
         break;
       }
     }
 
     FileIO::fclose(f);
+  }
+
+  if(ret == 0)
+  {
+    RDCWARN("Couldn't locate renderdoc target control listening port between @renderdoc_%u and @renderdoc_%u in %s",
+            (uint32_t)RenderDoc_FirstTargetControlPort, (uint32_t)RenderDoc_LastTargetControlPort,
+            procfile.c_str());
   }
 
   return ret;

--- a/renderdoc/os/posix/apple/apple_network.cpp
+++ b/renderdoc/os/posix/apple/apple_network.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "os/os_specific.h"
+#include "os/posix/posix_network.h"
+
+namespace Network
+{
+uint32_t Socket::GetRemoteIP() const
+{
+  return GetIPFromTCPSocket((int)socket);
+}
+
+Socket *CreateServerSocket(const char *bindaddr, uint16_t port, int queuesize)
+{
+  return CreateTCPServerSocket(bindaddr, port, queuesize);
+}
+};

--- a/renderdoc/os/posix/linux/linux_network.cpp
+++ b/renderdoc/os/posix/linux/linux_network.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "os/os_specific.h"
+#include "os/posix/posix_network.h"
+
+namespace Network
+{
+uint32_t Socket::GetRemoteIP() const
+{
+  return GetIPFromTCPSocket((int)socket);
+}
+
+Socket *CreateServerSocket(const char *bindaddr, uint16_t port, int queuesize)
+{
+  return CreateTCPServerSocket(bindaddr, port, queuesize);
+}
+};

--- a/renderdoc/os/posix/posix_network.h
+++ b/renderdoc/os/posix/posix_network.h
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+namespace Network
+{
+uint32_t GetIPFromTCPSocket(int socket);
+Socket *CreateAbstractServerSocket(uint16_t port, int queuesize);
+Socket *CreateTCPServerSocket(const char *bindaddr, uint16_t port, int queuesize);
+}


### PR DESCRIPTION
Replace Android TCP communication with unix abstract sockets.
This makes it possible to not require INTERNET permission for
Android applications.