### PR TITLE
D3D11: Resource data serialization fix.

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_resources.cpp
+++ b/renderdoc/driver/d3d11/d3d11_resources.cpp
@@ -250,6 +250,28 @@ UINT GetMipForSubresource(ID3D11Resource *res, int Subresource)
   return mipLevel;
 }
 
+ResourcePitch GetResourcePitchForSubresource(ID3D11DeviceContext* ctx, ID3D11Resource *res, int Subresource)
+{
+  ResourcePitch pitch = {};
+  D3D11_MAPPED_SUBRESOURCE mapped = {};
+  HRESULT hr = E_INVALIDARG;
+
+  hr = ctx->Map(res, Subresource, D3D11_MAP_READ, 0, &mapped);
+
+  if(FAILED(hr))
+  {
+    RDCERR("Failed to map while getting resource pitch HRESULT: %s", ToStr(hr).c_str());
+  }
+  else
+  {
+    pitch.m_RowPitch = mapped.RowPitch;
+    pitch.m_DepthPitch = mapped.DepthPitch;
+    ctx->Unmap(res, Subresource);
+  }
+
+  return pitch;
+}
+
 UINT GetByteSize(ID3D11Texture1D *tex, int SubResource)
 {
   D3D11_TEXTURE1D_DESC desc;

--- a/renderdoc/driver/d3d11/d3d11_resources.h
+++ b/renderdoc/driver/d3d11/d3d11_resources.h
@@ -75,6 +75,14 @@ UINT GetByteSize(ID3D11Texture3D *tex, int SubResource);
 
 UINT GetMipForSubresource(ID3D11Resource *res, int Subresource);
 
+struct ResourcePitch
+{
+  UINT m_RowPitch;
+  UINT m_DepthPitch;
+};
+
+ResourcePitch GetResourcePitchForSubresource(ID3D11DeviceContext* ctx, ID3D11Resource *res, int Subresource);
+
 template <typename derived, typename base>
 bool CanQuery(base *b)
 {


### PR DESCRIPTION
During size estimation phase of serialization, the row + depth pitch were not conservative enough estimates on some drivers. To remedy this, it's determined exactly at estimation time by attempting to map the resources.