### PR TITLE
Fix segmentation faults when subpass has unused attachments

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -6117,9 +6117,11 @@ ResourceId VulkanDebugManager::RenderOverlay(ResourceId texid, DebugOverlay over
       for(size_t i = 0; i < rp.subpasses[m_pDriver->m_RenderState.subpass].colorAttachments.size();
           i++)
       {
-        blackclear.colorAttachment =
-            rp.subpasses[m_pDriver->m_RenderState.subpass].colorAttachments[i];
-        atts.push_back(blackclear);
+        if(rp.subpasses[m_pDriver->m_RenderState.subpass].colorAttachments[i] != VK_ATTACHMENT_UNUSED)
+        {
+          blackclear.colorAttachment = i;
+          atts.push_back(blackclear);
+        }
       }
 
       VkClearRect rect = {

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -2051,9 +2051,13 @@ bool WrappedVulkan::Serialise_vkCmdClearAttachments(Serialiser *localSerialiser,
         for(size_t i = 0; i < rp.subpasses[state.subpass].colorAttachments.size(); i++)
         {
           uint32_t att = rp.subpasses[state.subpass].colorAttachments[i];
-          drawNode.resourceUsage.push_back(std::make_pair(
-              m_CreationInfo.m_ImageView[fb.attachments[att].view].image,
-              EventUsage(drawNode.draw.eventID, ResourceUsage::Clear, fb.attachments[att].view)));
+
+          if(att != VK_ATTACHMENT_UNUSED)
+          {
+            drawNode.resourceUsage.push_back(std::make_pair(
+                m_CreationInfo.m_ImageView[fb.attachments[att].view].image,
+                EventUsage(drawNode.draw.eventID, ResourceUsage::Clear, fb.attachments[att].view)));
+          }
         }
 
         if(draw.flags & DrawFlags::ClearDepthStencil &&


### PR DESCRIPTION
This fixes two issues related to color attachments in subpasses.

1. ```Serialise_vkCmdClearAttachments``` uses the render pass attachment index from the subpass description without checking whether the attachment is used in the subpass.

2. ```VulkanDebugManager::RenderOverlay``` uses the wrong attachment indices for ```vkCmdClearAttachments```. The correct index is the index into the color attachment reference array of the current subpass description, *not* the index into the attachment description array of the render pass description.
Section 17.2 from the Vulkan specification says:
> ```colorAttachment``` is only meaningful if VK_IMAGE_ASPECT_COLOR_BIT is set in aspectMask, in which
> case it is an index to the pColorAttachments array in the VkSubpassDescription structure of the
> current subpass which selects the color attachment to clear.

Issue #2 occurs when trying to use the "Clear before draw/pass" overlays in case the attachment index in the render pass description differs from the attachment index in the subpass description.