### PR TITLE
Add version checking to Android workflow

### DIFF
--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -430,8 +430,9 @@ void CaptureDialog::CheckAndroidSetup(QString &filename)
 
     const bool missingLibrary = bool(m_AndroidFlags & AndroidFlags::MissingLibrary);
     const bool missingPermissions = bool(m_AndroidFlags & AndroidFlags::MissingPermissions);
+    const bool wrongLayerVersion = bool(m_AndroidFlags & AndroidFlags::WrongLayerVersion);
 
-    if(missingLibrary || missingPermissions)
+    if(missingLibrary || missingPermissions || wrongLayerVersion)
     {
       // Check failed - set the warning visible
       GUIInvoke::call([this]() {
@@ -463,6 +464,7 @@ void CaptureDialog::androidWarn_mouseClick()
 
   bool missingPermissions = bool(m_AndroidFlags & AndroidFlags::MissingPermissions);
   bool missingLibrary = bool(m_AndroidFlags & AndroidFlags::MissingLibrary);
+  bool wrongLayerVersion = bool(m_AndroidFlags & AndroidFlags::WrongLayerVersion);
   bool rootAccess = bool(m_AndroidFlags & AndroidFlags::RootAccess);
 
   if(missingPermissions)
@@ -479,6 +481,14 @@ void CaptureDialog::androidWarn_mouseClick()
         tr("<b>Missing library</b><br>"
            "The RenderDoc library must be present in the "
            "installed application.<br><br>");
+  }
+
+  if(wrongLayerVersion)
+  {
+    msg +=
+        tr("<b>Wrong layer version</b><br>"
+           "The RenderDoc library was found, but its version "
+           "does not match that of the host.<br><br>");
   }
 
   if(missingPermissions)

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -3508,6 +3508,10 @@ DOCUMENT(R"(A set of flags giving details of the current status of Android traca
 
   The application is not debuggable.
 
+.. data:: WrongLayerVersion
+
+   The found RenderDoc layer does not match the server's version.
+
 .. data:: RootAccess
 
    The device being targeted has root access.
@@ -3522,8 +3526,9 @@ enum class AndroidFlags : uint32_t
   MissingLibrary = 0x1,
   MissingPermissions = 0x2,
   NotDebuggable = 0x4,
-  RootAccess = 0x8,
-  Unfixable = 0x10,
+  WrongLayerVersion = 0x8,
+  RootAccess = 0x10,
+  Unfixable = 0x20,
 };
 
 BITMASK_OPERATORS(AndroidFlags);


### PR DESCRIPTION
Several of us have been burned by this recently, where differences in the layer cause communication issues that are difficult to debug.  This CL adds the ability to detect what version of RenderDoc the detected layer was built against.

* Tag the RenderDoc layer with a version string that matches the host, including git hash.
* Check that version when scanning the application for RenderDoc support.
* Pass the warning back to the UI to offer ways to fix.
* Update APK patching to remove existing layer.
* Update layer search order to prefer system location used for debug.