### PR TITLE
Set TextureDescription.resType in image_viewer

### DIFF
--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -450,6 +450,7 @@ void ImageViewer::RefreshFile()
   texDetails.format = rgba8_unorm;
 
   // reasonable defaults
+  texDetails.resType = TextureDim::Texture2D;
   texDetails.dimension = 2;
   texDetails.arraysize = 1;
   texDetails.width = 1;
@@ -608,11 +609,29 @@ void ImageViewer::RefreshFile()
     texDetails.depth = read_data.depth;
     texDetails.mips = read_data.mips;
     texDetails.format = read_data.format;
-    texDetails.dimension = 1;
-    if(texDetails.width > 1)
-      texDetails.dimension = 2;
     if(texDetails.depth > 1)
+    {
+      texDetails.resType = TextureDim::Texture3D;
       texDetails.dimension = 3;
+    }
+    else if(texDetails.cubemap)
+    {
+      texDetails.resType =
+          texDetails.arraysize > 1 ? TextureDim::TextureCubeArray : TextureDim::TextureCube;
+      texDetails.dimension = 2;
+    }
+    else if(texDetails.width > 1)
+    {
+      texDetails.resType =
+          texDetails.arraysize > 1 ? TextureDim::Texture2DArray : TextureDim::Texture2D;
+      texDetails.dimension = 2;
+    }
+    else
+    {
+      texDetails.resType =
+          texDetails.arraysize > 1 ? TextureDim::Texture1DArray : TextureDim::Texture1D;
+      texDetails.dimension = 1;
+    }
 
     m_FrameRecord.frameInfo.uncompressedFileSize = 0;
     for(uint32_t i = 0; i < texDetails.arraysize * texDetails.mips; i++)


### PR DESCRIPTION
This fixes image_viewer on gl_replay.  Previously, images would show up
as <Uninitialised Texture>.

I've tested .exr, .png, and a 2D .dds on opengl.  I haven't tested this on any other APIs, and I haven't tested other types of .dds images (1d, cube, 3d, arrays).  If anyone knows where I can get a set of .dds test images, let me know.  It would be easier than making them, but I haven't found anything like that yet.