### PR TITLE
LiveCapture: specify bpl when creating RGB888 thumbnail

### DIFF
--- a/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
@@ -913,8 +913,9 @@ void LiveCapture::captureAdded(uint32_t ID, const QString &executable, const QSt
   cap->name = executable;
   cap->api = api;
   cap->timestamp = timestamp;
-  cap->thumb = QImage(thumbnail.data(), thumbWidth, thumbHeight, QImage::Format_RGB888)
-                   .copy(0, 0, thumbWidth, thumbHeight);
+  cap->thumb =
+      QImage(thumbnail.data(), thumbWidth, thumbHeight, thumbWidth * 3, QImage::Format_RGB888)
+          .copy(0, 0, thumbWidth, thumbHeight);
   cap->saved = false;
   cap->path = path;
   cap->local = local;


### PR DESCRIPTION
Qt rounds up the bpl to a multiple of 4 bytes, so this was crashing for me with
odd sized thumbnails.

https://github.com/qt/qtbase/blob/160533328cae32c8647cecafad21233aa3529659/src/gui/image/qimage.cpp#L785

This seems like a safe assumption based on:

https://github.com/baldurk/renderdoc/blob/de7a74c7e542f3f543e017902d564f9c8688dd97/renderdoc/core/target_control.cpp#L624