### PR TITLE
gl: fix corruption related to ranged buffer flushes

### DIFF
--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -436,6 +436,8 @@ GLRenderState::GLRenderState(const GLHookSet *funcs) : m_Real(funcs)
     TransformFeedback[i].res.Namespace = eResBuffer;
   for(GLuint i = 0; i < (GLuint)ARRAY_COUNT(UniformBinding); i++)
     UniformBinding[i].res.Namespace = eResBuffer;
+  for(GLuint i = 0; i < (GLuint)ARRAY_COUNT(Images); i++)
+    Images[i].res.Namespace = eResTexture;
 
   ReadFBO.Namespace = DrawFBO.Namespace = eResFramebuffer;
 }


### PR DESCRIPTION
The offset argument to FlushMapped[Named]BufferRange was being treated
as relative to the start of the buffer, rather than
relative to the mapped range.

During a capture, if a buffer was mapped for write with a non-zero
offset using Map[Named]BufferRange, the offset wouldn't be taken into
account when using the shadow buffer.

****

I was getting incorrect buffer contents in a capture, and corruption on the real GL context during a captured frame, after doing offset flushes on offset mapped buffers.

http://docs.gl/gl4/glFlushMappedBufferRange
"offset and length indicate the modified subrange of the mapping, in basic machine units. The specified subrange to flush is relative to the start of the currently mapped range of the buffer."

Previously it seemed to be taking the flush range as relative to the start of the buffer.

I went through all the map/unmap/flush code line-by-line and adjusted everything that looked wrong.  It fixed the problem I was having, but I wouldn't say it's thoroughly tested, given how complex this stuff is.  I've also only tested it so far on mesa.