### PR TITLE
gl: fix corruption when initial data is prepared on multiple contexts

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -821,6 +821,8 @@ void WrappedOpenGL::DeleteContext(void *contextHandle)
 
   RenderDoc::Inst().RemoveDeviceFrameCapturer(ctxdata.ctx);
 
+  GetResourceManager()->DeleteContext(contextHandle);
+
   if(ctxdata.built && ctxdata.ready)
   {
     if(ctxdata.Program)

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1128,7 +1128,7 @@ void WrappedOpenGL::ActivateContext(GLWindowingData winData)
       auto it = std::lower_bound(m_QueuedInitialFetches.begin(), m_QueuedInitialFetches.end(), fetch);
       for(; it != m_QueuedInitialFetches.end();)
       {
-        GetResourceManager()->Prepare_InitialState(it->res, it->blob);
+        GetResourceManager()->ContextPrepare_InitialState(it->res);
         it = m_QueuedInitialFetches.erase(it);
       }
 
@@ -2808,11 +2808,10 @@ void WrappedOpenGL::FreeCaptureData()
 {
 }
 
-void WrappedOpenGL::QueuePrepareInitialState(GLResource res, byte *blob)
+void WrappedOpenGL::QueuePrepareInitialState(GLResource res)
 {
   QueuedInitialStateFetch fetch;
   fetch.res = res;
-  fetch.blob = blob;
 
   auto insertPos =
       std::lower_bound(m_QueuedInitialFetches.begin(), m_QueuedInitialFetches.end(), fetch);

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1125,12 +1125,18 @@ void WrappedOpenGL::ActivateContext(GLWindowingData winData)
       // For now we assume we'll only get GL commands from a single thread
       QueuedInitialStateFetch fetch;
       fetch.res.Context = winData.ctx;
+      size_t before = m_QueuedInitialFetches.size();
       auto it = std::lower_bound(m_QueuedInitialFetches.begin(), m_QueuedInitialFetches.end(), fetch);
-      for(; it != m_QueuedInitialFetches.end();)
+      for(; it->res.Context == winData.ctx && it != m_QueuedInitialFetches.end();)
       {
         GetResourceManager()->ContextPrepare_InitialState(it->res);
         it = m_QueuedInitialFetches.erase(it);
       }
+      size_t after = m_QueuedInitialFetches.size();
+
+      (void)before;
+      (void)after;
+      RDCDEBUG("Prepared %zu resources on context %p, %zu left", before - after, winData.ctx, after);
 
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(GLChunk::MakeContextCurrent);

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -491,14 +491,13 @@ private:
   struct QueuedInitialStateFetch
   {
     GLResource res;
-    byte *blob;
 
     bool operator<(const QueuedInitialStateFetch &o) const { return res.Context < o.res.Context; }
   };
 
   vector<QueuedInitialStateFetch> m_QueuedInitialFetches;
 
-  void QueuePrepareInitialState(GLResource res, byte *blob);
+  void QueuePrepareInitialState(GLResource res);
 
   static const int FONT_TEX_WIDTH = 256;
   static const int FONT_TEX_HEIGHT = 128;

--- a/renderdoc/driver/gl/gl_manager.h
+++ b/renderdoc/driver/gl/gl_manager.h
@@ -229,7 +229,7 @@ public:
   template <typename SerialiserType>
   bool Serialise_InitialState(SerialiserType &ser, ResourceId resid, GLResource res);
 
-  bool Prepare_InitialState(GLResource res, byte *blob);
+  void ContextPrepare_InitialState(GLResource res);
   bool Serialise_InitialState(WriteSerialiser &ser, ResourceId resid, GLResource res)
   {
     return Serialise_InitialState<WriteSerialiser>(ser, resid, res);

--- a/renderdoc/driver/gl/gl_manager.h
+++ b/renderdoc/driver/gl/gl_manager.h
@@ -92,6 +92,26 @@ public:
     ResourceManager::Shutdown();
   }
 
+  void DeleteContext(void *context)
+  {
+    size_t count = 0;
+    for(auto it = m_CurrentResourceIds.begin(); it != m_CurrentResourceIds.end(); it++)
+    {
+      if(it->first.Context == context)
+      {
+        ++count;
+        ResourceId res = it->second;
+        MarkCleanResource(res);
+        if(HasResourceRecord(res))
+          GetResourceRecord(res)->Delete(this);
+        ReleaseCurrentResource(it->second);
+        it = m_CurrentResourceIds.erase(it);
+      }
+    }
+    RDCDEBUG("Removed %zu/%zu resources belonging to context %p", count,
+             m_CurrentResourceIds.size(), context);
+  }
+
   inline void RemoveResourceRecord(ResourceId id)
   {
     for(auto it = m_GLResourceRecords.begin(); it != m_GLResourceRecords.end(); it++)


### PR DESCRIPTION
If a resource was marked dirty on multiple contexts, it could be enqueued by
Prepare_InitialState multiple times, and each successive time would delete the
buffer previously referenced in the queue.

- don't reallocate initial data if it exists
- get data pointer from resource manager instead of storing it in the queue
- early out from ContextPrepare_InitialState if valid data exists
- only prepare resources for current context in ActivateContext