### PR TITLE
image_viewer: fix corruption when viewing rgba32_float images

### DIFF
--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -441,6 +441,7 @@ void ImageViewer::RefreshFile()
   ResourceFormat rgba32_float = rgba8_unorm;
   rgba32_float.compByteWidth = 4;
   rgba32_float.compType = CompType::Float;
+  rgba32_float.srgbCorrected = false;
 
   texDetails.creationFlags = TextureCategory::SwapBuffer | TextureCategory::ColorTarget;
   texDetails.cubemap = false;


### PR DESCRIPTION
This seems to have been broken by b877f022fe44c200f8c19ae409ce69e2d148966d.