### PR TITLE
Remove VK_IMAGE_USAGE_TRANSIENT to fix preparing initial state.

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -1338,6 +1338,7 @@ bool WrappedVulkan::Serialise_vkCreateImage(SerialiserType &ser, VkDevice device
     // ensure we can always display and copy from/to textures
     CreateInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    CreateInfo.usage &= ~VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
 
     // ensure we can cast multisampled images, for copying to arrays
     if((int)CreateInfo.samples > 1)
@@ -1459,6 +1460,7 @@ VkResult WrappedVulkan::vkCreateImage(VkDevice device, const VkImageCreateInfo *
   if(IsCaptureMode(m_State))
   {
     createInfo_adjusted.usage |= VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    createInfo_adjusted.usage &= ~VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
   }
 
   if(createInfo_adjusted.samples != VK_SAMPLE_COUNT_1_BIT)


### PR DESCRIPTION
On some drivers vkCmdCopyImageToBuffer will crash if we sample from
transient images. The spec also forbids using it with USAGE_SAMPLED_BIT.