### PR TITLE
Speed up linux process connection

### DIFF
--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -44,7 +44,7 @@ int GetIdentPort(pid_t childPid)
   int waitTime = INITIAL_WAIT_TIME;
 
   // try for a little while for the /proc entry to appear
-  while(waitTime <= MAX_WAIT_TIME)
+  while(ret == 0 && waitTime <= MAX_WAIT_TIME)
   {
     // back-off for each retry
     usleep(waitTime);
@@ -75,7 +75,6 @@ int GetIdentPort(pid_t childPid)
          hexport <= RenderDoc_LastTargetControlPort)
       {
         ret = hexport;
-        break;
       }
     }
 


### PR DESCRIPTION
There's no need to wait for exponential back-off to satisfy waitTime > MAX_WAIT_TIME if we already found the result.

This makes the connection process much faster, and helps with the race condition mentioned in #857. It doesn't actually fix the underlying race, but the speedup helps lessen the problem somewhat. Before this patch, I generally couldn't capture Frames 16 and below. Now it appears the only frame I can't capture is Frame 0.