### PR TITLE
[v1.x] Resolve GL ES hooking on Linux

### DIFF
--- a/renderdoc/driver/gl/gl_hooks_egl.cpp
+++ b/renderdoc/driver/gl/gl_hooks_egl.cpp
@@ -435,7 +435,9 @@ bool EGLHook::CreateHooks(const char *libName)
     PosixHookLibrary("libGLESv2.so.2", NULL);
     PosixHookLibrary("libGLESv3.so", NULL);
 
+#if ENABLED(RDOC_ANDROID)
     return true;
+#endif
   }
 
   bool success = PopulateHooks();


### PR DESCRIPTION
After a change in the GL ES library hooking, capturing
on Linux was unable to start the target application.
This is because the hooks were not loaded correctly
(all gl/egl pointers were Null pointers), as an early
exit obstructed the initialization of the pointers.