### PR TITLE
Buffer viewer now updates contents when EID changes

### DIFF
--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -1421,6 +1421,15 @@ void BufferViewer::OnEventChanged(uint32_t eventId)
       m_ModelVSOut->primRestart = m_ModelVSIn->primRestart;
     }
   }
+  else
+  {
+    QString errors;
+    QList<FormatElement> cols = FormatElement::ParseFormatString(m_Format, 0, true, errors);
+
+    ClearModels();
+
+    m_ModelVSIn->columns = cols;
+  }
 
   EnableCameraGuessControls();
 


### PR DESCRIPTION
Previously when changing the selected event id, the contents of the current buffer the user is viewing were updated from the API side, but not updated in the UI. The user needed to close the viewer and open it again. This change makes it so the UI also updates. I tested this change on a DX11, 12 and Vulkan trace and it seems to work.

However I find that in some traces (DX12 in this case), the buffer contents change when they are not used in the draw call/dispatch. I think this may be a seperate bug.