### PR TITLE
Fix VkClearValue serialization.

### DIFF
--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -1733,7 +1733,6 @@ template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VkClearValue &el)
 {
   SERIALISE_MEMBER(color);
-  SERIALISE_MEMBER(depthStencil);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
VkClearValue is a union, but it get's serialized as a struct.
Therefore it is sufficient to serialize just the color member.