### PR TITLE
Encountered a multi-threading problem on Android OpenGL ES

### DIFF
--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -57,6 +57,11 @@ struct GLWindowingData
     wnd = NULL;
   }
 
+  bool operator==(GLWindowingData data) const
+  {
+    return DC == data.DC && ctx == data.ctx && wnd == data.wnd;
+  }
+
   void SetCtx(void *c) { ctx = (HGLRC)c; }
   HDC DC;
   HGLRC ctx;
@@ -90,6 +95,11 @@ struct GLWindowingData
     dpy = NULL;
     ctx = NULL;
     wnd = 0;
+  }
+
+  bool operator==(GLWindowingData data) const
+  {
+    return dpy == data.dpy && ctx == data.ctx && wnd == data.wnd;
   }
 
   void SetCtx(void *c) { ctx = (GLContextPtr)c; }
@@ -141,6 +151,7 @@ struct GLWindowingData
     wnd = 0;
   }
 
+  bool operator==(GLWindowingData data) const { return ctx == data.ctx && wnd == data.wnd; }
   void SetCtx(void *c) { ctx = (void *)c; }
   void *ctx;
   void *wnd;
@@ -163,6 +174,11 @@ struct GLWindowingData
     egl_ctx = 0;
     egl_dpy = 0;
     egl_wnd = 0;
+  }
+
+  bool operator==(GLWindowingData data) const
+  {
+    return egl_ctx == data.egl_ctx && egl_dpy == data.egl_dpy && egl_wnd == data.egl_wnd;
   }
 
   void SetCtx(void *c) { egl_ctx = (void *)c; }

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -132,6 +132,8 @@ private:
 
   std::vector<GLWindowingData> m_LastContexts;
 
+  GLWindowingData m_CapturingContext;
+
 public:
   enum
   {
@@ -595,6 +597,7 @@ public:
   void RegisterContext(GLWindowingData winData, void *shareContext, bool core, bool attribsCreate);
   void DeleteContext(void *contextHandle);
   void ActivateContext(GLWindowingData winData);
+  bool IsCapturingContext() const;
   void WindowSize(void *windowHandle, uint32_t w, uint32_t h);
   void SwapBuffers(void *windowHandle);
   void CreateVRAPITextureSwapChain(GLuint tex, GLenum textureType, GLenum internalformat,
@@ -2222,7 +2225,6 @@ public:
     m_GL = gl;
     m_GL->SetDebugMsgContext(buf);
   }
-
   ~ScopedDebugContext() { m_GL->SetDebugMsgContext(""); }
 private:
   WrappedOpenGL *m_GL;

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -234,7 +234,7 @@ void WrappedOpenGL::glBindBuffer(GLenum target, GLuint buffer)
 
   size_t idx = BufferIdx(target);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     Chunk *chunk = NULL;
 
@@ -665,7 +665,7 @@ void WrappedOpenGL::glNamedBufferDataEXT(GLuint buffer, GLsizeiptr size, const v
     // the frame record so we can 'update' the buffer as it goes in the frame.
     // if we haven't created the buffer at all, it could be a mid-frame create and we
     // should place it in the resource record, to happen before the frame.
-    if(IsActiveCapturing(m_State) && record->HasDataPtr())
+    if(IsActiveCapturing(m_State) && IsCapturingContext() && record->HasDataPtr())
     {
       // we could perhaps substitute this for a 'fake' glBufferSubData chunk?
       m_ContextRecord->AddChunk(chunk);
@@ -805,7 +805,7 @@ void WrappedOpenGL::glBufferData(GLenum target, GLsizeiptr size, const void *dat
     // the frame record so we can 'update' the buffer as it goes in the frame.
     // if we haven't created the buffer at all, it could be a mid-frame create and we
     // should place it in the resource record, to happen before the frame.
-    if(IsActiveCapturing(m_State) && record->HasDataPtr())
+    if(IsActiveCapturing(m_State) && IsCapturingContext() && record->HasDataPtr())
     {
       // we could perhaps substitute this for a 'fake' glBufferSubData chunk?
       m_ContextRecord->AddChunk(chunk);
@@ -872,7 +872,7 @@ void WrappedOpenGL::glNamedBufferSubDataEXT(GLuint buffer, GLintptr offset, GLsi
 
     Chunk *chunk = scope.Get();
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(chunk);
       m_MissingTracks.insert(record->GetResourceID());
@@ -925,7 +925,7 @@ void WrappedOpenGL::glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr s
 
     Chunk *chunk = scope.Get();
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(chunk);
       m_MissingTracks.insert(record->GetResourceID());
@@ -1006,7 +1006,7 @@ void WrappedOpenGL::glNamedCopyBufferSubDataEXT(GLuint readBuffer, GLuint writeB
 
     Chunk *chunk = scope.Get();
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(chunk);
       m_MissingTracks.insert(writerecord->GetResourceID());
@@ -1068,7 +1068,7 @@ void WrappedOpenGL::glCopyBufferSubData(GLenum readTarget, GLenum writeTarget, G
 
     Chunk *chunk = scope.Get();
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(chunk);
       m_MissingTracks.insert(writerecord->GetResourceID());
@@ -1128,7 +1128,7 @@ void WrappedOpenGL::glBindBufferBase(GLenum target, GLuint index, GLuint buffer)
       r = cd.m_BufferRecord[idx] =
           GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
 
-    if(buffer && IsActiveCapturing(m_State))
+    if(buffer && IsActiveCapturing(m_State) && IsCapturingContext())
     {
       FrameRefType refType = eFrameRef_Read;
 
@@ -1179,13 +1179,13 @@ void WrappedOpenGL::glBindBufferBase(GLenum target, GLuint index, GLuint buffer)
     if(r && (target == eGL_TRANSFORM_FEEDBACK_BUFFER || target == eGL_SHADER_STORAGE_BUFFER ||
              target == eGL_ATOMIC_COUNTER_BUFFER))
     {
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(r->GetResourceID());
       else
         GetResourceManager()->MarkDirtyResource(BufferRes(GetCtx(), buffer));
     }
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1238,7 +1238,7 @@ void WrappedOpenGL::glBindBufferRange(GLenum target, GLuint index, GLuint buffer
       r = cd.m_BufferRecord[idx] =
           GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
 
-    if(buffer && IsActiveCapturing(m_State))
+    if(buffer && IsActiveCapturing(m_State) && IsCapturingContext())
     {
       FrameRefType refType = eFrameRef_Read;
 
@@ -1289,13 +1289,13 @@ void WrappedOpenGL::glBindBufferRange(GLenum target, GLuint index, GLuint buffer
     if(r && (target == eGL_TRANSFORM_FEEDBACK_BUFFER || target == eGL_SHADER_STORAGE_BUFFER ||
              target == eGL_ATOMIC_COUNTER_BUFFER))
     {
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(r->GetResourceID());
       else
         GetResourceManager()->MarkDirtyResource(BufferRes(GetCtx(), buffer));
     }
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1364,7 +1364,7 @@ void WrappedOpenGL::glBindBuffersBase(GLenum target, GLuint first, GLsizei count
       r = cd.m_BufferRecord[idx] =
           GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffers[0]));
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       FrameRefType refType = eFrameRef_Read;
 
@@ -1438,7 +1438,7 @@ void WrappedOpenGL::glBindBuffersBase(GLenum target, GLuint first, GLsizei count
       }
     }
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1544,7 +1544,7 @@ void WrappedOpenGL::glBindBuffersRange(GLenum target, GLuint first, GLsizei coun
       cd.m_BufferRecord[idx] =
           GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffers[0]));
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       FrameRefType refType = eFrameRef_Read;
 
@@ -1621,7 +1621,7 @@ void WrappedOpenGL::glBindBuffersRange(GLenum target, GLuint first, GLsizei coun
       }
     }
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1982,7 +1982,7 @@ void *WrappedOpenGL::glMapNamedBufferRangeEXT(GLuint buffer, GLintptr offset, GL
         record->Map.ptr = ptr = record->GetShadowPtr(0) + offset;
         record->Map.status = GLResourceRecord::Mapped_Write;
       }
-      else if(IsActiveCapturing(m_State))
+      else if(IsActiveCapturing(m_State) && IsCapturingContext())
       {
         byte *shadow = (byte *)record->GetShadowPtr(0);
 
@@ -2276,7 +2276,7 @@ GLboolean WrappedOpenGL::glUnmapNamedBufferEXT(GLuint buffer)
     GLResourceRecord *record = GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
     auto status = record->Map.status;
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(),
@@ -2488,7 +2488,7 @@ void WrappedOpenGL::glFlushMappedNamedBufferRangeEXT(GLuint buffer, GLintptr off
     m_Real.glFlushMappedNamedBufferRangeEXT(buffer, offset, length);
   }
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     if(record)
     {
@@ -2780,7 +2780,7 @@ void WrappedOpenGL::glTransformFeedbackBufferBase(GLuint xfb, GLuint index, GLui
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glTransformFeedbackBufferBase(ser, xfb, index, buffer);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(BufferRes(GetCtx(), buffer),
@@ -2836,7 +2836,7 @@ void WrappedOpenGL::glTransformFeedbackBufferRange(GLuint xfb, GLuint index, GLu
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glTransformFeedbackBufferRange(ser, xfb, index, buffer, offset, size);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(BufferRes(GetCtx(), buffer),
@@ -2891,7 +2891,7 @@ void WrappedOpenGL::glBindTransformFeedback(GLenum target, GLuint id)
     }
   }
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -2925,7 +2925,7 @@ void WrappedOpenGL::glBeginTransformFeedback(GLenum primitiveMode)
   SERIALISE_TIME_CALL(m_Real.glBeginTransformFeedback(primitiveMode));
   m_ActiveFeedback = true;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -2950,7 +2950,7 @@ void WrappedOpenGL::glPauseTransformFeedback()
 {
   SERIALISE_TIME_CALL(m_Real.glPauseTransformFeedback());
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -2975,7 +2975,7 @@ void WrappedOpenGL::glResumeTransformFeedback()
 {
   SERIALISE_TIME_CALL(m_Real.glResumeTransformFeedback());
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -3002,7 +3002,7 @@ void WrappedOpenGL::glEndTransformFeedback()
   SERIALISE_TIME_CALL(m_Real.glEndTransformFeedback());
   m_ActiveFeedback = false;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -3098,9 +3098,9 @@ void WrappedOpenGL::glVertexArrayVertexAttribOffsetEXT(GLuint vaobj, GLuint buff
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -3131,9 +3131,9 @@ void WrappedOpenGL::glVertexAttribPointer(GLuint index, GLint size, GLenum type,
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -3224,9 +3224,9 @@ void WrappedOpenGL::glVertexArrayVertexAttribIOffsetEXT(GLuint vaobj, GLuint buf
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -3257,9 +3257,9 @@ void WrappedOpenGL::glVertexAttribIPointer(GLuint index, GLint size, GLenum type
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -3350,9 +3350,9 @@ void WrappedOpenGL::glVertexArrayVertexAttribLOffsetEXT(GLuint vaobj, GLuint buf
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -3383,9 +3383,9 @@ void WrappedOpenGL::glVertexAttribLPointer(GLuint index, GLint size, GLenum type
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -3439,7 +3439,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribBindingEXT(GLuint vaobj, GLuint att
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3467,7 +3467,7 @@ void WrappedOpenGL::glVertexAttribBinding(GLuint attribindex, GLuint bindinginde
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3528,7 +3528,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribFormatEXT(GLuint vaobj, GLuint attr
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3559,7 +3559,7 @@ void WrappedOpenGL::glVertexAttribFormat(GLuint attribindex, GLint size, GLenum 
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3617,7 +3617,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribIFormatEXT(GLuint vaobj, GLuint att
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3647,7 +3647,7 @@ void WrappedOpenGL::glVertexAttribIFormat(GLuint attribindex, GLint size, GLenum
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3704,7 +3704,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribLFormatEXT(GLuint vaobj, GLuint att
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3734,7 +3734,7 @@ void WrappedOpenGL::glVertexAttribLFormat(GLuint attribindex, GLint size, GLenum
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3798,7 +3798,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribDivisorEXT(GLuint vaobj, GLuint ind
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3826,7 +3826,7 @@ void WrappedOpenGL::glVertexAttribDivisor(GLuint index, GLuint divisor)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3882,7 +3882,7 @@ void WrappedOpenGL::glEnableVertexArrayAttribEXT(GLuint vaobj, GLuint index)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3910,7 +3910,7 @@ void WrappedOpenGL::glEnableVertexAttribArray(GLuint index)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3965,7 +3965,7 @@ void WrappedOpenGL::glDisableVertexArrayAttribEXT(GLuint vaobj, GLuint index)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -3993,7 +3993,7 @@ void WrappedOpenGL::glDisableVertexAttribArray(GLuint index)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -4162,7 +4162,7 @@ void WrappedOpenGL::glBindVertexArray(GLuint array)
     }
   }
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -4223,9 +4223,9 @@ void WrappedOpenGL::glVertexArrayElementBuffer(GLuint vaobj, GLuint buffer)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -4291,9 +4291,9 @@ void WrappedOpenGL::glVertexArrayBindVertexBufferEXT(GLuint vaobj, GLuint bindin
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -4324,9 +4324,9 @@ void WrappedOpenGL::glBindVertexBuffer(GLuint bindingindex, GLuint buffer, GLint
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
-      if(IsActiveCapturing(m_State) && bufrecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && bufrecord)
         GetResourceManager()->MarkResourceFrameReferenced(bufrecord->GetResourceID(), eFrameRef_Read);
 
       {
@@ -4434,7 +4434,7 @@ void WrappedOpenGL::glVertexArrayVertexBuffers(GLuint vaobj, GLuint first, GLsiz
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -4445,7 +4445,7 @@ void WrappedOpenGL::glVertexArrayVertexBuffers(GLuint vaobj, GLuint first, GLsiz
         r->AddChunk(scope.Get());
       }
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
       {
         for(GLsizei i = 0; i < count; i++)
         {
@@ -4478,7 +4478,7 @@ void WrappedOpenGL::glBindVertexBuffers(GLuint first, GLsizei count, const GLuin
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -4490,7 +4490,7 @@ void WrappedOpenGL::glBindVertexBuffers(GLuint first, GLsizei count, const GLuin
         r->AddChunk(scope.Get());
       }
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
       {
         for(GLsizei i = 0; i < count; i++)
         {
@@ -4547,7 +4547,7 @@ void WrappedOpenGL::glVertexArrayVertexBindingDivisorEXT(GLuint vaobj, GLuint bi
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -4575,7 +4575,7 @@ void WrappedOpenGL::glVertexBindingDivisor(GLuint bindingindex, GLuint divisor)
     {
       if(IsBackgroundCapturing(m_State) && !RecordUpdateCheck(varecord))
         return;
-      if(IsActiveCapturing(m_State) && varecord)
+      if(IsActiveCapturing(m_State) && IsCapturingContext() && varecord)
         GetResourceManager()->MarkVAOReferenced(varecord->Resource, eFrameRef_ReadBeforeWrite);
 
       {
@@ -4859,7 +4859,7 @@ bool WrappedOpenGL::Serialise_glVertexAttrib(SerialiserType &ser, GLuint index, 
   {                                                                               \
     SERIALISE_TIME_CALL(m_Real.CONCAT(glVertexAttrib, suffix)(index, ARRAYLIST)); \
                                                                                   \
-    if(IsActiveCapturing(m_State))                                                \
+    if(IsActiveCapturing(m_State) && IsCapturingContext())                        \
     {                                                                             \
       USE_SCRATCH_SERIALISER();                                                   \
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                        \
@@ -4919,7 +4919,7 @@ ATTRIB_FUNC(4, 4Nub, Attrib_N, GLubyte, GLubyte x, GLubyte y, GLubyte z, GLubyte
   {                                                                                        \
     m_Real.CONCAT(glVertexAttrib, suffix)(index, value);                                   \
                                                                                            \
-    if(IsActiveCapturing(m_State))                                                         \
+    if(IsActiveCapturing(m_State) && IsCapturingContext())                                 \
     {                                                                                      \
       USE_SCRATCH_SERIALISER();                                                            \
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                 \
@@ -4983,7 +4983,7 @@ ATTRIB_FUNC(4, 4Nusv, Attrib_N, GLushort)
   {                                                                                            \
     m_Real.CONCAT(CONCAT(glVertexAttribP, count), suffix)(index, type, normalized, value);     \
                                                                                                \
-    if(IsActiveCapturing(m_State))                                                             \
+    if(IsActiveCapturing(m_State) && IsCapturingContext())                                     \
     {                                                                                          \
       USE_SCRATCH_SERIALISER();                                                                \
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                     \

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -196,7 +196,7 @@ void WrappedOpenGL::glDebugMessageInsert(GLenum source, GLenum type, GLuint id, 
 {
   SERIALISE_TIME_CALL(m_Real.glDebugMessageInsert(source, type, id, severity, length, buf));
 
-  if(IsActiveCapturing(m_State) && type == eGL_DEBUG_TYPE_MARKER)
+  if(IsActiveCapturing(m_State) && IsCapturingContext() && type == eGL_DEBUG_TYPE_MARKER)
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -209,7 +209,7 @@ void WrappedOpenGL::glDebugMessageInsert(GLenum source, GLenum type, GLuint id, 
 
 void WrappedOpenGL::glPushGroupMarkerEXT(GLsizei length, const GLchar *marker)
 {
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -221,7 +221,7 @@ void WrappedOpenGL::glPushGroupMarkerEXT(GLsizei length, const GLchar *marker)
 
 void WrappedOpenGL::glPopGroupMarkerEXT()
 {
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -263,7 +263,7 @@ bool WrappedOpenGL::Serialise_glInsertEventMarkerEXT(SerialiserType &ser, GLsize
 
 void WrappedOpenGL::glInsertEventMarkerEXT(GLsizei length, const GLchar *marker)
 {
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -281,7 +281,7 @@ void WrappedOpenGL::glFrameTerminatorGREMEDY()
 
 void WrappedOpenGL::glStringMarkerGREMEDY(GLsizei len, const void *string)
 {
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -329,7 +329,7 @@ void WrappedOpenGL::glPushDebugGroup(GLenum source, GLuint id, GLsizei length, c
 {
   SERIALISE_TIME_CALL(m_Real.glPushDebugGroup(source, id, length, message));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -364,7 +364,7 @@ void WrappedOpenGL::glPopDebugGroup()
 {
   SERIALISE_TIME_CALL(m_Real.glPopDebugGroup());
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();

--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -124,7 +124,7 @@ void WrappedOpenGL::glDispatchCompute(GLuint num_groups_x, GLuint num_groups_y, 
 
   SERIALISE_TIME_CALL(m_Real.glDispatchCompute(num_groups_x, num_groups_y, num_groups_z));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -231,7 +231,7 @@ void WrappedOpenGL::glDispatchComputeGroupSizeARB(GLuint num_groups_x, GLuint nu
   SERIALISE_TIME_CALL(m_Real.glDispatchComputeGroupSizeARB(
       num_groups_x, num_groups_y, num_groups_z, group_size_x, group_size_y, group_size_z));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -301,7 +301,7 @@ void WrappedOpenGL::glDispatchComputeIndirect(GLintptr indirect)
 
   SERIALISE_TIME_CALL(m_Real.glDispatchComputeIndirect(indirect));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -347,7 +347,7 @@ void WrappedOpenGL::glMemoryBarrier(GLbitfield barriers)
 
   SERIALISE_TIME_CALL(m_Real.glMemoryBarrier(barriers));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -383,7 +383,7 @@ void WrappedOpenGL::glMemoryBarrierByRegion(GLbitfield barriers)
 
   SERIALISE_TIME_CALL(m_Real.glMemoryBarrierByRegion(barriers));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -410,7 +410,7 @@ void WrappedOpenGL::glTextureBarrier()
 
   SERIALISE_TIME_CALL(m_Real.glTextureBarrier());
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -466,7 +466,7 @@ void WrappedOpenGL::glDrawTransformFeedback(GLenum mode, GLuint id)
 
   SERIALISE_TIME_CALL(m_Real.glDrawTransformFeedback(mode, id));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -535,7 +535,7 @@ void WrappedOpenGL::glDrawTransformFeedbackInstanced(GLenum mode, GLuint id, GLs
 
   SERIALISE_TIME_CALL(m_Real.glDrawTransformFeedbackInstanced(mode, id, instancecount));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -603,7 +603,7 @@ void WrappedOpenGL::glDrawTransformFeedbackStream(GLenum mode, GLuint id, GLuint
 
   SERIALISE_TIME_CALL(m_Real.glDrawTransformFeedbackStream(mode, id, stream));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -676,7 +676,7 @@ void WrappedOpenGL::glDrawTransformFeedbackStreamInstanced(GLenum mode, GLuint i
 
   SERIALISE_TIME_CALL(m_Real.glDrawTransformFeedbackStreamInstanced(mode, id, stream, instancecount));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -741,7 +741,7 @@ WrappedOpenGL::ClientMemoryData *WrappedOpenGL::CopyClientMemoryArrays(GLint fir
                                                                        const void *&indices)
 {
   PUSH_CURRENT_CHUNK;
-  RDCASSERT(IsActiveCapturing(m_State));
+  RDCASSERT(IsActiveCapturing(m_State) && IsCapturingContext());
   ContextData &cd = GetCtxData();
 
   GLint idxbuf = 0;
@@ -904,7 +904,7 @@ void WrappedOpenGL::glDrawArrays(GLenum mode, GLint first, GLsizei count)
 
   SERIALISE_TIME_CALL(m_Real.glDrawArrays(mode, first, count));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     const void *indices = NULL;
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(first, count, eGL_NONE, indices);
@@ -983,7 +983,7 @@ void WrappedOpenGL::glDrawArraysIndirect(GLenum mode, const void *indirect)
 
   SERIALISE_TIME_CALL(m_Real.glDrawArraysIndirect(mode, indirect));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -1051,7 +1051,7 @@ void WrappedOpenGL::glDrawArraysInstanced(GLenum mode, GLint first, GLsizei coun
 
   SERIALISE_TIME_CALL(m_Real.glDrawArraysInstanced(mode, first, count, instancecount));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     const void *indices = NULL;
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(first, count, eGL_NONE, indices);
@@ -1128,7 +1128,7 @@ void WrappedOpenGL::glDrawArraysInstancedBaseInstance(GLenum mode, GLint first, 
   SERIALISE_TIME_CALL(
       m_Real.glDrawArraysInstancedBaseInstance(mode, first, count, instancecount, baseinstance));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     const void *indices = NULL;
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(first, count, eGL_NONE, indices);
@@ -1219,7 +1219,7 @@ void WrappedOpenGL::glDrawElements(GLenum mode, GLsizei count, GLenum type, cons
 
   SERIALISE_TIME_CALL(m_Real.glDrawElements(mode, count, type, indices));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1303,7 +1303,7 @@ void WrappedOpenGL::glDrawElementsIndirect(GLenum mode, GLenum type, const void 
 
   SERIALISE_TIME_CALL(m_Real.glDrawElementsIndirect(mode, type, indirect));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -1378,7 +1378,7 @@ void WrappedOpenGL::glDrawRangeElements(GLenum mode, GLuint start, GLuint end, G
 
   SERIALISE_TIME_CALL(m_Real.glDrawRangeElements(mode, start, end, count, type, indices));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1462,7 +1462,7 @@ void WrappedOpenGL::glDrawRangeElementsBaseVertex(GLenum mode, GLuint start, GLu
   SERIALISE_TIME_CALL(
       m_Real.glDrawRangeElementsBaseVertex(mode, start, end, count, type, indices, basevertex));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1540,7 +1540,7 @@ void WrappedOpenGL::glDrawElementsBaseVertex(GLenum mode, GLsizei count, GLenum 
 
   SERIALISE_TIME_CALL(m_Real.glDrawElementsBaseVertex(mode, count, type, indices, basevertex));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1618,7 +1618,7 @@ void WrappedOpenGL::glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum t
 
   SERIALISE_TIME_CALL(m_Real.glDrawElementsInstanced(mode, count, type, indices, instancecount));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1702,7 +1702,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseInstance(GLenum mode, GLsizei cou
   SERIALISE_TIME_CALL(m_Real.glDrawElementsInstancedBaseInstance(mode, count, type, indices,
                                                                  instancecount, baseinstance));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1787,7 +1787,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertex(GLenum mode, GLsizei count
   SERIALISE_TIME_CALL(m_Real.glDrawElementsInstancedBaseVertex(mode, count, type, indices,
                                                                instancecount, basevertex));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -1873,7 +1873,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertexBaseInstance(GLenum mode, G
   SERIALISE_TIME_CALL(m_Real.glDrawElementsInstancedBaseVertexBaseInstance(
       mode, count, type, indices, instancecount, basevertex, baseinstance));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     ClientMemoryData *clientMemory = CopyClientMemoryArrays(-1, count, type, indices);
 
@@ -2004,7 +2004,7 @@ void WrappedOpenGL::glMultiDrawArrays(GLenum mode, const GLint *first, const GLs
 
   SERIALISE_TIME_CALL(m_Real.glMultiDrawArrays(mode, first, count, drawcount));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -2154,7 +2154,7 @@ void WrappedOpenGL::glMultiDrawElements(GLenum mode, const GLsizei *count, GLenu
 
   SERIALISE_TIME_CALL(m_Real.glMultiDrawElements(mode, count, type, indices, drawcount));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -2311,7 +2311,7 @@ void WrappedOpenGL::glMultiDrawElementsBaseVertex(GLenum mode, const GLsizei *co
   SERIALISE_TIME_CALL(
       m_Real.glMultiDrawElementsBaseVertex(mode, count, type, indices, drawcount, basevertex));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -2497,7 +2497,7 @@ void WrappedOpenGL::glMultiDrawArraysIndirect(GLenum mode, const void *indirect,
 
   SERIALISE_TIME_CALL(m_Real.glMultiDrawArraysIndirect(mode, indirect, drawcount, stride));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -2695,7 +2695,7 @@ void WrappedOpenGL::glMultiDrawElementsIndirect(GLenum mode, GLenum type, const 
 
   SERIALISE_TIME_CALL(m_Real.glMultiDrawElementsIndirect(mode, type, indirect, drawcount, stride));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -2893,7 +2893,7 @@ void WrappedOpenGL::glMultiDrawArraysIndirectCountARB(GLenum mode, const void *i
   SERIALISE_TIME_CALL(
       m_Real.glMultiDrawArraysIndirectCountARB(mode, indirect, drawcount, maxdrawcount, stride));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3101,7 +3101,7 @@ void WrappedOpenGL::glMultiDrawElementsIndirectCountARB(GLenum mode, GLenum type
   SERIALISE_TIME_CALL(m_Real.glMultiDrawElementsIndirectCountARB(mode, type, indirect, drawcount,
                                                                  maxdrawcount, stride));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3206,7 +3206,7 @@ void WrappedOpenGL::glClearNamedFramebufferfv(GLuint framebuffer, GLenum buffer,
 
   SERIALISE_TIME_CALL(m_Real.glClearNamedFramebufferfv(framebuffer, buffer, drawbuffer, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3233,7 +3233,7 @@ void WrappedOpenGL::glClearBufferfv(GLenum buffer, GLint drawbuffer, const GLflo
 
   SERIALISE_TIME_CALL(m_Real.glClearBufferfv(buffer, drawbuffer, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLuint framebuffer = 0;
     if(GetCtxData().m_DrawFramebufferRecord)
@@ -3332,7 +3332,7 @@ void WrappedOpenGL::glClearNamedFramebufferiv(GLuint framebuffer, GLenum buffer,
 
   SERIALISE_TIME_CALL(m_Real.glClearNamedFramebufferiv(framebuffer, buffer, drawbuffer, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3350,7 +3350,7 @@ void WrappedOpenGL::glClearBufferiv(GLenum buffer, GLint drawbuffer, const GLint
 
   SERIALISE_TIME_CALL(m_Real.glClearBufferiv(buffer, drawbuffer, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLuint framebuffer = 0;
     if(GetCtxData().m_DrawFramebufferRecord)
@@ -3437,7 +3437,7 @@ void WrappedOpenGL::glClearNamedFramebufferuiv(GLuint framebuffer, GLenum buffer
 
   SERIALISE_TIME_CALL(m_Real.glClearNamedFramebufferuiv(framebuffer, buffer, drawbuffer, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3455,7 +3455,7 @@ void WrappedOpenGL::glClearBufferuiv(GLenum buffer, GLint drawbuffer, const GLui
 
   SERIALISE_TIME_CALL(m_Real.glClearBufferuiv(buffer, drawbuffer, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLuint framebuffer = 0;
     if(GetCtxData().m_DrawFramebufferRecord)
@@ -3561,7 +3561,7 @@ void WrappedOpenGL::glClearNamedFramebufferfi(GLuint framebuffer, GLenum buffer,
   SERIALISE_TIME_CALL(
       m_Real.glClearNamedFramebufferfi(framebuffer, buffer, drawbuffer, depth, stencil));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3579,7 +3579,7 @@ void WrappedOpenGL::glClearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat dep
 
   SERIALISE_TIME_CALL(m_Real.glClearBufferfi(buffer, drawbuffer, depth, stencil));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLuint framebuffer = 0;
     if(GetCtxData().m_DrawFramebufferRecord)
@@ -3684,7 +3684,7 @@ void WrappedOpenGL::glClearNamedBufferDataEXT(GLuint buffer, GLenum internalform
 
   SERIALISE_TIME_CALL(m_Real.glClearNamedBufferDataEXT(buffer, internalformat, format, type, data));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3715,7 +3715,7 @@ void WrappedOpenGL::glClearBufferData(GLenum target, GLenum internalformat, GLen
 
     if(record)
     {
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
       {
         USE_SCRATCH_SERIALISER();
 
@@ -3828,7 +3828,7 @@ void WrappedOpenGL::glClearNamedBufferSubDataEXT(GLuint buffer, GLenum internalf
   SERIALISE_TIME_CALL(m_Real.glClearNamedBufferSubDataEXT(buffer, internalformat, offset, size,
                                                           format, type, data));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -3870,7 +3870,7 @@ void WrappedOpenGL::glClearBufferSubData(GLenum target, GLenum internalformat, G
 
     if(record)
     {
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
       {
         USE_SCRATCH_SERIALISER();
 
@@ -4029,7 +4029,7 @@ void WrappedOpenGL::glClear(GLbitfield mask)
 
   SERIALISE_TIME_CALL(m_Real.glClear(mask));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -4128,7 +4128,7 @@ void WrappedOpenGL::glClearTexImage(GLuint texture, GLint level, GLenum format, 
 
   SERIALISE_TIME_CALL(m_Real.glClearTexImage(texture, level, format, type, data));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 
@@ -4244,7 +4244,7 @@ void WrappedOpenGL::glClearTexSubImage(GLuint texture, GLint level, GLint xoffse
   SERIALISE_TIME_CALL(m_Real.glClearTexSubImage(texture, level, xoffset, yoffset, zoffset, width,
                                                 height, depth, format, type, data));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
 

--- a/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
@@ -1406,7 +1406,7 @@ void WrappedOpenGL::glFramebufferReadBufferEXT(GLuint framebuffer, GLenum buf)
 {
   SERIALISE_TIME_CALL(m_Real.glFramebufferReadBufferEXT(framebuffer, buf));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1435,7 +1435,7 @@ void WrappedOpenGL::glReadBuffer(GLenum mode)
   if(IsCaptureMode(m_State))
   {
     GLResourceRecord *readrecord = GetCtxData().m_ReadFramebufferRecord;
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1477,7 +1477,7 @@ void WrappedOpenGL::glBindFramebuffer(GLenum target, GLuint framebuffer)
 
   SERIALISE_TIME_CALL(m_Real.glBindFramebuffer(target, framebuffer));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1530,7 +1530,7 @@ void WrappedOpenGL::glFramebufferDrawBufferEXT(GLuint framebuffer, GLenum buf)
 {
   SERIALISE_TIME_CALL(m_Real.glFramebufferDrawBufferEXT(framebuffer, buf));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1559,7 +1559,7 @@ void WrappedOpenGL::glDrawBuffer(GLenum buf)
   if(IsCaptureMode(m_State))
   {
     GLResourceRecord *drawrecord = GetCtxData().m_DrawFramebufferRecord;
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1611,7 +1611,7 @@ void WrappedOpenGL::glFramebufferDrawBuffersEXT(GLuint framebuffer, GLsizei n, c
 {
   SERIALISE_TIME_CALL(m_Real.glFramebufferDrawBuffersEXT(framebuffer, n, bufs));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1640,7 +1640,7 @@ void WrappedOpenGL::glDrawBuffers(GLsizei n, const GLenum *bufs)
   if(IsCaptureMode(m_State))
   {
     GLResourceRecord *drawrecord = GetCtxData().m_DrawFramebufferRecord;
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       USE_SCRATCH_SERIALISER();
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1930,7 +1930,7 @@ void WrappedOpenGL::glBlitNamedFramebuffer(GLuint readFramebuffer, GLuint drawFr
                                                     srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask,
                                                     filter));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -1955,7 +1955,7 @@ void WrappedOpenGL::glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLi
   SERIALISE_TIME_CALL(m_Real.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1,
                                                dstY1, mask, filter));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLuint readFramebuffer = 0, drawFramebuffer = 0;
 

--- a/renderdoc/driver/gl/wrappers/gl_interop_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_interop_funcs.cpp
@@ -174,7 +174,7 @@ BOOL WrappedOpenGL::wglDXLockObjectsNV(HANDLE hDevice, GLint count, HANDLE *hObj
   BOOL ret;
   SERIALISE_TIME_CALL(ret = m_Real.wglDXLockObjectsNV(hDevice, count, unwrapped));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     for(GLint i = 0; i < count; i++)
     {

--- a/renderdoc/driver/gl/wrappers/gl_query_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_query_funcs.cpp
@@ -98,7 +98,7 @@ GLsync WrappedOpenGL::glFenceSync(GLenum condition, GLbitfield flags)
   GetResourceManager()->RegisterSync(GetCtx(), sync, name, id);
   GLResource res = SyncRes(GetCtx(), name);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     Chunk *chunk = NULL;
 
@@ -144,7 +144,7 @@ GLenum WrappedOpenGL::glClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 t
   GLenum ret;
   SERIALISE_TIME_CALL(ret = m_Real.glClientWaitSync(sync, flags, timeout));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -179,7 +179,7 @@ void WrappedOpenGL::glWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
 {
   SERIALISE_TIME_CALL(m_Real.glWaitSync(sync, flags, timeout));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -345,7 +345,7 @@ void WrappedOpenGL::glBeginQuery(GLenum target, GLuint id)
     RDCLOG("Query already active %s", ToStr(target).c_str());
   m_ActiveQueries[QueryIdx(target)][0] = true;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -380,7 +380,7 @@ void WrappedOpenGL::glBeginQueryIndexed(GLenum target, GLuint index, GLuint id)
   SERIALISE_TIME_CALL(m_Real.glBeginQueryIndexed(target, index, id));
   m_ActiveQueries[QueryIdx(target)][index] = true;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -416,7 +416,7 @@ void WrappedOpenGL::glEndQuery(GLenum target)
   SERIALISE_TIME_CALL(m_Real.glEndQuery(target));
   m_ActiveQueries[QueryIdx(target)][0] = false;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -448,7 +448,7 @@ void WrappedOpenGL::glEndQueryIndexed(GLenum target, GLuint index)
   SERIALISE_TIME_CALL(m_Real.glEndQueryIndexed(target, index));
   m_ActiveQueries[QueryIdx(target)][index] = false;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -481,7 +481,7 @@ void WrappedOpenGL::glBeginConditionalRender(GLuint id, GLenum mode)
 
   m_ActiveConditional = true;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -509,7 +509,7 @@ void WrappedOpenGL::glEndConditionalRender()
   SERIALISE_TIME_CALL(m_Real.glEndConditionalRender());
   m_ActiveConditional = false;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -537,7 +537,7 @@ void WrappedOpenGL::glQueryCounter(GLuint query, GLenum target)
 {
   SERIALISE_TIME_CALL(m_Real.glQueryCounter(query, target));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);

--- a/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
@@ -168,7 +168,7 @@ void WrappedOpenGL::glBindSampler(GLuint unit, GLuint sampler)
 {
   SERIALISE_TIME_CALL(m_Real.glBindSampler(unit, sampler));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -216,7 +216,7 @@ void WrappedOpenGL::glBindSamplers(GLuint first, GLsizei count, const GLuint *sa
 {
   SERIALISE_TIME_CALL(m_Real.glBindSamplers(first, count, samplers));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);

--- a/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
@@ -991,7 +991,7 @@ void WrappedOpenGL::glUniformSubroutinesuiv(GLenum shadertype, GLsizei count, co
 {
   SERIALISE_TIME_CALL(m_Real.glUniformSubroutinesuiv(shadertype, count, indices));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1157,7 +1157,7 @@ void WrappedOpenGL::glUseProgram(GLuint program)
 
   GetCtxData().m_Program = program;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1298,7 +1298,7 @@ void WrappedOpenGL::glUseProgramStages(GLuint pipeline, GLbitfield stages, GLuin
 
     Chunk *chunk = scope.Get();
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(chunk);
     }
@@ -1497,7 +1497,7 @@ void WrappedOpenGL::glBindProgramPipeline(GLuint pipeline)
 
   GetCtxData().m_ProgramPipeline = pipeline;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);

--- a/renderdoc/driver/gl/wrappers/gl_state_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_state_funcs.cpp
@@ -47,7 +47,7 @@ void WrappedOpenGL::glBlendFunc(GLenum sfactor, GLenum dfactor)
 {
   SERIALISE_TIME_CALL(m_Real.glBlendFunc(sfactor, dfactor));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -78,7 +78,7 @@ void WrappedOpenGL::glBlendFunci(GLuint buf, GLenum src, GLenum dst)
 {
   SERIALISE_TIME_CALL(m_Real.glBlendFunci(buf, src, dst));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -111,7 +111,7 @@ void WrappedOpenGL::glBlendColor(GLfloat red, GLfloat green, GLfloat blue, GLflo
 {
   SERIALISE_TIME_CALL(m_Real.glBlendColor(red, green, blue, alpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -146,7 +146,7 @@ void WrappedOpenGL::glBlendFuncSeparate(GLenum sfactorRGB, GLenum dfactorRGB, GL
 {
   SERIALISE_TIME_CALL(m_Real.glBlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -183,7 +183,7 @@ void WrappedOpenGL::glBlendFuncSeparatei(GLuint buf, GLenum sfactorRGB, GLenum d
   SERIALISE_TIME_CALL(
       m_Real.glBlendFuncSeparatei(buf, sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -212,7 +212,7 @@ void WrappedOpenGL::glBlendEquation(GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glBlendEquation(mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -242,7 +242,7 @@ void WrappedOpenGL::glBlendEquationi(GLuint buf, GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glBlendEquationi(buf, mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -273,7 +273,7 @@ void WrappedOpenGL::glBlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
 {
   SERIALISE_TIME_CALL(m_Real.glBlendEquationSeparate(modeRGB, modeAlpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -305,7 +305,7 @@ void WrappedOpenGL::glBlendEquationSeparatei(GLuint buf, GLenum modeRGB, GLenum 
 {
   SERIALISE_TIME_CALL(m_Real.glBlendEquationSeparatei(buf, modeRGB, modeAlpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -335,7 +335,7 @@ void WrappedOpenGL::glBlendBarrierKHR()
 
   SERIALISE_TIME_CALL(m_Real.glBlendBarrierKHR());
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -351,7 +351,7 @@ void WrappedOpenGL::glBlendBarrier()
 
   SERIALISE_TIME_CALL(m_Real.glBlendBarrier());
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -380,7 +380,7 @@ void WrappedOpenGL::glLogicOp(GLenum opcode)
 {
   SERIALISE_TIME_CALL(m_Real.glLogicOp(opcode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -411,7 +411,7 @@ void WrappedOpenGL::glStencilFunc(GLenum func, GLint ref, GLuint mask)
 {
   SERIALISE_TIME_CALL(m_Real.glStencilFunc(func, ref, mask));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -444,7 +444,7 @@ void WrappedOpenGL::glStencilFuncSeparate(GLenum face, GLenum func, GLint ref, G
 {
   SERIALISE_TIME_CALL(m_Real.glStencilFuncSeparate(face, func, ref, mask));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -473,7 +473,7 @@ void WrappedOpenGL::glStencilMask(GLuint mask)
 {
   SERIALISE_TIME_CALL(m_Real.glStencilMask(mask));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -503,7 +503,7 @@ void WrappedOpenGL::glStencilMaskSeparate(GLenum face, GLuint mask)
 {
   SERIALISE_TIME_CALL(m_Real.glStencilMaskSeparate(face, mask));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -534,7 +534,7 @@ void WrappedOpenGL::glStencilOp(GLenum fail, GLenum zfail, GLenum zpass)
 {
   SERIALISE_TIME_CALL(m_Real.glStencilOp(fail, zfail, zpass));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -567,7 +567,7 @@ void WrappedOpenGL::glStencilOpSeparate(GLenum face, GLenum sfail, GLenum dpfail
 {
   SERIALISE_TIME_CALL(m_Real.glStencilOpSeparate(face, sfail, dpfail, dppass));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -600,7 +600,7 @@ void WrappedOpenGL::glClearColor(GLclampf red, GLclampf green, GLclampf blue, GL
 {
   SERIALISE_TIME_CALL(m_Real.glClearColor(red, green, blue, alpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -629,7 +629,7 @@ void WrappedOpenGL::glClearStencil(GLint stencil)
 {
   SERIALISE_TIME_CALL(m_Real.glClearStencil(stencil));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -661,7 +661,7 @@ void WrappedOpenGL::glClearDepth(GLdouble depth)
 {
   SERIALISE_TIME_CALL(m_Real.glClearDepth(depth));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -675,7 +675,7 @@ void WrappedOpenGL::glClearDepthf(GLfloat depth)
 {
   SERIALISE_TIME_CALL(m_Real.glClearDepthf(depth));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -704,7 +704,7 @@ void WrappedOpenGL::glDepthFunc(GLenum func)
 {
   SERIALISE_TIME_CALL(m_Real.glDepthFunc(func));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -733,7 +733,7 @@ void WrappedOpenGL::glDepthMask(GLboolean flag)
 {
   SERIALISE_TIME_CALL(m_Real.glDepthMask(flag));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -761,7 +761,7 @@ void WrappedOpenGL::glDepthRange(GLdouble nearVal, GLdouble farVal)
 {
   SERIALISE_TIME_CALL(m_Real.glDepthRange(nearVal, farVal));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -789,7 +789,7 @@ void WrappedOpenGL::glDepthRangef(GLfloat nearVal, GLfloat farVal)
 {
   SERIALISE_TIME_CALL(m_Real.glDepthRangef(nearVal, farVal));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -824,7 +824,7 @@ void WrappedOpenGL::glDepthRangeIndexed(GLuint index, GLdouble nearVal, GLdouble
 {
   SERIALISE_TIME_CALL(m_Real.glDepthRangeIndexed(index, nearVal, farVal));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -838,7 +838,7 @@ void WrappedOpenGL::glDepthRangeIndexedfOES(GLuint index, GLfloat nearVal, GLflo
 {
   SERIALISE_TIME_CALL(m_Real.glDepthRangeIndexedfOES(index, nearVal, farVal));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -883,7 +883,7 @@ void WrappedOpenGL::glDepthRangeArrayv(GLuint first, GLsizei count, const GLdoub
 {
   SERIALISE_TIME_CALL(m_Real.glDepthRangeArrayv(first, count, v));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -897,7 +897,7 @@ void WrappedOpenGL::glDepthRangeArrayfvOES(GLuint first, GLsizei count, const GL
 {
   SERIALISE_TIME_CALL(m_Real.glDepthRangeArrayfvOES(first, count, v));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLdouble *dv = new GLdouble[count * 2];
     for(GLsizei i = 0; i < count * 2; ++i)
@@ -933,7 +933,7 @@ void WrappedOpenGL::glDepthBoundsEXT(GLclampd nearVal, GLclampd farVal)
 {
   SERIALISE_TIME_CALL(m_Real.glDepthBoundsEXT(nearVal, farVal));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -963,7 +963,7 @@ void WrappedOpenGL::glClipControl(GLenum origin, GLenum depth)
 {
   SERIALISE_TIME_CALL(m_Real.glClipControl(origin, depth));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -992,7 +992,7 @@ void WrappedOpenGL::glProvokingVertex(GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glProvokingVertex(mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1021,7 +1021,7 @@ void WrappedOpenGL::glPrimitiveRestartIndex(GLuint index)
 {
   SERIALISE_TIME_CALL(m_Real.glPrimitiveRestartIndex(index));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1050,7 +1050,7 @@ void WrappedOpenGL::glDisable(GLenum cap)
 {
   SERIALISE_TIME_CALL(m_Real.glDisable(cap));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     // Skip some compatibility caps purely for the sake of avoiding debug message spam.
     // We don't explicitly support compatibility, but where it's trivial we try and support it.
@@ -1090,7 +1090,7 @@ void WrappedOpenGL::glEnable(GLenum cap)
 {
   SERIALISE_TIME_CALL(m_Real.glEnable(cap));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1120,7 +1120,7 @@ void WrappedOpenGL::glDisablei(GLenum cap, GLuint index)
 {
   SERIALISE_TIME_CALL(m_Real.glDisablei(cap, index));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1150,7 +1150,7 @@ void WrappedOpenGL::glEnablei(GLenum cap, GLuint index)
 {
   SERIALISE_TIME_CALL(m_Real.glEnablei(cap, index));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1179,7 +1179,7 @@ void WrappedOpenGL::glFrontFace(GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glFrontFace(mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1208,7 +1208,7 @@ void WrappedOpenGL::glCullFace(GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glCullFace(mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1238,7 +1238,7 @@ void WrappedOpenGL::glHint(GLenum target, GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glHint(target, mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1272,7 +1272,7 @@ void WrappedOpenGL::glColorMask(GLboolean red, GLboolean green, GLboolean blue, 
 {
   SERIALISE_TIME_CALL(m_Real.glColorMask(red, green, blue, alpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1308,7 +1308,7 @@ void WrappedOpenGL::glColorMaski(GLuint buf, GLboolean red, GLboolean green, GLb
 {
   SERIALISE_TIME_CALL(m_Real.glColorMaski(buf, red, green, blue, alpha));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1338,7 +1338,7 @@ void WrappedOpenGL::glSampleMaski(GLuint maskNumber, GLbitfield mask)
 {
   SERIALISE_TIME_CALL(m_Real.glSampleMaski(maskNumber, mask));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1368,7 +1368,7 @@ void WrappedOpenGL::glSampleCoverage(GLfloat value, GLboolean invert)
 {
   SERIALISE_TIME_CALL(m_Real.glSampleCoverage(value, invert));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1397,7 +1397,7 @@ void WrappedOpenGL::glMinSampleShading(GLfloat value)
 {
   SERIALISE_TIME_CALL(m_Real.glMinSampleShading(value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1428,7 +1428,7 @@ void WrappedOpenGL::glRasterSamplesEXT(GLuint samples, GLboolean fixedsampleloca
 {
   SERIALISE_TIME_CALL(m_Real.glRasterSamplesEXT(samples, fixedsamplelocations));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1458,7 +1458,7 @@ void WrappedOpenGL::glPatchParameteri(GLenum pname, GLint value)
 {
   SERIALISE_TIME_CALL(m_Real.glPatchParameteri(pname, value));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1489,7 +1489,7 @@ void WrappedOpenGL::glPatchParameterfv(GLenum pname, const GLfloat *values)
 {
   SERIALISE_TIME_CALL(m_Real.glPatchParameterfv(pname, values));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1518,7 +1518,7 @@ void WrappedOpenGL::glLineWidth(GLfloat width)
 {
   SERIALISE_TIME_CALL(m_Real.glLineWidth(width));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1547,7 +1547,7 @@ void WrappedOpenGL::glPointSize(GLfloat size)
 {
   SERIALISE_TIME_CALL(m_Real.glPointSize(size));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1588,7 +1588,7 @@ void WrappedOpenGL::glPointParameteri(GLenum pname, GLint param)
 {
   SERIALISE_TIME_CALL(m_Real.glPointParameteri(pname, param));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1619,7 +1619,7 @@ void WrappedOpenGL::glPointParameteriv(GLenum pname, const GLint *params)
 {
   SERIALISE_TIME_CALL(m_Real.glPointParameteriv(pname, params));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1649,7 +1649,7 @@ void WrappedOpenGL::glPointParameterf(GLenum pname, GLfloat param)
 {
   SERIALISE_TIME_CALL(m_Real.glPointParameterf(pname, param));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1680,7 +1680,7 @@ void WrappedOpenGL::glPointParameterfv(GLenum pname, const GLfloat *params)
 {
   SERIALISE_TIME_CALL(m_Real.glPointParameterfv(pname, params));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1713,7 +1713,7 @@ void WrappedOpenGL::glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
   SERIALISE_TIME_CALL(m_Real.glViewport(x, y, width, height));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1745,7 +1745,7 @@ void WrappedOpenGL::glViewportArrayv(GLuint index, GLuint count, const GLfloat *
 {
   SERIALISE_TIME_CALL(m_Real.glViewportArrayv(index, count, v));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1789,7 +1789,7 @@ void WrappedOpenGL::glScissor(GLint x, GLint y, GLsizei width, GLsizei height)
 {
   SERIALISE_TIME_CALL(m_Real.glScissor(x, y, width, height));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1821,7 +1821,7 @@ void WrappedOpenGL::glScissorArrayv(GLuint first, GLsizei count, const GLint *v)
 {
   SERIALISE_TIME_CALL(m_Real.glScissorArrayv(first, count, v));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1863,7 +1863,7 @@ void WrappedOpenGL::glPolygonMode(GLenum face, GLenum mode)
 {
   SERIALISE_TIME_CALL(m_Real.glPolygonMode(face, mode));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1893,7 +1893,7 @@ void WrappedOpenGL::glPolygonOffset(GLfloat factor, GLfloat units)
 {
   SERIALISE_TIME_CALL(m_Real.glPolygonOffset(factor, units));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1925,7 +1925,7 @@ void WrappedOpenGL::glPolygonOffsetClampEXT(GLfloat factor, GLfloat units, GLflo
 {
   SERIALISE_TIME_CALL(m_Real.glPolygonOffsetClampEXT(factor, units, clamp));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1964,7 +1964,7 @@ void WrappedOpenGL::glPrimitiveBoundingBox(GLfloat minX, GLfloat minY, GLfloat m
 {
   SERIALISE_TIME_CALL(m_Real.glPrimitiveBoundingBox(minX, minY, minZ, minW, maxX, maxY, maxZ, maxW));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -246,7 +246,7 @@ void WrappedOpenGL::glBindTexture(GLenum target, GLuint texture)
   if(texture != 0 && GetResourceManager()->GetID(TextureRes(GetCtx(), texture)) == ResourceId())
     return;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     Chunk *chunk = NULL;
 
@@ -261,7 +261,7 @@ void WrappedOpenGL::glBindTexture(GLenum target, GLuint texture)
     m_ContextRecord->AddChunk(chunk);
     GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture), eFrameRef_Read);
   }
-  else if(IsBackgroundCapturing(m_State))
+  else if(IsCaptureMode(m_State))
   {
     m_Textures[GetResourceManager()->GetID(TextureRes(GetCtx(), texture))].curType =
         TextureTarget(target);
@@ -351,7 +351,7 @@ void WrappedOpenGL::glBindTextures(GLuint first, GLsizei count, const GLuint *te
 {
   SERIALISE_TIME_CALL(m_Real.glBindTextures(first, count, textures));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -407,7 +407,7 @@ void WrappedOpenGL::glBindMultiTextureEXT(GLenum texunit, GLenum target, GLuint 
   if(texture != 0 && GetResourceManager()->GetID(TextureRes(GetCtx(), texture)) == ResourceId())
     return;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     Chunk *chunk = NULL;
 
@@ -422,7 +422,7 @@ void WrappedOpenGL::glBindMultiTextureEXT(GLenum texunit, GLenum target, GLuint 
     m_ContextRecord->AddChunk(chunk);
     GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture), eFrameRef_Read);
   }
-  else if(IsBackgroundCapturing(m_State))
+  else if(IsCaptureMode(m_State))
   {
     m_Textures[GetResourceManager()->GetID(TextureRes(GetCtx(), texture))].curType =
         TextureTarget(target);
@@ -490,7 +490,7 @@ void WrappedOpenGL::glBindTextureUnit(GLuint unit, GLuint texture)
   if(texture != 0 && GetResourceManager()->GetID(TextureRes(GetCtx(), texture)) == ResourceId())
     return;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -544,7 +544,7 @@ void WrappedOpenGL::glBindImageTexture(GLuint unit, GLuint texture, GLint level,
 {
   SERIALISE_TIME_CALL(m_Real.glBindImageTexture(unit, texture, level, layered, layer, access, format));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     Chunk *chunk = NULL;
 
@@ -606,7 +606,7 @@ void WrappedOpenGL::glBindImageTextures(GLuint first, GLsizei count, const GLuin
 {
   SERIALISE_TIME_CALL(m_Real.glBindImageTextures(first, count, textures));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -769,7 +769,7 @@ void WrappedOpenGL::Common_glGenerateTextureMipmapEXT(GLResourceRecord *record, 
 
   CoherentMapImplicitBarrier();
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     ser.SetDrawChunk();
@@ -780,7 +780,7 @@ void WrappedOpenGL::Common_glGenerateTextureMipmapEXT(GLResourceRecord *record, 
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
-  else if(IsBackgroundCapturing(m_State))
+  else if(IsCaptureMode(m_State))
   {
     GetResourceManager()->MarkDirtyResource(record->GetResourceID());
   }
@@ -923,7 +923,7 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
                                                 dstName, dstTarget, dstLevel, dstX, dstY, dstZ,
                                                 srcWidth, srcHeight, srcDepth));
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     GLResourceRecord *srcrecord =
         GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), srcName));
@@ -948,7 +948,7 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
     GetResourceManager()->MarkResourceFrameReferenced(dstrecord->GetResourceID(), eFrameRef_Read);
     GetResourceManager()->MarkResourceFrameReferenced(srcrecord->GetResourceID(), eFrameRef_Read);
   }
-  else if(IsBackgroundCapturing(m_State))
+  else if(IsCaptureMode(m_State))
   {
     GetResourceManager()->MarkDirtyResource(TextureRes(GetCtx(), dstName));
   }
@@ -999,7 +999,7 @@ void WrappedOpenGL::Common_glCopyTextureSubImage1DEXT(GLResourceRecord *record, 
   {
     GetResourceManager()->MarkDirtyResource(record->GetResourceID());
   }
-  else if(IsActiveCapturing(m_State))
+  else if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1104,7 +1104,7 @@ void WrappedOpenGL::Common_glCopyTextureSubImage2DEXT(GLResourceRecord *record, 
   {
     GetResourceManager()->MarkDirtyResource(record->GetResourceID());
   }
-  else if(IsActiveCapturing(m_State))
+  else if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1218,7 +1218,7 @@ void WrappedOpenGL::Common_glCopyTextureSubImage3DEXT(GLResourceRecord *record, 
     GetResourceManager()->MarkDirtyResource(record->GetResourceID());
     m_MissingTracks.insert(record->GetResourceID());
   }
-  else if(IsActiveCapturing(m_State))
+  else if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1342,7 +1342,7 @@ void WrappedOpenGL::Common_glTextureParameteriEXT(GLResourceRecord *record, GLen
   SCOPED_SERIALISE_CHUNK(gl_CurChunk);
   Serialise_glTextureParameteriEXT(ser, record->Resource.name, target, pname, param);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     m_ContextRecord->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -1444,7 +1444,7 @@ void WrappedOpenGL::Common_glTextureParameterivEXT(GLResourceRecord *record, GLe
   SCOPED_SERIALISE_CHUNK(gl_CurChunk);
   Serialise_glTextureParameterivEXT(ser, record->Resource.name, target, pname, params);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     m_ContextRecord->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -1549,7 +1549,7 @@ void WrappedOpenGL::Common_glTextureParameterIivEXT(GLResourceRecord *record, GL
   SCOPED_SERIALISE_CHUNK(gl_CurChunk);
   Serialise_glTextureParameterIivEXT(ser, record->Resource.name, target, pname, params);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     m_ContextRecord->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -1654,7 +1654,7 @@ void WrappedOpenGL::Common_glTextureParameterIuivEXT(GLResourceRecord *record, G
   SCOPED_SERIALISE_CHUNK(gl_CurChunk);
   Serialise_glTextureParameterIuivEXT(ser, record->Resource.name, target, pname, params);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     m_ContextRecord->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -1757,7 +1757,7 @@ void WrappedOpenGL::Common_glTextureParameterfEXT(GLResourceRecord *record, GLen
   SCOPED_SERIALISE_CHUNK(gl_CurChunk);
   Serialise_glTextureParameterfEXT(ser, record->Resource.name, target, pname, param);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     m_ContextRecord->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -1859,7 +1859,7 @@ void WrappedOpenGL::Common_glTextureParameterfvEXT(GLResourceRecord *record, GLe
   SCOPED_SERIALISE_CHUNK(gl_CurChunk);
   Serialise_glTextureParameterfvEXT(ser, record->Resource.name, target, pname, params);
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     m_ContextRecord->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -1938,7 +1938,7 @@ void WrappedOpenGL::glPixelStorei(GLenum pname, GLint param)
 
   // except for capturing frames we ignore this and embed the relevant
   // parameters in the chunks that reference them.
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
@@ -1972,7 +1972,7 @@ void WrappedOpenGL::glActiveTexture(GLenum texture)
 
   GetCtxData().m_TextureUnit = texture - eGL_TEXTURE0;
 
-  if(IsActiveCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
   {
     Chunk *chunk = NULL;
 
@@ -2130,7 +2130,7 @@ void WrappedOpenGL::Common_glTextureImage1DEXT(ResourceId texId, GLenum target, 
       // illegal to re-type textures
       record->VerifyDataType(target);
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(record->GetResourceID());
       else if(fromunpackbuf)
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
@@ -2369,7 +2369,7 @@ void WrappedOpenGL::Common_glTextureImage2DEXT(ResourceId texId, GLenum target, 
       // illegal to re-type textures
       record->VerifyDataType(target);
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(record->GetResourceID());
       else if(fromunpackbuf)
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
@@ -2592,7 +2592,7 @@ void WrappedOpenGL::Common_glTextureImage3DEXT(ResourceId texId, GLenum target, 
       // illegal to re-type textures
       record->VerifyDataType(target);
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(record->GetResourceID());
       else if(fromunpackbuf)
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
@@ -2817,7 +2817,7 @@ void WrappedOpenGL::Common_glCompressedTextureImage1DEXT(ResourceId texId, GLenu
       // illegal to re-type textures
       record->VerifyDataType(target);
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(record->GetResourceID());
       else if(fromunpackbuf)
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
@@ -3169,7 +3169,7 @@ void WrappedOpenGL::Common_glCompressedTextureImage2DEXT(ResourceId texId, GLenu
       // illegal to re-type textures
       record->VerifyDataType(target);
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(record->GetResourceID());
       else if(fromunpackbuf)
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
@@ -3408,7 +3408,7 @@ void WrappedOpenGL::Common_glCompressedTextureImage3DEXT(ResourceId texId, GLenu
       // illegal to re-type textures
       record->VerifyDataType(target);
 
-      if(IsActiveCapturing(m_State))
+      if(IsActiveCapturing(m_State) && IsCapturingContext())
         m_MissingTracks.insert(record->GetResourceID());
       else if(fromunpackbuf)
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
@@ -3560,7 +3560,18 @@ void WrappedOpenGL::Common_glCopyTextureImage1DEXT(GLResourceRecord *record, GLe
   if(IsProxyTarget(target) || internalformat == 0)
     return;
 
-  if(IsBackgroundCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
+  {
+    USE_SCRATCH_SERIALISER();
+    SCOPED_SERIALISE_CHUNK(gl_CurChunk);
+    Serialise_glCopyTextureImage1DEXT(ser, record->Resource.name, target, level, internalformat, x,
+                                      y, width, border);
+
+    m_ContextRecord->AddChunk(scope.Get());
+    m_MissingTracks.insert(record->GetResourceID());
+    GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
+  }
+  else if(IsCaptureMode(m_State))
   {
     // add a fake teximage1D chunk to create the texture properly on live (as we won't replay this
     // copy chunk).
@@ -3579,17 +3590,6 @@ void WrappedOpenGL::Common_glCopyTextureImage1DEXT(GLResourceRecord *record, GLe
 
       GetResourceManager()->MarkDirtyResource(record->GetResourceID());
     }
-  }
-  else if(IsActiveCapturing(m_State))
-  {
-    USE_SCRATCH_SERIALISER();
-    SCOPED_SERIALISE_CHUNK(gl_CurChunk);
-    Serialise_glCopyTextureImage1DEXT(ser, record->Resource.name, target, level, internalformat, x,
-                                      y, width, border);
-
-    m_ContextRecord->AddChunk(scope.Get());
-    m_MissingTracks.insert(record->GetResourceID());
-    GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
 
   if(level == 0)
@@ -3716,7 +3716,18 @@ void WrappedOpenGL::Common_glCopyTextureImage2DEXT(GLResourceRecord *record, GLe
   if(IsProxyTarget(target) || internalformat == 0)
     return;
 
-  if(IsBackgroundCapturing(m_State))
+  if(IsActiveCapturing(m_State) && IsCapturingContext())
+  {
+    USE_SCRATCH_SERIALISER();
+    SCOPED_SERIALISE_CHUNK(gl_CurChunk);
+    Serialise_glCopyTextureImage2DEXT(ser, record->Resource.name, target, level, internalformat, x,
+                                      y, width, height, border);
+
+    m_ContextRecord->AddChunk(scope.Get());
+    m_MissingTracks.insert(record->GetResourceID());
+    GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
+  }
+  else if(IsCaptureMode(m_State))
   {
     // add a fake teximage1D chunk to create the texture properly on live (as we won't replay this
     // copy chunk).
@@ -3735,17 +3746,6 @@ void WrappedOpenGL::Common_glCopyTextureImage2DEXT(GLResourceRecord *record, GLe
 
       GetResourceManager()->MarkDirtyResource(record->GetResourceID());
     }
-  }
-  else if(IsActiveCapturing(m_State))
-  {
-    USE_SCRATCH_SERIALISER();
-    SCOPED_SERIALISE_CHUNK(gl_CurChunk);
-    Serialise_glCopyTextureImage2DEXT(ser, record->Resource.name, target, level, internalformat, x,
-                                      y, width, height, border);
-
-    m_ContextRecord->AddChunk(scope.Get());
-    m_MissingTracks.insert(record->GetResourceID());
-    GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
 
   if(level == 0)
@@ -4727,7 +4727,7 @@ void WrappedOpenGL::Common_glTextureSubImage1DEXT(GLResourceRecord *record, GLen
     Serialise_glTextureSubImage1DEXT(ser, record->Resource.name, target, level, xoffset, width,
                                      format, type, pixels);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -4938,7 +4938,7 @@ void WrappedOpenGL::Common_glTextureSubImage2DEXT(GLResourceRecord *record, GLen
     Serialise_glTextureSubImage2DEXT(ser, record->Resource.name, target, level, xoffset, yoffset,
                                      width, height, format, type, pixels);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -5157,7 +5157,7 @@ void WrappedOpenGL::Common_glTextureSubImage3DEXT(GLResourceRecord *record, GLen
     Serialise_glTextureSubImage3DEXT(ser, record->Resource.name, target, level, xoffset, yoffset,
                                      zoffset, width, height, depth, format, type, pixels);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -5357,7 +5357,7 @@ void WrappedOpenGL::Common_glCompressedTextureSubImage1DEXT(GLResourceRecord *re
     Serialise_glCompressedTextureSubImage1DEXT(ser, record->Resource.name, target, level, xoffset,
                                                width, format, imageSize, pixels);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -5569,7 +5569,7 @@ void WrappedOpenGL::Common_glCompressedTextureSubImage2DEXT(GLResourceRecord *re
     Serialise_glCompressedTextureSubImage2DEXT(ser, record->Resource.name, target, level, xoffset,
                                                yoffset, width, height, format, imageSize, pixels);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -5785,7 +5785,7 @@ void WrappedOpenGL::Common_glCompressedTextureSubImage3DEXT(GLResourceRecord *re
                                                yoffset, zoffset, width, height, depth, format,
                                                imageSize, pixels);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -5959,7 +5959,7 @@ void WrappedOpenGL::Common_glTextureBufferRangeEXT(ResourceId texId, GLenum targ
     Serialise_glTextureBufferRangeEXT(ser, record->Resource.name, target, internalformat, buffer,
                                       offset, size);
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
@@ -6133,7 +6133,7 @@ void WrappedOpenGL::Common_glTextureBufferEXT(ResourceId texId, GLenum target,
 
     Chunk *chunk = scope.Get();
 
-    if(IsActiveCapturing(m_State))
+    if(IsActiveCapturing(m_State) && IsCapturingContext())
     {
       m_ContextRecord->AddChunk(chunk);
       m_MissingTracks.insert(record->GetResourceID());

--- a/renderdoc/driver/gl/wrappers/gl_uniform_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_uniform_funcs.cpp
@@ -338,7 +338,7 @@ bool WrappedOpenGL::Serialise_glProgramUniformMatrix(SerialiserType &ser, GLuint
   {                                                                                              \
     SERIALISE_TIME_CALL(m_Real.CONCAT(CONCAT(FUNCNAME, count), suffix)(FUNCARGPASS, ARRAYLIST)); \
                                                                                                  \
-    if(IsActiveCapturing(m_State))                                                               \
+    if(IsActiveCapturing(m_State) && IsCapturingContext())                                       \
     {                                                                                            \
       USE_SCRATCH_SERIALISER();                                                                  \
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                       \
@@ -442,7 +442,7 @@ UNIFORM_FUNC(4, d, GLdouble, GLdouble v0, GLdouble v1, GLdouble v2, GLdouble v3)
     SERIALISE_TIME_CALL(                                                                          \
         m_Real.CONCAT(CONCAT(FUNCNAME, unicount), CONCAT(suffix, v))(FUNCARGPASS, count, value)); \
                                                                                                   \
-    if(IsActiveCapturing(m_State))                                                                \
+    if(IsActiveCapturing(m_State) && IsCapturingContext())                                        \
     {                                                                                             \
       USE_SCRATCH_SERIALISER();                                                                   \
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                        \
@@ -524,7 +524,7 @@ UNIFORM_FUNC(4, d, GLdouble)
     SERIALISE_TIME_CALL(                                                                     \
         m_Real.CONCAT(CONCAT(FUNCNAME, dim), suffix)(FUNCARGPASS, count, transpose, value)); \
                                                                                              \
-    if(IsActiveCapturing(m_State))                                                           \
+    if(IsActiveCapturing(m_State) && IsCapturingContext())                                   \
     {                                                                                        \
       USE_SCRATCH_SERIALISER();                                                              \
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                   \


### PR DESCRIPTION
Hi! I am seeing a problem on Android where my UE4 app capture is also capturing some android system thread drawcalls as well as gearvr system thread drawcalls. UE4 submits all opengl calls in the renderthread so the problem is that eventhough the app is not doing multithreaded opengl calls, other system threads' opengl calls are making the replay not reflect what the app is actually doing.

I believe I have fixed this on our internal fork by checking for the context currently capturing so that any other opengl context will not get serialized. Do you think this is a good solution for the problem?