### PR TITLE
fixed a problem that prevents capture for UE4 android app

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -837,6 +837,14 @@ void WrappedOpenGL::DeleteContext(void *contextHandle)
     }
   }
 
+  for(auto it = ctxdata.windows.begin(); it != ctxdata.windows.end();)
+  {
+    void *wndHandle = it->first;
+    it++;
+
+    ctxdata.UnassociateWindow(wndHandle);
+  }
+
   m_ContextData.erase(contextHandle);
 }
 


### PR DESCRIPTION
Continuing from a previous pr #945, I think I have figured out the root of the problem making UE4 android apps not responding to capture.

I think what is happening is that, for some reason (possibly due to Android Activity lifecycle), the context got deleted, but is chosen as the active window. Since the context is no longer in the context list, the decay logic won't execute on the deleted context.
