### PR TITLE
Fixed the removal of the device frame capturer in vkDestroyInstance.

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -573,10 +573,9 @@ void WrappedVulkan::vkDestroyInstance(VkInstance instance, const VkAllocationCal
   // application is well behaved. If not, we just leak.
 
   ObjDisp(m_Instance)->DestroyInstance(Unwrap(m_Instance), NULL);
-  GetResourceManager()->ReleaseWrappedResource(m_Instance);
-
   RenderDoc::Inst().RemoveDeviceFrameCapturer(LayerDisp(m_Instance));
 
+  GetResourceManager()->ReleaseWrappedResource(m_Instance);
   m_Instance = VK_NULL_HANDLE;
 }
 


### PR DESCRIPTION
I've swapped the RemoveDeviceFrameCapturer and ReleaseWrappedResource calls around in WrappedVulkan::vkDestroyInstance so RemoveDeviceFrameCapturer is called first. This fixes an issue where ReleaseWrappedResource would delete m_instance's wrapping before the RemoveDeviceFrameCapturer call uses it.