### PR TITLE
Compile fixes

### DIFF
--- a/renderdoc/api/replay/basic_types.h
+++ b/renderdoc/api/replay/basic_types.h
@@ -761,7 +761,7 @@ struct rdcstr : public rdcarray<char>
     return !strcmp(elems, o);
   }
   bool operator==(const std::string &o) const { return o == elems; }
-  bool operator==(const rdcstr &o) const { return *this == (const char *const)o.elems; }
+  bool operator==(const rdcstr &o) const { return *this == (const char *)o.elems; }
   bool operator!=(const char *const o) const { return !(*this == o); }
   bool operator!=(const std::string &o) const { return !(*this == o); }
   bool operator!=(const rdcstr &o) const { return !(*this == o); }


### PR DESCRIPTION
## Description

This is a couple of 1-line changes that fix build errors on GCC 8.0 and clang 6.0.  These fixes are not sufficient to get it building on GCC 8.0 but building on clang 6.0 now works.