### PR TITLE
Fix xcode9.3 -Wunused-lambda-capture errors

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -701,7 +701,7 @@ void CaptureContext::RecompressCapture()
   // convert from the currently open cap to the destination
   float progress = 0.0f;
 
-  LambdaThread *th = new LambdaThread([this, cap, destFilename, &progress]() {
+  LambdaThread *th = new LambdaThread([cap, destFilename, &progress]() {
     cap->Convert(destFilename.toUtf8().data(), "rdc", NULL, [&progress](float p) { progress = p; });
   });
   th->start();
@@ -984,7 +984,7 @@ void CaptureContext::ExportCapture(const CaptureFileFormat &fmt, const rdcstr &e
 
   float progress = 0.0f;
 
-  LambdaThread *th = new LambdaThread([this, file, sdfile, ext, exportfile, &progress, &status]() {
+  LambdaThread *th = new LambdaThread([file, sdfile, ext, exportfile, &progress, &status]() {
     status = file->Convert(exportfile.c_str(), ext.toUtf8().data(), sdfile,
                            [&progress](float p) { progress = p; });
   });

--- a/qrenderdoc/Widgets/Extended/RDHeaderView.cpp
+++ b/qrenderdoc/Widgets/Extended/RDHeaderView.cpp
@@ -209,7 +209,7 @@ int RDHeaderView::visualIndexAt(int position) const
     search.offset = position;
     auto it = std::lower_bound(
         m_sections.begin(), m_sections.end(), search,
-        [this](const SectionData &a, const SectionData &b) { return a.offset <= b.offset; });
+        [](const SectionData &a, const SectionData &b) { return a.offset <= b.offset; });
 
     if(it != m_sections.begin())
       --it;

--- a/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
@@ -449,7 +449,7 @@ private:
       return;
 
     Renderer.ListFolder(
-        makePath(node), true, [this, node](const rdcstr &path, const rdcarray<PathEntry> &files) {
+        makePath(node), true, [node](const rdcstr &path, const rdcarray<PathEntry> &files) {
 
           if(files.count() == 1 && (files[0].flags & PathProperty::ErrorAccessDenied))
           {

--- a/qrenderdoc/Windows/ResourceInspector.cpp
+++ b/qrenderdoc/Windows/ResourceInspector.cpp
@@ -218,7 +218,7 @@ void ResourceInspector::Inspect(ResourceId id)
 
     rdcarray<ShaderEntryPoint> entries = r->GetShaderEntryPoints(id);
 
-    GUIInvoke::call([this, id, entries, usage] {
+    GUIInvoke::call([this, entries, usage] {
 
       if(!entries.isEmpty())
       {
@@ -226,22 +226,21 @@ void ResourceInspector::Inspect(ResourceId id)
         ui->viewContents->setVisible(true);
       }
 
-      CombineUsageEvents(
-          m_Ctx, usage, [this, id](uint32_t startEID, uint32_t endEID, ResourceUsage use) {
-            QString text;
+      CombineUsageEvents(m_Ctx, usage, [this](uint32_t startEID, uint32_t endEID, ResourceUsage use) {
+        QString text;
 
-            if(startEID == endEID)
-              text = QFormatStr("EID %1").arg(startEID);
-            else
-              text = QFormatStr("EID %1-%2").arg(startEID).arg(endEID);
+        if(startEID == endEID)
+          text = QFormatStr("EID %1").arg(startEID);
+        else
+          text = QFormatStr("EID %1-%2").arg(startEID).arg(endEID);
 
-            RDTreeWidgetItem *item =
-                new RDTreeWidgetItem({text, ToQStr(use, m_Ctx.APIProps().pipelineType)});
-            item->setData(0, ResourceIdRole, QVariant(endEID));
-            item->setData(1, ResourceIdRole, QVariant(endEID));
+        RDTreeWidgetItem *item =
+            new RDTreeWidgetItem({text, ToQStr(use, m_Ctx.APIProps().pipelineType)});
+        item->setData(0, ResourceIdRole, QVariant(endEID));
+        item->setData(1, ResourceIdRole, QVariant(endEID));
 
-            ui->resourceUsage->addTopLevelItem(item);
-          });
+        ui->resourceUsage->addTopLevelItem(item);
+      });
     });
   });
 
@@ -268,8 +267,9 @@ void ResourceInspector::Inspect(ResourceId id)
       derivedResources.push_back(qMakePair(derived, m_Ctx.GetResourceName(derived)));
 
     std::sort(derivedResources.begin(), derivedResources.end(),
-              [this](const QPair<ResourceId, QString> &a,
-                     const QPair<ResourceId, QString> &b) -> bool { return a.second < b.second; });
+              [](const QPair<ResourceId, QString> &a, const QPair<ResourceId, QString> &b) -> bool {
+                return a.second < b.second;
+              });
 
     for(const QPair<ResourceId, QString> &derived : derivedResources)
     {

--- a/qrenderdoc/Windows/TimelineBar.cpp
+++ b/qrenderdoc/Windows/TimelineBar.cpp
@@ -355,7 +355,7 @@ void TimelineBar::mousePressEvent(QMouseEvent *e)
     if(!m_Draws.isEmpty() && m_dataArea.contains(m_lastPos))
     {
       uint32_t eid = eventAt(x);
-      auto it = std::find_if(m_Draws.begin(), m_Draws.end(), [this, eid](uint32_t d) {
+      auto it = std::find_if(m_Draws.begin(), m_Draws.end(), [eid](uint32_t d) {
         if(d >= eid)
           return true;
 

--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -271,6 +271,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR APPLE)
         set_property(SOURCE strings/utf8printf.cpp
             APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-unknown-warning -Wno-format-truncation")
     endif()
+    # Need to add -Wno-unknown-warning-option since only newer clang versions have
+    # -Wno-unused-lambda-capture available
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND APPLE)
+		# Only clang has this warning. Fixing it in this file causes a compile error on windows
+		set_source_files_properties(os/os_specific.cpp
+			PROPERTIES COMPILE_FLAGS "-Wno-unknown-warning-option -Wno-unused-lambda-capture")
+    endif()
 endif()
 
 set(data

--- a/renderdoc/driver/gl/gl_shader_refl.cpp
+++ b/renderdoc/driver/gl/gl_shader_refl.cpp
@@ -2343,7 +2343,7 @@ void ResortBindings(ShaderReflection *refl, ShaderBindpointMapping *mapping)
 
   // apply the permutation to the mapping array, and update the bindPoint values in the shader
   // reflection to match, so that the re-order is applied
-  ApplyPermutation(permutation, [mapping, refl](size_t a, size_t b) {
+  ApplyPermutation(permutation, [mapping](size_t a, size_t b) {
     std::swap(mapping->readOnlyResources[a], mapping->readOnlyResources[b]);
   });
 
@@ -2356,7 +2356,7 @@ void ResortBindings(ShaderReflection *refl, ShaderBindpointMapping *mapping)
 
   std::sort(permutation.begin(), permutation.end(), permutation_sort());
 
-  ApplyPermutation(permutation, [mapping, refl](size_t a, size_t b) {
+  ApplyPermutation(permutation, [mapping](size_t a, size_t b) {
     std::swap(mapping->readWriteResources[a], mapping->readWriteResources[b]);
   });
 
@@ -2369,7 +2369,7 @@ void ResortBindings(ShaderReflection *refl, ShaderBindpointMapping *mapping)
 
   std::sort(permutation.begin(), permutation.end(), permutation_sort());
 
-  ApplyPermutation(permutation, [mapping, refl](size_t a, size_t b) {
+  ApplyPermutation(permutation, [mapping](size_t a, size_t b) {
     std::swap(mapping->constantBlocks[a], mapping->constantBlocks[b]);
   });
 

--- a/renderdoc/driver/shaders/spirv/CMakeLists.txt
+++ b/renderdoc/driver/shaders/spirv/CMakeLists.txt
@@ -108,6 +108,14 @@ set_source_files_properties(${glslang_sources}
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set_source_files_properties(${glslang_dir}/SPIRV/GlslangToSpv.cpp
         PROPERTIES COMPILE_FLAGS "-Wno-tautological-constant-out-of-range-compare")
+
+    if(APPLE)
+        # Need to add -Wno-unknown-warning-option since only newer clang versions have
+        # -Wno-unused-lambda-capture available
+        # Do not want modify glslang for a clang specific warning
+        set_source_files_properties(${glslang_dir}/hlsl/hlslParseHelper.cpp
+            PROPERTY COMPILE_FLAGS " -Wno-unknown-warning-option -Wno-unused-lambda-capture")
+    endif()
 endif()
 
 add_library(rdoc_spirv OBJECT ${sources})


### PR DESCRIPTION
Disable the warning on 3rdparty files
${glslang_dir}/hlsl/hlslParseHelper.cpp

Disable the warning on files where fixing it would cause a non-OSX compile error
os/os_specific.cpp

<!--
Before submitting a pull request you are strongly recommended to read the
CONTRIBUTING.md file which gives some information on how to prepare a change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
