### PR TITLE
Fixed the opengl es hooking on linux when the app dlopens the api libs

### DIFF
--- a/renderdoc/driver/gl/gl_hooks_egl.cpp
+++ b/renderdoc/driver/gl/gl_hooks_egl.cpp
@@ -428,9 +428,7 @@ bool EGLHook::CreateHooks(const char *libName)
 
     // load the libEGL.so library and when loaded call libHooked which initialises GLES capture
     PosixHookLibrary("libEGL.so", &libHooked);
-    PosixHookLibrary("libEGL.so.1", NULL);
-    PosixHookLibrary("libGL.so.1", NULL);
-    PosixHookLibrary("libGLESv1_CM.so", NULL);
+    PosixHookLibrary("libEGL.so.1", &libHooked);
     PosixHookLibrary("libGLESv2.so", NULL);
     PosixHookLibrary("libGLESv2.so.2", NULL);
     PosixHookLibrary("libGLESv3.so", NULL);
@@ -453,6 +451,10 @@ bool EGLHook::CreateHooks(const char *libName)
 bool EGLHook::PopulateHooks()
 {
   SetupHooks();
+
+  // check to see if we managed to setup our hooks
+  if(eglhooks.real.GetDisplay == NULL)
+    return false;
 
   if(m_PopulatedHooks)
     return true;

--- a/renderdoc/os/posix/linux/linux_hook.cpp
+++ b/renderdoc/os/posix/linux/linux_hook.cpp
@@ -54,9 +54,6 @@ static std::map<std::string, dlopenCallback> libraryHooks;
 
 void PosixHookLibrary(const char *name, dlopenCallback cb)
 {
-  if(cb == NULL)
-    return;
-
   SCOPED_LOCK(libLock);
   libraryHooks[name] = cb;
 }
@@ -97,7 +94,10 @@ __attribute__((visibility("default"))) void *dlopen(const char *filename, int fl
       {
         RDCDEBUG("Redirecting dlopen to ourselves for %s", filename);
 
-        it->second(ret);
+        if(it->second)
+        {
+          it->second(ret);
+        }
 
         ret = realdlopen("librenderdoc.so", flag);
       }


### PR DESCRIPTION
I've removed the callback check from linux's PosixHookLibrary so all requested libraries get hooked by RenderDoc's dlopen implementation.

I've also added a check to PopulateHooks to make sure we've got our egl hooks before attempting to populate the gl hooks as egl may not have been loaded when PopulateHooks is first called.