### PR TITLE
Fix crash when getting EGL function proc address

### DIFF
--- a/renderdoc/driver/gl/gl_hooks_egl.cpp
+++ b/renderdoc/driver/gl/gl_hooks_egl.cpp
@@ -464,6 +464,9 @@ bool EGLHook::PopulateHooks()
   if(m_PopulatedHooks)
     return true;
 
+  if(real.GetProcAddress == NULL)
+    return false;
+
   // dlsym can return GL symbols during a GLES context
   bool dlsymFirst = false;
 


### PR DESCRIPTION
Unable to load EGL functions while launching a Vulkan desktop application and it causes the local capture to crash on Linux.
