### PR TITLE
add support for VR end-of-frame markers via glDebugMessageInsert

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -200,9 +200,10 @@ ExecuteResult StartAndroidPackageForCapture(const char *host, const char *packag
   adbExecCommand(deviceID, "shell am force-stop " + packageName);
   // enable the vulkan layer (will only be used by vulkan programs)
   adbExecCommand(deviceID, "shell setprop debug.vulkan.layers " RENDERDOC_VULKAN_LAYER_NAME);
+  // if in VR mode, enable frame delimiter markers
+  adbExecCommand(deviceID, "shell setprop debug.vr.profiler 1");
   // create the data directory we will use for storing, in case the application doesn't
   adbExecCommand(deviceID, "shell mkdir -p /sdcard/Android/data/" + packageName);
-
   // set our property with the capture options encoded, to be picked up by the library on the device
   adbExecCommand(deviceID, StringFormat::Fmt("shell setprop debug.rdoc.RENDERDOC_CAPTUREOPTS %s",
                                              opts.EncodeAsString().c_str()));

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -513,6 +513,8 @@ WrappedOpenGL::WrappedOpenGL(const GLHookSet &funcs, GLPlatform &platform)
 
   m_AppControlledCapture = false;
 
+  m_UseVRMarkers = true;
+
   m_RealDebugFunc = NULL;
   m_RealDebugFuncParam = NULL;
   m_SuppressDebugMessages = false;

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -117,6 +117,8 @@ private:
 
   bool m_MarkedActive = false;
 
+  bool m_UseVRMarkers;
+
   GLReplay m_Replay;
   RDCDriver m_DriverType;
 
@@ -616,6 +618,7 @@ public:
   void CreateVRAPITextureSwapChain(GLuint tex, GLenum textureType, GLenum internalformat,
                                    GLsizei width, GLsizei height, GLint levels);
   void HandleVRFrameMarkers(const GLchar *buf, GLsizei length);
+  void DisableVRFrameMarkers();
 
   void FirstFrame(void *ctx, void *wndHandle);
 

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -615,7 +615,7 @@ public:
   void SwapBuffers(void *windowHandle);
   void CreateVRAPITextureSwapChain(GLuint tex, GLenum textureType, GLenum internalformat,
                                    GLsizei width, GLsizei height, GLint levels);
-  void HandleVRFrameMarkers(const GLchar *buf,GLsizei length);
+  void HandleVRFrameMarkers(const GLchar *buf, GLsizei length);
 
   void FirstFrame(void *ctx, void *wndHandle);
 

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -615,6 +615,7 @@ public:
   void SwapBuffers(void *windowHandle);
   void CreateVRAPITextureSwapChain(GLuint tex, GLenum textureType, GLenum internalformat,
                                    GLsizei width, GLsizei height, GLint levels);
+  void HandleVRFrameMarkers(const GLchar *buf,GLsizei length);
 
   void FirstFrame(void *ctx, void *wndHandle);
 

--- a/renderdoc/driver/gl/gl_hooks_vrapi.cpp
+++ b/renderdoc/driver/gl/gl_hooks_vrapi.cpp
@@ -31,6 +31,7 @@
 #include "official/VrApi_Types.h"
 
 //-----------------------------------------------------------------------------------------------------------------
+typedef void (*PFN_vrapi_SubmitFrame)(ovrMobile *, const ovrFrameParms *);
 typedef int (*PFN_vrapi_GetTextureSwapChainLength)(ovrTextureSwapChain *);
 typedef unsigned int (*PFN_vrapi_GetTextureSwapChainHandle)(ovrTextureSwapChain *, int);
 typedef int (*PFN_vrapi_GetSystemPropertyInt)(const ovrJava *, const ovrSystemProperty);
@@ -47,7 +48,8 @@ class VRAPIHook : LibraryHook
 {
 public:
   VRAPIHook()
-      : vrapi_GetTextureSwapChainLength_real(NULL),
+      : vrapi_SubmitFrame_real(NULL),
+        vrapi_GetTextureSwapChainLength_real(NULL),
         vrapi_GetTextureSwapChainHandle_real(NULL),
         vrapi_GetSystemPropertyInt_real(NULL),
         m_PopulatedHooks(false),
@@ -55,7 +57,7 @@ public:
   {
     LibraryHooks::GetInstance().RegisterHook("libvrapi.so", this);
 
-    m_EnabledHooks = false;
+    m_EnabledHooks = true;
   }
   ~VRAPIHook() {}
   static void libHooked(void *realLib);
@@ -73,6 +75,7 @@ public:
   //---------------------------------------------------------------------------------------------------------
   PFN_vrapi_CreateTextureSwapChain2 vrapi_CreateTextureSwapChain2_real;
   PFN_vrapi_CreateTextureSwapChain vrapi_CreateTextureSwapChain_real;
+  PFN_vrapi_SubmitFrame vrapi_SubmitFrame_real;
 
   PFN_vrapi_GetTextureSwapChainLength vrapi_GetTextureSwapChainLength_real;
   PFN_vrapi_GetTextureSwapChainHandle vrapi_GetTextureSwapChainHandle_real;
@@ -90,6 +93,9 @@ public:
     if(vrapi_CreateTextureSwapChain_real == NULL)
       vrapi_CreateTextureSwapChain_real = (PFN_vrapi_CreateTextureSwapChain)PosixGetFunction(
           libvrapi_symHandle, "vrapi_CreateTextureSwapChain");
+    if(vrapi_SubmitFrame_real == NULL)
+      vrapi_SubmitFrame_real =
+          (PFN_vrapi_SubmitFrame)PosixGetFunction(libvrapi_symHandle, "vrapi_SubmitFrame");
 
     if(vrapi_GetTextureSwapChainLength_real == NULL)
       vrapi_GetTextureSwapChainLength_real = (PFN_vrapi_GetTextureSwapChainLength)PosixGetFunction(
@@ -101,7 +107,7 @@ public:
       vrapi_GetSystemPropertyInt_real = (PFN_vrapi_GetSystemPropertyInt)PosixGetFunction(
           libvrapi_symHandle, "vrapi_GetSystemPropertyInt");
 
-    return vrapi_CreateTextureSwapChain2_real != NULL;
+    return vrapi_SubmitFrame_real != NULL;
   }
 
 } vrapi_hooks;
@@ -226,6 +232,23 @@ __attribute__((visibility("default"))) ovrTextureSwapChain *vrapi_CreateTextureS
   return texture_swapchain;
 }
 
+__attribute__((visibility("default"))) void vrapi_SubmitFrame(ovrMobile *ovr,
+                                                              const ovrFrameParms *parms)
+{
+  if(vrapi_hooks.vrapi_SubmitFrame_real == NULL || vrapi_hooks.vrapi_GetSystemPropertyInt_real == NULL)
+  {
+    vrapi_hooks.SetupHooks();
+  }
+
+  if(m_GLDriver)
+  {
+    SCOPED_LOCK(glLock);
+    m_GLDriver->DisableVRFrameMarkers();
+    m_GLDriver->SwapBuffers(ovr);
+  }
+
+  vrapi_hooks.vrapi_SubmitFrame_real(ovr, parms);
+}
 }    // extern "C"
 
 void VRAPIHook::libHooked(void *realLib)
@@ -243,6 +266,7 @@ bool VRAPIHook::CreateHooks(const char *libName)
   {
     PosixHookFunction("vrapi_CreateTextureSwapChain2", (void *)&vrapi_CreateTextureSwapChain2);
     PosixHookFunction("vrapi_CreateTextureSwapChain", (void *)&vrapi_CreateTextureSwapChain);
+    PosixHookFunction("vrapi_SubmitFrame", (void *)&vrapi_SubmitFrame);
 
     PosixHookLibrary(libName, &libHooked);
     return true;

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -191,9 +191,14 @@ bool WrappedOpenGL::Serialise_glDebugMessageInsert(SerialiserType &ser, GLenum s
   return true;
 }
 
+void WrappedOpenGL::DisableVRFrameMarkers()
+{
+  m_UseVRMarkers = false;
+}
+
 void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
 {
-  if(strstr(buf, "vr-marker,frame_end,type,application") != NULL)
+  if(m_UseVRMarkers && strstr(buf, "vr-marker,frame_end,type,application") != NULL)
   {
     void *ctx = NULL, *wnd = NULL;
     RenderDoc::Inst().GetActiveWindow(ctx, wnd);

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -193,12 +193,12 @@ bool WrappedOpenGL::Serialise_glDebugMessageInsert(SerialiserType &ser, GLenum s
 
 void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
 {
-	if (strstr(buf, "vr-marker,frame_end,type,application") != NULL)
-	{
-		void *ctx = NULL, *wnd = NULL;
-		RenderDoc::Inst().GetActiveWindow(ctx, wnd);
-		SwapBuffers(wnd);
-	}
+  if(strstr(buf, "vr-marker,frame_end,type,application") != NULL)
+  {
+    void *ctx = NULL, *wnd = NULL;
+    RenderDoc::Inst().GetActiveWindow(ctx, wnd);
+    SwapBuffers(wnd);
+  }
 }
 
 void WrappedOpenGL::glDebugMessageInsert(GLenum source, GLenum type, GLuint id, GLenum severity,

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -191,10 +191,22 @@ bool WrappedOpenGL::Serialise_glDebugMessageInsert(SerialiserType &ser, GLenum s
   return true;
 }
 
+void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
+{
+	if (strstr(buf, "vr-marker,frame_end,type,application") != NULL)
+	{
+		void *ctx = NULL, *wnd = NULL;
+		RenderDoc::Inst().GetActiveWindow(ctx, wnd);
+		SwapBuffers(wnd);
+	}
+}
+
 void WrappedOpenGL::glDebugMessageInsert(GLenum source, GLenum type, GLuint id, GLenum severity,
                                          GLsizei length, const GLchar *buf)
 {
   SERIALISE_TIME_CALL(m_Real.glDebugMessageInsert(source, type, id, severity, length, buf));
+
+  HandleVRFrameMarkers(buf, length);
 
   if(IsActiveCapturing(m_State) && type == eGL_DEBUG_TYPE_MARKER)
   {


### PR DESCRIPTION
 also removes vrapi_submitframe hooking as that's now unecessary (since handled by the markers)

## Description
on VR platforms, we don't call eglSwapBuffers as the application doesn't own the frontbuffer, we call VR API-specific end of frame calls. instead of hooking those, which would be API-specific and prone to break whenever that API changes, we look at a glDebugMessageInsert call in the VR compositor that tells us when an app frame has ended. 

(added bonus : this lets us know which context is the app context and which context is the compositor context for a further CL). 