### PR TITLE
multicontext support for GL, app-only replay for VR frame captures. 

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -802,7 +802,7 @@ GLResourceRecord *WrappedOpenGL::GetContextRecord()
   }
   else
   {
-    ContextData dat = GetCtxData();
+    ContextData &dat = GetCtxData();
     dat.CreateResourceRecord(this, GetCtx().ctx);
     return dat.m_ContextDataRecord;
   }
@@ -864,6 +864,14 @@ void WrappedOpenGL::DeleteContext(void *contextHandle)
     glDeleteBuffers(ARRAY_COUNT(ctxdata.m_ClientMemoryVBOs), ctxdata.m_ClientMemoryVBOs);
   if(ctxdata.m_ClientMemoryIBO)
     glDeleteBuffers(1, &ctxdata.m_ClientMemoryIBO);
+
+  if(ctxdata.m_ContextDataRecord)
+  {
+    RDCASSERT(ctxdata.m_ContextDataRecord->GetRefCount() == 1);
+    ctxdata.m_ContextDataRecord->Delete(GetResourceManager());
+    GetResourceManager()->ReleaseCurrentResource(ctxdata.m_ContextDataResourceID);
+    ctxdata.m_ContextDataRecord = NULL;
+  }
 
   for(auto it = m_LastContexts.begin(); it != m_LastContexts.end(); ++it)
   {

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -131,6 +131,7 @@ private:
   StreamReader *m_FrameReader = NULL;
 
   static std::map<uint64_t, GLWindowingData> m_ActiveContexts;
+  static std::map<uint64_t, ResourceId> m_ActiveContextResourceIDs;
 
   ContextPair m_EmptyPair;
   uint64_t m_CurCtxPairTLS;
@@ -139,6 +140,8 @@ private:
   uintptr_t m_ShareGroupID;
 
   std::vector<GLWindowingData> m_LastContexts;
+
+  std::set<uint64_t> m_AcceptedThreads;
 
 public:
   enum
@@ -377,7 +380,7 @@ private:
   bool HasSuccessfulCapture(CaptureFailReason &reason)
   {
     reason = m_FailureReason;
-    return m_SuccessfulCapture && m_ContextRecord->NumChunks() > 0;
+    return m_SuccessfulCapture && RecordingHasChunks();
   }
   void AttemptCapture();
   template <typename SerialiserType>
@@ -386,6 +389,7 @@ private:
   void FinishCapture();
   void ContextEndFrame();
 
+  void CleanupResourceRecord(GLResourceRecord *record);
   void CleanupCapture();
   void FreeCaptureData();
 
@@ -566,7 +570,9 @@ public:
   static std::string GetChunkName(uint32_t idx);
   GLResourceManager *GetResourceManager() { return m_ResourceManager; }
   ResourceId GetDeviceResourceID() { return m_DeviceResourceID; }
-  ResourceId GetContextResourceID() { return m_ContextResourceID; }
+  ResourceId GetContextResourceID();
+  GLResourceRecord *GetContextRecord();
+  bool RecordingHasChunks();
   CaptureState GetState() { return m_State; }
   GLReplay *GetReplay() { return &m_Replay; }
   WriteSerialiser &GetSerialiser() { return m_ScratchSerialiser; }

--- a/renderdoc/driver/gl/gl_resources.h
+++ b/renderdoc/driver/gl/gl_resources.h
@@ -321,3 +321,11 @@ private:
   byte *ShadowPtr[2];
   size_t ShadowSize;
 };
+
+struct GLContextTLSData
+{
+  GLContextTLSData() {}
+  GLContextTLSData(ContextPair p, GLResourceRecord *r) : ctxPair(p), ctxRecord(r) {}
+  ContextPair ctxPair;
+  GLResourceRecord *ctxRecord;
+};

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -268,7 +268,7 @@ void WrappedOpenGL::glBindBuffer(GLenum target, GLuint buffer)
                                                         refType);
     }
 
-    m_ContextRecord->AddChunk(chunk);
+    GetContextRecord()->AddChunk(chunk);
   }
 
   if(buffer == 0)
@@ -668,7 +668,7 @@ void WrappedOpenGL::glNamedBufferDataEXT(GLuint buffer, GLsizeiptr size, const v
     if(IsActiveCapturing(m_State) && record->HasDataPtr())
     {
       // we could perhaps substitute this for a 'fake' glBufferSubData chunk?
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Write);
     }
     else
@@ -808,7 +808,7 @@ void WrappedOpenGL::glBufferData(GLenum target, GLsizeiptr size, const void *dat
     if(IsActiveCapturing(m_State) && record->HasDataPtr())
     {
       // we could perhaps substitute this for a 'fake' glBufferSubData chunk?
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Write);
     }
     else
@@ -874,7 +874,7 @@ void WrappedOpenGL::glNamedBufferSubDataEXT(GLuint buffer, GLintptr offset, GLsi
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(),
                                                         eFrameRef_ReadBeforeWrite);
@@ -927,7 +927,7 @@ void WrappedOpenGL::glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr s
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(),
                                                         eFrameRef_ReadBeforeWrite);
@@ -1008,7 +1008,7 @@ void WrappedOpenGL::glNamedCopyBufferSubDataEXT(GLuint readBuffer, GLuint writeB
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       m_MissingTracks.insert(writerecord->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(writerecord->GetResourceID(),
                                                         eFrameRef_ReadBeforeWrite);
@@ -1070,7 +1070,7 @@ void WrappedOpenGL::glCopyBufferSubData(GLenum readTarget, GLenum writeTarget, G
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       m_MissingTracks.insert(writerecord->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(writerecord->GetResourceID(),
                                                         eFrameRef_ReadBeforeWrite);
@@ -1191,7 +1191,7 @@ void WrappedOpenGL::glBindBufferBase(GLenum target, GLuint index, GLuint buffer)
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_glBindBufferBase(ser, target, index, buffer);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
     }
   }
 }
@@ -1301,7 +1301,7 @@ void WrappedOpenGL::glBindBufferRange(GLenum target, GLuint index, GLuint buffer
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_glBindBufferRange(ser, target, index, buffer, offset, size);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
     }
   }
 }
@@ -1444,7 +1444,7 @@ void WrappedOpenGL::glBindBuffersBase(GLenum target, GLuint first, GLsizei count
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_glBindBuffersBase(ser, target, first, count, buffers);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
     }
   }
 }
@@ -1627,7 +1627,7 @@ void WrappedOpenGL::glBindBuffersRange(GLenum target, GLuint first, GLsizei coun
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_glBindBuffersRange(ser, target, first, count, buffers, offsets, sizes);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
     }
   }
 }
@@ -2337,7 +2337,7 @@ GLboolean WrappedOpenGL::glUnmapNamedBufferEXT(GLuint buffer)
           USE_SCRATCH_SERIALISER();
           SCOPED_SERIALISE_CHUNK(gl_CurChunk);
           Serialise_glUnmapNamedBufferEXT(ser, buffer);
-          m_ContextRecord->AddChunk(scope.Get());
+          GetContextRecord()->AddChunk(scope.Get());
         }
         else if(IsBackgroundCapturing(m_State))
         {
@@ -2532,7 +2532,7 @@ void WrappedOpenGL::glFlushMappedNamedBufferRangeEXT(GLuint buffer, GLintptr off
         USE_SCRATCH_SERIALISER();
         SCOPED_SERIALISE_CHUNK(gl_CurChunk);
         Serialise_glFlushMappedNamedBufferRangeEXT(ser, buffer, record->Map.offset + offset, length);
-        m_ContextRecord->AddChunk(scope.Get());
+        GetContextRecord()->AddChunk(scope.Get());
       }
       // other statuses is GLResourceRecord::Mapped_Read
     }
@@ -2782,7 +2782,7 @@ void WrappedOpenGL::glTransformFeedbackBufferBase(GLuint xfb, GLuint index, GLui
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(BufferRes(GetCtx(), buffer),
                                                         eFrameRef_ReadBeforeWrite);
     }
@@ -2838,7 +2838,7 @@ void WrappedOpenGL::glTransformFeedbackBufferRange(GLuint xfb, GLuint index, GLu
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(BufferRes(GetCtx(), buffer),
                                                         eFrameRef_ReadBeforeWrite);
     }
@@ -2897,7 +2897,7 @@ void WrappedOpenGL::glBindTransformFeedback(GLenum target, GLuint id)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindTransformFeedback(ser, target, id);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     if(record)
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
@@ -2931,7 +2931,7 @@ void WrappedOpenGL::glBeginTransformFeedback(GLenum primitiveMode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBeginTransformFeedback(ser, primitiveMode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -2956,7 +2956,7 @@ void WrappedOpenGL::glPauseTransformFeedback()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPauseTransformFeedback(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -2981,7 +2981,7 @@ void WrappedOpenGL::glResumeTransformFeedback()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glResumeTransformFeedback(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3008,7 +3008,7 @@ void WrappedOpenGL::glEndTransformFeedback()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glEndTransformFeedback(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3092,7 +3092,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribOffsetEXT(GLuint vaobj, GLuint buff
         GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3125,7 +3125,7 @@ void WrappedOpenGL::glVertexAttribPointer(GLuint index, GLint size, GLenum type,
     ContextData &cd = GetCtxData();
     GLResourceRecord *bufrecord = cd.m_BufferRecord[BufferIdx(eGL_ARRAY_BUFFER)];
     GLResourceRecord *varecord = cd.m_VertexArrayRecord;
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3218,7 +3218,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribIOffsetEXT(GLuint vaobj, GLuint buf
         GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3251,7 +3251,7 @@ void WrappedOpenGL::glVertexAttribIPointer(GLuint index, GLint size, GLenum type
     ContextData &cd = GetCtxData();
     GLResourceRecord *bufrecord = cd.m_BufferRecord[BufferIdx(eGL_ARRAY_BUFFER)];
     GLResourceRecord *varecord = cd.m_VertexArrayRecord;
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3344,7 +3344,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribLOffsetEXT(GLuint vaobj, GLuint buf
         GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3377,7 +3377,7 @@ void WrappedOpenGL::glVertexAttribLPointer(GLuint index, GLint size, GLenum type
     ContextData &cd = GetCtxData();
     GLResourceRecord *bufrecord = cd.m_BufferRecord[BufferIdx(eGL_ARRAY_BUFFER)];
     GLResourceRecord *varecord = cd.m_VertexArrayRecord;
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3433,7 +3433,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribBindingEXT(GLuint vaobj, GLuint att
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3461,7 +3461,7 @@ void WrappedOpenGL::glVertexAttribBinding(GLuint attribindex, GLuint bindinginde
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3522,7 +3522,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribFormatEXT(GLuint vaobj, GLuint attr
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3553,7 +3553,7 @@ void WrappedOpenGL::glVertexAttribFormat(GLuint attribindex, GLint size, GLenum 
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3611,7 +3611,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribIFormatEXT(GLuint vaobj, GLuint att
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3641,7 +3641,7 @@ void WrappedOpenGL::glVertexAttribIFormat(GLuint attribindex, GLint size, GLenum
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3698,7 +3698,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribLFormatEXT(GLuint vaobj, GLuint att
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3728,7 +3728,7 @@ void WrappedOpenGL::glVertexAttribLFormat(GLuint attribindex, GLint size, GLenum
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3792,7 +3792,7 @@ void WrappedOpenGL::glVertexArrayVertexAttribDivisorEXT(GLuint vaobj, GLuint ind
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3820,7 +3820,7 @@ void WrappedOpenGL::glVertexAttribDivisor(GLuint index, GLuint divisor)
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3876,7 +3876,7 @@ void WrappedOpenGL::glEnableVertexArrayAttribEXT(GLuint vaobj, GLuint index)
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3904,7 +3904,7 @@ void WrappedOpenGL::glEnableVertexAttribArray(GLuint index)
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3959,7 +3959,7 @@ void WrappedOpenGL::glDisableVertexArrayAttribEXT(GLuint vaobj, GLuint index)
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -3987,7 +3987,7 @@ void WrappedOpenGL::glDisableVertexAttribArray(GLuint index)
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4168,7 +4168,7 @@ void WrappedOpenGL::glBindVertexArray(GLuint array)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindVertexArray(ser, array);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     if(record)
       GetResourceManager()->MarkVAOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
   }
@@ -4217,7 +4217,7 @@ void WrappedOpenGL::glVertexArrayElementBuffer(GLuint vaobj, GLuint buffer)
     GLResourceRecord *bufrecord =
         GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4285,7 +4285,7 @@ void WrappedOpenGL::glVertexArrayBindVertexBufferEXT(GLuint vaobj, GLuint bindin
     GLResourceRecord *bufrecord =
         GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4318,7 +4318,7 @@ void WrappedOpenGL::glBindVertexBuffer(GLuint bindingindex, GLuint buffer, GLint
     GLResourceRecord *bufrecord =
         GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4428,7 +4428,7 @@ void WrappedOpenGL::glVertexArrayVertexBuffers(GLuint vaobj, GLuint first, GLsiz
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4472,7 +4472,7 @@ void WrappedOpenGL::glBindVertexBuffers(GLuint first, GLsizei count, const GLuin
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4541,7 +4541,7 @@ void WrappedOpenGL::glVertexArrayVertexBindingDivisorEXT(GLuint vaobj, GLuint bi
     GLResourceRecord *varecord =
         GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), vaobj));
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4569,7 +4569,7 @@ void WrappedOpenGL::glVertexBindingDivisor(GLuint bindingindex, GLuint divisor)
   {
     GLResourceRecord *varecord = GetCtxData().m_VertexArrayRecord;
 
-    GLResourceRecord *r = IsActiveCapturing(m_State) ? m_ContextRecord : varecord;
+    GLResourceRecord *r = IsActiveCapturing(m_State) ? GetContextRecord() : varecord;
 
     if(r)
     {
@@ -4867,7 +4867,7 @@ bool WrappedOpenGL::Serialise_glVertexAttrib(SerialiserType &ser, GLuint index, 
       Serialise_glVertexAttrib(ser, index, count, eGL_NONE, GL_FALSE, vals,       \
                                AttribType(TypeOr | CONCAT(Attrib_, paramtype)));  \
                                                                                   \
-      m_ContextRecord->AddChunk(scope.Get());                                     \
+      GetContextRecord()->AddChunk(scope.Get());                                  \
     }                                                                             \
   }
 
@@ -4926,7 +4926,7 @@ ATTRIB_FUNC(4, 4Nub, Attrib_N, GLubyte, GLubyte x, GLubyte y, GLubyte z, GLubyte
       Serialise_glVertexAttrib(ser, index, count, eGL_NONE, GL_FALSE, value,               \
                                AttribType(TypeOr | CONCAT(Attrib_, paramtype)));           \
                                                                                            \
-      m_ContextRecord->AddChunk(scope.Get());                                              \
+      GetContextRecord()->AddChunk(scope.Get());                                           \
     }                                                                                      \
   }
 
@@ -4989,7 +4989,7 @@ ATTRIB_FUNC(4, 4Nusv, Attrib_N, GLushort)
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                     \
       Serialise_glVertexAttrib(ser, index, count, type, normalized, passparam, Attrib_packed); \
                                                                                                \
-      m_ContextRecord->AddChunk(scope.Get());                                                  \
+      GetContextRecord()->AddChunk(scope.Get());                                               \
     }                                                                                          \
   }
 

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -206,8 +206,9 @@ void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
 
     if(IsActiveCapturing(m_State))
     {
-      m_AcceptedThreads.clear();
-      m_AcceptedThreads.insert(Threading::GetCurrentID());
+      m_AcceptedCtx.clear();
+      m_AcceptedCtx.insert(GetCtx().ctx);
+      RDCDEBUG("Only resource ID accepted is %llu", GetCtxData().m_ContextDataResourceID);
     }
   }
 }

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -203,6 +203,12 @@ void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
     void *ctx = NULL, *wnd = NULL;
     RenderDoc::Inst().GetActiveWindow(ctx, wnd);
     SwapBuffers(wnd);
+
+    if(IsActiveCapturing(m_State))
+    {
+      m_AcceptedThreads.clear();
+      m_AcceptedThreads.insert(Threading::GetCurrentID());
+    }
   }
 }
 
@@ -220,7 +226,7 @@ void WrappedOpenGL::glDebugMessageInsert(GLenum source, GLenum type, GLuint id, 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDebugMessageInsert(ser, source, type, id, severity, length, buf);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -232,7 +238,7 @@ void WrappedOpenGL::glPushGroupMarkerEXT(GLsizei length, const GLchar *marker)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPushDebugGroup(ser, eGL_DEBUG_SOURCE_APPLICATION, 0, length, marker);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -244,7 +250,7 @@ void WrappedOpenGL::glPopGroupMarkerEXT()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPopDebugGroup(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -287,7 +293,7 @@ void WrappedOpenGL::glInsertEventMarkerEXT(GLsizei length, const GLchar *marker)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glInsertEventMarkerEXT(ser, length, marker);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -304,7 +310,7 @@ void WrappedOpenGL::glStringMarkerGREMEDY(GLsizei len, const void *string)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glInsertEventMarkerEXT(ser, len, (const GLchar *)string);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -353,7 +359,7 @@ void WrappedOpenGL::glPushDebugGroup(GLenum source, GLuint id, GLsizei length, c
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPushDebugGroup(ser, source, id, length, message);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -388,7 +394,7 @@ void WrappedOpenGL::glPopDebugGroup()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPopDebugGroup(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 

--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -131,7 +131,7 @@ void WrappedOpenGL::glDispatchCompute(GLuint num_groups_x, GLuint num_groups_y, 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDispatchCompute(ser, num_groups_x, num_groups_y, num_groups_z);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -239,7 +239,7 @@ void WrappedOpenGL::glDispatchComputeGroupSizeARB(GLuint num_groups_x, GLuint nu
     Serialise_glDispatchComputeGroupSizeARB(ser, num_groups_x, num_groups_y, num_groups_z,
                                             group_size_x, group_size_y, group_size_z);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -308,7 +308,7 @@ void WrappedOpenGL::glDispatchComputeIndirect(GLintptr indirect)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDispatchComputeIndirect(ser, indirect);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -353,7 +353,7 @@ void WrappedOpenGL::glMemoryBarrier(GLbitfield barriers)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMemoryBarrier(ser, barriers);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -389,7 +389,7 @@ void WrappedOpenGL::glMemoryBarrierByRegion(GLbitfield barriers)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMemoryBarrierByRegion(ser, barriers);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -416,7 +416,7 @@ void WrappedOpenGL::glTextureBarrier()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glTextureBarrier(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -474,7 +474,7 @@ void WrappedOpenGL::glDrawTransformFeedback(GLenum mode, GLuint id)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawTransformFeedback(ser, mode, id);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -543,7 +543,7 @@ void WrappedOpenGL::glDrawTransformFeedbackInstanced(GLenum mode, GLuint id, GLs
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawTransformFeedbackInstanced(ser, mode, id, instancecount);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -611,7 +611,7 @@ void WrappedOpenGL::glDrawTransformFeedbackStream(GLenum mode, GLuint id, GLuint
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawTransformFeedbackStream(ser, mode, id, stream);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -684,7 +684,7 @@ void WrappedOpenGL::glDrawTransformFeedbackStreamInstanced(GLenum mode, GLuint i
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawTransformFeedbackStreamInstanced(ser, mode, id, stream, instancecount);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -915,7 +915,7 @@ void WrappedOpenGL::glDrawArrays(GLenum mode, GLint first, GLsizei count)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawArrays(ser, mode, first, count);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -991,7 +991,7 @@ void WrappedOpenGL::glDrawArraysIndirect(GLenum mode, const void *indirect)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawArraysIndirect(ser, mode, indirect);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1062,7 +1062,7 @@ void WrappedOpenGL::glDrawArraysInstanced(GLenum mode, GLint first, GLsizei coun
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawArraysInstanced(ser, mode, first, count, instancecount);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1139,7 +1139,7 @@ void WrappedOpenGL::glDrawArraysInstancedBaseInstance(GLenum mode, GLint first, 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawArraysInstancedBaseInstance(ser, mode, first, count, instancecount, baseinstance);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1229,7 +1229,7 @@ void WrappedOpenGL::glDrawElements(GLenum mode, GLsizei count, GLenum type, cons
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawElements(ser, mode, count, type, indices);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1311,7 +1311,7 @@ void WrappedOpenGL::glDrawElementsIndirect(GLenum mode, GLenum type, const void 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawElementsIndirect(ser, mode, type, indirect);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1388,7 +1388,7 @@ void WrappedOpenGL::glDrawRangeElements(GLenum mode, GLuint start, GLuint end, G
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawRangeElements(ser, mode, start, end, count, type, indices);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1472,7 +1472,7 @@ void WrappedOpenGL::glDrawRangeElementsBaseVertex(GLenum mode, GLuint start, GLu
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawRangeElementsBaseVertex(ser, mode, start, end, count, type, indices, basevertex);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1550,7 +1550,7 @@ void WrappedOpenGL::glDrawElementsBaseVertex(GLenum mode, GLsizei count, GLenum 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawElementsBaseVertex(ser, mode, count, type, indices, basevertex);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1628,7 +1628,7 @@ void WrappedOpenGL::glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum t
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDrawElementsInstanced(ser, mode, count, type, indices, instancecount);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1713,7 +1713,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseInstance(GLenum mode, GLsizei cou
     Serialise_glDrawElementsInstancedBaseInstance(ser, mode, count, type, indices, instancecount,
                                                   baseinstance);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1798,7 +1798,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertex(GLenum mode, GLsizei count
     Serialise_glDrawElementsInstancedBaseVertex(ser, mode, count, type, indices, instancecount,
                                                 basevertex);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -1884,7 +1884,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertexBaseInstance(GLenum mode, G
     Serialise_glDrawElementsInstancedBaseVertexBaseInstance(
         ser, mode, count, type, indices, instancecount, basevertex, baseinstance);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -2013,7 +2013,7 @@ void WrappedOpenGL::glMultiDrawArrays(GLenum mode, const GLint *first, const GLs
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMultiDrawArrays(ser, mode, first, count, drawcount);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -2164,7 +2164,7 @@ void WrappedOpenGL::glMultiDrawElements(GLenum mode, const GLsizei *count, GLenu
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMultiDrawElements(ser, mode, count, type, indices, drawcount);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -2322,7 +2322,7 @@ void WrappedOpenGL::glMultiDrawElementsBaseVertex(GLenum mode, const GLsizei *co
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMultiDrawElementsBaseVertex(ser, mode, count, type, indices, drawcount, basevertex);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -2509,7 +2509,7 @@ void WrappedOpenGL::glMultiDrawArraysIndirect(GLenum mode, const void *indirect,
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMultiDrawArraysIndirect(ser, mode, indirect, drawcount, stride);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -2708,7 +2708,7 @@ void WrappedOpenGL::glMultiDrawElementsIndirect(GLenum mode, GLenum type, const 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMultiDrawElementsIndirect(ser, mode, type, indirect, drawcount, stride);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -2907,7 +2907,7 @@ void WrappedOpenGL::glMultiDrawArraysIndirectCountARB(GLenum mode, const void *i
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMultiDrawArraysIndirectCountARB(ser, mode, indirect, drawcount, maxdrawcount, stride);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -3117,7 +3117,7 @@ void WrappedOpenGL::glMultiDrawElementsIndirectCountARB(GLenum mode, GLenum type
     Serialise_glMultiDrawElementsIndirectCountARB(ser, mode, type, indirect, drawcount,
                                                   maxdrawcount, stride);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -3218,7 +3218,7 @@ void WrappedOpenGL::glClearNamedFramebufferfv(GLuint framebuffer, GLenum buffer,
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferfv(ser, framebuffer, buffer, drawbuffer, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     GLRenderState state(&m_Real);
     state.FetchState(this);
@@ -3249,7 +3249,7 @@ void WrappedOpenGL::glClearBufferfv(GLenum buffer, GLint drawbuffer, const GLflo
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferfv(ser, framebuffer, buffer, drawbuffer, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3341,7 +3341,7 @@ void WrappedOpenGL::glClearNamedFramebufferiv(GLuint framebuffer, GLenum buffer,
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferiv(ser, framebuffer, buffer, drawbuffer, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3363,7 +3363,7 @@ void WrappedOpenGL::glClearBufferiv(GLenum buffer, GLint drawbuffer, const GLint
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferiv(ser, framebuffer, buffer, drawbuffer, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3443,7 +3443,7 @@ void WrappedOpenGL::glClearNamedFramebufferuiv(GLuint framebuffer, GLenum buffer
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferuiv(ser, framebuffer, buffer, drawbuffer, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3465,7 +3465,7 @@ void WrappedOpenGL::glClearBufferuiv(GLenum buffer, GLint drawbuffer, const GLui
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferuiv(ser, framebuffer, buffer, drawbuffer, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3564,7 +3564,7 @@ void WrappedOpenGL::glClearNamedFramebufferfi(GLuint framebuffer, GLenum buffer,
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferfi(ser, framebuffer, buffer, drawbuffer, depth, stencil);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3586,7 +3586,7 @@ void WrappedOpenGL::glClearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat dep
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedFramebufferfi(ser, framebuffer, buffer, drawbuffer, depth, stencil);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -3687,7 +3687,7 @@ void WrappedOpenGL::glClearNamedBufferDataEXT(GLuint buffer, GLenum internalform
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearNamedBufferDataEXT(ser, buffer, internalformat, format, type, data);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
   else if(IsBackgroundCapturing(m_State))
   {
@@ -3719,7 +3719,7 @@ void WrappedOpenGL::glClearBufferData(GLenum target, GLenum internalformat, GLen
         Serialise_glClearNamedBufferDataEXT(ser, record->Resource.name, internalformat, format,
                                             type, data);
 
-        m_ContextRecord->AddChunk(scope.Get());
+        GetContextRecord()->AddChunk(scope.Get());
       }
       else if(IsBackgroundCapturing(m_State))
       {
@@ -3832,7 +3832,7 @@ void WrappedOpenGL::glClearNamedBufferSubDataEXT(GLuint buffer, GLenum internalf
     Serialise_glClearNamedBufferSubDataEXT(ser, buffer, internalformat, offset, size, format, type,
                                            data);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
   else if(IsBackgroundCapturing(m_State))
   {
@@ -3874,7 +3874,7 @@ void WrappedOpenGL::glClearBufferSubData(GLenum target, GLenum internalformat, G
         Serialise_glClearNamedBufferSubDataEXT(ser, record->Resource.name, internalformat, offset,
                                                size, format, type, data);
 
-        m_ContextRecord->AddChunk(scope.Get());
+        GetContextRecord()->AddChunk(scope.Get());
       }
       else if(IsBackgroundCapturing(m_State))
       {
@@ -4032,7 +4032,7 @@ void WrappedOpenGL::glClear(GLbitfield mask)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClear(ser, mask);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -4131,7 +4131,7 @@ void WrappedOpenGL::glClearTexImage(GLuint texture, GLint level, GLenum format, 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearTexImage(ser, texture, level, format, type, data);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(GetResourceManager()->GetID(TextureRes(GetCtx(), texture)));
   }
   else if(IsBackgroundCapturing(m_State))
@@ -4248,7 +4248,7 @@ void WrappedOpenGL::glClearTexSubImage(GLuint texture, GLint level, GLint xoffse
     Serialise_glClearTexSubImage(ser, texture, level, xoffset, yoffset, zoffset, width, height,
                                  depth, format, type, data);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(GetResourceManager()->GetID(TextureRes(GetCtx(), texture)));
   }
   else if(IsBackgroundCapturing(m_State))

--- a/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
@@ -218,7 +218,7 @@ void WrappedOpenGL::glNamedFramebufferTextureEXT(GLuint framebuffer, GLenum atta
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -280,7 +280,7 @@ void WrappedOpenGL::glFramebufferTexture(GLenum target, GLenum attachment, GLuin
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -361,7 +361,7 @@ void WrappedOpenGL::glNamedFramebufferTexture1DEXT(GLuint framebuffer, GLenum at
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -425,7 +425,7 @@ void WrappedOpenGL::glFramebufferTexture1D(GLenum target, GLenum attachment, GLe
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -506,7 +506,7 @@ void WrappedOpenGL::glNamedFramebufferTexture2DEXT(GLuint framebuffer, GLenum at
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -570,7 +570,7 @@ void WrappedOpenGL::glFramebufferTexture2D(GLenum target, GLenum attachment, GLe
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -677,7 +677,7 @@ void WrappedOpenGL::glFramebufferTexture2DMultisampleEXT(GLenum target, GLenum a
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -762,7 +762,7 @@ void WrappedOpenGL::glNamedFramebufferTexture3DEXT(GLuint framebuffer, GLenum at
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -827,7 +827,7 @@ void WrappedOpenGL::glFramebufferTexture3D(GLenum target, GLenum attachment, GLe
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -900,7 +900,7 @@ void WrappedOpenGL::glNamedFramebufferRenderbufferEXT(GLuint framebuffer, GLenum
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(RenderbufferRes(GetCtx(), renderbuffer),
                                                         eFrameRef_Read);
@@ -955,7 +955,7 @@ void WrappedOpenGL::glFramebufferRenderbuffer(GLenum target, GLenum attachment,
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(RenderbufferRes(GetCtx(), renderbuffer),
                                                         eFrameRef_Read);
@@ -1037,7 +1037,7 @@ void WrappedOpenGL::glNamedFramebufferTextureLayerEXT(GLuint framebuffer, GLenum
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -1101,7 +1101,7 @@ void WrappedOpenGL::glFramebufferTextureLayer(GLenum target, GLenum attachment, 
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -1201,7 +1201,7 @@ void WrappedOpenGL::glFramebufferTextureMultiviewOVR(GLenum target, GLenum attac
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -1300,7 +1300,7 @@ void WrappedOpenGL::glFramebufferTextureMultisampleMultiviewOVR(GLenum target, G
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
       GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
                                                         eFrameRef_Read);
@@ -1414,7 +1414,7 @@ void WrappedOpenGL::glFramebufferReadBufferEXT(GLuint framebuffer, GLenum buf)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glFramebufferReadBufferEXT(ser, framebuffer, buf);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
                                             eFrameRef_ReadBeforeWrite);
   }
@@ -1443,7 +1443,7 @@ void WrappedOpenGL::glReadBuffer(GLenum mode)
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_glFramebufferReadBufferEXT(ser, readrecord ? readrecord->Resource.name : 0, mode);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       if(readrecord)
         GetResourceManager()->MarkFBOReferenced(readrecord->Resource, eFrameRef_ReadBeforeWrite);
     }
@@ -1485,7 +1485,7 @@ void WrappedOpenGL::glBindFramebuffer(GLenum target, GLuint framebuffer)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindFramebuffer(ser, target, framebuffer);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
                                             eFrameRef_ReadBeforeWrite);
   }
@@ -1535,7 +1535,7 @@ void WrappedOpenGL::glFramebufferDrawBufferEXT(GLuint framebuffer, GLenum buf)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glFramebufferDrawBufferEXT(ser, framebuffer, buf);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
                                             eFrameRef_ReadBeforeWrite);
   }
@@ -1564,7 +1564,7 @@ void WrappedOpenGL::glDrawBuffer(GLenum buf)
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_glFramebufferDrawBufferEXT(ser, drawrecord ? drawrecord->Resource.name : 0, buf);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       if(drawrecord)
         GetResourceManager()->MarkFBOReferenced(drawrecord->Resource, eFrameRef_ReadBeforeWrite);
     }
@@ -1619,7 +1619,7 @@ void WrappedOpenGL::glFramebufferDrawBuffersEXT(GLuint framebuffer, GLsizei n, c
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glFramebufferDrawBuffersEXT(ser, framebuffer, n, bufs);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
                                             eFrameRef_ReadBeforeWrite);
   }
@@ -1651,7 +1651,7 @@ void WrappedOpenGL::glDrawBuffers(GLsizei n, const GLenum *bufs)
       else
         Serialise_glFramebufferDrawBuffersEXT(ser, 0, n, bufs);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       if(drawrecord)
         GetResourceManager()->MarkFBOReferenced(drawrecord->Resource, eFrameRef_ReadBeforeWrite);
     }
@@ -1938,7 +1938,7 @@ void WrappedOpenGL::glBlitNamedFramebuffer(GLuint readFramebuffer, GLuint drawFr
     Serialise_glBlitNamedFramebuffer(ser, readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1,
                                      srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), readFramebuffer),
                                             eFrameRef_ReadBeforeWrite);
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), drawFramebuffer),
@@ -1969,7 +1969,7 @@ void WrappedOpenGL::glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLi
     Serialise_glBlitNamedFramebuffer(ser, readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1,
                                      srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), readFramebuffer),
                                             eFrameRef_ReadBeforeWrite);
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), drawFramebuffer),

--- a/renderdoc/driver/gl/wrappers/gl_interop_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_interop_funcs.cpp
@@ -184,7 +184,7 @@ BOOL WrappedOpenGL::wglDXLockObjectsNV(HANDLE hDevice, GLint count, HANDLE *hObj
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);
       Serialise_wglDXLockObjectsNV(ser, w->res);
 
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(GetResourceManager()->GetID(w->res),
                                                         eFrameRef_Read);
     }

--- a/renderdoc/driver/gl/wrappers/gl_query_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_query_funcs.cpp
@@ -110,7 +110,7 @@ GLsync WrappedOpenGL::glFenceSync(GLenum condition, GLbitfield flags)
       chunk = scope.Get();
     }
 
-    m_ContextRecord->AddChunk(chunk);
+    GetContextRecord()->AddChunk(chunk);
   }
   else
   {
@@ -150,7 +150,7 @@ GLenum WrappedOpenGL::glClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 t
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClientWaitSync(ser, sync, flags, timeout);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 
   return ret;
@@ -185,7 +185,7 @@ void WrappedOpenGL::glWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glWaitSync(ser, sync, flags, timeout);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -351,7 +351,7 @@ void WrappedOpenGL::glBeginQuery(GLenum target, GLuint id)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBeginQuery(ser, target, id);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(QueryRes(GetCtx(), id), eFrameRef_Read);
   }
 }
@@ -386,7 +386,7 @@ void WrappedOpenGL::glBeginQueryIndexed(GLenum target, GLuint index, GLuint id)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBeginQueryIndexed(ser, target, index, id);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(QueryRes(GetCtx(), id), eFrameRef_Read);
   }
 }
@@ -422,7 +422,7 @@ void WrappedOpenGL::glEndQuery(GLenum target)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glEndQuery(ser, target);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -454,7 +454,7 @@ void WrappedOpenGL::glEndQueryIndexed(GLenum target, GLuint index)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glEndQueryIndexed(ser, target, index);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -487,7 +487,7 @@ void WrappedOpenGL::glBeginConditionalRender(GLuint id, GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBeginConditionalRender(ser, id, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(QueryRes(GetCtx(), id), eFrameRef_Read);
   }
 }
@@ -515,7 +515,7 @@ void WrappedOpenGL::glEndConditionalRender()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glEndConditionalRender(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -543,7 +543,7 @@ void WrappedOpenGL::glQueryCounter(GLuint query, GLenum target)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glQueryCounter(ser, query, target);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(QueryRes(GetCtx(), query), eFrameRef_Read);
   }
 }

--- a/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
@@ -174,7 +174,7 @@ void WrappedOpenGL::glBindSampler(GLuint unit, GLuint sampler)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindSampler(ser, unit, sampler);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler), eFrameRef_Read);
   }
 }
@@ -222,7 +222,7 @@ void WrappedOpenGL::glBindSamplers(GLuint first, GLsizei count, const GLuint *sa
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindSamplers(ser, first, count, samplers);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     for(GLsizei i = 0; i < count; i++)
       if(samplers != NULL && samplers[i] != 0)
         GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), samplers[i]),
@@ -279,7 +279,7 @@ void WrappedOpenGL::glSamplerParameteri(GLuint sampler, GLenum pname, GLint para
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
                                                         eFrameRef_Read);
     }
@@ -322,7 +322,7 @@ void WrappedOpenGL::glSamplerParameterf(GLuint sampler, GLenum pname, GLfloat pa
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
                                                         eFrameRef_Read);
     }
@@ -366,7 +366,7 @@ void WrappedOpenGL::glSamplerParameteriv(GLuint sampler, GLenum pname, const GLi
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
                                                         eFrameRef_Read);
     }
@@ -410,7 +410,7 @@ void WrappedOpenGL::glSamplerParameterfv(GLuint sampler, GLenum pname, const GLf
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
                                                         eFrameRef_Read);
     }
@@ -454,7 +454,7 @@ void WrappedOpenGL::glSamplerParameterIiv(GLuint sampler, GLenum pname, const GL
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
                                                         eFrameRef_Read);
     }
@@ -498,7 +498,7 @@ void WrappedOpenGL::glSamplerParameterIuiv(GLuint sampler, GLenum pname, const G
     }
     else
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
                                                         eFrameRef_Read);
     }

--- a/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
@@ -997,7 +997,7 @@ void WrappedOpenGL::glUniformSubroutinesuiv(GLenum shadertype, GLsizei count, co
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glUniformSubroutinesuiv(ser, shadertype, count, indices);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1163,7 +1163,7 @@ void WrappedOpenGL::glUseProgram(GLuint program)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glUseProgram(ser, program);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(ProgramRes(GetCtx(), program), eFrameRef_Read);
   }
 }
@@ -1300,7 +1300,7 @@ void WrappedOpenGL::glUseProgramStages(GLuint pipeline, GLbitfield stages, GLuin
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
     }
     else
     {
@@ -1503,7 +1503,7 @@ void WrappedOpenGL::glBindProgramPipeline(GLuint pipeline)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindProgramPipeline(ser, pipeline);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(ProgramPipeRes(GetCtx(), pipeline),
                                                       eFrameRef_Read);
   }

--- a/renderdoc/driver/gl/wrappers/gl_state_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_state_funcs.cpp
@@ -53,7 +53,7 @@ void WrappedOpenGL::glBlendFunc(GLenum sfactor, GLenum dfactor)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendFunc(ser, sfactor, dfactor);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -84,7 +84,7 @@ void WrappedOpenGL::glBlendFunci(GLuint buf, GLenum src, GLenum dst)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendFunci(ser, buf, src, dst);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -117,7 +117,7 @@ void WrappedOpenGL::glBlendColor(GLfloat red, GLfloat green, GLfloat blue, GLflo
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendColor(ser, red, green, blue, alpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -152,7 +152,7 @@ void WrappedOpenGL::glBlendFuncSeparate(GLenum sfactorRGB, GLenum dfactorRGB, GL
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendFuncSeparate(ser, sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -189,7 +189,7 @@ void WrappedOpenGL::glBlendFuncSeparatei(GLuint buf, GLenum sfactorRGB, GLenum d
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendFuncSeparatei(ser, buf, sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -218,7 +218,7 @@ void WrappedOpenGL::glBlendEquation(GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendEquation(ser, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -248,7 +248,7 @@ void WrappedOpenGL::glBlendEquationi(GLuint buf, GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendEquationi(ser, buf, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -279,7 +279,7 @@ void WrappedOpenGL::glBlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendEquationSeparate(ser, modeRGB, modeAlpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -311,7 +311,7 @@ void WrappedOpenGL::glBlendEquationSeparatei(GLuint buf, GLenum modeRGB, GLenum 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendEquationSeparatei(ser, buf, modeRGB, modeAlpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -341,7 +341,7 @@ void WrappedOpenGL::glBlendBarrierKHR()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendBarrierKHR(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -357,7 +357,7 @@ void WrappedOpenGL::glBlendBarrier()
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBlendBarrierKHR(ser);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -386,7 +386,7 @@ void WrappedOpenGL::glLogicOp(GLenum opcode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glLogicOp(ser, opcode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -417,7 +417,7 @@ void WrappedOpenGL::glStencilFunc(GLenum func, GLint ref, GLuint mask)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glStencilFunc(ser, func, ref, mask);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -450,7 +450,7 @@ void WrappedOpenGL::glStencilFuncSeparate(GLenum face, GLenum func, GLint ref, G
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glStencilFuncSeparate(ser, face, func, ref, mask);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -479,7 +479,7 @@ void WrappedOpenGL::glStencilMask(GLuint mask)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glStencilMask(ser, mask);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -509,7 +509,7 @@ void WrappedOpenGL::glStencilMaskSeparate(GLenum face, GLuint mask)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glStencilMaskSeparate(ser, face, mask);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -540,7 +540,7 @@ void WrappedOpenGL::glStencilOp(GLenum fail, GLenum zfail, GLenum zpass)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glStencilOp(ser, fail, zfail, zpass);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -573,7 +573,7 @@ void WrappedOpenGL::glStencilOpSeparate(GLenum face, GLenum sfail, GLenum dpfail
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glStencilOpSeparate(ser, face, sfail, dpfail, dppass);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -606,7 +606,7 @@ void WrappedOpenGL::glClearColor(GLclampf red, GLclampf green, GLclampf blue, GL
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearColor(ser, red, green, blue, alpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -635,7 +635,7 @@ void WrappedOpenGL::glClearStencil(GLint stencil)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearStencil(ser, stencil);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -667,7 +667,7 @@ void WrappedOpenGL::glClearDepth(GLdouble depth)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearDepth(ser, depth);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -681,7 +681,7 @@ void WrappedOpenGL::glClearDepthf(GLfloat depth)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClearDepth(ser, depth);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -710,7 +710,7 @@ void WrappedOpenGL::glDepthFunc(GLenum func)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthFunc(ser, func);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -739,7 +739,7 @@ void WrappedOpenGL::glDepthMask(GLboolean flag)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthMask(ser, flag);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -767,7 +767,7 @@ void WrappedOpenGL::glDepthRange(GLdouble nearVal, GLdouble farVal)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthRange(ser, nearVal, farVal);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -795,7 +795,7 @@ void WrappedOpenGL::glDepthRangef(GLfloat nearVal, GLfloat farVal)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthRangef(ser, nearVal, farVal);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -830,7 +830,7 @@ void WrappedOpenGL::glDepthRangeIndexed(GLuint index, GLdouble nearVal, GLdouble
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthRangeIndexed(ser, index, nearVal, farVal);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -844,7 +844,7 @@ void WrappedOpenGL::glDepthRangeIndexedfOES(GLuint index, GLfloat nearVal, GLflo
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthRangeIndexed(ser, index, (GLdouble)nearVal, (GLdouble)farVal);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -889,7 +889,7 @@ void WrappedOpenGL::glDepthRangeArrayv(GLuint first, GLsizei count, const GLdoub
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthRangeArrayv(ser, first, count, v);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -909,7 +909,7 @@ void WrappedOpenGL::glDepthRangeArrayfvOES(GLuint first, GLsizei count, const GL
 
     delete[] dv;
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -939,7 +939,7 @@ void WrappedOpenGL::glDepthBoundsEXT(GLclampd nearVal, GLclampd farVal)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDepthBoundsEXT(ser, nearVal, farVal);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -969,7 +969,7 @@ void WrappedOpenGL::glClipControl(GLenum origin, GLenum depth)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glClipControl(ser, origin, depth);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -998,7 +998,7 @@ void WrappedOpenGL::glProvokingVertex(GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glProvokingVertex(ser, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1027,7 +1027,7 @@ void WrappedOpenGL::glPrimitiveRestartIndex(GLuint index)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPrimitiveRestartIndex(ser, index);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1067,7 +1067,7 @@ void WrappedOpenGL::glDisable(GLenum cap)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDisable(ser, cap);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1096,7 +1096,7 @@ void WrappedOpenGL::glEnable(GLenum cap)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glEnable(ser, cap);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1126,7 +1126,7 @@ void WrappedOpenGL::glDisablei(GLenum cap, GLuint index)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glDisablei(ser, cap, index);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1156,7 +1156,7 @@ void WrappedOpenGL::glEnablei(GLenum cap, GLuint index)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glEnablei(ser, cap, index);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1185,7 +1185,7 @@ void WrappedOpenGL::glFrontFace(GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glFrontFace(ser, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1214,7 +1214,7 @@ void WrappedOpenGL::glCullFace(GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glCullFace(ser, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1244,7 +1244,7 @@ void WrappedOpenGL::glHint(GLenum target, GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glHint(ser, target, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1278,7 +1278,7 @@ void WrappedOpenGL::glColorMask(GLboolean red, GLboolean green, GLboolean blue, 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glColorMask(ser, red, green, blue, alpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1314,7 +1314,7 @@ void WrappedOpenGL::glColorMaski(GLuint buf, GLboolean red, GLboolean green, GLb
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glColorMaski(ser, buf, red, green, blue, alpha);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1344,7 +1344,7 @@ void WrappedOpenGL::glSampleMaski(GLuint maskNumber, GLbitfield mask)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glSampleMaski(ser, maskNumber, mask);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1374,7 +1374,7 @@ void WrappedOpenGL::glSampleCoverage(GLfloat value, GLboolean invert)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glSampleCoverage(ser, value, invert);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1403,7 +1403,7 @@ void WrappedOpenGL::glMinSampleShading(GLfloat value)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glMinSampleShading(ser, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1434,7 +1434,7 @@ void WrappedOpenGL::glRasterSamplesEXT(GLuint samples, GLboolean fixedsampleloca
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glRasterSamplesEXT(ser, samples, fixedsamplelocations);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1464,7 +1464,7 @@ void WrappedOpenGL::glPatchParameteri(GLenum pname, GLint value)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPatchParameteri(ser, pname, value);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1495,7 +1495,7 @@ void WrappedOpenGL::glPatchParameterfv(GLenum pname, const GLfloat *values)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPatchParameterfv(ser, pname, values);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1524,7 +1524,7 @@ void WrappedOpenGL::glLineWidth(GLfloat width)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glLineWidth(ser, width);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1553,7 +1553,7 @@ void WrappedOpenGL::glPointSize(GLfloat size)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPointSize(ser, size);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1594,7 +1594,7 @@ void WrappedOpenGL::glPointParameteri(GLenum pname, GLint param)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPointParameteri(ser, pname, param);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1625,7 +1625,7 @@ void WrappedOpenGL::glPointParameteriv(GLenum pname, const GLint *params)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPointParameteriv(ser, pname, params);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1655,7 +1655,7 @@ void WrappedOpenGL::glPointParameterf(GLenum pname, GLfloat param)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPointParameterf(ser, pname, param);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1686,7 +1686,7 @@ void WrappedOpenGL::glPointParameterfv(GLenum pname, const GLfloat *params)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPointParameterfv(ser, pname, params);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1719,7 +1719,7 @@ void WrappedOpenGL::glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glViewport(ser, x, y, width, height);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1751,7 +1751,7 @@ void WrappedOpenGL::glViewportArrayv(GLuint index, GLuint count, const GLfloat *
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glViewportArrayv(ser, index, count, v);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1795,7 +1795,7 @@ void WrappedOpenGL::glScissor(GLint x, GLint y, GLsizei width, GLsizei height)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glScissor(ser, x, y, width, height);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1827,7 +1827,7 @@ void WrappedOpenGL::glScissorArrayv(GLuint first, GLsizei count, const GLint *v)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glScissorArrayv(ser, first, count, v);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1869,7 +1869,7 @@ void WrappedOpenGL::glPolygonMode(GLenum face, GLenum mode)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPolygonMode(ser, face, mode);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1899,7 +1899,7 @@ void WrappedOpenGL::glPolygonOffset(GLfloat factor, GLfloat units)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPolygonOffset(ser, factor, units);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1931,7 +1931,7 @@ void WrappedOpenGL::glPolygonOffsetClampEXT(GLfloat factor, GLfloat units, GLflo
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPolygonOffsetClampEXT(ser, factor, units, clamp);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1969,7 +1969,7 @@ void WrappedOpenGL::glPrimitiveBoundingBox(GLfloat minX, GLfloat minY, GLfloat m
     USE_SCRATCH_SERIALISER();
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPrimitiveBoundingBox(ser, minX, minY, minZ, minW, maxX, maxY, maxZ, maxW);
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -258,7 +258,7 @@ void WrappedOpenGL::glBindTexture(GLenum target, GLuint texture)
       chunk = scope.Get();
     }
 
-    m_ContextRecord->AddChunk(chunk);
+    GetContextRecord()->AddChunk(chunk);
     GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture), eFrameRef_Read);
   }
   else if(IsBackgroundCapturing(m_State))
@@ -357,7 +357,7 @@ void WrappedOpenGL::glBindTextures(GLuint first, GLsizei count, const GLuint *te
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindTextures(ser, first, count, textures);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     for(GLsizei i = 0; i < count; i++)
       if(textures != NULL && textures[i] != 0)
@@ -419,7 +419,7 @@ void WrappedOpenGL::glBindMultiTextureEXT(GLenum texunit, GLenum target, GLuint 
       chunk = scope.Get();
     }
 
-    m_ContextRecord->AddChunk(chunk);
+    GetContextRecord()->AddChunk(chunk);
     GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture), eFrameRef_Read);
   }
   else if(IsBackgroundCapturing(m_State))
@@ -496,7 +496,7 @@ void WrappedOpenGL::glBindTextureUnit(GLuint unit, GLuint texture)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindTextureUnit(ser, unit, texture);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture), eFrameRef_Read);
   }
 
@@ -556,7 +556,7 @@ void WrappedOpenGL::glBindImageTexture(GLuint unit, GLuint texture, GLint level,
       chunk = scope.Get();
     }
 
-    m_ContextRecord->AddChunk(chunk);
+    GetContextRecord()->AddChunk(chunk);
     GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture), eFrameRef_Read);
   }
 }
@@ -612,7 +612,7 @@ void WrappedOpenGL::glBindImageTextures(GLuint first, GLsizei count, const GLuin
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glBindImageTextures(ser, first, count, textures);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
 
     for(GLsizei i = 0; i < count; i++)
       if(textures != NULL && textures[i] != 0)
@@ -776,7 +776,7 @@ void WrappedOpenGL::Common_glGenerateTextureMipmapEXT(GLResourceRecord *record, 
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glGenerateTextureMipmapEXT(ser, record->Resource.name, target);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
@@ -943,7 +943,7 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
                                  dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight,
                                  srcDepth);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(dstrecord->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(dstrecord->GetResourceID(), eFrameRef_Read);
     GetResourceManager()->MarkResourceFrameReferenced(srcrecord->GetResourceID(), eFrameRef_Read);
@@ -1006,7 +1006,7 @@ void WrappedOpenGL::Common_glCopyTextureSubImage1DEXT(GLResourceRecord *record, 
     Serialise_glCopyTextureSubImage1DEXT(ser, record->Resource.name, target, level, xoffset, x, y,
                                          width);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
@@ -1111,7 +1111,7 @@ void WrappedOpenGL::Common_glCopyTextureSubImage2DEXT(GLResourceRecord *record, 
     Serialise_glCopyTextureSubImage2DEXT(ser, record->Resource.name, target, level, xoffset,
                                          yoffset, x, y, width, height);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
@@ -1225,7 +1225,7 @@ void WrappedOpenGL::Common_glCopyTextureSubImage3DEXT(GLResourceRecord *record, 
     Serialise_glCopyTextureSubImage3DEXT(ser, record->Resource.name, target, level, xoffset,
                                          yoffset, zoffset, x, y, width, height);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
@@ -1344,7 +1344,7 @@ void WrappedOpenGL::Common_glTextureParameteriEXT(GLResourceRecord *record, GLen
 
   if(IsActiveCapturing(m_State))
   {
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
   else
@@ -1446,7 +1446,7 @@ void WrappedOpenGL::Common_glTextureParameterivEXT(GLResourceRecord *record, GLe
 
   if(IsActiveCapturing(m_State))
   {
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
   else
@@ -1551,7 +1551,7 @@ void WrappedOpenGL::Common_glTextureParameterIivEXT(GLResourceRecord *record, GL
 
   if(IsActiveCapturing(m_State))
   {
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
   else
@@ -1656,7 +1656,7 @@ void WrappedOpenGL::Common_glTextureParameterIuivEXT(GLResourceRecord *record, G
 
   if(IsActiveCapturing(m_State))
   {
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
   else
@@ -1759,7 +1759,7 @@ void WrappedOpenGL::Common_glTextureParameterfEXT(GLResourceRecord *record, GLen
 
   if(IsActiveCapturing(m_State))
   {
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
   else
@@ -1861,7 +1861,7 @@ void WrappedOpenGL::Common_glTextureParameterfvEXT(GLResourceRecord *record, GLe
 
   if(IsActiveCapturing(m_State))
   {
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
   else
@@ -1944,7 +1944,7 @@ void WrappedOpenGL::glPixelStorei(GLenum pname, GLint param)
     SCOPED_SERIALISE_CHUNK(gl_CurChunk);
     Serialise_glPixelStorei(ser, pname, param);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
   }
 }
 
@@ -1984,7 +1984,7 @@ void WrappedOpenGL::glActiveTexture(GLenum texture)
       chunk = scope.Get();
     }
 
-    m_ContextRecord->AddChunk(chunk);
+    GetContextRecord()->AddChunk(chunk);
   }
 }
 
@@ -3587,7 +3587,7 @@ void WrappedOpenGL::Common_glCopyTextureImage1DEXT(GLResourceRecord *record, GLe
     Serialise_glCopyTextureImage1DEXT(ser, record->Resource.name, target, level, internalformat, x,
                                       y, width, border);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
@@ -3743,7 +3743,7 @@ void WrappedOpenGL::Common_glCopyTextureImage2DEXT(GLResourceRecord *record, GLe
     Serialise_glCopyTextureImage2DEXT(ser, record->Resource.name, target, level, internalformat, x,
                                       y, width, height, border);
 
-    m_ContextRecord->AddChunk(scope.Get());
+    GetContextRecord()->AddChunk(scope.Get());
     m_MissingTracks.insert(record->GetResourceID());
     GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
   }
@@ -4729,7 +4729,7 @@ void WrappedOpenGL::Common_glTextureSubImage1DEXT(GLResourceRecord *record, GLen
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
     }
@@ -4940,7 +4940,7 @@ void WrappedOpenGL::Common_glTextureSubImage2DEXT(GLResourceRecord *record, GLen
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
     }
@@ -5159,7 +5159,7 @@ void WrappedOpenGL::Common_glTextureSubImage3DEXT(GLResourceRecord *record, GLen
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
     }
@@ -5359,7 +5359,7 @@ void WrappedOpenGL::Common_glCompressedTextureSubImage1DEXT(GLResourceRecord *re
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
     }
@@ -5571,7 +5571,7 @@ void WrappedOpenGL::Common_glCompressedTextureSubImage2DEXT(GLResourceRecord *re
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
     }
@@ -5787,7 +5787,7 @@ void WrappedOpenGL::Common_glCompressedTextureSubImage3DEXT(GLResourceRecord *re
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
     }
@@ -5961,7 +5961,7 @@ void WrappedOpenGL::Common_glTextureBufferRangeEXT(ResourceId texId, GLenum targ
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
 
@@ -6135,7 +6135,7 @@ void WrappedOpenGL::Common_glTextureBufferEXT(ResourceId texId, GLenum target,
 
     if(IsActiveCapturing(m_State))
     {
-      m_ContextRecord->AddChunk(chunk);
+      GetContextRecord()->AddChunk(chunk);
       m_MissingTracks.insert(record->GetResourceID());
       GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Read);
 

--- a/renderdoc/driver/gl/wrappers/gl_uniform_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_uniform_funcs.cpp
@@ -345,7 +345,7 @@ bool WrappedOpenGL::Serialise_glProgramUniformMatrix(SerialiserType &ser, GLuint
       const paramtype vals[] = {ARRAYLIST};                                                      \
       Serialise_glProgramUniformVector(ser, PROGRAM, location, 1, vals,                          \
                                        CONCAT(CONCAT(VEC, count), CONCAT(suffix, v)));           \
-      m_ContextRecord->AddChunk(scope.Get());                                                    \
+      GetContextRecord()->AddChunk(scope.Get());                                                 \
     }                                                                                            \
     else if(IsBackgroundCapturing(m_State))                                                      \
     {                                                                                            \
@@ -448,7 +448,7 @@ UNIFORM_FUNC(4, d, GLdouble, GLdouble v0, GLdouble v1, GLdouble v2, GLdouble v3)
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                        \
       Serialise_glProgramUniformVector(ser, PROGRAM, location, count, value,                      \
                                        CONCAT(CONCAT(VEC, unicount), CONCAT(suffix, v)));         \
-      m_ContextRecord->AddChunk(scope.Get());                                                     \
+      GetContextRecord()->AddChunk(scope.Get());                                                  \
     }                                                                                             \
     else if(IsBackgroundCapturing(m_State))                                                       \
     {                                                                                             \
@@ -530,7 +530,7 @@ UNIFORM_FUNC(4, d, GLdouble)
       SCOPED_SERIALISE_CHUNK(gl_CurChunk);                                                   \
       Serialise_glProgramUniformMatrix(ser, PROGRAM, location, count, transpose, value,      \
                                        CONCAT(CONCAT(MAT, dim), suffix));                    \
-      m_ContextRecord->AddChunk(scope.Get());                                                \
+      GetContextRecord()->AddChunk(scope.Get());                                             \
     }                                                                                        \
     else if(IsBackgroundCapturing(m_State))                                                  \
     {                                                                                        \


### PR DESCRIPTION
## Description

adds multicontext support for GL, where every thread's chunks are now stored in their respective ContextResourceRecord, where the ID is stored in m_ActiveContextResourceIDs. Global information such as start/end of frame is still stored in m_contextRecord. 

VR applications, upon reception of a end-of-frame marker, choose to only replay the app's context. 