### PR TITLE
adding support for multiview and MSAA in GL replays

### DIFF
--- a/renderdoc/driver/gl/gl_common.cpp
+++ b/renderdoc/driver/gl/gl_common.cpp
@@ -794,7 +794,10 @@ bool GLInitParams::IsSupportedVersion(uint64_t ver)
   if(ver == CurrentVersion)
     return true;
 
-  // we can check other older versions we support here.
+  // 0x1A -> 0x1B - supported MSAA and Multiview framebuffer attachments, which added
+  // number of samples, number of views, and base view index to the serialized data
+  if(ver == 0x1A)
+    return true;
 
   return false;
 }

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -457,7 +457,9 @@ extern bool IsGLES;
   EXT_TO_CHECK(99, 99, NV_read_depth)                            \
   EXT_TO_CHECK(99, 99, NV_read_stencil)                          \
   EXT_TO_CHECK(99, 99, NV_read_depth_stencil)                    \
-  EXT_TO_CHECK(99, 99, EXT_disjoint_timer_query)
+  EXT_TO_CHECK(99, 99, EXT_disjoint_timer_query)                 \
+  EXT_TO_CHECK(99, 99, EXT_multisampled_render_to_texture)       \
+  EXT_TO_CHECK(99, 99, OVR_multiview)
 
 // GL extensions equivalents
 // Either promoted extensions from EXT to ARB, or

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -53,7 +53,7 @@ struct GLInitParams
   uint32_t height;
 
   // check if a frame capture section version is supported
-  static const uint64_t CurrentVersion = 0x1A;
+  static const uint64_t CurrentVersion = 0x1B;
   static bool IsSupportedVersion(uint64_t ver);
 };
 

--- a/renderdoc/driver/gl/gl_initstate.h
+++ b/renderdoc/driver/gl/gl_initstate.h
@@ -78,6 +78,10 @@ struct FramebufferAttachmentData
   bool layered;
   int32_t layer;
   int32_t level;
+  int32_t numVirtualSamples;    // number of samples for mobile MSAA framebuffers, where the tiler
+                                // resolves into non-msaa textures
+  int32_t numViews;             // number of views for multiview framebuffers
+  int32_t startView;            // index of the first view for multiview framebuffers
   GLResource obj;
 };
 


### PR DESCRIPTION


## Description

adding support for multiview and MSAA in GL replays, as talked about in IRC. adding 3 new members, MSAA samples, number of views and first view index. 