### PR TITLE
Fix releasing Vulkan resources

### DIFF
--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -303,6 +303,9 @@ public:
   {
     ResourceId id = GetResID(obj);
 
+    if(m_CurrentResourceMap.find(id) == m_CurrentResourceMap.end())
+      return;
+
     auto origit = m_OriginalIDs.find(id);
     if(origit != m_OriginalIDs.end())
       EraseLiveResource(origit->second);


### PR DESCRIPTION
RenderDoc crashes on Android when it tries to release a VkImage resource during vkDestroySwapchainKHR that was already released with vkDestroyImage.