### PR TITLE
disable eglSwapBuffers if VR markers are being used

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -518,7 +518,7 @@ WrappedOpenGL::WrappedOpenGL(const GLHookSet &funcs, GLPlatform &platform)
 
   m_AppControlledCapture = false;
 
-  m_UseVRMarkers = true;
+  m_UsesVRMarkers = false;
 
   m_RealDebugFunc = NULL;
   m_RealDebugFuncParam = NULL;

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -117,7 +117,7 @@ private:
 
   bool m_MarkedActive = false;
 
-  bool m_UseVRMarkers;
+  bool m_UsesVRMarkers;
 
   GLReplay m_Replay;
   RDCDriver m_DriverType;
@@ -646,8 +646,7 @@ public:
   void CreateVRAPITextureSwapChain(GLuint tex, GLenum textureType, GLenum internalformat,
                                    GLsizei width, GLsizei height, GLint levels);
   void HandleVRFrameMarkers(const GLchar *buf, GLsizei length);
-  void DisableVRFrameMarkers();
-
+  bool UsesVRFrameMarkers() { return m_UsesVRMarkers; }
   void FirstFrame(void *ctx, void *wndHandle);
 
   void StartFrameCapture(void *dev, void *wnd);

--- a/renderdoc/driver/gl/gl_hooks_egl.cpp
+++ b/renderdoc/driver/gl/gl_hooks_egl.cpp
@@ -369,7 +369,8 @@ __attribute__((visibility("default"))) EGLBoolean eglSwapBuffers(EGLDisplay dpy,
 
   eglhooks.GetDriver()->SetDriverType(RDCDriver::OpenGLES);
   eglhooks.GetDriver()->WindowSize(surface, width, height);
-  eglhooks.GetDriver()->SwapBuffers(surface);
+  if(!eglhooks.GetDriver()->UsesVRFrameMarkers())
+    eglhooks.GetDriver()->SwapBuffers(surface);
 
   return eglhooks.real.SwapBuffers(dpy, surface);
 }

--- a/renderdoc/driver/gl/gl_hooks_vrapi.cpp
+++ b/renderdoc/driver/gl/gl_hooks_vrapi.cpp
@@ -240,10 +240,9 @@ __attribute__((visibility("default"))) void vrapi_SubmitFrame(ovrMobile *ovr,
     vrapi_hooks.SetupHooks();
   }
 
-  if(m_GLDriver)
+  if(m_GLDriver && !m_GLDriver->UsesVRFrameMarkers())
   {
     SCOPED_LOCK(glLock);
-    m_GLDriver->DisableVRFrameMarkers();
     m_GLDriver->SwapBuffers(ovr);
   }
 

--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -191,18 +191,14 @@ bool WrappedOpenGL::Serialise_glDebugMessageInsert(SerialiserType &ser, GLenum s
   return true;
 }
 
-void WrappedOpenGL::DisableVRFrameMarkers()
-{
-  m_UseVRMarkers = false;
-}
-
 void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
 {
-  if(m_UseVRMarkers && strstr(buf, "vr-marker,frame_end,type,application") != NULL)
+  if(strstr(buf, "vr-marker,frame_end,type,application") != NULL)
   {
     void *ctx = NULL, *wnd = NULL;
     RenderDoc::Inst().GetActiveWindow(ctx, wnd);
     SwapBuffers(wnd);
+    m_UsesVRMarkers = true;
 
     if(IsActiveCapturing(m_State))
     {


### PR DESCRIPTION
## Description

avoid standard eglSwapBuffers or vrapi_submitframe-based SwapBuffers if we're using the VR end-of-frame markers. some badly behaving VR apps call eglSwapBuffers anyway although there is really nothing for them to swap. 
