### PR TITLE
Specify fields for VkSamplerCreateInfo

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -50,6 +50,16 @@ static void create(WrappedVulkan *driver, const char *objName, const int line, V
   sampInfo.addressModeU = sampInfo.addressModeV = sampInfo.addressModeW =
       VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
   sampInfo.maxLod = 128.0f;
+  sampInfo.minLod = 0.0f;
+  sampInfo.mipLodBias = 0.0f;
+  sampInfo.anisotropyEnable = VK_FALSE;
+  sampInfo.maxAnisotropy = 1.0f;
+  sampInfo.flags = 0;
+  sampInfo.compareEnable = VK_FALSE;
+  sampInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+  sampInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+  sampInfo.unnormalizedCoordinates = VK_FALSE;
+  sampInfo.pNext = NULL;
 
   VkResult vkr = driver->vkCreateSampler(driver->GetDev(), &sampInfo, NULL, sampler);
   if(vkr != VK_SUCCESS)

--- a/renderdoc/driver/vulkan/vk_rendertext.cpp
+++ b/renderdoc/driver/vulkan/vk_rendertext.cpp
@@ -49,6 +49,16 @@ VulkanTextRenderer::VulkanTextRenderer(WrappedVulkan *driver)
   sampInfo.addressModeU = sampInfo.addressModeV = sampInfo.addressModeW =
       VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
   sampInfo.maxLod = 128.0f;
+  sampInfo.minLod = 0.0f;
+  sampInfo.mipLodBias = 0.0f;
+  sampInfo.anisotropyEnable = VK_FALSE;
+  sampInfo.maxAnisotropy = 1.0f;
+  sampInfo.flags = 0;
+  sampInfo.compareEnable = VK_FALSE;
+  sampInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+  sampInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+  sampInfo.unnormalizedCoordinates = VK_FALSE;
+  sampInfo.pNext = NULL;
 
   vkr = m_pDriver->vkCreateSampler(dev, &sampInfo, NULL, &m_LinearSampler);
   RDCASSERTEQUAL(vkr, VK_SUCCESS);


### PR DESCRIPTION
When a validation layer is used in a Vulkan application, the debug callback shows a warning message saying the max anisotropy should be 1.
Specify all field to make sure the members are initialized.

