### PR TITLE
Fix order that InitialContents are applied for Vulkan.

### DIFF
--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -612,6 +612,16 @@ void VulkanResourceManager::Apply_InitialState(WrappedVkRes *live, VkInitialCont
   return m_Core->Apply_InitialState(live, initial);
 }
 
+std::vector<ResourceId> VulkanResourceManager::InitialContentResources()
+{
+  std::vector<ResourceId> resources =
+      ResourceManager<VulkanResourceManagerConfiguration>::InitialContentResources();
+  std::sort(resources.begin(), resources.end(), [this](ResourceId a, ResourceId b) {
+    return m_InitialContents[a].type < m_InitialContents[b].type;
+  });
+  return resources;
+}
+
 bool VulkanResourceManager::ResourceTypeRelease(WrappedVkRes *res)
 {
   return m_Core->ReleaseResource(res);

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -419,6 +419,7 @@ private:
   bool Serialise_InitialState(WriteSerialiser &ser, ResourceId resid, WrappedVkRes *res);
   void Create_InitialState(ResourceId id, WrappedVkRes *live, bool hasData);
   void Apply_InitialState(WrappedVkRes *live, VkInitialContents initial);
+  std::vector<ResourceId> InitialContentResources();
 
   CaptureState m_State;
   WrappedVulkan *m_Core;


### PR DESCRIPTION
This fixes a bug where the memory backing an image could be initialized
after the image itself, causing corruptions. ApplyInitialContents was
processing the resources in order of resource id. It is possible that a
VkImage and the VkDeviceMemory it is bound to both have InitialContent
(e.g. because the VkDeviceMemory also backs a buffer), and it is also
possible that the VkImage has a lower resource id than the
VkDeviceMemory. In this case, the VkImage's InitialContent is loaded,
and then the VkDeviceMemory's InitialContent is loaded. This direct
write of the backing memory causes the VkImage content to become
undefined and, at least on my AMD card, causes image corruption.

This is fixed by sorting the resource ids by type, which works because
`eResDeviceMemory < eResImage`. This sorting is applied only for
VulkanResourceManager.