### PR TITLE
Fix malformed path exception

### DIFF
--- a/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
@@ -590,9 +590,19 @@ VirtualFileDialog::VirtualFileDialog(ICaptureContext &ctx, QString initialDirect
 
   ui->buttonBox->button(QDialogButtonBox::Ok)->setDefault(false);
 
+  QModelIndex index;
+
+  if(!initialDirectory.isEmpty() && !ctx.Replay().CurrentRemote()->IsADB())
+  {
+    index = m_Model->indexForPath(initialDirectory);
+  }
+  if(!index.isValid())
+  {
+    index = m_Model->homeFolder();
+  }
   // switch to home folder and expand it
-  changeCurrentDir(initialDirectory.isEmpty() ? m_Model->homeFolder()
-                                              : m_Model->indexForPath(initialDirectory));
+  changeCurrentDir(index);
+
   ui->dirList->expand(m_DirProxy->mapFromSource(currentDir()));
 
   QObject::connect(ui->fileList->selectionModel(), &QItemSelectionModel::selectionChanged, this,


### PR DESCRIPTION
Malformed/unexpected path exception is thrown when File Browser is opened to select an Executable Path or Working Directory if Replay Context was switched from Local to Android device.
Wrong Executable Path is set (Android package name is appended to RenderDoc's build folder path) e.g. /home/tabikati/Workspace/build-renderdoc-Desktop_Qt_5_6_1_GCC_64bit-Debug/com.example.native_activity while it should be the package name (com.example.native_activity) only.