### PR TITLE
Changing active context with button

### DIFF
--- a/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
@@ -122,6 +122,7 @@ LiveCapture::LiveCapture(ICaptureContext &ctx, const QString &hostname, const QS
   ui->triggerDelayedCapture->setEnabled(false);
   ui->triggerImmediateCapture->setEnabled(false);
   ui->queueCap->setEnabled(false);
+  ui->cycleActiveWindow->setEnabled(false);
 
   ui->target->setText(QString());
 
@@ -280,6 +281,11 @@ void LiveCapture::on_triggerImmediateCapture_clicked()
 {
   m_TriggerCapture = true;
   m_CaptureNumFrames = (int)ui->numFrames->value();
+}
+
+void LiveCapture::on_cycleActiveWindow_clicked()
+{
+  m_Connection->CycleActiveWindow();
 }
 
 void LiveCapture::on_triggerDelayedCapture_clicked()
@@ -1257,6 +1263,12 @@ void LiveCapture::connectionThreadEntry()
         }
       }
     }
+
+    if(msg.type == TargetControlMessageType::CapturableWindowCount)
+    {
+      uint32_t windows = msg.capturableWindowCount;
+      GUIInvoke::call(this, [this, windows]() { ui->cycleActiveWindow->setEnabled(windows > 1); });
+    }
   }
 
   GUIInvoke::call(this, [this]() {
@@ -1269,6 +1281,7 @@ void LiveCapture::connectionThreadEntry()
     ui->triggerDelayedCapture->setEnabled(false);
     ui->triggerImmediateCapture->setEnabled(false);
     ui->queueCap->setEnabled(false);
+    ui->cycleActiveWindow->setEnabled(false);
 
     ui->apiStatus->setText(tr("None"));
     ui->apiIcon->setVisible(false);

--- a/qrenderdoc/Windows/Dialogs/LiveCapture.h
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.h
@@ -70,6 +70,7 @@ private slots:
   void on_captures_itemActivated(QListWidgetItem *item);
   void on_childProcesses_itemActivated(QListWidgetItem *item);
   void on_triggerImmediateCapture_clicked();
+  void on_cycleActiveWindow_clicked();
   void on_triggerDelayedCapture_clicked();
   void on_queueCap_clicked();
   void on_previewSplit_splitterMoved(int pos, int index);

--- a/qrenderdoc/Windows/Dialogs/LiveCapture.ui
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.ui
@@ -190,7 +190,14 @@
          <string>Tools</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="2" column="1">
+         <item row="1" column="0" colspan="2">
+          <widget class="QPushButton" name="triggerImmediateCapture">
+           <property name="text">
+            <string>Capture Frame(s) Immediately</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
           <widget class="QDoubleSpinBox" name="captureDelay">
            <property name="baseSize">
             <size>
@@ -212,7 +219,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <widget class="QDoubleSpinBox" name="captureFrame">
            <property name="prefix">
             <string>Frame </string>
@@ -225,14 +232,14 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QPushButton" name="triggerDelayedCapture">
            <property name="text">
             <string>Capture After Delay:</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QPushButton" name="queueCap">
            <property name="text">
             <string>Capture Specific Frame(s):</string>
@@ -267,7 +274,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0" colspan="2">
+         <item row="5" column="0" colspan="2">
           <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -280,10 +287,10 @@
            </property>
           </spacer>
          </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QPushButton" name="triggerImmediateCapture">
+         <item row="6" column="0">
+          <widget class="QPushButton" name="cycleActiveWindow">
            <property name="text">
-            <string>Capture Frame(s) Immediately</string>
+            <string>Cycle Active Window</string>
            </property>
           </widget>
          </item>

--- a/renderdoc/api/replay/control_types.h
+++ b/renderdoc/api/replay/control_types.h
@@ -542,6 +542,9 @@ When valid, will be in the range of 0.0 to 1.0 (0 - 100%). If not valid when a c
 or has finished, it will be -1.0
 )");
   float capProgress = -1.0f;
+
+  DOCUMENT("The number of the capturable windows");
+  uint32_t capturableWindowCount = 0;
 };
 
 DECLARE_REFLECTION_STRUCT(TargetControlMessage);

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -1342,6 +1342,9 @@ The details of the types of messages that can be received are listed under
 )");
   virtual TargetControlMessage ReceiveMessage(RENDERDOC_ProgressCallback progress) = 0;
 
+  DOCUMENT("Cycle the currently active window if there are more windows to capture.");
+  virtual void CycleActiveWindow() = 0;
+
 protected:
   ITargetControl() = default;
   ~ITargetControl() = default;

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -3143,6 +3143,7 @@ enum class TargetControlMessageType : uint32_t
   RegisterAPI,
   NewChild,
   CaptureProgress,
+  CapturableWindowCount
 };
 
 DECLARE_REFLECTION_ENUM(TargetControlMessageType);

--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -542,27 +542,7 @@ void RenderDoc::Tick()
 
   if(!prev_focus && cur_focus)
   {
-    m_Cap = 0;
-
-    // can only shift focus if we have multiple windows
-    if(m_WindowFrameCapturers.size() > 1)
-    {
-      for(auto it = m_WindowFrameCapturers.begin(); it != m_WindowFrameCapturers.end(); ++it)
-      {
-        if(it->first == m_ActiveWindow)
-        {
-          auto nextit = it;
-          ++nextit;
-
-          if(nextit != m_WindowFrameCapturers.end())
-            m_ActiveWindow = nextit->first;
-          else
-            m_ActiveWindow = m_WindowFrameCapturers.begin()->first;
-
-          break;
-        }
-      }
-    }
+    CycleActiveWindow();
   }
   if(!prev_cap && cur_cap)
   {
@@ -571,6 +551,31 @@ void RenderDoc::Tick()
 
   prev_focus = cur_focus;
   prev_cap = cur_cap;
+}
+
+void RenderDoc::CycleActiveWindow()
+{
+  m_Cap = 0;
+
+  // can only shift focus if we have multiple windows
+  if(m_WindowFrameCapturers.size() > 1)
+  {
+    for(auto it = m_WindowFrameCapturers.begin(); it != m_WindowFrameCapturers.end(); ++it)
+    {
+      if(it->first == m_ActiveWindow)
+      {
+        auto nextit = it;
+        ++nextit;
+
+        if(nextit != m_WindowFrameCapturers.end())
+          m_ActiveWindow = nextit->first;
+        else
+          m_ActiveWindow = m_WindowFrameCapturers.begin()->first;
+
+        break;
+      }
+    }
+  }
 }
 
 string RenderDoc::GetOverlayText(RDCDriver driver, uint32_t frameNumber, int flags)

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -536,6 +536,8 @@ public:
 
   string GetOverlayText(RDCDriver driver, uint32_t frameNumber, int flags);
 
+  void CycleActiveWindow();
+  uint32_t GetCapturableWindowCount() { return (uint32_t)m_WindowFrameCapturers.size(); }
 private:
   RenderDoc();
   ~RenderDoc();


### PR DESCRIPTION
A new button is added to the UI so that we can change the currently active context when there are more context to capture.  It's like pressing the F11 button but it works on Android too.