### PR TITLE
Retry memory allocation for Vulkan resources

### DIFF
--- a/renderdoc/driver/vulkan/vk_memory.cpp
+++ b/renderdoc/driver/vulkan/vk_memory.cpp
@@ -316,6 +316,16 @@ MemoryAllocation WrappedVulkan::AllocateMemoryForResource(bool buffer, VkMemoryR
 
     // do the actual allocation
     VkResult vkr = ObjDisp(d)->AllocateMemory(Unwrap(d), &info, NULL, &chunk.mem);
+
+    if(vkr == VK_ERROR_OUT_OF_HOST_MEMORY)
+    {
+      RDCDEBUG("Allocation failed. Creating new allocation of 0x%llx bytes", ret.size);
+      info.allocationSize = ret.size;
+      chunk.size = info.allocationSize;
+      vkr = ObjDisp(d)->AllocateMemory(Unwrap(d), &info, NULL, &chunk.mem);
+      allocSize = 0;
+    }
+
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
     GetResourceManager()->WrapResource(Unwrap(d), chunk.mem);


### PR DESCRIPTION
Allocating memory for Vulkan resources may produce VK_ERROR_OUT_OF_HOST_MEMORY error. In this case, we can retry to allocate memory with the exact allocation size.