### PR TITLE
Handle failed APK installation and patching

### DIFF
--- a/qrenderdoc/Code/Interface/RemoteHost.cpp
+++ b/qrenderdoc/Code/Interface/RemoteHost.cpp
@@ -105,19 +105,23 @@ void RemoteHost::CheckStatus()
   QThread::msleep(15);
 }
 
-void RemoteHost::Launch()
+ReplayStatus RemoteHost::Launch()
 {
+  ReplayStatus status = ReplayStatus::Succeeded;
+
   int WAIT_TIME = 2000;
 
   if(IsADB())
   {
-    RENDERDOC_StartAndroidRemoteServer(hostname.c_str());
+    status = RENDERDOC_StartAndroidRemoteServer(hostname.c_str());
     QThread::msleep(WAIT_TIME);
-    return;
+    return status;
   }
 
   RDProcess process;
   process.start(runCommand);
   process.waitForFinished(WAIT_TIME);
   process.detach();
+
+  return status;
 }

--- a/qrenderdoc/Code/Interface/RemoteHost.h
+++ b/qrenderdoc/Code/Interface/RemoteHost.h
@@ -48,8 +48,10 @@ public:
   DOCUMENT(
       "Ping the host to check current status - if the server is running, connection status, etc.");
   void CheckStatus();
-  DOCUMENT("Runs the command specified in :data:`runCommand`.");
-  void Launch();
+  DOCUMENT(
+      "Runs the command specified in :data:`runCommand`. Returns :class:`ReplayStatus` which "
+      "indicates success or the type of failure.");
+  ReplayStatus Launch();
 
   DOCUMENT("``True`` if a remote server is currently running on this host.");
   bool serverRunning : 1;

--- a/qrenderdoc/Code/pyrenderdoc/qrenderdoc_stub.cpp
+++ b/qrenderdoc/Code/pyrenderdoc/qrenderdoc_stub.cpp
@@ -171,6 +171,7 @@ void RemoteHost::CheckStatus()
 {
 }
 
-void RemoteHost::Launch()
+ReplayStatus RemoteHost::Launch()
 {
+  return ReplayStatus::Succeeded;
 }

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -1843,7 +1843,11 @@ void MainWindow::switchContext()
           statusProgress->setMaximum(0);
         });
 
-        host->Launch();
+        ReplayStatus launchStatus = host->Launch();
+        if(launchStatus != ReplayStatus::Succeeded)
+        {
+          showLaunchError(launchStatus);
+        }
 
         // check if it's running now
         host->CheckStatus();
@@ -2799,4 +2803,33 @@ bool MainWindow::LoadLayout(int layout)
   qInfo() << "Couldn't load layout from " << path << " " << f.errorString();
 
   return false;
+}
+
+void MainWindow::showLaunchError(ReplayStatus status)
+{
+  QString title;
+  QString message;
+  switch(status)
+  {
+    case ReplayStatus::AndroidGrantPermissionsFailed:
+      title = tr("Permission is required");
+      message = tr("Enable RenderDocCmd to access storage on your device.");
+      break;
+    case ReplayStatus::AndroidABINotFound:
+      title = tr("Failed to install RenderDoc server");
+      message = tr("Couldn't determine supported ABIs.");
+      break;
+    case ReplayStatus::AndroidAPKFolderNotFound:
+      title = tr("Failed to install RenderDoc server");
+      message = tr("APK folder missing.");
+      break;
+    case ReplayStatus::AndroidAPKInstallFailed:
+      title = tr("Failed to install RenderDoc server");
+      message = tr("Couldn't find any installed APKs.");
+    default:
+      title = tr("Failed to install RenderDoc server");
+      message = tr("Unknown error.");
+      break;
+  }
+  GUIInvoke::call(this, [this, title, message]() { RDDialog::warning(this, title, message); });
 }

--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -248,4 +248,6 @@ private:
   bool SaveLayout(int layout);
 
   void FillRemotesMenu(QMenu *menu, bool includeLocalhost);
+
+  void showLaunchError(ReplayStatus status);
 };

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -2243,7 +2243,8 @@ DOCUMENT("Internal function for checking android support.");
 extern "C" RENDERDOC_API bool RENDERDOC_CC RENDERDOC_IsAndroidSupported(const char *device);
 
 DOCUMENT("Internal function for starting an android remote server.");
-extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_StartAndroidRemoteServer(const char *device);
+extern "C" RENDERDOC_API ReplayStatus RENDERDOC_CC
+RENDERDOC_StartAndroidRemoteServer(const char *device);
 
 DOCUMENT("Internal function for checking remote Android package for requirements");
 extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_CheckAndroidPackage(const char *hostname,

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -3078,6 +3078,22 @@ a remote server.
 
   The API failed to replay the capture, with some runtime error that couldn't be determined until
   the replay began.
+
+.. data:: AndroidGrantPermissionsFailed
+
+  Failed to grant runtime permissions when installing Android remote server.
+
+.. data:: AndroidABINotFound
+
+  Couldn't determine supported ABIs when installing Android remote server.
+
+.. data:: AndroidAPKFolderNotFound
+
+  Couldn't find the build-android folder which contains the Android remote server APK.
+
+.. data:: AndroidAPKInstallFailed
+
+  Failed to install Android remote server.
 )");
 enum class ReplayStatus : uint32_t
 {
@@ -3101,6 +3117,10 @@ enum class ReplayStatus : uint32_t
   APIDataCorrupted,
   APIReplayFailed,
   JDWPFailure,
+  AndroidGrantPermissionsFailed,
+  AndroidABINotFound,
+  AndroidAPKFolderNotFound,
+  AndroidAPKInstallFailed
 };
 
 DECLARE_REFLECTION_ENUM(ReplayStatus);


### PR DESCRIPTION
If "adb install" command is used with "-g" flag, we may get java.lang.SecurityException on some devices because granting runtime permissions at installation time is only allowed for system apps (however we can enable it in the device's Developer options menu).
Also, pulling APK from /data/app/ may be restricted. We can workaround by copying the APK to a directory which we can access then try to pull the APK from there.