### PR TITLE
Fix warning on setting uniform for image

### DIFF
--- a/renderdoc/driver/gl/gl_overlay.cpp
+++ b/renderdoc/driver/gl/gl_overlay.cpp
@@ -1344,7 +1344,7 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, CompType typeHint, DebugOve
 
           GLint loc = drv.glGetUniformLocation(DebugData.overlayProg, "overdrawImage");
           if(loc != -1)
-            drv.glUniform1ui(loc, 0);
+            drv.glUniform1i(loc, 0);
           else
             RDCERR("Couldn't get location of overdrawImage");
 


### PR DESCRIPTION
When selecting "Quad Overdraw (Pass)" from the texture viewer, I get this warning :

Log     - Got a Debug message from GL_DEBUG_SOURCE_API, type GL_DEBUG_TYPE_ERROR, ID 81, severity GL_DEBUG_SEVERITY_HIGH:
'GL_INVALID_OPERATION in glUniform1("overdrawImage"@12 is image, not uint)'
