### PR TITLE
insert activecontext's window pointer in VR swapbuffer

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_debug_funcs.cpp
@@ -219,9 +219,7 @@ void WrappedOpenGL::HandleVRFrameMarkers(const GLchar *buf, GLsizei length)
 {
   if(strstr(buf, "vr-marker,frame_end,type,application") != NULL)
   {
-    void *ctx = NULL, *wnd = NULL;
-    RenderDoc::Inst().GetActiveWindow(ctx, wnd);
-    SwapBuffers(wnd);
+    SwapBuffers((void *)m_ActiveContexts[Threading::GetCurrentID()].wnd);
     m_UsesVRMarkers = true;
 
     if(IsActiveCapturing(m_State))


### PR DESCRIPTION
## Description
If there has never been an active window before (no eglSwapBuffers ever), then GetActiveWindow will return a NULL pointer and SwapBuffers won't select an active window due to it being called with a null pointer. 

With this change, instead of using GetActiveWindow, we use the current context's EGL window which is the one you would submit in an eglSwapBuffers call, and which after the first call to eglSwapBuffers is exactly equivalent to GetActiveWindow(ctx,wnd). 