### PR TITLE
Display any counter in EventBrowser

### DIFF
--- a/qrenderdoc/Windows/EventBrowser.h
+++ b/qrenderdoc/Windows/EventBrowser.h
@@ -68,7 +68,7 @@ private slots:
   // automatic slots
   void on_find_clicked();
   void on_gotoEID_clicked();
-  void on_timeDraws_clicked();
+  void on_countersRefresh_clicked();
   void on_bookmark_clicked();
   void on_HideFindJump();
   void on_jumpToEID_returnPressed();
@@ -95,10 +95,11 @@ public slots:
   void jumpToBookmark(int idx);
 
 private:
+  void SetColumns(bool initialSetup);
   bool ShouldHide(const DrawcallDescription &drawcall);
   QPair<uint32_t, uint32_t> AddDrawcalls(RDTreeWidgetItem *parent,
                                          const rdcarray<DrawcallDescription> &draws);
-  void SetDrawcallTimes(RDTreeWidgetItem *node, const rdcarray<CounterResult> &results);
+  void SetDrawcallCounters(RDTreeWidgetItem *node, const rdcarray<CounterResult> &results);
 
   void ExpandNode(RDTreeWidgetItem *node);
 
@@ -126,12 +127,20 @@ private:
                         const DrawcallDescription &drawcall);
   void ExportDrawcall(QTextStream &writer, int maxNameLength, int indent, bool firstchild,
                       const DrawcallDescription &drawcall);
+  GPUCounter ColumnToGPUCounter(int column);
+  CounterDescription DescribeCounter(GPUCounter counter);
+
+  int m_DurationColumn;
 
   QPalette m_redPalette;
 
   TimeUnit m_TimeUnit = TimeUnit::Count;
 
-  rdcarray<CounterResult> m_Times;
+  QVector<CounterDescription> m_CounterDescriptions;
+  QMap<GPUCounter, int> m_CounterToColumn;
+  std::vector<GPUCounter> m_SelectedCounters;
+
+  rdcarray<CounterResult> m_Counters;
 
   QTimer *m_FindHighlight;
 

--- a/qrenderdoc/Windows/EventBrowser.ui
+++ b/qrenderdoc/Windows/EventBrowser.ui
@@ -130,9 +130,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="timeDraws">
+      <widget class="QToolButton" name="countersRefresh">
        <property name="toolTip">
-        <string>Time durations for the drawcalls</string>
+        <string>Refresh counter values</string>
        </property>
        <property name="text">
         <string/>


### PR DESCRIPTION
Since EventGPUDuration is a counter like any other, I figured people
might want to display any counter instead.

This change makes all the counters visible in the selection dialog and
allows the user to pick the ones he/she wants to see in the browser.

Here is a screenshot of what that looks like with Intel counters (for another PR) : 
![screenshot from 2018-10-26 12-59-44](https://user-images.githubusercontent.com/434333/47565670-3750f200-d921-11e8-94c3-cfe6e4e67fcb.png)
