### PR TITLE
Mark interface destructors as virtual

### DIFF
--- a/qrenderdoc/Code/Interface/QRDInterface.h
+++ b/qrenderdoc/Code/Interface/QRDInterface.h
@@ -173,7 +173,7 @@ See the documentation for :meth:`RegisterShortcut` for what these shortcuts are 
 
 protected:
   IMainWindow() = default;
-  ~IMainWindow() = default;
+  virtual ~IMainWindow() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IMainWindow);
@@ -191,7 +191,7 @@ struct IEventBrowser
 
 protected:
   IEventBrowser() = default;
-  ~IEventBrowser() = default;
+  virtual ~IEventBrowser() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IEventBrowser);
@@ -209,7 +209,7 @@ struct IAPIInspector
 
 protected:
   IAPIInspector() = default;
-  ~IAPIInspector() = default;
+  virtual ~IAPIInspector() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IAPIInspector);
@@ -231,7 +231,7 @@ struct IPipelineStateViewer
 
 protected:
   IPipelineStateViewer() = default;
-  ~IPipelineStateViewer() = default;
+  virtual ~IPipelineStateViewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IPipelineStateViewer);
@@ -260,7 +260,7 @@ struct ITextureViewer
 
 protected:
   ITextureViewer() = default;
-  ~ITextureViewer() = default;
+  virtual ~ITextureViewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(ITextureViewer);
@@ -301,7 +301,7 @@ struct IBufferViewer
 
 protected:
   IBufferViewer() = default;
-  ~IBufferViewer() = default;
+  virtual ~IBufferViewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IBufferViewer);
@@ -330,7 +330,7 @@ struct IResourceInspector
 
 protected:
   IResourceInspector() = default;
-  ~IResourceInspector() = default;
+  virtual ~IResourceInspector() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IResourceInspector);
@@ -416,7 +416,7 @@ struct ICaptureDialog
 
 protected:
   ICaptureDialog() = default;
-  ~ICaptureDialog() = default;
+  virtual ~ICaptureDialog() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(ICaptureDialog);
@@ -432,7 +432,7 @@ struct IDebugMessageView
 
 protected:
   IDebugMessageView() = default;
-  ~IDebugMessageView() = default;
+  virtual ~IDebugMessageView() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IDebugMessageView);
@@ -448,7 +448,7 @@ struct ICommentView
 
 protected:
   ICommentView() = default;
-  ~ICommentView() = default;
+  virtual ~ICommentView() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(ICommentView);
@@ -464,7 +464,7 @@ struct IStatisticsViewer
 
 protected:
   IStatisticsViewer() = default;
-  ~IStatisticsViewer() = default;
+  virtual ~IStatisticsViewer() = default;
 };
 
 DOCUMENT("The timeline bar.");
@@ -490,7 +490,7 @@ struct ITimelineBar
 
 protected:
   ITimelineBar() = default;
-  ~ITimelineBar() = default;
+  virtual ~ITimelineBar() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IStatisticsViewer);
@@ -506,7 +506,7 @@ struct IPerformanceCounterViewer
 
 protected:
   IPerformanceCounterViewer() = default;
-  ~IPerformanceCounterViewer() = default;
+  virtual ~IPerformanceCounterViewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IPerformanceCounterViewer);
@@ -521,7 +521,7 @@ struct IPythonShell
 
 protected:
   IPythonShell() = default;
-  ~IPythonShell() = default;
+  virtual ~IPythonShell() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IPythonShell);
@@ -596,7 +596,7 @@ struct IShaderViewer
 
 protected:
   IShaderViewer() = default;
-  ~IShaderViewer() = default;
+  virtual ~IShaderViewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IShaderViewer);
@@ -612,7 +612,7 @@ struct IConstantBufferPreviewer
 
 protected:
   IConstantBufferPreviewer() = default;
-  ~IConstantBufferPreviewer() = default;
+  virtual ~IConstantBufferPreviewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IConstantBufferPreviewer);
@@ -634,7 +634,7 @@ struct IPixelHistoryView
 
 protected:
   IPixelHistoryView() = default;
-  ~IPixelHistoryView() = default;
+  virtual ~IPixelHistoryView() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IPixelHistoryView);
@@ -673,7 +673,7 @@ to a marker region.
 
 protected:
   ICaptureViewer() = default;
-  ~ICaptureViewer() = default;
+  virtual ~ICaptureViewer() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(ICaptureViewer);
@@ -858,7 +858,7 @@ comes in, we remove any other requests in the queue before it that have the same
 
 protected:
   IReplayManager() = default;
-  ~IReplayManager() = default;
+  virtual ~IReplayManager() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IReplayManager);
@@ -1959,7 +1959,7 @@ capture's API.
 
 protected:
   ICaptureContext() = default;
-  ~ICaptureContext() = default;
+  virtual ~ICaptureContext() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(ICaptureContext);

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -761,7 +761,7 @@ Should only be called for mesh outputs.
 
 protected:
   IReplayOutput() = default;
-  ~IReplayOutput() = default;
+  virtual ~IReplayOutput() = default;
 };
 
 DOCUMENT(R"(The primary interface to access the information in a capture and the current state, as
@@ -1240,7 +1240,7 @@ sample 0, etc.
 
 protected:
   IReplayController() = default;
-  ~IReplayController() = default;
+  virtual ~IReplayController() = default;
 };
 
 DECLARE_REFLECTION_STRUCT(IReplayController);
@@ -1347,7 +1347,7 @@ The details of the types of messages that can be received are listed under
 
 protected:
   ITargetControl() = default;
-  ~ITargetControl() = default;
+  virtual ~ITargetControl() = default;
 };
 
 DOCUMENT(R"(An interface for accessing a capture, possibly over a network connection. This is a
@@ -1442,7 +1442,7 @@ Must only be called after :meth:`InitResolver` has returned ``True``.
 
 protected:
   ICaptureAccess() = default;
-  ~ICaptureAccess() = default;
+  virtual ~ICaptureAccess() = default;
 };
 
 DOCUMENT(R"(A connection to a running remote RenderDoc server on another machine. This allows the
@@ -1599,7 +1599,7 @@ or an error has occurred.
 
 protected:
   IRemoteServer() = default;
-  ~IRemoteServer() = default;
+  virtual ~IRemoteServer() = default;
 };
 
 DOCUMENT(R"(A handle to a capture file. Used for simple cheap processing and meta-data fetching
@@ -1796,7 +1796,7 @@ The data is copied internally so it can be destroyed after calling this function
 
 protected:
   ICaptureFile() = default;
-  ~ICaptureFile() = default;
+  virtual ~ICaptureFile() = default;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -1884,7 +1884,7 @@ drag.
 
 protected:
   ICamera() = default;
-  ~ICamera() = default;
+  virtual ~ICamera() = default;
 };
 
 DOCUMENT(R"(Create a new camera of a given type.


### PR DESCRIPTION
Interfaces, i.e. structs/classes with virtual methods require a virtual
destructor to allow deriving classes to execute their dtors correctly.