### PR TITLE
SPIRV: Add support for BitField{Insert,SExtract,UExtract}

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_disassemble.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_disassemble.cpp
@@ -5867,6 +5867,9 @@ void ParseSPIRV(uint32_t *spirv, size_t spirvLength, SPVModule &module)
       case spv::OpUConvert:
       case spv::OpSConvert:
       case spv::OpBitcast:
+      case spv::OpBitFieldInsert:
+      case spv::OpBitFieldSExtract:
+      case spv::OpBitFieldUExtract:
       case spv::OpBitReverse:
       case spv::OpBitCount:
       case spv::OpAny:


### PR DESCRIPTION
They should behave just like any other standard opcode.

Signed-off-by: Nicolai Hähnle <nicolai.haehnle@amd.com>
