### PR TITLE
Fix invalid error message

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -1121,7 +1121,7 @@ void RenderDoc::RemoveDeviceFrameCapturer(void *dev)
 {
   if(dev == NULL)
   {
-    RDCERR("Invalid device pointer: %#p / %#p", dev);
+    RDCERR("Invalid device pointer: %#p", dev);
     return;
   }
 


### PR DESCRIPTION
The error string requests two arguments, but only one is available.