### PR TITLE
Fix temporary memory allocation for VkImageFormatListCreateInfoKHR

### DIFF
--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -403,6 +403,8 @@ size_t GetNextPatchSize(const void *pNext)
       memSize += sizeof(VkImageSwapchainCreateInfoKHR);
     else if(next->sType == VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV)
       memSize += sizeof(VkDedicatedAllocationImageCreateInfoNV);
+    else if(next->sType == VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR)
+      memSize += sizeof(VkImageFormatListCreateInfoKHR);
 
     // VkBufferCreateInfo
     else if(next->sType == VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO)


### PR DESCRIPTION
The struct gets serialized, but no memory is allocated for it. Fixes a crash/hang and funny messages like `free(): invalid next size (fast)` when using Renderdoc with DXVK.