### PR TITLE
Vector assert

### DIFF
--- a/renderdoc/driver/vulkan/vk_shader_cache.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_cache.cpp
@@ -294,7 +294,7 @@ void VulkanShaderCache::MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &p
   specMapEntries.resize(specEntries);
   specdata.resize(specSize);
 
-  VkSpecializationMapEntry *entry = &specMapEntries[0];
+  VkSpecializationMapEntry *entry = specMapEntries.data();
 
   uint32_t stageCount = 0;
   specSize = 0;

--- a/renderdoccmd/3rdparty/cmdline/cmdline.h
+++ b/renderdoccmd/3rdparty/cmdline/cmdline.h
@@ -398,6 +398,8 @@ public:
     int argc=static_cast<int>(args.size());
     std::vector<const char*> argv(argc);
 
+    if (argc<1) return false;
+
     for (int i=0; i<argc; i++)
       argv[i]=args[i].c_str();
 


### PR DESCRIPTION
gcc's debug std::vector will assert if operator[] indexes outside the vector's size.

I've run into a couple of places where &vector[0] is used unconditionally before iterating over the vector.