### PR TITLE
Fix fragment shader compile error

### DIFF
--- a/renderdoc/data/glsl/trisize.frag
+++ b/renderdoc/data/glsl/trisize.frag
@@ -28,5 +28,6 @@ layout (location = 0) out vec4 color_out;
 
 void main(void)
 {
-	color_out = vec4(max(pixarea, 0.001f).xxx, 1.0f);
+	float area = max(pixarea, 0.001f);
+	color_out = vec4(area, area, area, 1.0f);
 }


### PR DESCRIPTION
OpenGL ES does not allow swizzles on scalar expressions. It causes error when replaying OpenGL ES desktop application.