### PR TITLE
Fix integer signedness in Vulkan ConvertToMeshOutputCompute

### DIFF
--- a/renderdoc/driver/vulkan/vk_postvs.cpp
+++ b/renderdoc/driver/vulkan/vk_postvs.cpp
@@ -826,11 +826,15 @@ static void ConvertToMeshOutputCompute(const ShaderReflection &refl, const SPIRV
 
         if(builtin == ShaderBuiltin::VertexIndex)
         {
-          ops.push_back(SPIRVOperation(spv::OpStore, {ins[i].variableID, vertexIndex}));
+          uint32_t uintVertexIndex = editor.MakeId();
+          ops.push_back(SPIRVOperation(spv::OpBitcast, {uint32ID, uintVertexIndex, vertexIndex}));
+          ops.push_back(SPIRVOperation(spv::OpStore, {ins[i].variableID, uintVertexIndex}));
         }
         else if(builtin == ShaderBuiltin::InstanceIndex)
         {
-          ops.push_back(SPIRVOperation(spv::OpStore, {ins[i].variableID, instIndex}));
+          uint32_t uintInstanceIndex = editor.MakeId();
+          ops.push_back(SPIRVOperation(spv::OpBitcast, {uint32ID, uintInstanceIndex, instIndex}));
+          ops.push_back(SPIRVOperation(spv::OpStore, {ins[i].variableID, uintInstanceIndex}));
         }
         else if(builtin == ShaderBuiltin::ViewportIndex)
         {
@@ -841,17 +845,17 @@ static void ConvertToMeshOutputCompute(const ShaderReflection &refl, const SPIRV
           if(draw->flags & DrawFlags::Indexed)
             ops.push_back(SPIRVOperation(
                 spv::OpStore, {ins[i].variableID, editor.AddConstantImmediate(
-                                                      int32_t(draw->vertexOffset & 0x7fffffff))}));
+                                                      uint32_t(draw->vertexOffset & 0x7fffffff))}));
           else
             ops.push_back(SPIRVOperation(
-                spv::OpStore, {ins[i].variableID,
-                               editor.AddConstantImmediate(int32_t(draw->baseVertex & 0x7fffffff))}));
+                spv::OpStore, {ins[i].variableID, editor.AddConstantImmediate(
+                                                      uint32_t(draw->baseVertex & 0x7fffffff))}));
         }
         else if(builtin == ShaderBuiltin::BaseInstance)
         {
           ops.push_back(SPIRVOperation(
               spv::OpStore, {ins[i].variableID, editor.AddConstantImmediate(
-                                                    int32_t(draw->instanceOffset & 0x7fffffff))}));
+                                                    uint32_t(draw->instanceOffset & 0x7fffffff))}));
         }
         else if(builtin == ShaderBuiltin::DrawIndex)
         {


### PR DESCRIPTION
Mesa's SPIR-V parser as well as spirv-val reject shaders generated by this
function because a sint32 {vertex,instance}{Index,Base} is stored in a
uint32 variable.

I'm not familiar enough with the code to be sure if this change is complete
or even the right way to do it -- I was a bit surprised to see that the
intermediate calculations are with signed integers in the first place.
Presumably it makes a difference for div/mod, although I'd have thought it's
more natural to just do all calculations as uint32.

This patch is simply the most conservative change that allowed me to debug
the trace that I needed to debug.

Signed-off-by: Nicolai Hähnle <nicolai.haehnle@amd.com>
