### PR TITLE
Added a section to thumbnail to store frame buffer pixels without compression.

### DIFF
--- a/renderdoc/api/replay/renderdoc_tostr.inl
+++ b/renderdoc/api/replay/renderdoc_tostr.inl
@@ -852,6 +852,7 @@ std::string DoStringise(const SectionType &el)
     STRINGISE_ENUM_CLASS_NAMED(Notes, "renderdoc/ui/notes");
     STRINGISE_ENUM_CLASS_NAMED(ResourceRenames, "renderdoc/ui/resrenames");
     STRINGISE_ENUM_CLASS_NAMED(AMDRGPProfile, "amd/rgp/profile");
+    STRINGISE_ENUM_CLASS_NAMED(ExtendedThumbnail, "renderdoc/internal/exthumb");
   }
   END_ENUM_STRINGISE();
 }

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -76,6 +76,13 @@ version of RenderDoc that addes a new section type. They should be considered eq
   This section contains a .rgp profile from AMD's RGP tool, which can be extracted and loaded.
 
   The name for this section will be "amd/rgp/profile".
+
+.. data:: ExtendedThumbnail
+
+  This section contains a thumbnail in format other than JPEG. For example, when it needs to be
+  lossless.
+
+  The name for this section will be "renderdoc/internal/exthumb".
 )");
 enum class SectionType : uint32_t
 {
@@ -87,6 +94,7 @@ enum class SectionType : uint32_t
   Notes,
   ResourceRenames,
   AMDRGPProfile,
+  ExtendedThumbnail,
   Count,
 };
 

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -392,7 +392,7 @@ public:
   void UnloadCrashHandler();
   ICrashHandler *GetCrashHandler() const { return m_ExHandler; }
   RDCFile *CreateRDC(RDCDriver driver, uint32_t frameNum, void *thpixels, size_t thlen,
-                     uint16_t thwidth, uint16_t thheight);
+                     uint16_t thwidth, uint16_t thheight, FileType thformat);
   void FinishCaptureWriting(RDCFile *rdc, uint32_t frameNumber);
 
   void AddChildProcess(uint32_t pid, uint32_t ident)

--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -1565,16 +1565,11 @@ bool WrappedID3D11Device::EndFrameCapture(void *dev, void *wnd)
           {
             byte *data = (byte *)mapped.pData;
 
-            float aspect = float(desc.Width) / float(desc.Height);
-
             thwidth = (uint16_t)RDCMIN(maxSize, desc.Width);
             thwidth &= ~0x7;    // align down to multiple of 8
-            thheight = uint16_t(float(thwidth) / aspect);
+            thheight = uint16_t(thwidth * desc.Height / desc.Width);
 
             thpixels = new byte[3U * thwidth * thheight];
-
-            float widthf = float(desc.Width);
-            float heightf = float(desc.Height);
 
             uint32_t stride = fmt.compByteWidth * fmt.compCount;
 
@@ -1593,11 +1588,10 @@ bool WrappedID3D11Device::EndFrameCapture(void *dev, void *wnd)
             {
               for(uint32_t x = 0; x < thwidth; x++)
               {
-                float xf = float(x) / float(thwidth);
-                float yf = float(y) / float(thheight);
+                uint32_t xSource = x * desc.Width / thwidth;
+                uint32_t ySource = y * desc.Height / thheight;
 
-                byte *src =
-                    &data[stride * uint32_t(xf * widthf) + mapped.RowPitch * uint32_t(yf * heightf)];
+                byte *src = &data[stride * xSource + mapped.RowPitch * ySource];
 
                 if(buf1010102)
                 {

--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -1677,8 +1677,8 @@ bool WrappedID3D11Device::EndFrameCapture(void *dev, void *wnd)
       }
     }
 
-    RDCFile *rdc = RenderDoc::Inst().CreateRDC(
-        RDCDriver::D3D11, m_CapturedFrames.back().frameNumber, jpgbuf, len, thwidth, thheight);
+    RDCFile *rdc = RenderDoc::Inst().CreateRDC(RDCDriver::D3D11, m_CapturedFrames.back().frameNumber,
+                                               jpgbuf, len, thwidth, thheight, FileType::JPG);
 
     SAFE_DELETE_ARRAY(jpgbuf);
     SAFE_DELETE_ARRAY(thpixels);

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -1647,7 +1647,7 @@ bool WrappedID3D12Device::EndFrameCapture(void *dev, void *wnd)
         WrappedID3D12Resource::RefBuffers(GetResourceManager());
 
     rdc = RenderDoc::Inst().CreateRDC(RDCDriver::D3D12, m_CapturedFrames.back().frameNumber, jpgbuf,
-                                      len, thwidth, thheight);
+                                      len, thwidth, thheight, FileType::JPG);
 
     SAFE_DELETE_ARRAY(jpgbuf);
     SAFE_DELETE_ARRAY(thpixels);

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -1521,16 +1521,11 @@ bool WrappedID3D12Device::EndFrameCapture(void *dev, void *wnd)
         {
           ResourceFormat fmt = MakeResourceFormat(desc.Format);
 
-          float aspect = float(desc.Width) / float(desc.Height);
-
           thwidth = (uint16_t)RDCMIN(maxSize, (uint32_t)desc.Width);
           thwidth &= ~0x7;    // align down to multiple of 8
-          thheight = uint16_t(float(thwidth) / aspect);
+          thheight = uint16_t(thwidth * desc.Height / desc.Width);
 
           thpixels = new byte[3U * thwidth * thheight];
-
-          float widthf = float(desc.Width);
-          float heightf = float(desc.Height);
 
           uint32_t stride = fmt.compByteWidth * fmt.compCount;
 
@@ -1549,11 +1544,10 @@ bool WrappedID3D12Device::EndFrameCapture(void *dev, void *wnd)
           {
             for(uint32_t x = 0; x < thwidth; x++)
             {
-              float xf = float(x) / float(thwidth);
-              float yf = float(y) / float(thheight);
+              uint32_t xSource = uint32_t(x * desc.Width / thwidth);
+              uint32_t ySource = uint32_t(y * desc.Height / thheight);
 
-              byte *srcPixels = &data[stride * uint32_t(xf * widthf) +
-                                      layout.Footprint.RowPitch * uint32_t(yf * heightf)];
+              byte *srcPixels = &data[stride * xSource + layout.Footprint.RowPitch * ySource];
 
               if(buf1010102)
               {

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1891,9 +1891,9 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
     if(bbim == NULL)
       bbim = SaveBackbufferImage();
 
-    RDCFile *rdc =
-        RenderDoc::Inst().CreateRDC(GetDriverType(), m_CapturedFrames.back().frameNumber,
-                                    bbim->jpgbuf, bbim->len, bbim->thwidth, bbim->thheight);
+    RDCFile *rdc = RenderDoc::Inst().CreateRDC(GetDriverType(), m_CapturedFrames.back().frameNumber,
+                                               bbim->jpgbuf, bbim->len, bbim->thwidth,
+                                               bbim->thheight, FileType::JPG);
 
     SAFE_DELETE(bbim);
 

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1667,7 +1667,7 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
   }
 
   RDCFile *rdc = RenderDoc::Inst().CreateRDC(RDCDriver::Vulkan, m_CapturedFrames.back().frameNumber,
-                                             jpgbuf, len, thwidth, thheight);
+                                             jpgbuf, len, thwidth, thheight, FileType::JPG);
 
   SAFE_DELETE_ARRAY(jpgbuf);
   SAFE_DELETE_ARRAY(thpixels);

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1532,14 +1532,9 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
 
       byte *data = (byte *)pData;
 
-      float widthf = float(swapInfo.extent.width);
-      float heightf = float(swapInfo.extent.height);
-
-      float aspect = widthf / heightf;
-
       thwidth = (uint16_t)RDCMIN(maxSize, swapInfo.extent.width);
       thwidth &= ~0x7;    // align down to multiple of 8
-      thheight = uint16_t(float(thwidth) / aspect);
+      thheight = uint16_t(thwidth * swapInfo.extent.height / swapInfo.extent.width);
 
       thpixels = new byte[3U * thwidth * thheight];
 
@@ -1572,10 +1567,10 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
       {
         for(uint32_t x = 0; x < thwidth; x++)
         {
-          float xf = float(x) / float(thwidth);
-          float yf = float(y) / float(thheight);
+          uint32_t xSource = x * swapInfo.extent.width / thwidth;
+          uint32_t ySource = y * swapInfo.extent.height / thheight;
 
-          byte *src = &data[stride * uint32_t(xf * widthf) + rowPitch * uint32_t(yf * heightf)];
+          byte *src = &data[stride * xSource + rowPitch * ySource];
 
           if(buf1010102)
           {

--- a/renderdoc/serialise/rdcfile.h
+++ b/renderdoc/serialise/rdcfile.h
@@ -44,6 +44,15 @@ struct RDCThumb
   uint32_t len = 0;
   uint16_t width = 0;
   uint16_t height = 0;
+  FileType format = FileType::JPG;
+};
+
+struct ExtThumbnailHeader
+{
+  uint16_t width;
+  uint16_t height;
+  uint32_t len;
+  uint32_t format;
 };
 
 class RDCFile


### PR DESCRIPTION
This PR adds a new section to the thumbnail, which allows to store framebuffer pixels without compression.  I would also like to put a PR which saves the color in PNG format next, but I didn't want to mix too many CLs in this PR.
It also fixes a small bug in resampling code, which caused rounding errors when writing out a thumbnail. In floating math, x,y coordinates of a pixel would occasionally get calculated as (a.999999) instead of (a+1) which would cause an entire row/column of pixels to be duplicated from previous row/column. This bug manifests itself when no resampling is required as well.