### PR TITLE
Prevent a crash when receiving a corrupt rdc file

### DIFF
--- a/renderdoc/serialise/lz4io.cpp
+++ b/renderdoc/serialise/lz4io.cpp
@@ -256,10 +256,20 @@ bool LZ4Decompressor::FillPage0()
   bool success = true;
 
   success &= m_Read->Read(compSize);
+  if(!success || compSize < 0 || compSize > (int)LZ4_COMPRESSBOUND(lz4BlockSize))
+  {
+    RDCERR("Error reading size: %i", compSize);
+    FreeAlignedBuffer(m_Page[0]);
+    FreeAlignedBuffer(m_Page[1]);
+    FreeAlignedBuffer(m_CompressBuffer);
+    m_Page[0] = m_Page[1] = m_CompressBuffer = NULL;
+    return false;
+  }
   success &= m_Read->Read(m_CompressBuffer, compSize);
 
   if(!success)
   {
+    RDCERR("Error reading block: %i", compSize);
     FreeAlignedBuffer(m_Page[0]);
     FreeAlignedBuffer(m_Page[1]);
     FreeAlignedBuffer(m_CompressBuffer);


### PR DESCRIPTION
It is possible to read a large value into compSize, and consequently read
a large number of bytes into m_CompressBuffer, which can only hold 64k,
which would lead to a crash.