### PR TITLE
Rdc thumbnail stores png and can export as ppm

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -29,9 +29,11 @@
 #include "api/replay/version.h"
 #include "common/common.h"
 #include "hooks/hooks.h"
+#include "maths/formatpacking.h"
 #include "replay/replay_driver.h"
 #include "serialise/rdcfile.h"
 #include "serialise/serialiser.h"
+#include "stb/stb_image_write.h"
 #include "strings/string_utils.h"
 #include "crash_handler.h"
 
@@ -716,8 +718,142 @@ bool RenderDoc::ShouldTriggerCapture(uint32_t frameNumber)
   return ret;
 }
 
-RDCFile *RenderDoc::CreateRDC(RDCDriver driver, uint32_t frameNum, void *thpixels, size_t thlen,
-                              uint16_t thwidth, uint16_t thheight, FileType thformat)
+void RenderDoc::ResamplePixels(const FramePixels &in, RDCThumb &out)
+{
+  // code below assumes pitch_requirement is a power of 2 number
+  RDCASSERT((in.pitch_requirement & (in.pitch_requirement - 1)) == 0);
+
+  out.width = (uint16_t)RDCMIN(in.max_width, in.width);
+  out.width &= ~(in.pitch_requirement - 1);    // align down to multiple of in.
+  out.height = uint16_t(out.width * in.height / in.width);
+  out.len = 3 * out.width * out.height;
+  out.pixels = new byte[out.len];
+  out.format = FileType::Raw;
+
+  byte *dst = (byte *)out.pixels;
+  byte *source = (byte *)in.data;
+
+  for(uint32_t y = 0; y < out.height; y++)
+  {
+    for(uint32_t x = 0; x < out.width; x++)
+    {
+      uint32_t xSource = x * in.width / out.width;
+      uint32_t ySource = y * in.height / out.height;
+      byte *src = &source[in.stride * xSource + in.pitch * ySource];
+
+      if(in.buf1010102)
+      {
+        uint32_t *src1010102 = (uint32_t *)src;
+        Vec4f unorm = ConvertFromR10G10B10A2(*src1010102);
+        dst[0] = (byte)(unorm.x * 255.0f);
+        dst[1] = (byte)(unorm.y * 255.0f);
+        dst[2] = (byte)(unorm.z * 255.0f);
+      }
+      else if(in.buf565)
+      {
+        uint16_t *src565 = (uint16_t *)src;
+        Vec3f unorm = ConvertFromB5G6R5(*src565);
+        dst[0] = (byte)(unorm.z * 255.0f);
+        dst[1] = (byte)(unorm.y * 255.0f);
+        dst[2] = (byte)(unorm.x * 255.0f);
+      }
+      else if(in.buf5551)
+      {
+        uint16_t *src5551 = (uint16_t *)src;
+        Vec4f unorm = ConvertFromB5G5R5A1(*src5551);
+        dst[0] = (byte)(unorm.z * 255.0f);
+        dst[1] = (byte)(unorm.y * 255.0f);
+        dst[2] = (byte)(unorm.x * 255.0f);
+      }
+      else if(in.bgra)
+      {
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+      }
+      else if(in.bpc == 2)    // R16G16B16A16 backbuffer
+      {
+        uint16_t *src16 = (uint16_t *)src;
+
+        float linearR = RDCCLAMP(ConvertFromHalf(src16[0]), 0.0f, 1.0f);
+        float linearG = RDCCLAMP(ConvertFromHalf(src16[1]), 0.0f, 1.0f);
+        float linearB = RDCCLAMP(ConvertFromHalf(src16[2]), 0.0f, 1.0f);
+
+        if(linearR < 0.0031308f)
+          dst[0] = byte(255.0f * (12.92f * linearR));
+        else
+          dst[0] = byte(255.0f * (1.055f * powf(linearR, 1.0f / 2.4f) - 0.055f));
+
+        if(linearG < 0.0031308f)
+          dst[1] = byte(255.0f * (12.92f * linearG));
+        else
+          dst[1] = byte(255.0f * (1.055f * powf(linearG, 1.0f / 2.4f) - 0.055f));
+
+        if(linearB < 0.0031308f)
+          dst[2] = byte(255.0f * (12.92f * linearB));
+        else
+          dst[2] = byte(255.0f * (1.055f * powf(linearB, 1.0f / 2.4f) - 0.055f));
+      }
+      else
+      {
+        dst[0] = src[0];
+        dst[1] = src[1];
+        dst[2] = src[2];
+      }
+      dst += 3;
+    }
+  }
+
+  if(!in.is_y_flipped)
+  {
+    for(uint16_t y = 0; y <= out.height / 2; y++)
+    {
+      uint16_t flipY = (out.height - 1 - y);
+      for(uint16_t x = 0; x < out.width; x++)
+      {
+        byte *src = (byte *)out.pixels;
+        byte save[3];
+        save[0] = src[(y * out.width + x) * 3 + 0];
+        save[1] = src[(y * out.width + x) * 3 + 1];
+        save[2] = src[(y * out.width + x) * 3 + 2];
+
+        src[(y * out.width + x) * 3 + 0] = src[(flipY * out.width + x) * 3 + 0];
+        src[(y * out.width + x) * 3 + 1] = src[(flipY * out.width + x) * 3 + 1];
+        src[(y * out.width + x) * 3 + 2] = src[(flipY * out.width + x) * 3 + 2];
+
+        src[(flipY * out.width + x) * 3 + 0] = save[0];
+        src[(flipY * out.width + x) * 3 + 1] = save[1];
+        src[(flipY * out.width + x) * 3 + 2] = save[2];
+      }
+    }
+  }
+}
+void RenderDoc::EncodePixelsPNG(const RDCThumb &in, RDCThumb &out)
+{
+  struct WriteCallbackData
+  {
+    std::vector<byte> buffer;
+
+    static void writeData(void *context, void *data, int size)
+    {
+      WriteCallbackData *pThis = (WriteCallbackData *)context;
+      const byte *start = (const byte *)data;
+      pThis->buffer.insert(pThis->buffer.end(), start, start + size);
+    }
+  };
+
+  WriteCallbackData callbackData;
+  stbi_write_png_to_func(&WriteCallbackData::writeData, &callbackData, in.width, in.height, 3,
+                         in.pixels, 0);
+  out.width = in.width;
+  out.height = in.height;
+  out.pixels = new byte[callbackData.buffer.size()];
+  memcpy((void *)out.pixels, callbackData.buffer.data(), callbackData.buffer.size());
+  out.len = (uint32_t)callbackData.buffer.size();
+  out.format = FileType::PNG;
+}
+
+RDCFile *RenderDoc::CreateRDC(RDCDriver driver, uint32_t frameNum, const FramePixels &fp)
 {
   RDCFile *ret = new RDCFile;
 
@@ -737,22 +873,17 @@ RDCFile *RenderDoc::CreateRDC(RDCDriver driver, uint32_t frameNum, void *thpixel
     }
   }
 
-  RDCThumb th;
-  RDCThumb *thumb = NULL;
-
-  if(thpixels)
+  RDCThumb outRaw, outPng;
+  if(fp.data)
   {
-    th.len = (uint32_t)thlen;
-    th.pixels = (const byte *)thpixels;
-    th.width = thwidth;
-    th.height = thheight;
-    RDCASSERT(thformat == FileType::JPG || thformat == FileType::PNG || thformat == FileType::BMP ||
-              thformat == FileType::TGA || thformat == FileType::Raw);
-    th.format = thformat;
-    thumb = &th;
+    // point sample info into raw buffer
+    ResamplePixels(fp, outRaw);
+    EncodePixelsPNG(outRaw, outPng);
   }
 
-  ret->SetData(driver, ToStr(driver).c_str(), OSUtility::GetMachineIdent(), thumb);
+  RDCASSERT(outPng.pixels != NULL);
+
+  ret->SetData(driver, ToStr(driver).c_str(), OSUtility::GetMachineIdent(), &outPng);
 
   FileIO::CreateParentDirectory(m_CurrentLogFile);
 
@@ -763,6 +894,9 @@ RDCFile *RenderDoc::CreateRDC(RDCDriver driver, uint32_t frameNum, void *thpixel
     RDCERR("Error creating RDC at '%s'", m_CurrentLogFile.c_str());
     SAFE_DELETE(ret);
   }
+
+  SAFE_DELETE_ARRAY(outRaw.pixels);
+  SAFE_DELETE_ARRAY(outPng.pixels);
 
   return ret;
 }

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1875,7 +1875,7 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
     ContextEndFrame();
     FinishCapture();
 
-    BackbufferImage *bbim = NULL;
+    RenderDoc::FramePixels *bbim = NULL;
 
     // if the specified context isn't current, try and see if we've saved
     // an appropriate backbuffer image during capture.
@@ -1895,9 +1895,8 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
     if(bbim == NULL)
       bbim = SaveBackbufferImage();
 
-    RDCFile *rdc = RenderDoc::Inst().CreateRDC(GetDriverType(), m_CapturedFrames.back().frameNumber,
-                                               bbim->jpgbuf, bbim->len, bbim->thwidth,
-                                               bbim->thheight, FileType::JPG);
+    RDCFile *rdc =
+        RenderDoc::Inst().CreateRDC(GetDriverType(), m_CapturedFrames.back().frameNumber, bbim[0]);
 
     SAFE_DELETE(bbim);
 
@@ -2106,13 +2105,10 @@ void WrappedOpenGL::FirstFrame(void *ctx, void *wndHandle)
   }
 }
 
-WrappedOpenGL::BackbufferImage *WrappedOpenGL::SaveBackbufferImage()
+RenderDoc::FramePixels *WrappedOpenGL::SaveBackbufferImage()
 {
   const uint16_t maxSize = 2048;
-
-  byte *thpixels = NULL;
-  uint16_t thwidth = 0;
-  uint16_t thheight = 0;
+  RenderDoc::FramePixels *fp = new RenderDoc::FramePixels();
 
   if(GL.glGetIntegerv && GL.glReadBuffer && GL.glBindFramebuffer && GL.glBindBuffer && GL.glReadPixels)
   {
@@ -2141,49 +2137,19 @@ WrappedOpenGL::BackbufferImage *WrappedOpenGL::SaveBackbufferImage()
 
     ContextData &dat = GetCtxData();
 
-    thwidth = (uint16_t)dat.initParams.width;
-    thheight = (uint16_t)dat.initParams.height;
-
-    thpixels = new byte[thwidth * thheight * 4];
+    fp->width = dat.initParams.width;
+    fp->height = dat.initParams.height;
+    fp->bpc = 1;
+    fp->stride = fp->bpc * 4;
+    fp->pitch = dat.initParams.width * fp->stride;
+    fp->max_width = maxSize;
+    fp->pitch_requirement = 4;
+    fp->len = (uint32_t)fp->pitch * fp->height;
+    fp->data = new uint8_t[fp->len];
+    fp->is_y_flipped = dat.initParams.isYFlipped;
 
     // GLES only supports GL_RGBA
-    GL.glReadPixels(0, 0, thwidth, thheight, eGL_RGBA, eGL_UNSIGNED_BYTE, thpixels);
-
-    // RGBA -> RGB
-    for(uint32_t y = 0; y < thheight; y++)
-    {
-      for(uint32_t x = 0; x < thwidth; x++)
-      {
-        thpixels[(y * thwidth + x) * 3 + 0] = thpixels[(y * thwidth + x) * 4 + 0];
-        thpixels[(y * thwidth + x) * 3 + 1] = thpixels[(y * thwidth + x) * 4 + 1];
-        thpixels[(y * thwidth + x) * 3 + 2] = thpixels[(y * thwidth + x) * 4 + 2];
-      }
-    }
-
-    // flip the image in-place
-    if(!dat.initParams.isYFlipped)
-    {
-      for(uint16_t y = 0; y <= thheight / 2; y++)
-      {
-        uint16_t flipY = (thheight - 1 - y);
-
-        for(uint16_t x = 0; x < thwidth; x++)
-        {
-          byte save[3];
-          save[0] = thpixels[(y * thwidth + x) * 3 + 0];
-          save[1] = thpixels[(y * thwidth + x) * 3 + 1];
-          save[2] = thpixels[(y * thwidth + x) * 3 + 2];
-
-          thpixels[(y * thwidth + x) * 3 + 0] = thpixels[(flipY * thwidth + x) * 3 + 0];
-          thpixels[(y * thwidth + x) * 3 + 1] = thpixels[(flipY * thwidth + x) * 3 + 1];
-          thpixels[(y * thwidth + x) * 3 + 2] = thpixels[(flipY * thwidth + x) * 3 + 2];
-
-          thpixels[(flipY * thwidth + x) * 3 + 0] = save[0];
-          thpixels[(flipY * thwidth + x) * 3 + 1] = save[1];
-          thpixels[(flipY * thwidth + x) * 3 + 2] = save[2];
-        }
-      }
-    }
+    GL.glReadPixels(0, 0, fp->width, fp->height, eGL_RGBA, eGL_UNSIGNED_BYTE, fp->data);
 
     GL.glBindBuffer(eGL_PIXEL_PACK_BUFFER, packBufBind);
     GL.glBindFramebuffer(eGL_READ_FRAMEBUFFER, prevBuf);
@@ -2192,69 +2158,9 @@ WrappedOpenGL::BackbufferImage *WrappedOpenGL::SaveBackbufferImage()
     GL.glPixelStorei(eGL_PACK_SKIP_ROWS, prevPackSkipRows);
     GL.glPixelStorei(eGL_PACK_SKIP_PIXELS, prevPackSkipPixels);
     GL.glPixelStorei(eGL_PACK_ALIGNMENT, prevPackAlignment);
-
-    // scale down if necessary using simple point sampling
-    thwidth = RDCMIN(maxSize, uint16_t(dat.initParams.width));
-    // TODO(akharlamov): why does OpenGL align to 4 when Vulkan and DX11 align to 8?
-    thwidth &= ~0x3;    // align down to multiple of 4
-    thheight = uint16_t(thwidth * dat.initParams.height / dat.initParams.width);
-
-    byte *src = thpixels;
-    byte *dst = thpixels = new byte[3U * thwidth * thheight];
-
-    for(uint32_t y = 0; y < thheight; y++)
-    {
-      for(uint32_t x = 0; x < thwidth; x++)
-      {
-        uint32_t xSource = x * dat.initParams.width / thwidth;
-        uint32_t ySource = y * dat.initParams.height / thheight;
-
-        byte *pixelsrc = &src[3 * xSource + dat.initParams.width * 3 * ySource];
-
-        memcpy(dst, pixelsrc, 3);
-
-        dst += 3;
-      }
-    }
-
-    // src is the raw unscaled pixels, which is no longer needed
-    SAFE_DELETE_ARRAY(src);
   }
 
-  byte *jpgbuf = NULL;
-  int len = thwidth * thheight;
-
-  if(len > 0)
-  {
-    // jpge::compress_image_to_jpeg_file_in_memory requires at least 1024 bytes
-    len = len >= 1024 ? len : 1024;
-
-    jpgbuf = new byte[len];
-
-    jpge::params p;
-    p.m_quality = 80;
-
-    bool success =
-        jpge::compress_image_to_jpeg_file_in_memory(jpgbuf, len, thwidth, thheight, 3, thpixels, p);
-
-    if(!success)
-    {
-      RDCERR("Failed to compress to jpg");
-      SAFE_DELETE_ARRAY(jpgbuf);
-      thwidth = 0;
-      thheight = 0;
-    }
-  }
-
-  SAFE_DELETE_ARRAY(thpixels);
-
-  BackbufferImage *bbim = new BackbufferImage();
-  bbim->jpgbuf = jpgbuf;
-  bbim->len = len;
-  bbim->thwidth = thwidth;
-  bbim->thheight = thheight;
-
-  return bbim;
+  return fp;
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -459,21 +459,11 @@ private:
   void RenderOverlayText(float x, float y, const char *fmt, ...);
   void RenderOverlayStr(float x, float y, const char *str);
 
-  struct BackbufferImage
-  {
-    BackbufferImage() : jpgbuf(NULL), len(0), thwidth(0), thheight(0) {}
-    ~BackbufferImage() { SAFE_DELETE_ARRAY(jpgbuf); }
-    byte *jpgbuf;
-    size_t len;
-    uint16_t thwidth;
-    uint16_t thheight;
-  };
-
   void CreateReplayBackbuffer(const GLInitParams &params, ResourceId fboOrigId, GLuint &fbo,
                               std::string bbname);
 
-  BackbufferImage *SaveBackbufferImage();
-  map<void *, BackbufferImage *> m_BackbufferImages;
+  RenderDoc::FramePixels *SaveBackbufferImage();
+  map<void *, RenderDoc::FramePixels *> m_BackbufferImages;
 
   void BuildGLExtensions();
   void BuildGLESExtensions();


### PR DESCRIPTION
This PR adds two small changes to rdc thumbnails:

1. thumbnails can be exported as ppm files
2. extthumbnail is stored as png