### PR TITLE
add support for VR end of frame markers in vulkan

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -770,6 +770,11 @@ private:
   void StartFrameCapture(void *dev, void *wnd);
   bool EndFrameCapture(void *dev, void *wnd);
 
+  void AdvanceFrame();
+  void Present(void *dev, void *wnd);
+
+  void HandleVRFrameMarkers(const char *marker, VkCommandBuffer commandBuffer);
+
   template <typename SerialiserType>
   bool Serialise_SetShaderDebugPath(SerialiserType &ser, VkShaderModule ShaderObject,
                                     std::string DebugPath);

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -929,6 +929,9 @@ struct CmdBufferRecordingInfo
   set<VkDescriptorSet> boundDescSets;
 
   vector<VkResourceRecord *> subcmds;
+
+  // AdvanceFrame/Present should be called after this buffer is submitted
+  bool present;
 };
 
 struct DescSetLayout;


### PR DESCRIPTION
## Description
Similar to the GL implementation, this uses string markers to decide when and when not to call SwapBuffers. This also creates the SwapBuffers function whose logic was before solely in vkQueuePresentKHR. I left the window management and thumbnail creation there and solely focus on the frame management in SwapBuffers. 
