### PR TITLE
Handle launching more apps on Android

### DIFF
--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -250,4 +250,6 @@ private:
   void FillRemotesMenu(QMenu *menu, bool includeLocalhost);
 
   void showLaunchError(ReplayStatus status);
+
+  bool isCapturableAppRunningOnAndroid();
 };


### PR DESCRIPTION
It can happen that we open an Android application to capture then we forget to close it and it's still running on the device when we try to capture another app. 

We can check whether an Android app has already been connected to RenderDoc, and warn the user to close the previous app before launching a new one.