### PR TITLE
Implement VK_EXT_conditional_rendering

### DIFF
--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -276,7 +276,7 @@ VulkanPipelineStateViewer::VulkanPipelineStateViewer(ICaptureContext &ctx,
     ui->scissors->setInstantTooltips(true);
   }
 
-  for(RDLabel *rp : {ui->renderpass, ui->framebuffer})
+  for(RDLabel *rp : {ui->renderpass, ui->framebuffer, ui->predicateBuffer})
   {
     rp->setAutoFillBackground(true);
     rp->setBackgroundRole(QPalette::ToolTipBase);
@@ -652,6 +652,8 @@ void VulkanPipelineStateViewer::clearState()
   ui->depthBounds->setText(lit("0.0-1.0"));
 
   ui->stencils->clear();
+
+  ui->conditionalRenderingGroup->setVisible(false);
 }
 
 QVariantList VulkanPipelineStateViewer::makeSampler(const QString &bindset, const QString &slotname,
@@ -1989,6 +1991,23 @@ void VulkanPipelineStateViewer::setState()
   ui->sampleMask->setText(Formatter::Format(state.multisample.sampleMask, true));
   ui->alphaToOne->setPixmap(state.colorBlend.alphaToOneEnable ? tick : cross);
   ui->alphaToCoverage->setPixmap(state.colorBlend.alphaToCoverageEnable ? tick : cross);
+
+  ////////////////////////////////////////////////
+  // Conditional Rendering
+
+  if(state.conditionalRendering.bufferId == ResourceId())
+  {
+    ui->conditionalRenderingGroup->setVisible(false);
+  }
+  else
+  {
+    ui->conditionalRenderingGroup->setVisible(true);
+    ui->predicateBuffer->setText(QFormatStr("%1 (Byte Offset %2)")
+                                     .arg(ToQStr(state.conditionalRendering.bufferId))
+                                     .arg(state.conditionalRendering.byteOffset));
+    ui->predicatePassing->setPixmap(state.conditionalRendering.isPassing ? tick : cross);
+    ui->predicateInverted->setPixmap(state.conditionalRendering.isInverted ? tick : cross);
+  }
 
   ////////////////////////////////////////////////
   // Output Merger
@@ -3352,6 +3371,26 @@ void VulkanPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const VKPipe::
   }
 }
 
+void VulkanPipelineStateViewer::exportHTML(QXmlStreamWriter &xml,
+                                           const VKPipe::ConditionalRendering &cr)
+{
+  if(cr.bufferId == ResourceId())
+    return;
+
+  xml.writeStartElement(lit("h3"));
+  xml.writeCharacters(tr("Conditional Rendering"));
+  xml.writeEndElement();
+
+  QString bufferName = m_Ctx.GetResourceName(cr.bufferId);
+
+  m_Common.exportHTMLTable(
+      xml, {tr("Predicate Passing"), tr("Is Inverted"), tr("Buffer"), tr("Byte Offset")},
+      {
+          cr.isPassing ? tr("Yes") : tr("No"), cr.isInverted ? tr("Yes") : tr("No"), bufferName,
+          (qulonglong)cr.byteOffset,
+      });
+}
+
 void VulkanPipelineStateViewer::on_exportHTML_clicked()
 {
   QXmlStreamWriter *xmlptr = m_Common.beginHTMLExport();
@@ -3400,7 +3439,10 @@ void VulkanPipelineStateViewer::on_exportHTML_clicked()
           exportHTML(xml, m_Ctx.CurVulkanPipelineState()->geometryShader);
           exportHTML(xml, m_Ctx.CurVulkanPipelineState()->transformFeedback);
           break;
-        case 5: exportHTML(xml, m_Ctx.CurVulkanPipelineState()->rasterizer); break;
+        case 5:
+          exportHTML(xml, m_Ctx.CurVulkanPipelineState()->rasterizer);
+          exportHTML(xml, m_Ctx.CurVulkanPipelineState()->conditionalRendering);
+          break;
         case 6: exportHTML(xml, m_Ctx.CurVulkanPipelineState()->fragmentShader); break;
         case 7:
           // FB
@@ -3436,4 +3478,13 @@ void VulkanPipelineStateViewer::on_meshView_clicked()
   if(!m_Ctx.HasMeshPreview())
     m_Ctx.ShowMeshPreview();
   ToolWindowManager::raiseToolWindow(m_Ctx.GetMeshPreview()->Widget());
+}
+
+void VulkanPipelineStateViewer::on_predicateBufferView_clicked()
+{
+  const VKPipe::ConditionalRendering &cr = m_Ctx.CurVulkanPipelineState()->conditionalRendering;
+
+  IBufferViewer *viewer = m_Ctx.ViewBuffer(cr.byteOffset, sizeof(uint32_t), cr.bufferId, "uint");
+
+  m_Ctx.AddDockWindow(viewer->Widget(), DockReference::AddTo, this);
 }

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.h
@@ -66,6 +66,7 @@ private slots:
   void on_showEmpty_toggled(bool checked);
   void on_exportHTML_clicked();
   void on_meshView_clicked();
+  void on_predicateBufferView_clicked();
   void on_viAttrs_itemActivated(RDTreeWidgetItem *item, int column);
   void on_viBuffers_itemActivated(RDTreeWidgetItem *item, int column);
   void on_viAttrs_mouseMove(QMouseEvent *event);
@@ -122,6 +123,7 @@ private:
   void exportHTML(QXmlStreamWriter &xml, const VKPipe::ColorBlendState &cb);
   void exportHTML(QXmlStreamWriter &xml, const VKPipe::DepthStencil &ds);
   void exportHTML(QXmlStreamWriter &xml, const VKPipe::CurrentPass &pass);
+  void exportHTML(QXmlStreamWriter &xml, const VKPipe::ConditionalRendering &cr);
 
   // keep track of the VB nodes (we want to be able to highlight them easily on hover)
   QList<RDTreeWidgetItem *> m_VBNodes;

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.ui
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.ui
@@ -1696,7 +1696,7 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QGroupBox" name="scissorGroup">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1751,7 +1751,7 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QGroupBox" name="viewportsGroup">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1802,6 +1802,81 @@
              <number>50</number>
             </attribute>
            </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QGroupBox" name="conditionalRenderingGroup">
+         <property name="title">
+          <string>Conditional Rendering</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_41">
+          <item>
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Passing:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="predicatePassing"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Inverted:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="predicateInverted"/>
+          </item>
+          <item>
+           <widget class="RDLabel" name="predicateBuffer">
+            <property name="frameShape">
+             <enum>QFrame::Box</enum>
+            </property>
+            <property name="margin">
+             <number>4</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="predicateBufferView">
+            <property name="cursor">
+             <cursorShape>PointingHandCursor</cursorShape>
+            </property>
+            <property name="toolTip">
+             <string>Open Predicate Buffer</string>
+            </property>
+            <property name="text">
+             <string>View</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../Resources/resources.qrc">
+              <normaloff>:/action.png</normaloff>:/action.png</iconset>
+            </property>
+            <property name="toolButtonStyle">
+             <enum>Qt::ToolButtonTextBesideIcon</enum>
+            </property>
+            <property name="autoRaise">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/renderdoc/api/replay/vk_pipestate.h
+++ b/renderdoc/api/replay/vk_pipestate.h
@@ -887,6 +887,27 @@ struct ImageData
   rdcarray<ImageLayout> layouts;
 };
 
+DOCUMENT("Contains the current conditional rendering state.");
+struct ConditionalRendering
+{
+  DOCUMENT("");
+  ConditionalRendering() = default;
+  ConditionalRendering(const ConditionalRendering &) = default;
+
+  DOCUMENT(
+      "The :class:`ResourceId` of the buffer containing the predicate for conditional rendering.");
+  ResourceId bufferId;
+
+  DOCUMENT("The byte offset into buffer where the predicate is located.");
+  uint64_t byteOffset = 0;
+
+  DOCUMENT("``True`` if predicate result is inverted.");
+  bool isInverted = false;
+
+  DOCUMENT("``True`` if the current predicate would render.");
+  bool isPassing = false;
+};
+
 DOCUMENT("The full current Vulkan pipeline state.");
 struct State
 {
@@ -945,6 +966,9 @@ struct State
 
   DOCUMENT("A list of :class:`VKImageData` entries, one for each image.");
   rdcarray<ImageData> images;
+
+  DOCUMENT("A :class:`ConditionalRendering` describing the current conditional rendering state.");
+  ConditionalRendering conditionalRendering;
 };
 
 };    // namespace VKPipe
@@ -977,4 +1001,5 @@ DECLARE_REFLECTION_STRUCT(VKPipe::RenderArea);
 DECLARE_REFLECTION_STRUCT(VKPipe::CurrentPass);
 DECLARE_REFLECTION_STRUCT(VKPipe::ImageLayout);
 DECLARE_REFLECTION_STRUCT(VKPipe::ImageData);
+DECLARE_REFLECTION_STRUCT(VKPipe::ConditionalRendering);
 DECLARE_REFLECTION_STRUCT(VKPipe::State);

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -504,6 +504,8 @@ enum class VulkanChunk : uint32_t
   vkCmdBeginQueryIndexedEXT,
   vkCmdEndQueryIndexedEXT,
   vkCmdDrawIndirectByteCountEXT,
+  vkCmdBeginConditionalRenderingEXT,
+  vkCmdEndConditionalRenderingEXT,
   Max,
 };
 
@@ -568,9 +570,11 @@ DECLARE_REFLECTION_STRUCT(VkBufferMemoryRequirementsInfo2);
 DECLARE_REFLECTION_STRUCT(VkBufferViewCreateInfo);
 DECLARE_REFLECTION_STRUCT(VkCommandBufferAllocateInfo);
 DECLARE_REFLECTION_STRUCT(VkCommandBufferBeginInfo);
+DECLARE_REFLECTION_STRUCT(VkCommandBufferInheritanceConditionalRenderingInfoEXT);
 DECLARE_REFLECTION_STRUCT(VkCommandBufferInheritanceInfo);
 DECLARE_REFLECTION_STRUCT(VkCommandPoolCreateInfo);
 DECLARE_REFLECTION_STRUCT(VkComputePipelineCreateInfo);
+DECLARE_REFLECTION_STRUCT(VkConditionalRenderingBeginInfoEXT);
 DECLARE_REFLECTION_STRUCT(VkCopyDescriptorSet);
 DECLARE_REFLECTION_STRUCT(VkDebugMarkerMarkerInfoEXT);
 DECLARE_REFLECTION_STRUCT(VkDebugMarkerObjectNameInfoEXT);
@@ -656,6 +660,7 @@ DECLARE_REFLECTION_STRUCT(VkMemoryRequirements2);
 DECLARE_REFLECTION_STRUCT(VkPhysicalDevice16BitStorageFeatures);
 DECLARE_REFLECTION_STRUCT(VkPhysicalDevice8BitStorageFeaturesKHR);
 DECLARE_REFLECTION_STRUCT(VkPhysicalDeviceASTCDecodeFeaturesEXT);
+DECLARE_REFLECTION_STRUCT(VkPhysicalDeviceConditionalRenderingFeaturesEXT);
 DECLARE_REFLECTION_STRUCT(VkPhysicalDeviceConservativeRasterizationPropertiesEXT);
 DECLARE_REFLECTION_STRUCT(VkPhysicalDeviceDriverPropertiesKHR);
 DECLARE_REFLECTION_STRUCT(VkPhysicalDeviceExternalBufferInfo);
@@ -761,9 +766,11 @@ DECLARE_DESERIALISE_TYPE(VkBufferMemoryRequirementsInfo2);
 DECLARE_DESERIALISE_TYPE(VkBufferViewCreateInfo);
 DECLARE_DESERIALISE_TYPE(VkCommandBufferAllocateInfo);
 DECLARE_DESERIALISE_TYPE(VkCommandBufferBeginInfo);
+DECLARE_DESERIALISE_TYPE(VkCommandBufferInheritanceConditionalRenderingInfoEXT);
 DECLARE_DESERIALISE_TYPE(VkCommandBufferInheritanceInfo);
 DECLARE_DESERIALISE_TYPE(VkCommandPoolCreateInfo);
 DECLARE_DESERIALISE_TYPE(VkComputePipelineCreateInfo);
+DECLARE_DESERIALISE_TYPE(VkConditionalRenderingBeginInfoEXT);
 DECLARE_DESERIALISE_TYPE(VkCopyDescriptorSet);
 DECLARE_DESERIALISE_TYPE(VkDebugMarkerMarkerInfoEXT);
 DECLARE_DESERIALISE_TYPE(VkDebugMarkerObjectNameInfoEXT);
@@ -849,6 +856,7 @@ DECLARE_DESERIALISE_TYPE(VkMemoryRequirements2);
 DECLARE_DESERIALISE_TYPE(VkPhysicalDevice16BitStorageFeatures);
 DECLARE_DESERIALISE_TYPE(VkPhysicalDevice8BitStorageFeaturesKHR);
 DECLARE_DESERIALISE_TYPE(VkPhysicalDeviceASTCDecodeFeaturesEXT);
+DECLARE_DESERIALISE_TYPE(VkPhysicalDeviceConditionalRenderingFeaturesEXT);
 DECLARE_DESERIALISE_TYPE(VkPhysicalDeviceConservativeRasterizationPropertiesEXT);
 DECLARE_DESERIALISE_TYPE(VkPhysicalDeviceDriverPropertiesKHR);
 DECLARE_DESERIALISE_TYPE(VkPhysicalDeviceExternalBufferInfo);

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -635,6 +635,9 @@ static const VkExtensionProperties supportedExtensions[] = {
         VK_EXT_ASTC_DECODE_MODE_EXTENSION_NAME, VK_EXT_ASTC_DECODE_MODE_SPEC_VERSION,
     },
     {
+        VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME, VK_EXT_CONDITIONAL_RENDERING_SPEC_VERSION,
+    },
+    {
         VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,
         VK_EXT_CONSERVATIVE_RASTERIZATION_SPEC_VERSION,
     },
@@ -2677,7 +2680,10 @@ bool WrappedVulkan::ProcessChunk(ReadSerialiser &ser, VulkanChunk chunk)
     case VulkanChunk::vkCmdDrawIndirectByteCountEXT:
       return Serialise_vkCmdDrawIndirectByteCountEXT(ser, VK_NULL_HANDLE, 0, 0, VK_NULL_HANDLE, 0,
                                                      0, 0);
-
+    case VulkanChunk::vkCmdBeginConditionalRenderingEXT:
+      return Serialise_vkCmdBeginConditionalRenderingEXT(ser, VK_NULL_HANDLE, NULL);
+    case VulkanChunk::vkCmdEndConditionalRenderingEXT:
+      return Serialise_vkCmdEndConditionalRenderingEXT(ser, VK_NULL_HANDLE);
     default:
     {
       SystemChunk system = (SystemChunk)chunk;
@@ -2889,6 +2895,10 @@ void WrappedVulkan::ReplayLog(uint32_t startEventID, uint32_t endEventID, Replay
       // end any active XFB
       if(!m_RenderState.xfbcounters.empty())
         m_RenderState.EndTransformFeedback(cmd);
+
+      // end any active conditional rendering
+      if(m_RenderState.IsConditionalRenderingEnabled())
+        m_RenderState.EndConditionalRendering(cmd);
 
       // check if the render pass is active - it could have become active
       // even if it wasn't before (if the above event was a CmdBeginRenderPass).

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -528,6 +528,8 @@ private:
     VkCommandBufferLevel level;
     VkCommandBufferUsageFlags beginFlags;
 
+    bool inheritConditionalRendering = false;
+
     int markerCount;
 
     std::vector<std::pair<ResourceId, EventUsage>> resourceUsage;
@@ -553,6 +555,13 @@ private:
       ResourceId renderPass;
       ResourceId framebuffer;
       uint32_t subpass = 0;
+
+      struct ConditionalRendering
+      {
+        ResourceId buffer;
+        VkDeviceSize offset;
+        VkConditionalRenderingFlagsEXT flags;
+      } conditionalRendering;
     } state;
 
     std::vector<std::pair<ResourceId, ImageRegionState>> imgbarriers;
@@ -1980,4 +1989,10 @@ public:
                                 uint32_t instanceCount, uint32_t firstInstance,
                                 VkBuffer counterBuffer, VkDeviceSize counterBufferOffset,
                                 uint32_t counterOffset, uint32_t vertexStride);
+
+  // VK_EXT_conditional_rendering
+  IMPLEMENT_FUNCTION_SERIALISED(void, vkCmdBeginConditionalRenderingEXT,
+                                VkCommandBuffer commandBuffer,
+                                const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin);
+  IMPLEMENT_FUNCTION_SERIALISED(void, vkCmdEndConditionalRenderingEXT, VkCommandBuffer commandBuffer);
 };

--- a/renderdoc/driver/vulkan/vk_hookset_defs.h
+++ b/renderdoc/driver/vulkan/vk_hookset_defs.h
@@ -353,7 +353,8 @@
   CheckExt(EXT_validation_cache, VKXX);           \
   CheckExt(KHR_shared_presentable_image, VKXX);   \
   CheckExt(KHR_create_renderpass2, VKXX);         \
-  CheckExt(EXT_transform_feedback, VKXX);
+  CheckExt(EXT_transform_feedback, VKXX);         \
+  CheckExt(EXT_conditional_rendering, VKXX);
 
 #define HookInitVulkanInstanceExts()                                                                 \
   HookInitExtension(KHR_surface, DestroySurfaceKHR);                                                 \
@@ -480,6 +481,8 @@
   HookInitExtension(EXT_transform_feedback, CmdBeginQueryIndexedEXT);                              \
   HookInitExtension(EXT_transform_feedback, CmdEndQueryIndexedEXT);                                \
   HookInitExtension(EXT_transform_feedback, CmdDrawIndirectByteCountEXT);                          \
+  HookInitExtension(EXT_conditional_rendering, CmdBeginConditionalRenderingEXT);                   \
+  HookInitExtension(EXT_conditional_rendering, CmdEndConditionalRenderingEXT);                     \
   HookInitDevice_PlatformSpecific()
 
 #define DefineHooks()                                                                                \
@@ -1033,6 +1036,9 @@
   HookDefine7(void, vkCmdDrawIndirectByteCountEXT, VkCommandBuffer, commandBuffer, uint32_t,         \
               instanceCount, uint32_t, firstInstance, VkBuffer, counterBuffer, VkDeviceSize,         \
               counterBufferOffset, uint32_t, counterOffset, uint32_t, vertexStride);                 \
+  HookDefine2(void, vkCmdBeginConditionalRenderingEXT, VkCommandBuffer, commandBuffer,               \
+              const VkConditionalRenderingBeginInfoEXT *, pConditionalRenderingBegin);               \
+  HookDefine1(void, vkCmdEndConditionalRenderingEXT, VkCommandBuffer, commandBuffer);                \
   HookDefine_PlatformSpecific()
 
 struct VkLayerInstanceDispatchTableExtended : VkLayerInstanceDispatchTable

--- a/renderdoc/driver/vulkan/vk_next_chains.cpp
+++ b/renderdoc/driver/vulkan/vk_next_chains.cpp
@@ -82,6 +82,8 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
   COPY_STRUCT(VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO, VkBindImagePlaneMemoryInfo);           \
   COPY_STRUCT(VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, VkBufferCreateInfo);                             \
   COPY_STRUCT(VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, VkCommandBufferBeginInfo);                \
+  COPY_STRUCT(VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT,           \
+              VkCommandBufferInheritanceConditionalRenderingInfoEXT);                                \
   COPY_STRUCT(VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, VkCommandPoolCreateInfo);                  \
   COPY_STRUCT(VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, VkDebugMarkerMarkerInfoEXT);           \
   COPY_STRUCT(VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,                               \
@@ -202,6 +204,8 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
               VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT);                                  \
   COPY_STRUCT(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR,                    \
               VkPhysicalDeviceVulkanMemoryModelFeaturesKHR);                                         \
+  COPY_STRUCT(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT,                  \
+              VkPhysicalDeviceConditionalRenderingFeaturesEXT);                                      \
   COPY_STRUCT(VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO, VkPipelineCacheCreateInfo);              \
   COPY_STRUCT(VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,                              \
               VkPipelineColorBlendStateCreateInfo);                                                  \
@@ -332,6 +336,8 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
                 UnwrapInPlace(out->renderPass), UnwrapInPlace(out->framebuffer));                    \
   UNWRAP_STRUCT(VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO, VkSamplerYcbcrConversionInfo,       \
                 UnwrapInPlace(out->conversion));                                                     \
+  UNWRAP_STRUCT(VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT,                              \
+                VkConditionalRenderingBeginInfoEXT, UnwrapInPlace(out->buffer));                     \
   UNWRAP_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR,                          \
                              VkAcquireNextImageInfoKHR, UnwrapInPlace(out->swapchain),               \
                              UnwrapInPlace(out->semaphore), UnwrapInPlace(out->fence));              \
@@ -383,8 +389,6 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
   case VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV:                                           \
   case VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX:                                \
   case VK_STRUCTURE_TYPE_CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX:                      \
-  case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:    \
-  case VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT:                         \
   case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT:         \
   case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT:          \
   case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT:   \
@@ -413,7 +417,6 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
   case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:        \
   case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:      \
   case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:       \
-  case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:           \
   case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:             \
   case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT:             \
   case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT:           \

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -845,6 +845,9 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, CompType typeHint, Debu
     if(overlay == DebugOverlay::Wireframe)
       m_pDriver->m_RenderState.lineWidth = 1.0f;
 
+    if(overlay == DebugOverlay::Drawcall || overlay == DebugOverlay::Wireframe)
+      m_pDriver->m_RenderState.conditionalRendering.forceDisable = true;
+
     if(patchedIndexCount == 0)
     {
       m_pDriver->ReplayLog(0, eventId, eReplay_OnlyDraw);

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -1559,6 +1559,28 @@ void VulkanReplay::SavePipelineState()
       i++;
     }
   }
+
+  if(state.conditionalRendering.buffer != ResourceId())
+  {
+    m_VulkanPipelineState.conditionalRendering.bufferId =
+        rm->GetOriginalID(state.conditionalRendering.buffer);
+    m_VulkanPipelineState.conditionalRendering.byteOffset = state.conditionalRendering.offset;
+    m_VulkanPipelineState.conditionalRendering.isInverted =
+        state.conditionalRendering.flags == VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT;
+
+    bytebuf data;
+    GetBufferData(state.conditionalRendering.buffer, state.conditionalRendering.offset,
+                  sizeof(uint32_t), data);
+
+    uint32_t value;
+    memcpy(&value, data.data(), sizeof(uint32_t));
+
+    m_VulkanPipelineState.conditionalRendering.isPassing = value != 0;
+
+    if(m_VulkanPipelineState.conditionalRendering.isInverted)
+      m_VulkanPipelineState.conditionalRendering.isPassing =
+          !m_VulkanPipelineState.conditionalRendering.isPassing;
+  }
 }
 
 void VulkanReplay::FillCBufferVariables(ResourceId shader, string entryPoint, uint32_t cbufSlot,

--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -279,6 +279,14 @@ SERIALISE_VK_HANDLES();
   PNEXT_STRUCT(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT,                            \
                VkPhysicalDeviceASTCDecodeFeaturesEXT)                                                 \
                                                                                                       \
+  /* VK_EXT_conditional_rendering */                                                                  \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT,           \
+               VkCommandBufferInheritanceConditionalRenderingInfoEXT)                                 \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT,                  \
+               VkPhysicalDeviceConditionalRenderingFeaturesEXT)                                       \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT,                                \
+               VkConditionalRenderingBeginInfoEXT)                                                    \
+                                                                                                      \
   /* VK_EXT_conservative_rasterization */                                                             \
   PNEXT_STRUCT(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT,           \
                VkPhysicalDeviceConservativeRasterizationPropertiesEXT)                                \
@@ -600,11 +608,6 @@ SERIALISE_VK_HANDLES();
                                                                                                       \
   /* VK_EXT_calibrated_timestamps */                                                                  \
   PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT)                                  \
-                                                                                                      \
-  /* VK_EXT_conditional_rendering */                                                                  \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT)      \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT)             \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT)                           \
                                                                                                       \
   /* VK_EXT_descriptor_indexing */                                                                    \
   PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT)            \
@@ -5551,6 +5554,56 @@ void Deserialise(const VkPhysicalDeviceSparseImageFormatInfo2 &el)
   DeserialiseNext(el.pNext);
 }
 
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkCommandBufferInheritanceConditionalRenderingInfoEXT &el)
+{
+  RDCASSERT(ser.IsReading() ||
+            el.sType == VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(conditionalRenderingEnable);
+}
+
+template <>
+void Deserialise(const VkCommandBufferInheritanceConditionalRenderingInfoEXT &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkPhysicalDeviceConditionalRenderingFeaturesEXT &el)
+{
+  RDCASSERT(ser.IsReading() ||
+            el.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(conditionalRendering);
+  SERIALISE_MEMBER(inheritedConditionalRendering);
+}
+
+template <>
+void Deserialise(const VkPhysicalDeviceConditionalRenderingFeaturesEXT &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkConditionalRenderingBeginInfoEXT &el)
+{
+  RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(buffer);
+  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER_TYPED(VkConditionalRenderingFlagsEXT, flags);
+}
+
+template <>
+void Deserialise(const VkConditionalRenderingBeginInfoEXT &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
 // pNext structs - always have deserialise for the next chain
 INSTANTIATE_SERIALISE_TYPE(VkAcquireNextImageInfoKHR);
 INSTANTIATE_SERIALISE_TYPE(VkApplicationInfo);
@@ -5570,6 +5623,7 @@ INSTANTIATE_SERIALISE_TYPE(VkBufferViewCreateInfo);
 INSTANTIATE_SERIALISE_TYPE(VkCommandBufferAllocateInfo);
 INSTANTIATE_SERIALISE_TYPE(VkCommandBufferBeginInfo);
 INSTANTIATE_SERIALISE_TYPE(VkCommandBufferInheritanceInfo);
+INSTANTIATE_SERIALISE_TYPE(VkCommandBufferInheritanceConditionalRenderingInfoEXT);
 INSTANTIATE_SERIALISE_TYPE(VkCommandPoolCreateInfo);
 INSTANTIATE_SERIALISE_TYPE(VkComputePipelineCreateInfo);
 INSTANTIATE_SERIALISE_TYPE(VkCopyDescriptorSet);
@@ -5691,6 +5745,7 @@ INSTANTIATE_SERIALISE_TYPE(VkPhysicalDeviceVariablePointerFeatures);
 INSTANTIATE_SERIALISE_TYPE(VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT);
 INSTANTIATE_SERIALISE_TYPE(VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT);
 INSTANTIATE_SERIALISE_TYPE(VkPhysicalDeviceVulkanMemoryModelFeaturesKHR);
+INSTANTIATE_SERIALISE_TYPE(VkPhysicalDeviceConditionalRenderingFeaturesEXT);
 INSTANTIATE_SERIALISE_TYPE(VkPipelineCacheCreateInfo);
 INSTANTIATE_SERIALISE_TYPE(VkPipelineColorBlendStateCreateInfo);
 INSTANTIATE_SERIALISE_TYPE(VkPipelineDepthStencilStateCreateInfo);
@@ -5743,6 +5798,7 @@ INSTANTIATE_SERIALISE_TYPE(VkTextureLODGatherFormatPropertiesAMD);
 INSTANTIATE_SERIALISE_TYPE(VkValidationCacheCreateInfoEXT);
 INSTANTIATE_SERIALISE_TYPE(VkValidationFlagsEXT);
 INSTANTIATE_SERIALISE_TYPE(VkWriteDescriptorSet);
+INSTANTIATE_SERIALISE_TYPE(VkConditionalRenderingBeginInfoEXT);
 
 // plain structs with no next chain
 INSTANTIATE_SERIALISE_TYPE(VkAllocationCallbacks);

--- a/renderdoc/driver/vulkan/vk_state.h
+++ b/renderdoc/driver/vulkan/vk_state.h
@@ -51,10 +51,14 @@ struct VulkanRenderState
 
   void EndTransformFeedback(VkCommandBuffer cmd);
 
+  void EndConditionalRendering(VkCommandBuffer cmd);
+
   void BindPipeline(VkCommandBuffer cmd, PipelineBinding binding, bool subpass0);
   void BindDescriptorSet(const DescSetLayout &descLayout, VkCommandBuffer cmd,
                          VkPipelineLayout layout, VkPipelineBindPoint bindPoint, uint32_t setIndex,
                          uint32_t *dynamicOffsets);
+
+  bool IsConditionalRenderingEnabled();
 
   // dynamic state
   vector<VkViewport> views;
@@ -123,6 +127,15 @@ struct VulkanRenderState
   };
   uint32_t firstxfbcounter = 0;
   vector<XFBCounter> xfbcounters;
+
+  struct ConditionalRendering
+  {
+    ResourceId buffer;
+    VkDeviceSize offset;
+    VkConditionalRenderingFlagsEXT flags;
+
+    bool forceDisable;
+  } conditionalRendering;
 
   VulkanResourceManager *GetResourceManager();
   VulkanCreationInfo *m_CreationInfo;

--- a/renderdoc/driver/vulkan/vk_stringise.cpp
+++ b/renderdoc/driver/vulkan/vk_stringise.cpp
@@ -28,7 +28,7 @@
 template <>
 std::string DoStringise(const VulkanChunk &el)
 {
-  RDCCOMPILE_ASSERT((uint32_t)VulkanChunk::Max == 1128, "Chunks changed without updating names");
+  RDCCOMPILE_ASSERT((uint32_t)VulkanChunk::Max == 1130, "Chunks changed without updating names");
 
   BEGIN_ENUM_STRINGISE(VulkanChunk)
   {
@@ -160,6 +160,8 @@ std::string DoStringise(const VulkanChunk &el)
     STRINGISE_ENUM_CLASS(vkCmdBeginQueryIndexedEXT)
     STRINGISE_ENUM_CLASS(vkCmdEndQueryIndexedEXT)
     STRINGISE_ENUM_CLASS(vkCmdDrawIndirectByteCountEXT)
+    STRINGISE_ENUM_CLASS(vkCmdBeginConditionalRenderingEXT)
+    STRINGISE_ENUM_CLASS(vkCmdEndConditionalRenderingEXT)
     STRINGISE_ENUM_CLASS_NAMED(Max, "Max Chunk");
   }
   END_ENUM_STRINGISE()

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -1673,6 +1673,14 @@ bool WrappedVulkan::Serialise_vkCreateDevice(SerialiserType &ser, VkPhysicalDevi
         CHECK_PHYS_EXT_FEATURE(vulkanMemoryModelDeviceScope);
       }
       END_PHYS_EXT_CHECK();
+
+      BEGIN_PHYS_EXT_CHECK(VkPhysicalDeviceConditionalRenderingFeaturesEXT,
+                           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT);
+      {
+        CHECK_PHYS_EXT_FEATURE(conditionalRendering);
+        CHECK_PHYS_EXT_FEATURE(inheritedConditionalRendering);
+      }
+      END_PHYS_EXT_CHECK();
     }
 
     if(availFeatures.depthClamp)

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -2119,6 +2119,17 @@ void DoSerialise(SerialiserType &ser, VKPipe::ImageData &el)
 }
 
 template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VKPipe::ConditionalRendering &el)
+{
+  SERIALISE_MEMBER(bufferId);
+  SERIALISE_MEMBER(byteOffset);
+  SERIALISE_MEMBER(isInverted);
+  SERIALISE_MEMBER(isPassing);
+
+  SIZE_CHECK(24);
+}
+
+template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, VKPipe::State &el)
 {
   SERIALISE_MEMBER(compute);
@@ -2147,7 +2158,9 @@ void DoSerialise(SerialiserType &ser, VKPipe::State &el)
 
   SERIALISE_MEMBER(images);
 
-  SIZE_CHECK(1360);
+  SERIALISE_MEMBER(conditionalRendering);
+
+  SIZE_CHECK(1384);
 }
 
 #pragma endregion Vulkan pipeline state
@@ -2254,4 +2267,5 @@ INSTANTIATE_SERIALISE_TYPE(VKPipe::DepthStencil)
 INSTANTIATE_SERIALISE_TYPE(VKPipe::CurrentPass)
 INSTANTIATE_SERIALISE_TYPE(VKPipe::ImageLayout)
 INSTANTIATE_SERIALISE_TYPE(VKPipe::ImageData)
+INSTANTIATE_SERIALISE_TYPE(VKPipe::ConditionalRendering)
 INSTANTIATE_SERIALISE_TYPE(VKPipe::State)


### PR DESCRIPTION
Implementation is similar to D3D11:
- Conditional rendering is skipped during replay
- Predicate value and result are displayed in the raster state

That's my attempt to implement VK_EXT_conditional_rendering, it's not in its final state since I need to add several serialization methods for VKPipe::ConditionalRendering, and test it some more.

It was tested on Sascha Willems' Vulkan sample on Linux with Amd and Intel GPUs.

Fixes #1180 