### PR TITLE
vk_info: fix uninitialized DescriptorSetSlot

### DIFF
--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -90,6 +90,7 @@ void DescSetLayout::UpdateBindingsArray(const DescSetLayout &prevLayout,
   {
     // allocate new slot array
     DescriptorSetSlot *newSlots = new DescriptorSetSlot[bindings[i].descriptorCount];
+    memset(newSlots, 0, sizeof(DescriptorSetSlot) * bindings[i].descriptorCount);
 
     // copy over any previous bindings that overlapped
     if(i < prevLayout.bindings.size())


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

This fixes a crash I had when opening a capture, in WrappedVulkan::AddUsage when iterating over bindings that were unitialized. There's probably a problem with descriptors in the capture though.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
