### PR TITLE
Osx fix getlibraryfilename

### DIFF
--- a/renderdoc/os/os_specific.cpp
+++ b/renderdoc/os/os_specific.cpp
@@ -199,6 +199,12 @@ string OSUtility::MakeMachineIdentString(uint64_t ident)
 
 TEST_CASE("Test OS-specific functions", "[osspecific]")
 {
+  SECTION("GetLibraryFilename")
+  {
+    std::string libPath;
+    FileIO::GetLibraryFilename(libPath);
+    CHECK_FALSE(libPath.empty());
+  }
   SECTION("Environment Variables")
   {
     const char *var = Process::GetEnvVariable("TMP");

--- a/renderdoc/os/posix/apple/apple_stringio.cpp
+++ b/renderdoc/os/posix/apple/apple_stringio.cpp
@@ -122,8 +122,8 @@ void GetLibraryFilename(string &selfName)
   else
   {
     RDCERR("dladdr failed to get library path");
+    selfName = "";
   }
-  selfName = "";
 }
 };
 


### PR DESCRIPTION
## Description

Added basic test for GetLibraryFilename and osx fix for it

> ./build/bin/renderdoccmd test -t unit [osspecific]
===============================================================================                                                  
All tests passed (352 assertions in 2 test cases)

And running tests with "-s"

-------------------------------------------------------------------------------                                                  
Test OS-specific functions
  GetLibraryFilename
-------------------------------------------------------------------------------                                                  
/Users/jake/Workspace/personal/renderdoc/renderdoc/os/os_specific.cpp:202                                                        
...............................................................................                                                  
                                                                                                                                 
/Users/jake/Workspace/personal/renderdoc/renderdoc/os/os_specific.cpp:206:                                                       
PASSED:
  CHECK_FALSE( libPath.empty() )
with expansion:
  !false
