### PR TITLE
osx: Implement Wide2UTF8

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -15,6 +15,7 @@ if(ANDROID)
         PRIVATE -landroid)
 elseif(APPLE)
     list(APPEND RDOC_LIBRARIES
+        PRIVATE -liconv
         PRIVATE -lm
         PRIVATE -ldl)
 


### PR DESCRIPTION
## Description

Copied from linux implementation using iconv API
Added if guard before calling iconv_close() to fix

> ./build/bin/renderdoccmd test
renderdoccmd(77013,0x11660e5c0) malloc: *** error for object 0xffffffffffffffff: pointer being freed was not allocated
renderdoccmd(77013,0x11660e5c0) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6

After fixing this all unit tests now pass on osx

> ./build/bin/renderdoccmd test -t unit
...
All tests passed (4143 assertions in 27 test cases)
