### PR TITLE
SPIR-V editor fixes

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_editor.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_editor.cpp
@@ -314,11 +314,18 @@ void SPIRVEditor::SetName(uint32_t id, const char *name)
 
   SPIRVOperation op(spv::OpName, uintName);
 
-  size_t offset = sections[SPIRVSection::Debug].endOffset;
+  SPIRVIterator it;
 
-  spirv.insert(spirv.begin() + offset, op.begin(), op.end());
-  RegisterOp(SPIRVIterator(spirv, offset));
-  addWords(offset, op.size());
+  // OpName must be before OpModuleProcessed.
+  for(it = Begin(SPIRVSection::Debug); it < End(SPIRVSection::Debug); ++it)
+  {
+    if(it.opcode() == spv::OpModuleProcessed)
+      break;
+  }
+
+  spirv.insert(spirv.begin() + it.offs(), op.begin(), op.end());
+  RegisterOp(SPIRVIterator(spirv, it.offs()));
+  addWords(it.offs(), op.size());
 }
 
 void SPIRVEditor::AddDecoration(const SPIRVOperation &op)

--- a/renderdoc/driver/shaders/spirv/spirv_editor.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_editor.cpp
@@ -201,7 +201,8 @@ SPIRVEditor::SPIRVEditor(std::vector<uint32_t> &spirvWords) : spirv(spirvWords)
     }
     else if(opcode == spv::OpDecorate || opcode == spv::OpMemberDecorate ||
             opcode == spv::OpGroupDecorate || opcode == spv::OpGroupMemberDecorate ||
-            opcode == spv::OpDecorationGroup)
+            opcode == spv::OpDecorationGroup || opcode == spv::OpDecorateStringGOOGLE ||
+            opcode == spv::OpMemberDecorateStringGOOGLE)
     {
       START_SECTION(SPIRVSection::Annotations);
     }


### PR DESCRIPTION
Fix for a crash seen with a shader containing OpDecorateStringGOOGLE opcodes, and another for a SPIR-V validation error spotted while debugging the crash.