### PR TITLE
Adding utility code for VK code generator p.2

### DIFF
--- a/renderdoc/core/intervals.h
+++ b/renderdoc/core/intervals.h
@@ -26,6 +26,8 @@
 #include <algorithm>
 #include <map>
 
+#include "common/common.h"
+
 template <typename T>
 struct Intervals;
 

--- a/renderdoc/driver/vulkan/cpp_codec/vk_cpp_codec_state.cpp
+++ b/renderdoc/driver/vulkan/cpp_codec/vk_cpp_codec_state.cpp
@@ -1,0 +1,955 @@
+/******************************************************************************
+* The MIT License (MIT)
+*
+* Copyright (c) 2018 Baldur Karlsson
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+******************************************************************************/
+#include "driver/vulkan/cpp_codec/vk_cpp_codec_state.h"
+#include "driver/vulkan/vk_resources.h"
+
+namespace vk_cpp_codec
+{
+MemRange MemRange::MakeRange(SDObject *offset, SDObject *reqs)
+{
+  start = offset->AsUInt64();
+  end = start + reqs->GetChild(0)->AsUInt64();
+  return *this;
+}
+
+bool MemRange::Intersect(MemRange &r)
+{
+  // interval '1' and '2' start and end points:
+  uint64_t i1_start = r.start;
+  uint64_t i1_end = r.end;
+  uint64_t i2_start = start;
+  uint64_t i2_end = end;
+
+  // two intervals i1 [s, e] and i2 [s, e] intersect
+  // if X = max(i1.s, i2.s) < Y = min(i1.e, i2.e).
+  return std::max<uint64_t>(i1_start, i2_start) < std::min<uint64_t>(i1_end, i2_end);
+}
+
+AccessState AccessStateClearTransition(AccessState s)
+{
+  switch(s)
+  {
+    case ACCESS_STATE_INIT:
+    case ACCESS_STATE_WRITE: return ACCESS_STATE_CLEAR;
+    case ACCESS_STATE_READ: return ACCESS_STATE_RESET;
+    default: return s;
+  }
+}
+
+AccessState AccessStateWriteTransition(AccessState s)
+{
+  switch(s)
+  {
+    case ACCESS_STATE_INIT: return ACCESS_STATE_WRITE;
+    case ACCESS_STATE_READ: return ACCESS_STATE_RESET;
+    default: return s;
+  }
+}
+
+AccessState AccessStateReadTransition(AccessState s)
+{
+  switch(s)
+  {
+    case ACCESS_STATE_INIT:
+    case ACCESS_STATE_WRITE: return ACCESS_STATE_READ;
+    default: return s;
+  }
+}
+
+AccessState AccessStateReadWriteTransition(AccessState s)
+{
+  switch(s)
+  {
+    case ACCESS_STATE_INIT:
+    case ACCESS_STATE_READ:
+    case ACCESS_STATE_WRITE: return ACCESS_STATE_RESET;
+    default: return s;
+  }
+}
+
+std::function<AccessState(AccessState)> GetAccessStateTransition(AccessAction action)
+{
+  switch(action)
+  {
+    case ACCESS_ACTION_READ: return AccessStateReadTransition;
+    case ACCESS_ACTION_WRITE: return AccessStateWriteTransition;
+    case ACCESS_ACTION_READ_WRITE: return AccessStateReadWriteTransition;
+    case ACCESS_ACTION_CLEAR: return AccessStateClearTransition;
+    default: RDCASSERT(0); return {};
+  }
+}
+
+bool MemoryAllocationWithBoundResources::HasAliasedResources()
+{
+  if(boundResources.empty())
+    hasAliasedResources = HasAliasedResourcesFalse;
+  RDCASSERT(hasAliasedResources != HasAliasedResourcesUnknown);
+  return hasAliasedResources == HasAliasedResourcesTrue;
+}
+
+bool MemoryAllocationWithBoundResources::NeedsReset()
+{
+  // allocations that have aliased resources need full reset.
+  if(HasAliasedResources())
+    return true;
+
+  // Loop through the resources, looking for one that needs a reset.
+  for(BoundResourcesIter it = Begin(); it != End(); it++)
+  {
+    // All bound resources must have a known reset requiriement before calling `NeedsReset`
+    RDCASSERT(it->reset != RESET_REQUIREMENT_UNKNOWN);
+    if(it->reset == RESET_REQUIREMENT_RESET)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MemoryAllocationWithBoundResources::NeedsInit()
+{
+  // allocations that have aliased resources don't need initialization, only reset.
+  if(HasAliasedResources())
+    return false;
+
+  // Loop through the resources, looking for one that needs an init.
+  for(BoundResourcesIter it = Begin(); it != End(); it++)
+  {
+    // All bound resources must have a known reset requiriement before calling `NeedsInit`
+    RDCASSERT(it->reset != RESET_REQUIREMENT_UNKNOWN);
+    if(it->reset == RESET_REQUIREMENT_INIT)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<size_t> MemoryAllocationWithBoundResources::OrderByResetRequiremnet()
+{
+  std::vector<size_t> result;
+  result.reserve(boundResources.size());
+  for(uint32_t reset_i = RESET_REQUIREMENT_RESET; reset_i <= RESET_REQUIREMENT_NO_RESET; reset_i++)
+  {
+    for(size_t i = 0; i < boundResources.size(); i++)
+    {
+      if(boundResources[i].reset == (ResetRequirement)reset_i)
+      {
+        result.push_back(i);
+      }
+    }
+  }
+
+  // All bound resources must have a known reset requiriement (RESET, INIT, NO_RESET)
+  // before calling `OrderByResetRequiremnet`. Therefore, result should
+  // have one entry for each bound resource.
+  RDCASSERT(result.size() == boundResources.size());
+  return result;
+}
+
+bool MemoryAllocationWithBoundResources::CheckAliasedResources(MemRange r)
+{
+  for(size_t i = 0; i < ranges.size(); i++)
+  {
+    if(r.Intersect(ranges[i]))
+    {
+      hasAliasedResources = HasAliasedResourcesTrue;
+      return true;
+    }
+  }
+  ranges.push_back(r);
+  hasAliasedResources = HasAliasedResourcesFalse;
+  return false;
+}
+
+void MemoryAllocationWithBoundResources::Access(uint64_t cmdQueueFamily, VkSharingMode sharingMode,
+                                                AccessAction action, uint64_t offset, uint64_t size)
+{
+  uint64_t end = offset + size;
+  std::function<AccessState(AccessState)> accessStateTransition = GetAccessStateTransition(action);
+  for(IntervalsIter<MemoryState> it = memoryState.find(offset);
+      it != memoryState.end() && it.start() < end; it++)
+  {
+    MemoryState state = it.value();
+    bool modified = false;
+    uint64_t memID = allocate->FindChild("Memory")->AsUInt64();
+    uint64_t iStart = std::max(offset, it.start());
+    uint64_t iEnd = std::min(end, it.end());
+    if(state.queueFamily != cmdQueueFamily && cmdQueueFamily != VK_QUEUE_FAMILY_IGNORED &&
+       sharingMode != VK_SHARING_MODE_CONCURRENT)
+    {
+      if(state.queueFamily == VK_QUEUE_FAMILY_IGNORED)
+      {
+        // Resource has not yet been used by any queue family
+        // Automatically acquired by the current queue family
+        state.queueFamily = cmdQueueFamily;
+        state.isAcquired = true;
+        modified = true;
+        RDCDEBUG("Memory %llu range [%llu,%llu) implicitly acquired by queue family %llu.", memID,
+                 iStart, iEnd, cmdQueueFamily);
+      }
+      else
+      {
+        RDCWARN(
+            "Memory %llu range [%llu,%llu) accessed by queue family %llu while owned by queue "
+            "family %llu.",
+            memID, iStart, iEnd, cmdQueueFamily, state.queueFamily);
+      }
+    }
+    AccessState newAccessState = accessStateTransition(state.accessState);
+    if(newAccessState != state.accessState)
+    {
+      state.accessState = newAccessState;
+      modified = true;
+    }
+    if(modified)
+    {
+      it.setValue(offset, end, state);
+    }
+  }
+}
+
+void MemoryAllocationWithBoundResources::TransitionQueueFamily(uint64_t cmdQueueFamily,
+                                                               VkSharingMode sharingMode,
+                                                               uint64_t srcQueueFamily,
+                                                               uint64_t dstQueueFamily,
+                                                               uint64_t offset, uint64_t size)
+{
+  if(srcQueueFamily == dstQueueFamily || sharingMode == VK_SHARING_MODE_CONCURRENT)
+  {
+    return;
+  }
+  uint64_t memID = allocate->FindChild("Memory")->AsUInt64();
+  uint64_t end = offset + size;
+  for(IntervalsIter<MemoryState> it = memoryState.find(offset);
+      it != memoryState.end() && it.start() < end; it++)
+  {
+    MemoryState state = it.value();
+    bool modified = false;
+    uint64_t iStart = std::max(offset, it.start());
+    uint64_t iEnd = std::min(end, it.end());
+    if(cmdQueueFamily == srcQueueFamily)
+    {
+      // Release
+      if(state.queueFamily == VK_QUEUE_FAMILY_IGNORED)
+      {
+        // We have yet to see any use of this memory on any queue.
+        // Assume it was previously used on the queue that is releasing it.
+        state.queueFamily = srcQueueFamily;
+        state.isAcquired = true;
+        modified = true;
+      }
+
+      if(srcQueueFamily != state.queueFamily)
+      {
+        RDCWARN(
+            "Memory %llu range [%llu,%llu) released by queue family %llu while owned by queue "
+            "family %llu",
+            memID, iStart, iEnd, srcQueueFamily, state.queueFamily);
+      }
+      if(state.isAcquired)
+      {
+        RDCDEBUG(
+            "Memory %llu range [%llu,%llu) released by queue family %llu to queue family %llu.",
+            memID, iStart, iEnd, srcQueueFamily, dstQueueFamily);
+        state.isAcquired = false;
+        modified = true;
+      }
+      else
+      {
+        RDCWARN(
+            "Memory %llu range [%llu,%llu) released by queue family %llu while it was not "
+            "acquired.",
+            memID, iStart, iEnd, srcQueueFamily);
+      }
+
+      if(dstQueueFamily == VK_QUEUE_FAMILY_EXTERNAL ||
+         dstQueueFamily == VK_QUEUE_FAMILY_EXTERNAL_KHR ||
+         dstQueueFamily == VK_QUEUE_FAMILY_FOREIGN_EXT)
+      {
+        // We won't see any acquires from the dstQueueFamily.
+        // Assume that the external queue family immediately acquires, and then releasese the
+        // resource.
+        // This way, the resource will be in the correct state when it is acquired back again.
+        state.queueFamily = dstQueueFamily;
+        modified = true;
+      }
+    }
+    else if(cmdQueueFamily == dstQueueFamily)
+    {
+      // Acquire
+      if(state.queueFamily == VK_QUEUE_FAMILY_IGNORED)
+      {
+        // We have yet to see any use of this memory on any queue.
+        // Assume it was previously used and released by the srcQueueFamily.
+        state.queueFamily = srcQueueFamily;
+        state.isAcquired = false;
+      }
+
+      if(srcQueueFamily != state.queueFamily)
+      {
+        RDCWARN(
+            "Memory %llu range [%llu,%llu) acquired from family %llu while owned by queue family "
+            "%llu",
+            memID, iStart, iEnd, srcQueueFamily, state.queueFamily);
+      }
+      if(state.isAcquired)
+      {
+        RDCWARN(
+            "Memory %llu range [%llu,%llu) acquired by queue family %llu while still owned by "
+            "queue family %llu.",
+            memID, iStart, iEnd, dstQueueFamily, srcQueueFamily);
+      }
+      else
+      {
+        RDCDEBUG(
+            "Memory %llu range [%llu,%llu) acquired by queue family %llu from queue family %llu.",
+            memID, iStart, iEnd, dstQueueFamily, srcQueueFamily);
+        state.isAcquired = true;
+        state.queueFamily = dstQueueFamily;
+        modified = true;
+      }
+    }
+    else
+    {
+      RDCWARN(
+          "Memory %llu range [%llu,%llu) was transitioned from queue family %llu to queue family "
+          "%llu by queue family %llu. The transition must be done by the source and destination "
+          "queue families.",
+          memID, iStart, iEnd, srcQueueFamily, dstQueueFamily, cmdQueueFamily);
+    }
+    if(modified)
+    {
+      it.setValue(offset, end, state);
+    }
+  }
+}
+
+uint32_t FrameGraph::FindCmdBufferIndex(SDObject *o)
+{
+  for(uint32_t i = 0; i < records.size(); i++)
+  {
+    if(records[i].cb->AsUInt64() == o->AsUInt64())
+      return i;
+  }
+  RDCASSERT(0);
+  return 0xFFFFFFFF;
+}
+
+size_t DescriptorBinding::Size()
+{
+  switch(type)
+  {
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+      RDCASSERT(bufferBindings.empty() && texelViewBindings.empty());
+      return imageBindings.size();
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+      RDCASSERT(imageBindings.empty() && texelViewBindings.empty());
+      return bufferBindings.size();
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+      RDCASSERT(imageBindings.empty() && bufferBindings.empty());
+      return texelViewBindings.size();
+
+    default: RDCASSERT(0); break;
+  }
+  return 0;
+}
+
+void DescriptorBinding::SetBindingObj(size_t index, SDObject *o, bool initialization)
+{
+  RDCASSERT(index < updated.size());
+  if(!initialization)
+    updated[index] = true;
+
+  switch(type)
+  {
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+      RDCASSERT(index < imageBindings.size());
+      if(o->NumChildren() == 0)
+        return;    // invalidated binding
+      RDCASSERT(o->NumChildren() == 3);
+      imageBindings[index] = BoundImage(o->GetChild(0)->AsUInt64(),                    // sampler
+                                        o->GetChild(1)->AsUInt64(),                    // imageIvew
+                                        (VkImageLayout)o->GetChild(2)->AsUInt64());    // imageLayout
+      break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+      RDCASSERT(index < bufferBindings.size());
+      if(o->NumChildren() == 0)
+        return;    // invalidated binding
+      RDCASSERT(o->NumChildren() == 3);
+      bufferBindings[index] = BoundBuffer(o->GetChild(0)->AsUInt64(),    // buffer
+                                          o->GetChild(1)->AsUInt64(),    // offset
+                                          o->GetChild(2)->AsUInt64(),    // size
+                                          0);                            // dynamicOffset
+      break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+      RDCASSERT(index < texelViewBindings.size());
+      texelViewBindings[index] = BoundTexelView(o->AsUInt64());    // buffer
+      break;
+
+    default: RDCASSERT(0); break;
+  }
+}
+
+void DescriptorBinding::CopyBinding(size_t index, const DescriptorBinding &other, size_t otherIndex)
+{
+  RDCASSERT(index < updated.size());
+  updated[index] = true;
+
+  RDCASSERT(type == other.type);
+  switch(type)
+  {
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+      RDCASSERT(index < imageBindings.size());
+      RDCASSERT(otherIndex < other.imageBindings.size());
+      imageBindings[index] = other.imageBindings[otherIndex];
+      break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+      RDCASSERT(index < bufferBindings.size());
+      RDCASSERT(otherIndex < other.bufferBindings.size());
+      bufferBindings[index] = other.bufferBindings[otherIndex];
+      break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+      RDCASSERT(index < texelViewBindings.size());
+      RDCASSERT(otherIndex < other.texelViewBindings.size());
+      texelViewBindings[index] = other.texelViewBindings[otherIndex];
+      break;
+
+    default: RDCASSERT(0); break;
+  }
+}
+
+void DescriptorBinding::Resize(uint64_t aType, size_t elementCount)
+{
+  type = (VkDescriptorType)aType;
+  switch(type)
+  {
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: bufferBindings.resize(elementCount); break;
+
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: imageBindings.resize(elementCount); break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: texelViewBindings.resize(elementCount); break;
+
+    default: RDCASSERT(0); break;
+  }
+  updated.resize(elementCount, false);
+}
+
+bool DescriptorBinding::NeedsReset(size_t element)
+{
+  RDCASSERT(updated.size() > element);
+  return updated[element];
+}
+
+bool DescriptorSetInfo::NeedsReset(size_t binding, size_t element)
+{
+  RDCASSERT(bindings.find(binding) != bindings.end());
+  return bindings[binding].NeedsReset(element);
+}
+
+void BindingState::attachmentUse(uint64_t subpassId, size_t attachmentId)
+{
+  if(attachmentId == VK_ATTACHMENT_UNUSED)
+  {
+    return;
+  }
+  RDCASSERT(attachmentId < attachmentFirstUse.size());
+  attachmentFirstUse[attachmentId] = std::min(attachmentFirstUse[attachmentId], subpassId);
+  attachmentLastUse[attachmentId] = subpassId;
+}
+
+void BindingState::BeginRenderPass(SDObject *aRenderPass, SDObject *aFramebuffer,
+                                   SDObject *aRenderArea)
+{
+  subpassIndex = 0;
+  renderPass = aRenderPass;
+  framebuffer = aFramebuffer;
+  uint64_t width = aFramebuffer->GetChild(6)->AsUInt64();
+  uint64_t height = aFramebuffer->GetChild(7)->AsUInt64();
+  isFullRenderArea = (aRenderArea->GetChild(0)->GetChild(0)->AsUInt64() == 0) &&
+                     (aRenderArea->GetChild(0)->GetChild(1)->AsUInt64() == 0) &&
+                     (aRenderArea->GetChild(1)->GetChild(0)->AsUInt64() == width) &&
+                     (aRenderArea->GetChild(1)->GetChild(1)->AsUInt64() == height);
+
+  size_t numAttachments = aRenderPass->GetChild(4)->NumChildren();
+  attachmentFirstUse.clear();
+  attachmentFirstUse.resize(numAttachments, UINT64_MAX);
+
+  attachmentLastUse.clear();
+  attachmentLastUse.resize(numAttachments, UINT64_MAX);
+
+  SDObject *subpasses = aRenderPass->GetChild(6);
+
+  for(size_t s = 0; s < subpasses->NumChildren(); s++)
+  {
+    SDObject *subpass = subpasses->GetChild(s);
+    SDObject *inputAttachments = subpass->GetChild(3);
+    SDObject *colorAttachments = subpass->GetChild(5);
+    SDObject *resolveAttachments = subpass->GetChild(6);
+    SDObject *depthStencilAttachment = subpass->GetChild(7);
+
+    for(size_t j = 0; j < inputAttachments->NumChildren(); j++)
+    {
+      attachmentUse(s, inputAttachments->GetChild(j)->GetChild(0)->AsUInt32());
+    }
+
+    for(size_t j = 0; j < colorAttachments->NumChildren(); j++)
+    {
+      attachmentUse(s, colorAttachments->GetChild(j)->GetChild(0)->AsUInt32());
+    }
+
+    for(size_t j = 0; j < resolveAttachments->NumChildren(); j++)
+    {
+      attachmentUse(s, resolveAttachments->GetChild(j)->GetChild(0)->AsUInt32());
+    }
+    if(!depthStencilAttachment->IsNULL())
+    {
+      attachmentUse(s, depthStencilAttachment->GetChild(0)->AsUInt32());
+    }
+  }
+
+  attachmentLayout.clear();
+  attachmentLayout.resize(numAttachments, VK_IMAGE_LAYOUT_MAX_ENUM);
+
+  for(size_t a = 0; a < numAttachments; a++)
+  {
+    SDObject *renderpassAttachments = renderPass->FindChild("pAttachments");
+    SDObject *attachmentDesc = renderpassAttachments->GetChild(a);
+    attachmentLayout[a] = (VkImageLayout)attachmentDesc->FindChild("initialLayout")->AsUInt64();
+  }
+}
+
+ImageSubresourceRangeIter &ImageSubresourceRangeIter::operator++()
+{
+  res.level++;
+  if(res.level >= range.baseMipLevel + range.levelCount)
+  {
+    res.level = range.baseMipLevel;
+    res.layer++;
+    if(res.layer >= range.baseArrayLayer + range.layerCount)
+    {
+      res.layer = range.baseArrayLayer;
+      VkImageAspectFlags aspect = (VkImageAspectFlags)res.aspect;
+      while(aspect < range.aspectMask && aspect < VK_IMAGE_ASPECT_END_BIT)
+      {
+        aspect <<= 1;
+        if(aspect & range.aspectMask)
+        {
+          res.aspect = (VkImageAspectFlagBits)aspect;
+          return *this;
+        }
+      }
+      setEnd();
+    }
+  }
+  return *this;
+}
+
+ImageSubresourceRangeIter ImageSubresourceRangeIter::end(const ImageSubresourceRange &range)
+{
+  ImageSubresourceRangeIter it;
+  it.range = range;
+  it.res.image = range.image;
+  it.setEnd();
+  return it;
+}
+
+ImageSubresourceRangeIter ImageSubresourceRangeIter::begin(const ImageSubresourceRange &range)
+{
+  ImageSubresourceRangeIter it;
+  it.range = range;
+  it.res.image = range.image;
+  if(range.aspectMask == 0 || range.levelCount == 0 || range.layerCount == 0)
+  {
+    it.setEnd();
+  }
+  else
+  {
+    VkImageAspectFlags aspect(1);
+    it.res.aspect = (VkImageAspectFlagBits)1;
+    while(!(aspect & range.aspectMask))
+    {
+      aspect <<= 1;
+    }
+    it.res.aspect = (VkImageAspectFlagBits)aspect;
+    it.res.level = range.baseMipLevel;
+    it.res.layer = range.baseArrayLayer;
+  }
+  return it;
+}
+
+void ImageSubresourceState::CheckLayout(VkImageLayout requestedLayout)
+{
+  if(layout == VK_IMAGE_LAYOUT_MAX_ENUM)
+  {
+    // This image subresource has not yet been used, and had no start layout in BeginCapture.
+    if(requestedLayout != VK_IMAGE_LAYOUT_UNDEFINED)
+    {
+      RDCWARN(
+          "Image first used in layout %s, but no start layout was found in BeginCapture. "
+          "Image: %llu, layer: %llu, level: %llu, aspect: %s",
+          ToStr(requestedLayout).c_str(), image, layer, mipLevel, ToStr(aspect).c_str());
+    }
+    layout = requestedLayout;
+  }
+  if(layout != requestedLayout && requestedLayout != VK_IMAGE_LAYOUT_UNDEFINED)
+  {
+    RDCWARN(
+        "Image requested in layout %s, but was in layout %s. Image: %llu, layer: %llu, level: "
+        "%llu, "
+        "aspect: %s.",
+        ToStr(requestedLayout).c_str(), ToStr(layout).c_str(), image, layer, mipLevel,
+        ToStr(aspect).c_str());
+  }
+}
+
+void ImageSubresourceState::CheckQueueFamily(uint64_t cmdQueueFamily)
+{
+  if(sharingMode == VK_SHARING_MODE_CONCURRENT)
+  {
+    return;
+  }
+  if(queueFamily == VK_QUEUE_FAMILY_IGNORED)
+  {
+    // No queue family has been set. Assume this use implicitly acquires the queue.
+    queueFamily = cmdQueueFamily;
+    isAcquiredByQueue = true;
+  }
+  if(cmdQueueFamily != queueFamily)
+  {
+    RDCWARN(
+        "Image used by queue family %llu while owned by queue family %llu. "
+        "Image: %llu, layer: %llu, level: %llu, aspect: %s",
+        cmdQueueFamily, queueFamily, image, layer, mipLevel, ToStr(aspect).c_str());
+  }
+}
+
+void ImageSubresourceState::Initialize(VkImageLayout aStartLayout, uint64_t aStartQueueFamily)
+{
+  isInitialized = true;
+  startLayout = aStartLayout;
+  layout = aStartLayout;
+  startQueueFamily = aStartQueueFamily;
+  queueFamily = aStartQueueFamily;
+  if(aStartQueueFamily != VK_QUEUE_FAMILY_IGNORED)
+  {
+    isAcquiredByQueue = true;
+  }
+}
+
+void ImageSubresourceState::Access(
+    uint64_t cmdQueueFamily, VkImageLayout requestedLayout,
+    const std::function<vk_cpp_codec::AccessState(vk_cpp_codec::AccessState)> &transition)
+{
+  CheckLayout(requestedLayout);
+  CheckQueueFamily(cmdQueueFamily);
+  accessState = transition(accessState);
+}
+
+void ImageSubresourceState::Transition(uint64_t cmdQueueFamily, VkImageLayout oldLayout,
+                                       VkImageLayout newLayout, uint64_t srcQueueFamily,
+                                       uint64_t dstQueueFamily)
+{
+  isTransitioned = true;
+
+  if(srcQueueFamily != dstQueueFamily && sharingMode != VK_SHARING_MODE_CONCURRENT)
+  {
+    RDCWARN(
+        "Queue transition detected! This is completely untested. Please let us know what breaks "
+        "(with a capture that reproduces it, if possible).");
+    if(cmdQueueFamily == srcQueueFamily)
+    {
+      // Release
+      if(srcQueueFamily != queueFamily)
+      {
+        RDCWARN(
+            "Image released by queue family %llu while owned by queue family %llu. "
+            "Image: %llu, layer: %llu, level: %llu, aspect: %s",
+            srcQueueFamily, queueFamily, image, layer, mipLevel, ToStr(aspect).c_str());
+      }
+      if(!isAcquiredByQueue)
+      {
+        RDCWARN(
+            "Image released multiple times by queue family %llu. "
+            "Image: %llu, layer: %llu, level: %llu, aspect: %s",
+            srcQueueFamily, image, layer, mipLevel, ToStr(aspect).c_str());
+      }
+      isAcquiredByQueue = false;
+
+      // Wait until the `acquire` to do the layout transition
+      return;
+    }
+    else if(cmdQueueFamily == dstQueueFamily)
+    {
+      // Acquire
+      if(isAcquiredByQueue)
+      {
+        RDCWARN(
+            "Image acquired by queue %llu before being released by queue %llu. "
+            "Image: %llu, layer: %llu, level: %llu, aspect: %s",
+            dstQueueFamily, srcQueueFamily, image, layer, mipLevel, ToStr(aspect).c_str());
+      }
+      isAcquiredByQueue = true;
+      queueFamily = dstQueueFamily;
+    }
+  }
+  CheckQueueFamily(cmdQueueFamily);
+  CheckLayout(oldLayout);
+  layout = newLayout;
+}
+
+ImageSubresourceRange ImageState::FullRange()
+{
+  ImageSubresourceRange range;
+  range.image = image;
+  range.aspectMask = availableAspects;
+  range.baseMipLevel = 0;
+  range.levelCount = mipLevels;
+  range.baseArrayLayer = 0;
+  range.layerCount = arrayLayers;
+  return range;
+}
+
+ImageState::ImageState(uint64_t aImage, SDObject *ci) : image(aImage)
+{
+  std::string ci_type(Type(ci));
+  if(ci_type == "VkImageCreateInfo")
+  {
+    type = (VkImageType)ci->FindChild("imageType")->AsUInt64();
+    format = (VkFormat)ci->FindChild("format")->AsUInt64();
+    mipLevels = ci->FindChild("mipLevels")->AsUInt64();
+    arrayLayers = ci->FindChild("arrayLayers")->AsUInt64();
+    SDObject *extent = ci->FindChild("extent");
+    width = extent->FindChild("width")->AsUInt64();
+    height = extent->FindChild("width")->AsUInt64();
+    depth = extent->FindChild("depth")->AsUInt64();
+    initialLayout = (VkImageLayout)ci->FindChild("initialLayout")->AsUInt64();
+  }
+  else if(ci_type == "VkSwapchainCreateInfoKHR")
+  {
+    type = VK_IMAGE_TYPE_2D;
+    format = (VkFormat)ci->FindChild("imageFormat")->AsUInt64();
+    mipLevels = 1;
+    arrayLayers = ci->FindChild("imageArrayLayers")->AsUInt64();
+    SDObject *extent = ci->FindChild("imageExtent");
+    width = extent->FindChild("width")->AsUInt64();
+    height = extent->FindChild("height")->AsUInt64();
+    depth = 1;
+    initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  }
+  else
+  {
+    RDCASSERT(0);
+  }
+
+  if(IsDepthAndStencilFormat(format))
+  {
+    // Depth and stencil image
+    availableAspects = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+  }
+  else if(IsDepthOrStencilFormat(format))
+  {
+    if(IsStencilFormat(format))
+    {
+      // Stencil only image
+      availableAspects = VK_IMAGE_ASPECT_STENCIL_BIT;
+    }
+    else
+    {
+      // Depth only image
+      availableAspects = VK_IMAGE_ASPECT_DEPTH_BIT;
+    }
+  }
+  else
+  {
+    // Color image
+    switch(GetYUVPlaneCount(format))
+    {
+      case 1: availableAspects = VK_IMAGE_ASPECT_COLOR_BIT; break;
+      case 2: availableAspects = VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT; break;
+      case 3:
+        availableAspects =
+            VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
+        break;
+      default: RDCASSERT(0);
+    }
+  }
+  if(type == VK_IMAGE_TYPE_3D)
+  {
+    arrayLayers = depth;
+  }
+  ImageSubresourceRange range = FullRange();
+  for(ImageSubresourceRangeIter res_it = range.begin(); res_it != range.end(); res_it++)
+  {
+    subresourceStates.insert(ImageSubresourceStateMapPair(
+        *res_it, ImageSubresourceState(image, initialLayout, sharingMode, *res_it)));
+  }
+}
+
+VkImageAspectFlags ImageState::NormalizeAspectMask(VkImageAspectFlags aspectMask) const
+{
+  if(aspectMask > VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM)
+  {
+    return availableAspects;
+  }
+  if((aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) && GetYUVPlaneCount(format) > 1)
+  {
+    // Accessing the Color aspect of a multi-planar image is equivilanet to accessing all planes.
+    RDCASSERT(aspectMask == VK_IMAGE_ASPECT_COLOR_BIT);
+    RDCASSERT((availableAspects & (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT |
+                                   VK_IMAGE_ASPECT_PLANE_2_BIT)) == availableAspects);
+    aspectMask = availableAspects;
+  }
+  return aspectMask;
+}
+
+ImageSubresourceRange ImageState::Range(VkImageAspectFlags aspectMask, uint64_t baseMipLevel,
+                                        uint64_t levelCount, uint64_t baseArrayLayer,
+                                        uint64_t layerCount, bool is2DView)
+{
+  ImageSubresourceRange range;
+  range.image = image;
+  range.aspectMask = NormalizeAspectMask(aspectMask);
+  range.baseMipLevel = baseMipLevel;
+  if(levelCount == VK_REMAINING_MIP_LEVELS)
+  {
+    range.levelCount = mipLevels - baseMipLevel;
+  }
+  else
+  {
+    range.levelCount = levelCount;
+  }
+  if(type == VK_IMAGE_TYPE_3D && !is2DView)
+  {
+    RDCASSERT(baseArrayLayer == 0);
+    RDCASSERT(layerCount == 1 || layerCount == VK_REMAINING_ARRAY_LAYERS);
+    range.baseArrayLayer = 0;
+    range.layerCount = arrayLayers;
+  }
+  else
+  {
+    range.baseArrayLayer = baseArrayLayer;
+    if(layerCount == VK_REMAINING_ARRAY_LAYERS)
+    {
+      range.layerCount = arrayLayers - baseArrayLayer;
+    }
+    else
+    {
+      range.layerCount = layerCount;
+    }
+  }
+  return range;
+}
+
+ImageSubresourceRangeStateChanges ImageState::RangeChanges(ImageSubresourceRange range) const
+{
+  ImageSubresourceRangeStateChanges changes{};
+  bool firstLayoutRes = true;
+  bool firstQueueRes = true;
+  for(ImageSubresourceRangeIter res_it = range.begin(); res_it != range.end(); res_it++)
+  {
+    const ImageSubresourceState &resState = At(*res_it);
+
+    if(resState.StartLayout() != VK_IMAGE_LAYOUT_UNDEFINED &&
+       resState.StartLayout() != VK_IMAGE_LAYOUT_MAX_ENUM)
+    {
+      changes.layoutChanged = changes.layoutChanged || resState.StartLayout() != resState.Layout();
+
+      if(firstLayoutRes)
+      {
+        changes.startLayout = resState.StartLayout();
+        changes.endLayout = resState.Layout();
+        firstLayoutRes = false;
+      }
+      else
+      {
+        changes.sameStartLayout =
+            changes.sameStartLayout && changes.startLayout == resState.StartLayout();
+        changes.sameEndLayout = changes.sameEndLayout && changes.endLayout == resState.Layout();
+      }
+    }
+    if(resState.StartQueueFamily() != VK_QUEUE_FAMILY_IGNORED &&
+       resState.SharingMode() != VK_SHARING_MODE_CONCURRENT)
+    {
+      changes.queueFamilyChanged =
+          changes.queueFamilyChanged || (resState.StartQueueFamily() != resState.QueueFamily() &&
+                                         resState.QueueFamily() != VK_QUEUE_FAMILY_IGNORED);
+      if(firstQueueRes)
+      {
+        changes.startQueueFamily = resState.StartQueueFamily();
+        changes.endQueueFamily = resState.QueueFamily();
+        firstQueueRes = false;
+      }
+      else
+      {
+        changes.sameStartQueueFamily =
+            changes.sameStartQueueFamily && changes.startQueueFamily == resState.StartQueueFamily();
+        changes.sameEndQueueFamily =
+            changes.sameEndQueueFamily && (changes.endQueueFamily == resState.QueueFamily() ||
+                                           resState.QueueFamily() == VK_QUEUE_FAMILY_IGNORED);
+      }
+    }
+  }
+  return changes;
+}
+
+}    // namespace vk_cpp_codec

--- a/renderdoc/driver/vulkan/cpp_codec/vk_cpp_codec_state.h
+++ b/renderdoc/driver/vulkan/cpp_codec/vk_cpp_codec_state.h
@@ -1,0 +1,588 @@
+/******************************************************************************
+* The MIT License (MIT)
+*
+* Copyright (c) 2018 Baldur Karlsson
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+******************************************************************************/
+#pragma once
+
+#include "core/intervals.h"
+#include "driver/vulkan/vk_common.h"
+#include "serialise/codecs/vk_cpp_codec_common.h"
+
+namespace vk_cpp_codec
+{
+// Enum representing the reset requirement.
+enum ResetRequirement
+{
+  RESET_REQUIREMENT_UNKNOWN = 0,    // reset requirement is unknown (possibly just not yet computed)
+  RESET_REQUIREMENT_RESET = 1,      // reset is required before each frame
+  RESET_REQUIREMENT_INIT = 2,       // initialization is required, but no reset between frames
+  RESET_REQUIREMENT_NO_RESET = 3,    // no reset is required
+};
+
+// BoundResource (BR) describes a resource binding information.
+struct BoundResource
+{
+  SDChunk *create;          // create call for the bound resource
+  SDChunk *bind;            // binding call
+  SDObject *resource;       // resource ID
+  SDObject *requirement;    // serialized memory requirements
+  SDObject *offset;         // binding offset
+  ResetRequirement reset;
+};
+
+typedef std::vector<BoundResource> BoundResources;
+typedef BoundResources::iterator BoundResourcesIter;
+
+// This structure describes a resource memory range.
+struct MemRange
+{
+  uint64_t start = 0;
+  uint64_t end = 0;
+  MemRange MakeRange(SDObject *offset, SDObject *reqs);
+  bool Intersect(MemRange &r);
+};
+
+/*************************************************************
+State machine diagram for AccessState/AccessAction.
+- The states are labeled in CAPS (INIT, READ, WRITE, CLEAR, RESET)
+- The actions are labeled lower case (read, write, clear).
+- All the actions that are not shown are loops
+(e.g. a `read` action in the CLEAR state remains in the CLEAR state)
+// clang-format off
+    +--------INIT-----------+
+    |          |            |
+read|          |write       |clear
+    |          |            |
+    V   read   V   clear    V
+   READ<------WRITE------->CLEAR
+    |
+    |write
+    |clear
+    V
+    RESET
+// clang-format on
+*************************************************************/
+
+// AccessState is used to store whether an image or memory range has been read, written, or both,
+// and whether a reset is required.
+enum AccessState
+{
+  // Resource has not been read or written
+  ACCESS_STATE_INIT = 0,
+
+  // Some regions of the resource may have been read; all reads occurred after all writes.
+  ACCESS_STATE_READ = 1,
+
+  // Some regions of the resource may have been written, but nothing has been read.
+  ACCESS_STATE_WRITE = 2,
+
+  // The entire resource was reset, without reading the initial contents
+  ACCESS_STATE_CLEAR = 3,
+
+  // Some piece of resource may have been read and later written, requiring a reset.
+  ACCESS_STATE_RESET = 4,
+};
+
+// Memory action encodes the possible effects on a region of memory.
+enum AccessAction
+{
+  ACCESS_ACTION_NONE = 0,
+
+  // Write the some regions of the resource
+  ACCESS_ACTION_WRITE = 1,
+
+  // Read some regions of the resource
+  ACCESS_ACTION_READ = 2,
+
+  // Overwrite the entire resource, ignoring the previous contents
+  ACCESS_ACTION_CLEAR = 4,
+
+  // Write some regions of the memory after possible reading some regions of the resource.
+  // Equivalent to a ACCESS_ACTION_READ followed by ACCESS_ACTION_WRITE.
+  ACCESS_ACTION_READ_WRITE = ACCESS_ACTION_WRITE | ACCESS_ACTION_READ,
+};
+
+// Returns the new AccessState resulting from clearing the entire resource
+AccessState AccessStateClearTransition(AccessState s);
+
+// Returns the new AccessState resulting from writing to some regions of the resource
+AccessState AccessStateWriteTransition(AccessState s);
+
+// Returns the new AccessState resulting from reading the resource
+AccessState AccessStateReadTransition(AccessState s);
+
+// Returns the new AccessState resulting from reading some regions of the resource, and then
+// writing some regions of the resource
+AccessState AccessStateReadWriteTransition(AccessState s);
+
+// Given an action, returns a function mapping the old state of a resource to the new state of that
+// resource
+std::function<AccessState(AccessState)> GetAccessStateTransition(AccessAction action);
+
+struct MemoryState
+{
+  // The "current" access state (read/write) of the subresource.
+  // Updated by the command analysis functions called from CodeTracker::AnalyzeInitResources.
+  AccessState accessState = ACCESS_STATE_INIT;
+
+  // The queue family owning the subresource at the beginning of the frame.
+  uint64_t startQueueFamily = VK_QUEUE_FAMILY_IGNORED;
+
+  // The "current" queue family owning the subresource
+  // Updated by the command analysis functions called from CodeTracker::AnalyzeInitResources.
+  uint64_t queueFamily = VK_QUEUE_FAMILY_IGNORED;
+
+  // Indicates whether this memory region is currently acquired by a queue family.
+  bool isAcquired = false;
+
+  inline bool operator==(const MemoryState &rhs) const
+  {
+    return accessState == rhs.accessState && startQueueFamily == rhs.startQueueFamily &&
+           queueFamily == rhs.queueFamily && isAcquired == rhs.isAcquired;
+  }
+  inline bool operator!=(const MemoryState &rhs) const
+  {
+    return accessState != rhs.accessState || startQueueFamily != rhs.startQueueFamily ||
+           queueFamily != rhs.queueFamily || isAcquired != rhs.isAcquired;
+  }
+};
+
+// MemoryAllocationWithBoundResources (MAWBR) describes a memory allocation (through
+// RenderDoc's SDChunk) and the list of all resources that are bound to that allocation.
+// It stores the list of memory ranges, which is used to keep track of
+// overlapping resources, detect resource aliasing, and memory state transitions.
+struct MemoryAllocationWithBoundResources
+{
+  enum HasAliasedResources
+  {
+    HasAliasedResourcesFalse,
+    HasAliasedResourcesTrue,
+    HasAliasedResourcesUnknown
+  };
+  SDChunk *allocate = NULL;
+  BoundResources boundResources;
+  std::vector<MemRange> ranges;
+  Intervals<MemoryState> memoryState;
+  uint64_t hasAliasedResources = HasAliasedResourcesUnknown;
+
+  inline MemoryAllocationWithBoundResources(SDChunk *alloc = NULL) : allocate(alloc) {}
+  inline size_t Size() { return boundResources.size(); }
+  inline BoundResourcesIter Begin() { return boundResources.begin(); }
+  inline BoundResourcesIter End() { return boundResources.end(); }
+  inline void Add(BoundResource &r) { boundResources.push_back(r); }
+  bool HasAliasedResources();
+  bool NeedsReset();
+  bool NeedsInit();
+  std::vector<size_t> OrderByResetRequiremnet();
+  bool CheckAliasedResources(MemRange r);
+  void Access(uint64_t cmdQueueFamily, VkSharingMode sharingMode, AccessAction action,
+              uint64_t offset, uint64_t size);
+  void TransitionQueueFamily(uint64_t cmdQueueFamily, VkSharingMode sharingMode,
+                             uint64_t srcQueueFamily, uint64_t dstQueueFamily, uint64_t offset,
+                             uint64_t size);
+};
+
+// For each memory allocation ID, the map type below store allocation
+// create info structure along with the list of bound resource.
+typedef std::map<uint64_t, MemoryAllocationWithBoundResources> MemAllocWithResourcesMap;
+typedef MemAllocWithResourcesMap::iterator MemAllocWithResourcesMapIter;
+typedef std::pair<uint64_t, MemoryAllocationWithBoundResources> MemAllocWithResourcesMapPair;
+
+// ResourceWithAssociations (RWA) stores a 'create' / 'allocate' chunk for a resource
+// and keeps a list of derived / parent objects in the list of associations.
+// This is needed to find the proper initial state and to determine if a resource
+// needs an expensive memory reset before each frame render.
+// Example: when VkImage is created, a RWA is created, where vkCreateImage is a 'create', and all
+// vkCreateImageView, vkCreateFramebuffers are 'associated' operations / resources.
+// In reverse, when a VkImageView is created, another RWA is created, that store vkCreateImageView
+// as 'create' and with VkImage stored as an associated resource.
+struct ResourceWithAssociations
+{
+  SDChunk *create;
+  SDObjectIDMap associations;
+};
+
+typedef std::map<uint64_t, ResourceWithAssociations> ResourceWithAssociationsMap;
+typedef ResourceWithAssociationsMap::iterator ResourceWithAssociationsMapIter;
+typedef std::pair<uint64_t, ResourceWithAssociations> ResourceWithAssociationsMapPair;
+
+struct MemStateUpdates
+{
+  SDChunkVec descset;
+  SDChunkVec memory;
+};
+
+struct CmdBufferRecord
+{
+  SDObject *cb;
+  SDChunkVec cmds;    // commands
+};
+
+struct QueueSubmit
+{
+  SDChunk *submit;            // queue submit chunk
+  SDObject *queue;            // vkqueue
+  uint64_t memoryUpdates;     // # of completed updates
+  uint64_t descsetUpdates;    // # of completed updates
+};
+
+typedef std::vector<QueueSubmit> QueueSubmits;
+typedef std::vector<QueueSubmit>::iterator QueueSubmitsIter;
+
+struct FrameGraph
+{
+  QueueSubmits submits;
+  MemStateUpdates updates;
+  std::vector<CmdBufferRecord> records;
+
+  inline void AddUnorderedSubmit(QueueSubmit qs) { submits.push_back(qs); }
+  uint32_t FindCmdBufferIndex(SDObject *o);
+};
+
+struct BoundBuffer
+{
+  uint64_t buffer = 0;
+  uint64_t offset = 0;
+  uint64_t size = 0;
+  uint64_t dynamicOffset = 0;
+  bool bound = false;
+
+  inline BoundBuffer() {}
+  inline BoundBuffer(uint64_t aBuffer, uint64_t aOffset, uint64_t aSize, uint64_t aDynamicOffset)
+      : buffer(aBuffer), offset(aOffset), size(aSize), dynamicOffset(aDynamicOffset), bound(true)
+  {
+  }
+};
+
+struct BoundImage
+{
+  uint64_t sampler = 0;
+  uint64_t imageView = 0;
+  VkImageLayout imageLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  bool bound = false;
+
+  inline BoundImage() {}
+  inline BoundImage(uint64_t aSampler, uint64_t aImageView, VkImageLayout aImageLayout)
+      : sampler(aSampler), imageView(aImageView), imageLayout(aImageLayout), bound(true)
+  {
+  }
+};
+
+struct BoundTexelView
+{
+  uint64_t texelBufferView = 0;
+  bool bound = false;
+
+  inline BoundTexelView() {}
+  inline BoundTexelView(uint64_t aTexelBufferView) : texelBufferView(aTexelBufferView), bound(true)
+  {
+  }
+};
+
+struct DescriptorBinding
+{
+  VkDescriptorType type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+  std::vector<BoundImage> imageBindings;
+  std::vector<BoundBuffer> bufferBindings;
+  std::vector<BoundTexelView> texelViewBindings;
+  std::vector<bool> updated;
+
+  inline DescriptorBinding() {}
+  inline DescriptorBinding(uint64_t type, size_t elementCount) { Resize(type, elementCount); }
+  size_t Size();
+
+  void SetBindingObj(size_t index, SDObject *o, bool initialization);
+  void CopyBinding(size_t index, const DescriptorBinding &other, size_t otherIndex);
+  void Resize(uint64_t aType, size_t elementCount);
+  bool NeedsReset(size_t element);
+};
+
+typedef std::map<uint64_t, DescriptorBinding> DescriptorBindingMap;
+typedef std::map<uint64_t, DescriptorBinding>::iterator DescriptorBindingMapIter;
+typedef std::pair<uint64_t, DescriptorBinding> DescriptorBindingMapPair;
+
+struct DescriptorSetInfo
+{
+  uint64_t layout;    // ID of a parent vkDescriptorSetLayout object
+  DescriptorBindingMap bindings;
+
+  bool NeedsReset(size_t binding, size_t element);
+};
+
+typedef std::map<uint64_t, DescriptorSetInfo> DescriptorSetInfoMap;
+typedef std::map<uint64_t, DescriptorSetInfo>::iterator DescriptorSetInfoMapIter;
+typedef std::pair<uint64_t, DescriptorSetInfo> DescriptorSetInfoMapPair;
+
+typedef std::map<uint64_t, int64_t> U64Map;
+typedef U64Map::iterator U64MapIter;
+typedef std::pair<uint64_t, uint64_t> U64MapPair;
+
+struct BoundPipeline
+{
+  // Identifier of the pipeline
+  uint64_t pipeline = 0;
+
+  // Map from the descriptor set number to the id of the bound descriptor set at that number
+  U64Map descriptorSets;
+
+  inline BoundPipeline() {}
+};
+
+struct BindingState
+{
+  BoundPipeline graphicsPipeline;
+  BoundPipeline computePipeline;
+  std::map<uint64_t, BoundBuffer> vertexBuffers;    // key = binding number
+  BoundBuffer indexBuffer;
+  uint64_t indexBufferType = 0;
+  SDObject *renderPass = NULL;
+  SDObject *framebuffer = NULL;
+  bool isFullRenderArea = false;
+  std::vector<VkImageLayout> attachmentLayout;
+  std::vector<uint64_t> attachmentFirstUse;
+  std::vector<uint64_t> attachmentLastUse;
+  uint64_t subpassIndex = 0;
+
+  BindingState() {}
+private:
+  void attachmentUse(uint64_t subpassId, size_t attachmentId);
+
+public:
+  void BeginRenderPass(SDObject *aRenderPass, SDObject *aFramebuffer, SDObject *aRenderArea);
+};
+
+struct ImageSubresource
+{
+  uint64_t image;
+  VkImageAspectFlagBits aspect;
+  uint64_t layer;
+  uint64_t level;
+
+  inline bool operator==(const ImageSubresource &rhs) const
+  {
+    return image == rhs.image && aspect == rhs.aspect && layer == rhs.layer && level == rhs.level;
+  }
+
+  inline bool operator!=(const ImageSubresource &rhs) const { return !operator==(rhs); }
+  inline bool operator<(const ImageSubresource &rhs) const
+  {
+    return std::tie(image, aspect, layer, level) <
+           std::tie(rhs.image, rhs.aspect, rhs.layer, rhs.level);
+  }
+};
+
+class ImageSubresourceRangeIter;
+
+struct ImageSubresourceRange
+{
+  uint64_t image;
+  VkImageAspectFlags aspectMask;
+  uint64_t baseMipLevel;
+  uint64_t levelCount;
+  uint64_t baseArrayLayer;
+  uint64_t layerCount;
+  ImageSubresourceRangeIter begin() const;
+  ImageSubresourceRangeIter end() const;
+};
+
+// ImageSubresourceRangeIter iterates through an image subresource range (aspect, mip level, array
+// layer).
+// The iteration order is:
+//   - For each aspect bit in aspectMask, in increasing order
+//     - For each level in range (baseMipLevel .. baseMipLevel + levelCount)
+//       - For each layer in  range (baseArrayLayer .. baseArrayLayer + layerCout)
+//         - yield (aspect, level, layer)
+class ImageSubresourceRangeIter
+{
+  static const VkImageAspectFlags VK_IMAGE_ASPECT_END_BIT = 0x00000080;
+  ImageSubresource res;
+  ImageSubresourceRange range;
+
+  // Set this iterator into a common 'end' state.
+  inline void setEnd()
+  {
+    res.level = (~0ULL) - 1;
+    res.layer = (~0ULL) - 1;
+    res.aspect = (VkImageAspectFlagBits)VK_IMAGE_ASPECT_END_BIT;
+  }
+
+public:
+  ImageSubresourceRangeIter &operator++();
+  inline ImageSubresourceRangeIter operator++(int)
+  {
+    ImageSubresourceRangeIter tmp(*this);
+    operator++();
+    return tmp;
+  }
+  inline bool operator==(const ImageSubresourceRangeIter &rhs) const { return res == rhs.res; }
+  inline bool operator!=(const ImageSubresourceRangeIter &rhs) const { return res != rhs.res; }
+  inline const ImageSubresource &operator*() { return res; }
+  inline const ImageSubresource *operator->() const { return &res; }
+  static ImageSubresourceRangeIter end(const ImageSubresourceRange &range);
+  static ImageSubresourceRangeIter begin(const ImageSubresourceRange &range);
+};
+
+inline ImageSubresourceRangeIter ImageSubresourceRange::begin() const
+{
+  return ImageSubresourceRangeIter::begin(*this);
+}
+inline ImageSubresourceRangeIter ImageSubresourceRange::end() const
+{
+  return ImageSubresourceRangeIter::end(*this);
+}
+
+class ImageSubresourceState
+{
+  uint64_t image;
+  VkImageAspectFlagBits aspect;
+  uint64_t mipLevel;
+  uint64_t layer;
+  VkSharingMode sharingMode;
+
+  // The "current" access state (read/write) of the subresource.
+  // Updated by the command analysis functions called from CodeTracker::AnalyzeInitResources.
+  AccessState accessState = ACCESS_STATE_INIT;
+
+  // The layout of the subresource at the beginning of the frame.
+  VkImageLayout startLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+
+  // The "current" layout of the subresource.
+  // Updated by the command analysis functions called from CodeTracker::AnalyzeInitResources.
+  VkImageLayout layout = VK_IMAGE_LAYOUT_MAX_ENUM;
+
+  // The queue family owning the subresource at the beginning of the frame.
+  uint64_t startQueueFamily = VK_QUEUE_FAMILY_IGNORED;
+
+  // The "current" queue family owning the subresource
+  // Updated by the command analysis functions called from CodeTracker::AnalyzeInitResources.
+  uint64_t queueFamily = VK_QUEUE_FAMILY_IGNORED;
+
+  bool isInitialized = false;
+  bool isTransitioned = false;
+  bool isAcquiredByQueue = false;
+
+  void CheckLayout(VkImageLayout requestedLayout);
+
+  void CheckQueueFamily(uint64_t cmdQueueFamily);
+
+public:
+  inline ImageSubresourceState(uint64_t image, VkImageLayout initialLayout,
+                               VkSharingMode aSharingMode, const ImageSubresource &res)
+      : image(image),
+        startLayout(initialLayout),
+        layout(initialLayout),
+        sharingMode(aSharingMode),
+        aspect(res.aspect),
+        mipLevel(res.level),
+        layer(res.layer)
+  {
+  }
+  void Initialize(VkImageLayout aStartLayout, uint64_t aStartQueueFamily);
+  void Access(uint64_t cmdQueueFamily, VkImageLayout requestedLayout,
+              const std::function<AccessState(AccessState)> &transition);
+  void Transition(uint64_t cmdQueueFamily, VkImageLayout oldLayout, VkImageLayout newLayout,
+                  uint64_t srcQueueFamily, uint64_t dstQueueFamily);
+
+  inline AccessState AccessState() const { return accessState; }
+  inline VkImageLayout StartLayout() const { return startLayout; }
+  inline VkImageLayout Layout() const { return layout; }
+  inline uint64_t StartQueueFamily() const { return startQueueFamily; }
+  inline uint64_t QueueFamily() const { return queueFamily; }
+  inline VkSharingMode SharingMode() const { return sharingMode; }
+};
+
+typedef std::map<ImageSubresource, ImageSubresourceState> ImageSubresourceStateMap;
+typedef std::pair<ImageSubresource, ImageSubresourceState> ImageSubresourceStateMapPair;
+typedef std::map<ImageSubresource, ImageSubresourceState>::iterator ImageSubresourceStateMapIter;
+typedef std::map<ImageSubresource, ImageSubresourceState>::const_iterator ImageSubresourceStateMapConstIter;
+
+struct ImageSubresourceRangeStateChanges
+{
+  VkImageLayout startLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  VkImageLayout endLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  bool sameStartLayout = true;
+  bool sameEndLayout = true;
+
+  // layoutChanged indicates whether any subresource in the range had a non-trivial layout change
+  // between the start and end of the frame.
+  // A layout change is "trivial" if either:
+  //   - the start layout is VK_IMAGE_LAYOUT_UNDEFINED (no need to transition to UNDEFINED),
+  //   - the start layout is VK_IMAGE_LAYOUT_MAX_ENUM (indicating no start layout was recorded while
+  //   capturing), or
+  //   - the end layout is VK_IMAGE_LAYOUT_MAX_ENUM (indicating the subresource was never used).
+  bool layoutChanged = false;
+  uint64_t startQueueFamily = VK_QUEUE_FAMILY_IGNORED;
+  uint64_t endQueueFamily = VK_QUEUE_FAMILY_IGNORED;
+  bool sameStartQueueFamily = true;
+  bool sameEndQueueFamily = true;
+  bool queueFamilyChanged = false;
+};
+
+class ImageState
+{
+  uint64_t image;
+  ImageSubresourceStateMap subresourceStates;
+  VkImageType type = VK_IMAGE_TYPE_2D;
+  VkFormat format = VK_FORMAT_UNDEFINED;
+  VkImageAspectFlags availableAspects = 0;
+  uint64_t mipLevels = 0;
+  uint64_t arrayLayers = 0;
+  uint64_t width = 0;
+  uint64_t height = 0;
+  uint64_t depth = 0;
+  VkImageLayout initialLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+  VkSharingMode sharingMode = VK_SHARING_MODE_MAX_ENUM;
+
+public:
+  ImageSubresourceRange FullRange();
+
+  inline ImageState() { RDCASSERT(0); }
+  ImageState(uint64_t aImage, SDObject *ci);
+
+  VkImageAspectFlags NormalizeAspectMask(VkImageAspectFlags aspectMask) const;
+
+  ImageSubresourceRange Range(VkImageAspectFlags aspectMask, uint64_t baseMipLevel,
+                              uint64_t levelCount, uint64_t baseArrayLayer, uint64_t layerCount,
+                              bool is2DView = false);
+
+  ImageSubresourceRangeStateChanges RangeChanges(ImageSubresourceRange range) const;
+
+  inline ImageSubresourceState &At(const ImageSubresource &res)
+  {
+    return subresourceStates.at(res);
+  }
+  inline const ImageSubresourceState &At(const ImageSubresource &res) const
+  {
+    return subresourceStates.at(res);
+  }
+  inline ImageSubresourceStateMapIter begin() { return subresourceStates.begin(); }
+  inline ImageSubresourceStateMapConstIter begin() const { return subresourceStates.begin(); }
+  inline ImageSubresourceStateMapIter end() { return subresourceStates.end(); }
+  inline ImageSubresourceStateMapConstIter end() const { return subresourceStates.end(); }
+  inline VkImageLayout InitialLayout() { return initialLayout; }
+};
+
+typedef std::map<uint64_t, ImageState> ImageStateMap;
+typedef std::pair<uint64_t, ImageState> ImageStateMapPair;
+typedef std::map<uint64_t, ImageState>::iterator ImageStateMapIter;
+
+}    // namespace vk_cpp_codec

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
@@ -99,6 +99,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="cpp_codec\vk_cpp_codec_state.cpp" />
     <ClCompile Include="precompiled.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -157,6 +158,7 @@
     <ClCompile Include="wrappers\vk_wsi_funcs.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="cpp_codec\vk_cpp_codec_state.h" />
     <ClInclude Include="official\vk_layer.h" />
     <ClInclude Include="official\vk_layer_dispatch_table.h" />
     <ClInclude Include="official\vk_platform.h" />

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="vk_next_chains.cpp">
       <Filter>Util</Filter>
     </ClCompile>
+    <ClCompile Include="cpp_codec\vk_cpp_codec_state.cpp">
+      <Filter>C++ Codec</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vk_replay.h">
@@ -219,6 +222,9 @@
     <ClInclude Include="official\vulkan_fuchsia.h">
       <Filter>official</Filter>
     </ClInclude>
+    <ClInclude Include="cpp_codec\vk_cpp_codec_state.h">
+      <Filter>C++ Codec</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="OS">
@@ -250,6 +256,9 @@
     </Filter>
     <Filter Include="PCH">
       <UniqueIdentifier>{356d20c5-9ffd-4c8d-86cc-4e674104f275}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="C++ Codec">
+      <UniqueIdentifier>{f5b8428d-7cad-413c-883f-3b93af48a786}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
CPP codec builds a simplified model of Vulkan execution based on the trace.
This CL adds small utility structures and types used by the codec to track
Vulkan resource and analyze the trace.

Change-Id: I5a33fc3de2f8230621787409a588c68078bc73b5