### PR TITLE
shorten android capture option str

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -205,7 +205,7 @@ ExecuteResult StartAndroidPackageForCapture(const char *host, const char *packag
   // create the data directory we will use for storing, in case the application doesn't
   adbExecCommand(deviceID, "shell mkdir -p /sdcard/Android/data/" + packageName);
   // set our property with the capture options encoded, to be picked up by the library on the device
-  adbExecCommand(deviceID, StringFormat::Fmt("shell setprop debug.rdoc.RENDERDOC_CAPTUREOPTS %s",
+  adbExecCommand(deviceID, StringFormat::Fmt("shell setprop debug.rdoc.RENDERDOC_CAPOPTS %s",
                                              opts.EncodeAsString().c_str()));
 
   std::string installedPath = GetPathForPackage(deviceID, packageName);

--- a/renderdoc/os/posix/posix_libentry.cpp
+++ b/renderdoc/os/posix/posix_libentry.cpp
@@ -46,7 +46,7 @@ void library_loaded()
     RenderDoc::Inst().Initialise();
 
     const char *capturefile = Process::GetEnvVariable("RENDERDOC_CAPFILE");
-    const char *opts = Process::GetEnvVariable("RENDERDOC_CAPTUREOPTS");
+    const char *opts = Process::GetEnvVariable("RENDERDOC_CAPOPTS");
 
     if(opts)
     {

--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -750,7 +750,7 @@ ExecuteResult Process::LaunchAndInjectIntoProcess(const char *app, const char *w
   modifications.push_back(
       EnvironmentModification(EnvMod::Set, EnvSep::NoSep, "RENDERDOC_CAPFILE", capturefile));
   modifications.push_back(
-      EnvironmentModification(EnvMod::Set, EnvSep::NoSep, "RENDERDOC_CAPTUREOPTS", optstr.c_str()));
+      EnvironmentModification(EnvMod::Set, EnvSep::NoSep, "RENDERDOC_CAPTOPTS", optstr.c_str()));
   modifications.push_back(EnvironmentModification(EnvMod::Set, EnvSep::NoSep,
                                                   "RENDERDOC_DEBUG_LOG_FILE", RDCGETLOGFILE()));
 


### PR DESCRIPTION
## Description
 setprop debug.rdoc.RENDERDOC_CAPTUREOPTS is too long for android : 

quest:/ # setprop debug.rdoc.RENDERDOC_CAPTUREOPTS ""
setprop: name 'debug.rdoc.RENDERDOC_CAPTUREOPTS' too long; try debug.rdoc.RENDERDOC_CAPTUREOPT'

so I renamed it, which makes "ref all resources" work again