### PR TITLE
Fix vulkan overlay crash due to incorrect colorAttachment idx

### DIFF
--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -1585,8 +1585,7 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, CompType typeHint, Debu
       for(size_t i = 0; i < rp.subpasses[m_pDriver->m_RenderState.subpass].colorAttachments.size();
           i++)
       {
-        blackclear.colorAttachment =
-            rp.subpasses[m_pDriver->m_RenderState.subpass].colorAttachments[i];
+        blackclear.colorAttachment = (uint32_t)i;
         atts.push_back(blackclear);
       }
 


### PR DESCRIPTION
Color attachment from `rp.subpasses[m_pDriver->m_RenderState.subpass].colorAttachments[i]` could be `VK_ATTACHMENT_UNUSED` which is illegal since `.colorAttachment` should be index of subpass' attachment. 

This caused crash on vulkan traces.