### PR TITLE
Add range info to Vulkan memory tracking

### DIFF
--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -365,14 +365,17 @@ void VulkanResourceManager::MarkSparseMapReferenced(ResourceInfo *sparse)
   }
 
   for(size_t i = 0; i < sparse->opaquemappings.size(); i++)
-    MarkResourceFrameReferenced(GetResID(sparse->opaquemappings[i].memory), eFrameRef_Read);
+    MarkMemoryFrameReferenced(GetResID(sparse->opaquemappings[i].memory),
+                              sparse->opaquemappings[i].memoryOffset,
+                              sparse->opaquemappings[i].size, eFrameRef_Read);
 
   for(int a = 0; a < NUM_VK_IMAGE_ASPECTS; a++)
   {
     VkDeviceSize totalSize =
         VkDeviceSize(sparse->imgdim.width) * sparse->imgdim.height * sparse->imgdim.depth;
     for(VkDeviceSize i = 0; sparse->pages[a] && i < totalSize; i++)
-      MarkResourceFrameReferenced(GetResID(sparse->pages[a][i].first), eFrameRef_Read);
+      MarkMemoryFrameReferenced(GetResID(sparse->pages[a][i].first), 0, VK_WHOLE_SIZE,
+                                eFrameRef_Read);
   }
 }
 
@@ -602,6 +605,12 @@ ResourceId VulkanResourceManager::GetFirstIDForHandle(uint64_t handle)
   }
 
   return ResourceId();
+}
+
+void VulkanResourceManager::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize offset,
+                                                      VkDeviceSize size, FrameRefType refType)
+{
+  MarkResourceFrameReferenced(mem, refType);
 }
 
 bool VulkanResourceManager::Force_InitialState(WrappedVkRes *res, bool prepare)

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -410,6 +410,9 @@ public:
 
   void SetInternalResource(ResourceId id);
 
+  void MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize start, VkDeviceSize end,
+                                 FrameRefType refType);
+
 private:
   bool ResourceTypeRelease(WrappedVkRes *res);
 

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1097,6 +1097,14 @@ public:
   ResourceId baseResource;
   ResourceId baseResourceMem;    // for image views, we need to point to both the image and mem
 
+  VkDeviceSize memOffset;
+  VkDeviceSize memSize;
+
+  void MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize offset, VkDeviceSize size,
+                                 FrameRefType refType);
+  void MarkBufferFrameReferenced(VkResourceRecord *buf, VkDeviceSize offset, VkDeviceSize size,
+                                 FrameRefType refType);
+  void MarkBufferViewFrameReferenced(VkResourceRecord *buf, FrameRefType refType);
   // these are all disjoint, so only a record of the right type will have each
   // Note some of these need to be deleted in the constructor, so we check the
   // allocation type of the Resource


### PR DESCRIPTION
## Description

Calls to `MarkResourceFrameReferenced` for `VkDeviceMemory` resources are replaced by calls to a new function `MarkMemoryFrameReferenced`, which additionally includes the range of the `VkDeviceMemory` being referenced. This includes memory accessed through buffers and mapped memory, but not memory backing images.

This PR does not actually use this range information; see https://github.com/bjoeris/renderdoc/tree/tracking for context of how the range information will be used to track the reference state of `VkDeviceMemory` by range, rather than having a single reference state for the entire `VkDeviceMemory`.