### PR TITLE
Add `InitReqType` to classify `FrameRefType` by init/reset requirements.

### DIFF
--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -61,7 +61,7 @@ FrameRefType ComposeFrameRefs(FrameRefType first, FrameRefType second)
   switch(first)
   {
     case eFrameRef_None:
-    case eFrameRef_Write:
+    case eFrameRef_PartialWrite:
       if(second == eFrameRef_None)
         // A `None` reference after any other reference type does not change
         // the first reference type
@@ -79,8 +79,8 @@ FrameRefType ComposeFrameRefs(FrameRefType first, FrameRefType second)
           // Only referenced as `Read` (and possibly `None`)
           return eFrameRef_Read;
 
-        case eFrameRef_Write:
-        case eFrameRef_Clear:
+        case eFrameRef_PartialWrite:
+        case eFrameRef_CompleteWrite:
         case eFrameRef_ReadBeforeWrite:
           // First read, and then written
           return eFrameRef_ReadBeforeWrite;
@@ -88,7 +88,7 @@ FrameRefType ComposeFrameRefs(FrameRefType first, FrameRefType second)
         default: RDCERR("Unknown FrameRefType: %d", second); return eFrameRef_Maximum;
       }
 
-    case eFrameRef_Clear:
+    case eFrameRef_CompleteWrite:
     case eFrameRef_ReadBeforeWrite:
       // These reference types are both locked in, and cannot be affected by
       // later references.
@@ -109,7 +109,8 @@ FrameRefType ComposeFrameRefsUnordered(FrameRefType first, FrameRefType second)
   if(first < second)
     std::swap(first, second);
 
-  if(first == eFrameRef_Read && (second == eFrameRef_Write || second == eFrameRef_Clear))
+  if(first == eFrameRef_Read &&
+     (second == eFrameRef_PartialWrite || second == eFrameRef_CompleteWrite))
     // The resource is referenced both read and write/clear;
     // We don't know whether the read or write/clear occurs first;
     // if the write happens first, the final state would be Read or Clear;

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -120,9 +120,18 @@ bool IsDirtyFrameRef(FrameRefType refType);
 // init/reset requirements.
 enum InitReqType
 {
-  // Initial contents of the resource are not used, and need not be initialized.
-  // Corresponds to `None`, `Write` or `Clear` ref types.
+  // Initial contents of the resource are not used, and also not modified.
+  // No initialization/reset is required for correct replay, but may be helpful
+  // to avoid user confusion when analyzing the resource.
+  // Corresponds to `None` ref type.
   eInitReq_None,
+
+  // Initial contents of the resource are not used, but the contents are
+  // potentially modified during the frame.
+  // No initialization/reset is required for correct replay, but may be helpful
+  // to avoid user confusion when analyzing the resource.
+  // Corresponds to `PartialWrite` and `CompleteWrite` ref types.
+  eInitReq_Clear,
 
   // Initial contents of the resource are read, but not overwritten;
   // the resource needs to be initialized before the first replay, but need not
@@ -141,9 +150,10 @@ inline InitReqType InitReq(FrameRefType refType)
 {
   switch(refType)
   {
+    case eFrameRef_None: return eInitReq_None;
     case eFrameRef_Read: return eInitReq_InitOnce;
     case eFrameRef_ReadBeforeWrite: return eInitReq_Reset;
-    default: return eInitReq_None;
+    default: return eInitReq_Clear;
   }
 }
 

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -74,13 +74,13 @@ enum FrameRefType
   // Write to some unknown subset of resource.
   // As a state, this represents that unlike clear, some part of the
   // initial contents might still be visible to later reads.
-  eFrameRef_Write = 1,
+  eFrameRef_PartialWrite = 1,
 
-  // Clear the entire resource.
+  // Write to the entire resource.
   // As a state, this represents that no later reads will even be able to see
   // the initial contents, and therefore, the initial contents need not be
   // restored for replay.
-  eFrameRef_Clear = 2,
+  eFrameRef_CompleteWrite = 2,
 
   // Read from the resource;
   // As a state, this represents a read that could have seen the resource's

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -114,6 +114,39 @@ FrameRefType ComposeFrameRefsUnordered(FrameRefType first, FrameRefType second);
 
 bool IsDirtyFrameRef(FrameRefType refType);
 
+// Captures the possible initialization/reset requirements for resources.
+// These requirements are entirely determined by the resource's FrameRefType,
+// but this type improves the readability of the code that checks
+// init/reset requirements.
+enum InitReqType
+{
+  // Initial contents of the resource are not used, and need not be initialized.
+  // Corresponds to `None`, `Write` or `Clear` ref types.
+  eInitReq_None,
+
+  // Initial contents of the resource are read, but not overwritten;
+  // the resource needs to be initialized before the first replay, but need not
+  // be reset before subsequent replays.
+  // Corresponds to `Read` ref type.
+  eInitReq_InitOnce,
+
+  // Initial contents of the resource are read, and later overwritten;
+  // the resource needs to be reset before each replay.
+  // Corresponds to `ReadBeforeWrite` ref type.
+  eInitReq_Reset,
+};
+
+// Return the initialization/reset requirements for a FrameRefType
+inline InitReqType InitReq(FrameRefType refType)
+{
+  switch(refType)
+  {
+    case eFrameRef_Read: return eInitReq_InitOnce;
+    case eFrameRef_ReadBeforeWrite: return eInitReq_Reset;
+    default: return eInitReq_None;
+  }
+}
+
 // handle marking a resource referenced for read or write and storing RAW access etc.
 bool MarkReferenced(std::map<ResourceId, FrameRefType> &refs, ResourceId id, FrameRefType refType);
 

--- a/renderdoc/driver/d3d11/d3d11_context1_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context1_wrap.cpp
@@ -180,7 +180,7 @@ bool WrappedID3D11DeviceContext::Serialise_UpdateSubresource1(
         // partial update
         if(SourceDataLength != (uint32_t)record->Length)
           MarkResourceReferenced(record->GetResourceID(), eFrameRef_Read);
-        MarkResourceReferenced(record->GetResourceID(), eFrameRef_Write);
+        MarkResourceReferenced(record->GetResourceID(), eFrameRef_PartialWrite);
       }
     }
 
@@ -377,7 +377,7 @@ void WrappedID3D11DeviceContext::UpdateSubresource1(ID3D11Resource *pDstResource
     Serialise_UpdateSubresource1(ser, pDstResource, DstSubresource, pDstBox, pSrcData, SrcRowPitch,
                                  SrcDepthPitch, CopyFlags);
 
-    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_PartialWrite);
 
     m_MissingTracks.insert(GetIDForResource(pDstResource));
 
@@ -622,7 +622,7 @@ void WrappedID3D11DeviceContext::ClearView(ID3D11View *pView, const FLOAT Color[
       pView->GetResource(&viewRes);
 
       m_MissingTracks.insert(GetIDForResource(viewRes));
-      MarkResourceReferenced(GetIDForResource(viewRes), eFrameRef_Write);
+      MarkResourceReferenced(GetIDForResource(viewRes), eFrameRef_PartialWrite);
 
       SAFE_RELEASE(viewRes);
 
@@ -1769,7 +1769,7 @@ void WrappedID3D11DeviceContext::DiscardResource(ID3D11Resource *pResource)
     Serialise_DiscardResource(ser, pResource);
 
     m_MissingTracks.insert(GetIDForResource(pResource));
-    MarkResourceReferenced(GetIDForResource(pResource), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pResource), eFrameRef_PartialWrite);
 
     m_ContextRecord->AddChunk(scope.Get());
   }
@@ -1925,7 +1925,7 @@ void WrappedID3D11DeviceContext::DiscardView(ID3D11View *pResourceView)
       pResourceView->GetResource(&viewRes);
 
       m_MissingTracks.insert(GetIDForResource(viewRes));
-      MarkResourceReferenced(GetIDForResource(viewRes), eFrameRef_Write);
+      MarkResourceReferenced(GetIDForResource(viewRes), eFrameRef_PartialWrite);
 
       SAFE_RELEASE(viewRes);
 
@@ -2093,7 +2093,7 @@ void WrappedID3D11DeviceContext::DiscardView1(ID3D11View *pResourceView, const D
       pResourceView->GetResource(&viewRes);
 
       m_MissingTracks.insert(GetIDForResource(viewRes));
-      MarkResourceReferenced(GetIDForResource(viewRes), eFrameRef_Write);
+      MarkResourceReferenced(GetIDForResource(viewRes), eFrameRef_PartialWrite);
 
       SAFE_RELEASE(viewRes);
 

--- a/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
@@ -2275,7 +2275,7 @@ void WrappedID3D11DeviceContext::SOSetTargets(UINT NumBuffers, ID3D11Buffer *con
       // Besides, it's unlikely an application will set an output then not draw to it
       if(IsActiveCapturing(m_State))
       {
-        MarkResourceReferenced(GetIDForResource(ppSOTargets[i]), eFrameRef_Write);
+        MarkResourceReferenced(GetIDForResource(ppSOTargets[i]), eFrameRef_PartialWrite);
 
         m_MissingTracks.insert(GetIDForResource(ppSOTargets[i]));
       }
@@ -3237,14 +3237,14 @@ void WrappedID3D11DeviceContext::OMSetRenderTargets(UINT NumViews,
       if(ppRenderTargetViews && ppRenderTargetViews[i])
       {
         MarkResourceReferenced(GetIDForResource(ppRenderTargetViews[i]), eFrameRef_Read);
-        MarkResourceReferenced(GetViewResourceResID(ppRenderTargetViews[i]), eFrameRef_Write);
+        MarkResourceReferenced(GetViewResourceResID(ppRenderTargetViews[i]), eFrameRef_PartialWrite);
       }
     }
 
     if(pDepthStencilView)
     {
       MarkResourceReferenced(GetIDForResource(pDepthStencilView), eFrameRef_Read);
-      MarkResourceReferenced(GetViewResourceResID(pDepthStencilView), eFrameRef_Write);
+      MarkResourceReferenced(GetViewResourceResID(pDepthStencilView), eFrameRef_PartialWrite);
     }
   }
 
@@ -5660,7 +5660,7 @@ void WrappedID3D11DeviceContext::CopySubresourceRegion(ID3D11Resource *pDstResou
     m_MissingTracks.insert(GetIDForResource(pDstResource));
     // assume partial update
     MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Read);
-    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_PartialWrite);
     MarkResourceReferenced(GetIDForResource(pSrcResource), eFrameRef_Read);
   }
   else if(IsBackgroundCapturing(m_State))
@@ -5802,7 +5802,7 @@ void WrappedID3D11DeviceContext::CopyResource(ID3D11Resource *pDstResource,
     m_ContextRecord->AddChunk(scope.Get());
 
     m_MissingTracks.insert(GetIDForResource(pDstResource));
-    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_PartialWrite);
     MarkResourceReferenced(GetIDForResource(pSrcResource), eFrameRef_Read);
   }
   else if(IsBackgroundCapturing(m_State))
@@ -5954,7 +5954,7 @@ void WrappedID3D11DeviceContext::UpdateSubresource(ID3D11Resource *pDstResource,
     Serialise_UpdateSubresource(GET_SERIALISER, pDstResource, DstSubresource, pDstBox, pSrcData,
                                 SrcRowPitch, SrcDepthPitch);
 
-    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_PartialWrite);
 
     m_MissingTracks.insert(GetIDForResource(pDstResource));
 
@@ -6237,7 +6237,7 @@ void WrappedID3D11DeviceContext::CopyStructureCount(ID3D11Buffer *pDstBuffer,
 
     m_MissingTracks.insert(GetIDForResource(pDstBuffer));
     MarkResourceReferenced(GetIDForResource(pDstBuffer), eFrameRef_Read);
-    MarkResourceReferenced(GetIDForResource(pDstBuffer), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pDstBuffer), eFrameRef_PartialWrite);
 
     MarkResourceReferenced(GetIDForResource(pSrcView), eFrameRef_Read);
   }
@@ -6351,7 +6351,7 @@ void WrappedID3D11DeviceContext::ResolveSubresource(ID3D11Resource *pDstResource
 
     m_MissingTracks.insert(GetIDForResource(pDstResource));
     MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Read);
-    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_Write);
+    MarkResourceReferenced(GetIDForResource(pDstResource), eFrameRef_PartialWrite);
     MarkResourceReferenced(GetIDForResource(pSrcResource), eFrameRef_Read);
   }
   else if(IsBackgroundCapturing(m_State))
@@ -6432,7 +6432,7 @@ void WrappedID3D11DeviceContext::GenerateMips(ID3D11ShaderResourceView *pShaderR
     m_MissingTracks.insert(id);
 
     MarkResourceReferenced(id, eFrameRef_Read);
-    MarkResourceReferenced(id, eFrameRef_Write);
+    MarkResourceReferenced(id, eFrameRef_PartialWrite);
     MarkResourceReferenced(GetIDForResource(pShaderResourceView), eFrameRef_Read);
   }
   else if(IsBackgroundCapturing(m_State))
@@ -6551,7 +6551,7 @@ void WrappedID3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView *p
 
     if(pRenderTargetView)
     {
-      MarkResourceReferenced(GetViewResourceResID(pRenderTargetView), eFrameRef_Write);
+      MarkResourceReferenced(GetViewResourceResID(pRenderTargetView), eFrameRef_PartialWrite);
       MarkResourceReferenced(GetIDForResource(pRenderTargetView), eFrameRef_Read);
     }
 
@@ -6631,7 +6631,7 @@ void WrappedID3D11DeviceContext::ClearUnorderedAccessViewUint(
 
     if(pUnorderedAccessView)
     {
-      MarkResourceReferenced(GetViewResourceResID(pUnorderedAccessView), eFrameRef_Write);
+      MarkResourceReferenced(GetViewResourceResID(pUnorderedAccessView), eFrameRef_PartialWrite);
       MarkResourceReferenced(GetIDForResource(pUnorderedAccessView), eFrameRef_Read);
     }
 
@@ -6711,7 +6711,7 @@ void WrappedID3D11DeviceContext::ClearUnorderedAccessViewFloat(
 
     if(pUnorderedAccessView)
     {
-      MarkResourceReferenced(GetViewResourceResID(pUnorderedAccessView), eFrameRef_Write);
+      MarkResourceReferenced(GetViewResourceResID(pUnorderedAccessView), eFrameRef_PartialWrite);
       MarkResourceReferenced(GetIDForResource(pUnorderedAccessView), eFrameRef_Read);
     }
 
@@ -6804,7 +6804,7 @@ void WrappedID3D11DeviceContext::ClearDepthStencilView(ID3D11DepthStencilView *p
 
     if(pDepthStencilView)
     {
-      MarkResourceReferenced(GetViewResourceResID(pDepthStencilView), eFrameRef_Write);
+      MarkResourceReferenced(GetViewResourceResID(pDepthStencilView), eFrameRef_PartialWrite);
       MarkResourceReferenced(GetIDForResource(pDepthStencilView), eFrameRef_Read);
     }
 
@@ -7952,7 +7952,7 @@ void WrappedID3D11DeviceContext::Unmap(ID3D11Resource *pResource, UINT Subresour
       else if(IsActiveCapturing(m_State))
       {
         MarkResourceReferenced(it->first.resource, eFrameRef_Read);
-        MarkResourceReferenced(it->first.resource, eFrameRef_Write);
+        MarkResourceReferenced(it->first.resource, eFrameRef_PartialWrite);
 
         USE_SCRATCH_SERIALISER();
         SCOPED_SERIALISE_CHUNK(D3D11Chunk::Unmap);

--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -1490,7 +1490,7 @@ void WrappedID3D11Device::StartFrameCapture(void *dev, void *wnd)
 
   GetResourceManager()->ClearReferencedResources();
 
-  GetResourceManager()->MarkResourceFrameReferenced(m_ResourceID, eFrameRef_Write);
+  GetResourceManager()->MarkResourceFrameReferenced(m_ResourceID, eFrameRef_PartialWrite);
 
   m_pImmediateContext->FreeCaptureData();
 
@@ -1908,7 +1908,7 @@ bool WrappedID3D11Device::EndFrameCapture(void *dev, void *wnd)
     }
     else
     {
-      GetResourceManager()->MarkResourceFrameReferenced(m_ResourceID, eFrameRef_Write);
+      GetResourceManager()->MarkResourceFrameReferenced(m_ResourceID, eFrameRef_PartialWrite);
       GetResourceManager()->PrepareInitialContents();
 
       m_pImmediateContext->AttemptCapture();

--- a/renderdoc/driver/d3d11/d3d11_renderstate.cpp
+++ b/renderdoc/driver/d3d11/d3d11_renderstate.cpp
@@ -212,17 +212,17 @@ void D3D11RenderState::MarkReferenced(WrappedID3D11DeviceContext *ctx, bool init
       ctx->MarkResourceReferenced(GetIDForResource(CSUAVs[i]),
                                   initial ? eFrameRef_None : eFrameRef_Read);
       ctx->MarkResourceReferenced(GetIDForResource(CSUAVs[i]),
-                                  initial ? eFrameRef_None : eFrameRef_Write);
+                                  initial ? eFrameRef_None : eFrameRef_PartialWrite);
       ctx->MarkResourceReferenced(GetViewResourceResID(CSUAVs[i]),
                                   initial ? eFrameRef_None : eFrameRef_Read);
       ctx->MarkResourceReferenced(GetViewResourceResID(CSUAVs[i]),
-                                  initial ? eFrameRef_None : eFrameRef_Write);
+                                  initial ? eFrameRef_None : eFrameRef_PartialWrite);
     }
   }
 
   for(UINT i = 0; i < D3D11_SO_BUFFER_SLOT_COUNT; i++)
     ctx->MarkResourceReferenced(GetIDForResource(SO.Buffers[i]),
-                                initial ? eFrameRef_None : eFrameRef_Write);
+                                initial ? eFrameRef_None : eFrameRef_PartialWrite);
 
   ctx->MarkResourceReferenced(GetIDForResource(RS.State), initial ? eFrameRef_None : eFrameRef_Read);
 
@@ -239,7 +239,7 @@ void D3D11RenderState::MarkReferenced(WrappedID3D11DeviceContext *ctx, bool init
       ctx->MarkResourceReferenced(GetIDForResource(OM.RenderTargets[i]),
                                   initial ? eFrameRef_None : eFrameRef_Read);
       ctx->MarkResourceReferenced(GetViewResourceResID(OM.RenderTargets[i]),
-                                  initial ? eFrameRef_None : eFrameRef_Write);
+                                  initial ? eFrameRef_None : eFrameRef_PartialWrite);
     }
   }
 
@@ -251,11 +251,11 @@ void D3D11RenderState::MarkReferenced(WrappedID3D11DeviceContext *ctx, bool init
       ctx->MarkResourceReferenced(GetIDForResource(OM.UAVs[i]),
                                   initial ? eFrameRef_None : eFrameRef_Read);
       ctx->MarkResourceReferenced(GetIDForResource(OM.UAVs[i]),
-                                  initial ? eFrameRef_None : eFrameRef_Write);
+                                  initial ? eFrameRef_None : eFrameRef_PartialWrite);
       ctx->MarkResourceReferenced(GetViewResourceResID(OM.UAVs[i]),
                                   initial ? eFrameRef_None : eFrameRef_Read);
       ctx->MarkResourceReferenced(GetViewResourceResID(OM.UAVs[i]),
-                                  initial ? eFrameRef_None : eFrameRef_Write);
+                                  initial ? eFrameRef_None : eFrameRef_PartialWrite);
     }
   }
 
@@ -264,7 +264,7 @@ void D3D11RenderState::MarkReferenced(WrappedID3D11DeviceContext *ctx, bool init
     ctx->MarkResourceReferenced(GetIDForResource(OM.DepthView),
                                 initial ? eFrameRef_None : eFrameRef_Read);
     ctx->MarkResourceReferenced(GetViewResourceResID(OM.DepthView),
-                                initial ? eFrameRef_None : eFrameRef_Write);
+                                initial ? eFrameRef_None : eFrameRef_PartialWrite);
   }
 
   if(Predicate)

--- a/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
@@ -137,7 +137,7 @@ void WrappedID3D12GraphicsCommandList2::AtomicCopyBufferUINT(
                                    ppDependentResources, pDependentSubresourceRanges);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstBuffer), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstBuffer), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrcBuffer), eFrameRef_Read);
 
     for(UINT i = 0; i < Dependencies; i++)
@@ -255,7 +255,7 @@ void WrappedID3D12GraphicsCommandList2::AtomicCopyBufferUINT64(
                                      ppDependentResources, pDependentSubresourceRanges);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstBuffer), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstBuffer), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrcBuffer), eFrameRef_Read);
 
     for(UINT i = 0; i < Dependencies; i++)
@@ -512,7 +512,7 @@ void WrappedID3D12GraphicsCommandList2::ResolveSubresourceRegion(
                                        SrcSubresource, pSrcRect, Format, ResolveMode);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstResource), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstResource), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrcResource), eFrameRef_Read);
   }
 }
@@ -637,7 +637,7 @@ void WrappedID3D12GraphicsCommandList2::WriteBufferImmediate(
     m_ListRecord->AddChunk(scope.Get());
     for(UINT i = 0; i < Count; i++)
       m_ListRecord->MarkResourceFrameReferenced(
-          WrappedID3D12Resource::GetResIDFromAddr(pParams[i].Dest), eFrameRef_Write);
+          WrappedID3D12Resource::GetResIDFromAddr(pParams[i].Dest), eFrameRef_PartialWrite);
   }
 }
 

--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -1429,14 +1429,14 @@ void WrappedID3D12GraphicsCommandList2::OMSetRenderTargets(
     {
       D3D12Descriptor *desc = GetWrapped(pRenderTargetDescriptors[i]);
       m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);
-      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_PartialWrite);
     }
 
     if(pDepthStencilDescriptor)
     {
       D3D12Descriptor *desc = GetWrapped(*pDepthStencilDescriptor);
       m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);
-      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_PartialWrite);
     }
   }
 }
@@ -2722,7 +2722,7 @@ void WrappedID3D12GraphicsCommandList2::ResolveQueryData(ID3D12QueryHeap *pQuery
     m_ListRecord->AddChunk(scope.Get());
 
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pQueryHeap), eFrameRef_Read);
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDestinationBuffer), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDestinationBuffer), eFrameRef_PartialWrite);
   }
 }
 
@@ -4564,13 +4564,13 @@ void WrappedID3D12GraphicsCommandList2::ClearUnorderedAccessViewUint(
     {
       D3D12Descriptor *desc = GetWrapped(ViewGPUHandleInCurrentHeap);
       m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);
-      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_PartialWrite);
 
       desc = GetWrapped(ViewCPUHandle);
       m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);
-      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_PartialWrite);
 
-      m_ListRecord->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_PartialWrite);
     }
   }
 }
@@ -4669,13 +4669,13 @@ void WrappedID3D12GraphicsCommandList2::ClearUnorderedAccessViewFloat(
     {
       D3D12Descriptor *desc = GetWrapped(ViewGPUHandleInCurrentHeap);
       m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);
-      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_PartialWrite);
 
       desc = GetWrapped(ViewCPUHandle);
       m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);
-      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(desc->GetResResourceId(), eFrameRef_PartialWrite);
 
-      m_ListRecord->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_Write);
+      m_ListRecord->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_PartialWrite);
     }
   }
 }
@@ -4726,7 +4726,7 @@ void WrappedID3D12GraphicsCommandList2::DiscardResource(ID3D12Resource *pResourc
     Serialise_DiscardResource(ser, pResource, pRegion);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_PartialWrite);
   }
 }
 
@@ -4820,7 +4820,7 @@ void WrappedID3D12GraphicsCommandList2::CopyBufferRegion(ID3D12Resource *pDstBuf
     Serialise_CopyBufferRegion(ser, pDstBuffer, DstOffset, pSrcBuffer, SrcOffset, NumBytes);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstBuffer), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstBuffer), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrcBuffer), eFrameRef_Read);
   }
 }
@@ -4924,7 +4924,7 @@ void WrappedID3D12GraphicsCommandList2::CopyTextureRegion(const D3D12_TEXTURE_CO
     Serialise_CopyTextureRegion(ser, pDst, DstX, DstY, DstZ, pSrc, pSrcBox);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDst->pResource), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDst->pResource), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrc->pResource), eFrameRef_Read);
   }
 }
@@ -5005,7 +5005,7 @@ void WrappedID3D12GraphicsCommandList2::CopyResource(ID3D12Resource *pDstResourc
     Serialise_CopyResource(ser, pDstResource, pSrcResource);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstResource), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstResource), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrcResource), eFrameRef_Read);
   }
 }
@@ -5098,7 +5098,7 @@ void WrappedID3D12GraphicsCommandList2::ResolveSubresource(ID3D12Resource *pDstR
                                  Format);
 
     m_ListRecord->AddChunk(scope.Get());
-    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstResource), eFrameRef_Write);
+    m_ListRecord->MarkResourceFrameReferenced(GetResID(pDstResource), eFrameRef_PartialWrite);
     m_ListRecord->MarkResourceFrameReferenced(GetResID(pSrcResource), eFrameRef_Read);
   }
 }

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -1166,7 +1166,7 @@ void WrappedID3D12Device::MapDataWrite(ID3D12Resource *Resource, UINT Subresourc
 
   m_FrameCaptureRecord->AddChunk(scope.Get());
 
-  GetResourceManager()->MarkResourceFrameReferenced(GetResID(Resource), eFrameRef_Write);
+  GetResourceManager()->MarkResourceFrameReferenced(GetResID(Resource), eFrameRef_PartialWrite);
 }
 
 template <typename SerialiserType>
@@ -1298,7 +1298,7 @@ void WrappedID3D12Device::WriteToSubresource(ID3D12Resource *Resource, UINT Subr
 
     m_FrameCaptureRecord->AddChunk(scope.Get());
 
-    GetResourceManager()->MarkResourceFrameReferenced(GetResID(Resource), eFrameRef_Write);
+    GetResourceManager()->MarkResourceFrameReferenced(GetResID(Resource), eFrameRef_PartialWrite);
   }
 }
 

--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -1040,9 +1040,10 @@ void WrappedID3D12Device::CreateUnorderedAccessView(ID3D12Resource *pResource,
       m_FrameCaptureRecord->AddChunk(scope.Get());
     }
 
-    GetResourceManager()->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_Write);
+    GetResourceManager()->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_PartialWrite);
     if(pCounterResource)
-      GetResourceManager()->MarkResourceFrameReferenced(GetResID(pCounterResource), eFrameRef_Write);
+      GetResourceManager()->MarkResourceFrameReferenced(GetResID(pCounterResource),
+                                                        eFrameRef_PartialWrite);
   }
 
   GetWrapped(DestDescriptor)->Init(pResource, pCounterResource, pDesc);
@@ -1084,7 +1085,7 @@ void WrappedID3D12Device::CreateRenderTargetView(ID3D12Resource *pResource,
       m_FrameCaptureRecord->AddChunk(scope.Get());
     }
 
-    GetResourceManager()->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_Write);
+    GetResourceManager()->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_PartialWrite);
   }
 
   GetWrapped(DestDescriptor)->Init(pResource, pDesc);
@@ -1124,7 +1125,7 @@ void WrappedID3D12Device::CreateDepthStencilView(ID3D12Resource *pResource,
       m_FrameCaptureRecord->AddChunk(scope.Get());
     }
 
-    GetResourceManager()->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_Write);
+    GetResourceManager()->MarkResourceFrameReferenced(GetResID(pResource), eFrameRef_PartialWrite);
   }
 
   GetWrapped(DestDescriptor)->Init(pResource, pDesc);

--- a/renderdoc/driver/d3d12/d3d12_manager.cpp
+++ b/renderdoc/driver/d3d12/d3d12_manager.cpp
@@ -458,7 +458,7 @@ void D3D12Descriptor::GetRefIDs(ResourceId &id, ResourceId &id2, FrameRefType &r
     // deliberate fall-through
     case D3D12DescriptorType::RTV:
     case D3D12DescriptorType::DSV:
-      ref = eFrameRef_Write;
+      ref = eFrameRef_PartialWrite;
       id = data.nonsamp.resource;
       break;
   }

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1852,7 +1852,7 @@ void WrappedOpenGL::StartFrameCapture(void *dev, void *wnd)
 
   GetResourceManager()->ClearReferencedResources();
 
-  GetResourceManager()->MarkResourceFrameReferenced(m_DeviceResourceID, eFrameRef_Write);
+  GetResourceManager()->MarkResourceFrameReferenced(m_DeviceResourceID, eFrameRef_PartialWrite);
 
   GetResourceManager()->PrepareInitialContents();
 
@@ -2117,7 +2117,7 @@ bool WrappedOpenGL::EndFrameCapture(void *dev, void *wnd)
     }
     else
     {
-      GetResourceManager()->MarkResourceFrameReferenced(m_DeviceResourceID, eFrameRef_Write);
+      GetResourceManager()->MarkResourceFrameReferenced(m_DeviceResourceID, eFrameRef_PartialWrite);
       GetResourceManager()->PrepareInitialContents();
 
       AttemptCapture();
@@ -2462,7 +2462,8 @@ void WrappedOpenGL::BeginCaptureFrame()
 
     GL.glBindVertexArray(0);
 
-    GetResourceManager()->MarkVAOReferenced(VertexArrayRes(GetCtx(), 0), eFrameRef_Write, true);
+    GetResourceManager()->MarkVAOReferenced(VertexArrayRes(GetCtx(), 0), eFrameRef_PartialWrite,
+                                            true);
 
     GL.glBindVertexArray(prevVAO);
   }

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -673,7 +673,8 @@ void WrappedOpenGL::glNamedBufferDataEXT(GLuint buffer, GLsizeiptr size, const v
     {
       // we could perhaps substitute this for a 'fake' glBufferSubData chunk?
       GetContextRecord()->AddChunk(chunk);
-      GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Write);
+      GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(),
+                                                        eFrameRef_PartialWrite);
     }
     else
     {
@@ -816,7 +817,8 @@ void WrappedOpenGL::glBufferData(GLenum target, GLsizeiptr size, const void *dat
     {
       // we could perhaps substitute this for a 'fake' glBufferSubData chunk?
       GetContextRecord()->AddChunk(chunk);
-      GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(), eFrameRef_Write);
+      GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(),
+                                                        eFrameRef_PartialWrite);
     }
     else
     {

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -783,7 +783,7 @@ FrameRefType GetRefType(VkDescriptorType descType)
     case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
     case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
     case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: return eFrameRef_Write; break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: return eFrameRef_PartialWrite; break;
     default: RDCERR("Unexpected descriptor type");
   }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1203,7 +1203,7 @@ void WrappedVulkan::vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
       if(att == NULL)
         break;
 
-      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_Write);
+      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_PartialWrite);
       if(att->baseResourceMem != ResourceId())
         record->MarkResourceFrameReferenced(att->baseResourceMem, eFrameRef_Read);
       if(att->resInfo)
@@ -1548,7 +1548,7 @@ void WrappedVulkan::vkCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
       if(att == NULL)
         break;
 
-      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_Write);
+      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_PartialWrite);
       if(att->baseResourceMem != ResourceId())
         record->MarkResourceFrameReferenced(att->baseResourceMem, eFrameRef_Read);
       if(att->resInfo)
@@ -2098,7 +2098,8 @@ void WrappedVulkan::vkCmdBindDescriptorSets(VkCommandBuffer commandBuffer,
 
       for(auto it = frameRefs.begin(); it != frameRefs.end(); ++it)
       {
-        if(it->second.second == eFrameRef_Write || it->second.second == eFrameRef_ReadBeforeWrite)
+        if(it->second.second == eFrameRef_PartialWrite ||
+           it->second.second == eFrameRef_ReadBeforeWrite)
           record->cmdInfo->dirtied.insert(it->first);
       }
     }
@@ -2330,7 +2331,8 @@ void WrappedVulkan::vkCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer de
 
     record->AddChunk(scope.Get());
 
-    record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, dataSize, eFrameRef_Write);
+    record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, dataSize,
+                                      eFrameRef_PartialWrite);
   }
 }
 
@@ -2391,7 +2393,8 @@ void WrappedVulkan::vkCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dest
 
     record->AddChunk(scope.Get());
 
-    record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, fillSize, eFrameRef_Write);
+    record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, fillSize,
+                                      eFrameRef_PartialWrite);
   }
 }
 
@@ -2762,7 +2765,8 @@ void WrappedVulkan::vkCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQ
     {
       size += 4;
     }
-    record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, size, eFrameRef_Write);
+    record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, size,
+                                      eFrameRef_PartialWrite);
   }
 }
 
@@ -4121,7 +4125,7 @@ void WrappedVulkan::vkCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer,
 
     record->AddChunk(scope.Get());
 
-    record->MarkBufferFrameReferenced(GetRecord(dstBuffer), dstOffset, 4, eFrameRef_Write);
+    record->MarkBufferFrameReferenced(GetRecord(dstBuffer), dstOffset, 4, eFrameRef_PartialWrite);
   }
 }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_descriptor_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_descriptor_funcs.cpp
@@ -936,7 +936,7 @@ void WrappedVulkan::vkUpdateDescriptorSets(VkDevice device, uint32_t writeCount,
     for(uint32_t i = 0; i < writeCount; i++)
     {
       GetResourceManager()->MarkResourceFrameReferenced(GetResID(pDescriptorWrites[i].dstSet),
-                                                        eFrameRef_Write);
+                                                        eFrameRef_PartialWrite);
     }
 
     for(uint32_t i = 0; i < copyCount; i++)
@@ -950,7 +950,7 @@ void WrappedVulkan::vkUpdateDescriptorSets(VkDevice device, uint32_t writeCount,
       // bound, but we only do this during frame capture so it's not too bad.
 
       GetResourceManager()->MarkResourceFrameReferenced(GetResID(pDescriptorCopies[i].dstSet),
-                                                        eFrameRef_Write);
+                                                        eFrameRef_PartialWrite);
       GetResourceManager()->MarkResourceFrameReferenced(GetResID(pDescriptorCopies[i].srcSet),
                                                         eFrameRef_Read);
 
@@ -1348,7 +1348,8 @@ void WrappedVulkan::vkUpdateDescriptorSetWithTemplate(
     m_FrameCaptureRecord->AddChunk(scope.Get());
 
     // mark the destination set and template as referenced
-    GetResourceManager()->MarkResourceFrameReferenced(GetResID(descriptorSet), eFrameRef_Write);
+    GetResourceManager()->MarkResourceFrameReferenced(GetResID(descriptorSet),
+                                                      eFrameRef_PartialWrite);
     GetResourceManager()->MarkResourceFrameReferenced(GetResID(descriptorUpdateTemplate),
                                                       eFrameRef_Read);
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -1413,7 +1413,7 @@ void WrappedVulkan::vkCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcIma
 
     record->MarkResourceFrameReferenced(GetResID(srcImage), eFrameRef_Read);
     record->MarkResourceFrameReferenced(GetRecord(srcImage)->baseResource, eFrameRef_Read);
-    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_Write);
+    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(destImage)->baseResource, eFrameRef_Read);
     record->cmdInfo->dirtied.insert(GetResID(destImage));
     if(GetRecord(srcImage)->resInfo)
@@ -1537,7 +1537,7 @@ void WrappedVulkan::vkCmdResolveImage(VkCommandBuffer commandBuffer, VkImage src
 
     record->MarkResourceFrameReferenced(GetResID(srcImage), eFrameRef_Read);
     record->MarkResourceFrameReferenced(GetRecord(srcImage)->baseResource, eFrameRef_Read);
-    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_Write);
+    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(destImage)->baseResource, eFrameRef_Read);
     record->cmdInfo->dirtied.insert(GetResID(destImage));
     if(GetRecord(srcImage)->resInfo)
@@ -1659,7 +1659,7 @@ void WrappedVulkan::vkCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcIma
     record->AddChunk(scope.Get());
     record->MarkResourceFrameReferenced(GetResID(srcImage), eFrameRef_Read);
     record->MarkResourceFrameReferenced(GetRecord(srcImage)->baseResource, eFrameRef_Read);
-    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_Write);
+    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(destImage)->baseResource, eFrameRef_Read);
     record->cmdInfo->dirtied.insert(GetResID(destImage));
     if(GetRecord(srcImage)->resInfo)
@@ -1772,7 +1772,7 @@ void WrappedVulkan::vkCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuff
 
     record->MarkResourceFrameReferenced(GetResID(srcBuffer), eFrameRef_Read);
     record->MarkResourceFrameReferenced(GetRecord(srcBuffer)->baseResource, eFrameRef_Read);
-    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_Write);
+    record->MarkResourceFrameReferenced(GetResID(destImage), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(destImage)->baseResource, eFrameRef_Read);
     record->cmdInfo->dirtied.insert(GetResID(destImage));
     if(GetRecord(srcBuffer)->resInfo)
@@ -1891,7 +1891,7 @@ void WrappedVulkan::vkCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImag
 
     // mark buffer just as read, and memory behind as write & dirtied
     record->MarkResourceFrameReferenced(buf->GetResourceID(), eFrameRef_Read);
-    record->MarkResourceFrameReferenced(buf->baseResource, eFrameRef_Write);
+    record->MarkResourceFrameReferenced(buf->baseResource, eFrameRef_PartialWrite);
     if(buf->baseResource != ResourceId())
       record->cmdInfo->dirtied.insert(buf->baseResource);
     if(GetRecord(srcImage)->resInfo)
@@ -2011,7 +2011,7 @@ void WrappedVulkan::vkCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcB
       record->MarkBufferFrameReferenced(GetRecord(srcBuffer), pRegions[i].srcOffset,
                                         pRegions[i].size, eFrameRef_Read);
       record->MarkBufferFrameReferenced(GetRecord(destBuffer), pRegions[i].dstOffset,
-                                        pRegions[i].size, eFrameRef_Write);
+                                        pRegions[i].size, eFrameRef_PartialWrite);
     }
   }
 }
@@ -2114,7 +2114,7 @@ void WrappedVulkan::vkCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage 
                                    pRanges);
 
     record->AddChunk(scope.Get());
-    record->MarkResourceFrameReferenced(GetResID(image), eFrameRef_Write);
+    record->MarkResourceFrameReferenced(GetResID(image), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(image)->baseResource, eFrameRef_Read);
     if(GetRecord(image)->resInfo)
       record->cmdInfo->sparse.insert(GetRecord(image)->resInfo);
@@ -2221,7 +2221,7 @@ void WrappedVulkan::vkCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, V
                                           rangeCount, pRanges);
 
     record->AddChunk(scope.Get());
-    record->MarkResourceFrameReferenced(GetResID(image), eFrameRef_Write);
+    record->MarkResourceFrameReferenced(GetResID(image), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(image)->baseResource, eFrameRef_Read);
     if(GetRecord(image)->resInfo)
       record->cmdInfo->sparse.insert(GetRecord(image)->resInfo);

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -656,7 +656,7 @@ void WrappedVulkan::vkUnmapMemory(VkDevice device, VkDeviceMemory mem)
           {
             m_FrameCaptureRecord->AddChunk(scope.Get());
             GetResourceManager()->MarkMemoryFrameReferenced(id, state.mapOffset, state.mapSize,
-                                                            eFrameRef_Write);
+                                                            eFrameRef_PartialWrite);
           }
         }
       }
@@ -803,7 +803,7 @@ VkResult WrappedVulkan::vkFlushMappedMemoryRanges(VkDevice device, uint32_t memR
       {
         GetResourceManager()->MarkMemoryFrameReferenced(GetResID(pMemRanges[i].memory),
                                                         pMemRanges[i].offset, pMemRanges[i].size,
-                                                        eFrameRef_Write);
+                                                        eFrameRef_PartialWrite);
       }
       else
       {


### PR DESCRIPTION
## Description

This change introduces a new enum `InitReqType` that describes how a resource needs to be initialized/reset for replay, according to its `FrameRefType`.