### PR TITLE
Add --replayhost command line option for qrenderdoc

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -1379,6 +1379,11 @@ void CaptureContext::SetEventID(const rdcarray<ICaptureViewer *> &exclude, uint3
   RefreshUIStatus(exclude, updateSelectedEvent, updateEvent);
 }
 
+void CaptureContext::SetRemoteHost(int hostIdx)
+{
+  m_MainWindow->setRemoteHost(hostIdx);
+}
+
 void CaptureContext::RefreshUIStatus(const rdcarray<ICaptureViewer *> &exclude,
                                      bool updateSelectedEvent, bool updateEvent)
 {

--- a/qrenderdoc/Code/CaptureContext.h
+++ b/qrenderdoc/Code/CaptureContext.h
@@ -111,7 +111,7 @@ public:
   void ExportCapture(const CaptureFileFormat &fmt, const rdcstr &exportfile) override;
   void SetEventID(const rdcarray<ICaptureViewer *> &exclude, uint32_t selectedEventID,
                   uint32_t eventId, bool force = false) override;
-
+  void SetRemoteHost(int hostIndex);
   void RefreshStatus() override { SetEventID({}, m_SelectedEventID, m_EventID, true); }
   void RefreshUIStatus(const rdcarray<ICaptureViewer *> &exclude, bool updateSelectedEvent,
                        bool updateEvent);

--- a/qrenderdoc/Code/Interface/RemoteHost.h
+++ b/qrenderdoc/Code/Interface/RemoteHost.h
@@ -29,7 +29,7 @@ class RemoteHost;
 // do not include any headers here, they must all be in QRDInterface.h
 #include "QRDInterface.h"
 
-DOCUMENT("A handle for interacting with a remote servers on a given host.");
+DOCUMENT("A handle for interacting with a remote server on a given host.");
 class RemoteHost
 {
 public:

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -1772,21 +1772,9 @@ void MainWindow::FillRemotesMenu(QMenu *menu, bool includeLocalhost)
   }
 }
 
-void MainWindow::switchContext()
+void MainWindow::setRemoteHost(int hostIdx)
 {
-  QAction *item = qobject_cast<QAction *>(QObject::sender());
-
-  if(!item)
-    return;
-
-  bool ok = false;
-  int hostIdx = item->data().toInt(&ok);
-
-  if(!ok)
-    return;
-
   RemoteHost *host = NULL;
-
   if(hostIdx >= 0 && hostIdx < m_Ctx.Config().RemoteHosts.count())
   {
     host = m_Ctx.Config().RemoteHosts[hostIdx];
@@ -1931,6 +1919,20 @@ void MainWindow::switchContext()
     th->selfDelete(true);
     th->start();
   }
+}
+
+void MainWindow::switchContext()
+{
+  QAction *item = qobject_cast<QAction *>(QObject::sender());
+
+  if(!item)
+    return;
+
+  bool ok = false;
+  int hostIdx = item->data().toInt(&ok);
+
+  if(ok)
+    setRemoteHost(hostIdx);
 }
 
 void MainWindow::contextChooser_menuShowing()

--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -73,6 +73,7 @@ public:
   void show();
 
   void setProgress(float val);
+  void setRemoteHost(int hostIdx);
   void takeCaptureOwnership() { m_OwnTempCapture = true; }
   void captureModified();
   void LoadFromFilename(const QString &filename, bool temporary);


### PR DESCRIPTION
This allows users to specify which remote host to connect to on startup.

## Description
If the user wants to connect to a remote server for replaying every time they launch qrenderdoc, there is currently no way to preset the replay context rather than manually switch through contextChooser dropdown menu. This commit allows qrenderdoc to preset the replay context to a remote host on startup. If the --replayhost option value is not found in config file, a new RemoteHost will be injected to the list of RemoteHost.
