### PR TITLE
Fix bug in resource tracking for resources bound in descriptor sets

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1039,17 +1039,18 @@ public:
       RDCERR("Unexpected NULL resource ID being added as a bind frame ref");
       return;
     }
-    auto it = descInfo->bindFrameRefs.find(id);
-    if((it->second.first & ~DescriptorSetData::SPARSE_REF_BIT) == 0)
+    pair<uint32_t, FrameRefType> &p = descInfo->bindFrameRefs[id];
+    if((p.first & ~DescriptorSetData::SPARSE_REF_BIT) == 0)
     {
-      it->second = std::make_pair(1 | (hasSparse ? DescriptorSetData::SPARSE_REF_BIT : 0), ref);
+      p.second = ref;
+      p.first = 1 | (hasSparse ? DescriptorSetData::SPARSE_REF_BIT : 0);
     }
     else
     {
       // be conservative - mark refs as read before write if we see a write and a read ref on it
-      descInfo->bindFrameRefs[id].second =
-          ComposeFrameRefsUnordered(descInfo->bindFrameRefs[id].second, ref);
-      descInfo->bindFrameRefs[id].first++;
+      p.second = ComposeFrameRefsUnordered(descInfo->bindFrameRefs[id].second, ref);
+      p.first++;
+      p.first |= (hasSparse ? DescriptorSetData::SPARSE_REF_BIT : 0);
     }
   }
 


### PR DESCRIPTION
## Description

Fixes a bug introduced in #1253 (incorrectly using an iterator instead of the index operator).

It also looked like the `else` case was not setting the `SPARSE_REF_BIT` in the same way that the `if` case was, so I added that. @baldurk can you verify whether the previous behaviour was intentional?