### PR TITLE
Track frame references to ranges of Vulkan `VkDeviceMemory`s

### DIFF
--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -132,28 +132,6 @@ bool IsDirtyFrameRef(FrameRefType refType)
   return (refType != eFrameRef_None && refType != eFrameRef_Read);
 }
 
-bool MarkReferenced(std::map<ResourceId, FrameRefType> &refs, ResourceId id, FrameRefType refType)
-{
-  auto refit = refs.find(id);
-  if(refit == refs.end())
-  {
-    refs[id] = refType;
-    return true;
-  }
-  else
-  {
-    refit->second = ComposeFrameRefs(refit->second, refType);
-  }
-  return false;
-}
-
-bool ResourceRecord::MarkResourceFrameReferenced(ResourceId id, FrameRefType refType)
-{
-  if(id == ResourceId())
-    return false;
-  return MarkReferenced(m_FrameRefs, id, refType);
-}
-
 void ResourceRecord::AddResourceReferences(ResourceRecordHandler *mgr)
 {
   for(auto it = m_FrameRefs.begin(); it != m_FrameRefs.end(); ++it)

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -837,10 +837,12 @@ void DescriptorSetSlot::AddBindRefs(VkResourceRecord *record, FrameRefType ref)
 {
   if(texelBufferView != VK_NULL_HANDLE)
   {
-    record->AddBindFrameRef(GetResID(texelBufferView), eFrameRef_Read,
-                            GetRecord(texelBufferView)->resInfo != NULL);
-    if(GetRecord(texelBufferView)->baseResource != ResourceId())
-      record->AddBindFrameRef(GetRecord(texelBufferView)->baseResource, ref);
+    VkResourceRecord *bufView = GetRecord(texelBufferView);
+    record->AddBindFrameRef(bufView->GetResourceID(), eFrameRef_Read, bufView->resInfo != NULL);
+    if(bufView->baseResource != ResourceId())
+      record->AddBindFrameRef(bufView->baseResource, eFrameRef_Read);
+    if(bufView->baseResourceMem != ResourceId())
+      record->AddMemFrameRef(bufView->baseResourceMem, bufView->memOffset, bufView->memSize, ref);
   }
   if(imageInfo.imageView != VK_NULL_HANDLE)
   {
@@ -856,9 +858,9 @@ void DescriptorSetSlot::AddBindRefs(VkResourceRecord *record, FrameRefType ref)
   }
   if(bufferInfo.buffer != VK_NULL_HANDLE)
   {
-    record->AddBindFrameRef(GetResID(bufferInfo.buffer), eFrameRef_Read,
-                            GetRecord(bufferInfo.buffer)->resInfo != NULL);
-    if(GetRecord(bufferInfo.buffer)->baseResource != ResourceId())
-      record->AddBindFrameRef(GetRecord(bufferInfo.buffer)->baseResource, ref);
+    VkResourceRecord *buf = GetRecord(bufferInfo.buffer);
+    record->AddBindFrameRef(GetResID(bufferInfo.buffer), eFrameRef_Read, buf->resInfo != NULL);
+    if(buf->baseResource != ResourceId())
+      record->AddMemFrameRef(buf->baseResource, buf->memOffset, buf->memSize, ref);
   }
 }

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1301,6 +1301,7 @@ void WrappedVulkan::StartFrameCapture(void *dev, void *wnd)
   m_CapturedFrames.push_back(frame);
 
   GetResourceManager()->ClearReferencedResources();
+  GetResourceManager()->ClearReferencedMemory();
 
   GetResourceManager()->MarkResourceFrameReferenced(GetResID(m_Instance), eFrameRef_Read);
   GetResourceManager()->MarkResourceFrameReferenced(GetResID(m_Device), eFrameRef_Read);
@@ -1750,6 +1751,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
   m_CmdBufferRecords.clear();
 
   GetResourceManager()->MarkUnwrittenResources();
+
+  GetResourceManager()->ClearReferencedMemory();
 
   GetResourceManager()->ClearReferencedResources();
 

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -413,6 +413,9 @@ public:
   void MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize start, VkDeviceSize end,
                                  FrameRefType refType);
 
+  void MergeReferencedMemory(std::map<ResourceId, MemRefs> &memRefs);
+  void ClearReferencedMemory();
+
 private:
   bool ResourceTypeRelease(WrappedVkRes *res);
 
@@ -428,4 +431,5 @@ private:
 
   CaptureState m_State;
   WrappedVulkan *m_Core;
+  std::map<ResourceId, MemRefs> m_MemFrameRefs;
 };

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3033,7 +3033,11 @@ VkResourceRecord::~VkResourceRecord()
 void VkResourceRecord::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize offset,
                                                  VkDeviceSize size, FrameRefType refType)
 {
-  MarkResourceFrameReferenced(mem, refType);
+  if(refType != eFrameRef_Read && refType != eFrameRef_None)
+    cmdInfo->dirtied.insert(mem);
+  FrameRefType maxRef = MarkMemoryReferenced(cmdInfo->memFrameRefs, mem, offset, size, refType);
+  MarkResourceFrameReferenced(
+      mem, maxRef, [](FrameRefType x, FrameRefType y) -> FrameRefType { return std::max(x, y); });
 }
 
 void VkResourceRecord::MarkBufferFrameReferenced(VkResourceRecord *buf, VkDeviceSize offset,

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -857,6 +857,7 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
               GetResourceManager()->MarkSparseMapReferenced(sparserecord->resInfo);
             }
           }
+          GetResourceManager()->MergeReferencedMemory(setrecord->descInfo->bindMemRefs);
         }
 
         for(auto it = record->bakedCommands->cmdInfo->sparse.begin();
@@ -867,6 +868,8 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
         record->bakedCommands->AddResourceReferences(GetResourceManager());
         record->bakedCommands->AddReferencedIDs(refdIDs);
 
+        GetResourceManager()->MergeReferencedMemory(record->bakedCommands->cmdInfo->memFrameRefs);
+
         // ref the parent command buffer's alloc record, this will pull in the cmd buffer pool
         GetResourceManager()->MarkResourceFrameReferenced(
             record->cmdInfo->allocRecord->GetResourceID(), eFrameRef_Read);
@@ -876,6 +879,8 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
           record->bakedCommands->cmdInfo->subcmds[sub]->bakedCommands->AddResourceReferences(
               GetResourceManager());
           record->bakedCommands->cmdInfo->subcmds[sub]->bakedCommands->AddReferencedIDs(refdIDs);
+          GetResourceManager()->MergeReferencedMemory(
+              record->bakedCommands->cmdInfo->subcmds[sub]->bakedCommands->cmdInfo->memFrameRefs);
           GetResourceManager()->MarkResourceFrameReferenced(
               record->bakedCommands->cmdInfo->subcmds[sub]->cmdInfo->allocRecord->GetResourceID(),
               eFrameRef_Read);


### PR DESCRIPTION
## Description

The current frame reference tracking handles `VkDeviceMemory`s as single resource--e.g. if one region of the memory is read, and a disjoint region of the memory is written, this is treated exactly the same way as if the read and write were on the same region of the memory.

The new behaviour tracks the frame references for ranges of device memory; this will be used to improve the detection of device memory that does not require initialization or resetting.

The `FrameRefType` associated with the entire memory resource (e.g. through `MarkResourceFrameReferenced`), should now keep an up-to-date maximum of the `FrameRefType`s of all of the intervals within that memory. Maximum is used here because `FrameRefType`s with stronger init/reset requirements have larger values. 

This change affects `Serialise_InitialContentsNeeded`, causing a `VkDeviceMemory` to be marked as requiring initial contents only if some region of that `VkDeviceMemory` is accessed in a way that requires initial contents.