### PR TITLE
Serialise ref types for Vulkan device memory ranges

### DIFF
--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -53,6 +53,20 @@ void SetReplayResourceIDs()
 
 INSTANTIATE_SERIALISE_TYPE(ResourceManagerInternal::WrittenRecord);
 
+template <>
+std::string DoStringise(const FrameRefType &el)
+{
+  BEGIN_ENUM_STRINGISE(FrameRefType)
+  {
+    STRINGISE_ENUM_CLASS_NAMED(eFrameRef_None, "None");
+    STRINGISE_ENUM_CLASS_NAMED(eFrameRef_PartialWrite, "Partial Write");
+    STRINGISE_ENUM_CLASS_NAMED(eFrameRef_CompleteWrite, "Complete Write");
+    STRINGISE_ENUM_CLASS_NAMED(eFrameRef_Read, "Read");
+    STRINGISE_ENUM_CLASS_NAMED(eFrameRef_ReadBeforeWrite, "Read Before Write");
+  }
+  END_ENUM_STRINGISE()
+}
+
 FrameRefType ComposeFrameRefs(FrameRefType first, FrameRefType second)
 {
   RDCASSERT(eFrameRef_Minimum <= first && first <= eFrameRef_Maximum);

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -100,6 +100,8 @@ enum FrameRefType
 const FrameRefType eFrameRef_Minimum = eFrameRef_None;
 const FrameRefType eFrameRef_Maximum = eFrameRef_ReadBeforeWrite;
 
+DECLARE_REFLECTION_ENUM(FrameRefType);
+
 // Compose frame refs that occur in a known order.
 // This can be thought of as a state (`first`) and a transition from that state
 // (`second`), returning the new state (see the state diagram for

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -522,6 +522,7 @@ enum class VulkanChunk : uint32_t
   vkCmdEndConditionalRenderingEXT,
   vkCmdSetSampleLocationsEXT,
   vkCmdSetDiscardRectangleEXT,
+  DeviceMemoryRefs,
   Max,
 };
 

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1690,6 +1690,7 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
     RDCDEBUG("Creating Capture Scope");
 
     GetResourceManager()->Serialise_InitialContentsNeeded(ser);
+    GetResourceManager()->InsertDeviceMemoryRefs(ser);
 
     {
       SCOPED_SERIALISE_CHUNK(SystemChunk::CaptureScope, 16);
@@ -2792,6 +2793,11 @@ bool WrappedVulkan::ProcessChunk(ReadSerialiser &ser, VulkanChunk chunk)
       return Serialise_vkCmdSetSampleLocationsEXT(ser, VK_NULL_HANDLE, NULL);
     case VulkanChunk::vkCmdSetDiscardRectangleEXT:
       return Serialise_vkCmdSetDiscardRectangleEXT(ser, VK_NULL_HANDLE, 0, 0, NULL);
+    case VulkanChunk::DeviceMemoryRefs:
+    {
+      std::vector<MemRefInterval> data;
+      return GetResourceManager()->Serialise_DeviceMemoryRefs(ser, data);
+    }
     default:
     {
       SystemChunk system = (SystemChunk)chunk;

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -176,6 +176,15 @@ struct VulkanResourceManagerConfiguration
   typedef VkInitialContents InitialContentData;
 };
 
+struct MemRefInterval
+{
+  ResourceId memory;
+  uint64_t start;
+  FrameRefType refType;
+};
+
+DECLARE_REFLECTION_STRUCT(MemRefInterval);
+
 class VulkanResourceManager : public ResourceManager<VulkanResourceManagerConfiguration>
 {
 public:
@@ -261,6 +270,11 @@ public:
   template <typename SerialiserType>
   void SerialiseImageStates(SerialiserType &ser, std::map<ResourceId, ImageLayouts> &states,
                             std::vector<VkImageMemoryBarrier> &barriers);
+
+  template <typename SerialiserType>
+  bool Serialise_DeviceMemoryRefs(SerialiserType &ser, std::vector<MemRefInterval> &data);
+
+  void InsertDeviceMemoryRefs(WriteSerialiser &ser);
 
   ResourceId GetID(WrappedVkRes *res)
   {

--- a/renderdoc/driver/vulkan/vk_stringise.cpp
+++ b/renderdoc/driver/vulkan/vk_stringise.cpp
@@ -28,7 +28,7 @@
 template <>
 std::string DoStringise(const VulkanChunk &el)
 {
-  RDCCOMPILE_ASSERT((uint32_t)VulkanChunk::Max == 1132, "Chunks changed without updating names");
+  RDCCOMPILE_ASSERT((uint32_t)VulkanChunk::Max == 1133, "Chunks changed without updating names");
 
   BEGIN_ENUM_STRINGISE(VulkanChunk)
   {
@@ -164,6 +164,7 @@ std::string DoStringise(const VulkanChunk &el)
     STRINGISE_ENUM_CLASS(vkCmdEndConditionalRenderingEXT)
     STRINGISE_ENUM_CLASS(vkCmdSetSampleLocationsEXT)
     STRINGISE_ENUM_CLASS(vkCmdSetDiscardRectangleEXT)
+    STRINGISE_ENUM_CLASS_NAMED(DeviceMemoryRefs, "Device Memory References")
     STRINGISE_ENUM_CLASS_NAMED(Max, "Max Chunk");
   }
   END_ENUM_STRINGISE()


### PR DESCRIPTION
## Description

This adds serialization (and deserialization) of the FrameRefType of each range of VkDeviceMemory resources. This makes the results of the capture-time tracking of the VkDeviceMemory usage available at replay time.

This serialization is implemented as a new chunk type (`DeviceMemoryRefs`) for each `VkDeviceMemory` resource; this chunk stores a serialized form of the `Intervals<FrameRefType>` associated with that `VkDeviceMemory` resource.