### PR TITLE
Mark simple copies into VkDeviceMemory as `CompleteWrite`

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -2011,7 +2011,7 @@ void WrappedVulkan::vkCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcB
       record->MarkBufferFrameReferenced(GetRecord(srcBuffer), pRegions[i].srcOffset,
                                         pRegions[i].size, eFrameRef_Read);
       record->MarkBufferFrameReferenced(GetRecord(destBuffer), pRegions[i].dstOffset,
-                                        pRegions[i].size, eFrameRef_PartialWrite);
+                                        pRegions[i].size, eFrameRef_CompleteWrite);
     }
   }
 }

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -803,7 +803,7 @@ VkResult WrappedVulkan::vkFlushMappedMemoryRanges(VkDevice device, uint32_t memR
       {
         GetResourceManager()->MarkMemoryFrameReferenced(GetResID(pMemRanges[i].memory),
                                                         pMemRanges[i].offset, pMemRanges[i].size,
-                                                        eFrameRef_PartialWrite);
+                                                        eFrameRef_CompleteWrite);
       }
       else
       {


### PR DESCRIPTION
## Description
These two commands access the specified memory ranges as `CompleteWrite`, because the contents of these memory ranges before calling the command cannot affect any later commands.