### PR TITLE
Fix GLES shader compile errors

### DIFF
--- a/renderdoc/data/glsl/glsl_globals.h
+++ b/renderdoc/data/glsl/glsl_globals.h
@@ -56,6 +56,8 @@
 #define PRECISION
 #else
 #define PRECISION highp
+precision highp float;
+precision highp int;
 #endif
 
 #ifndef FLT_EPSILON

--- a/renderdoc/data/glsl/trisize.geom
+++ b/renderdoc/data/glsl/trisize.geom
@@ -22,12 +22,12 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "glsl_globals.h"
-
 #if defined(OPENGL_ES)
 #extension GL_EXT_geometry_shader : enable
 #extension GL_OES_geometry_shader : enable
 #endif
+
+#include "glsl_globals.h"
 
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;

--- a/renderdoc/data/glsl_shaders.cpp
+++ b/renderdoc/data/glsl_shaders.cpp
@@ -98,9 +98,7 @@ std::string GenerateGLSLShader(const std::string &shader, ShaderType type, int v
   if(type == eShaderGLSLES)
     combined +=
         "#define OPENGL 1\n"
-        "#define OPENGL_ES 1\n"
-        "precision highp float;\n"
-        "precision highp int;\n";
+        "#define OPENGL_ES 1\n";
   else if(type == eShaderGLSL)
     combined +=
         "#define OPENGL 1\n"

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -734,8 +734,8 @@ extern bool IsGLES;
   EXT_TO_CHECK(99, 32, EXT_primitive_bounding_box)               \
   EXT_TO_CHECK(99, 32, OES_primitive_bounding_box)               \
   EXT_TO_CHECK(99, 32, OES_texture_border_color)                 \
-  EXT_TO_CHECK(99, 32, EXT_texture_cube_map_array)               \
-  EXT_TO_CHECK(99, 32, OES_texture_cube_map_array)               \
+  EXT_TO_CHECK(99, 99, EXT_texture_cube_map_array)               \
+  EXT_TO_CHECK(99, 99, OES_texture_cube_map_array)               \
   EXT_TO_CHECK(99, 32, OES_texture_storage_multisample_2d_array) \
   EXT_TO_CHECK(99, 99, EXT_clip_cull_distance)                   \
   EXT_TO_CHECK(99, 99, EXT_multisample_compatibility)            \

--- a/renderdoc/driver/gl/gl_debug.cpp
+++ b/renderdoc/driver/gl/gl_debug.cpp
@@ -332,7 +332,7 @@ void GLReplay::InitDebugData()
     if(GLCoreVersion >= 32)
       glslVersion = glslBaseVer = glslCSVer = 320;
 
-    if(HasExt[OES_texture_cube_map_array] || HasExt[EXT_texture_cube_map_array])
+    if(HasExt[OES_texture_cube_map_array] || HasExt[EXT_texture_cube_map_array] || GLCoreVersion >= 32)
       texSampleDefines += "#define TEXSAMPLE_CUBE_ARRAY 1\n";
 
     if(HasExt[OES_texture_cube_map_array])


### PR DESCRIPTION
Detected two shader compile errors while replaying GLES apps:
1. „#extension directive must occur before any non-preprocessor token” -  Fix the order of precisions and extensions in the shader code.
2. „extension 'GL_OES_texture_cube_map_array' is not supported”  - Do not add extensions if they are actually not supported. TEXTURE_CUBE_MAP_ARRAY was added to GLES 3.2 so   GL_OES_texture_cube_map_array and GL_EXT_texture_cube_map_array are no longer used.