### PR TITLE
Fix WrappedID3D12Device::CreateHeap worngly returning E_NOINTERFACE.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -1411,7 +1411,7 @@ HRESULT WrappedID3D12Device::CreateHeap(const D3D12_HEAP_DESC *pDesc, REFIID rii
   if(ppvHeap == NULL)
     return m_pDevice->CreateHeap(pDesc, riid, ppvHeap);
 
-  if(riid != __uuidof(ID3D12Heap) || riid != __uuidof(ID3D12Heap1))
+  if(riid != __uuidof(ID3D12Heap) && riid != __uuidof(ID3D12Heap1))
     return E_NOINTERFACE;
 
   void *realptr = NULL;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

WrappedID3D12Device::CreateHeap currently early exits with E_NOINTERFACE as the interface id check always fails. This makes it impossible to create DX12 heaps when renderdoc is active.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
