### PR TITLE
 Fix another issue with MSAA depth buffer copying during replay with D3D12 

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "driver/dxgi/dxgi_common.h"
 #include "d3d12_command_list.h"
 #include "driver/dxgi/dxgi_common.h"
 

--- a/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list1_wrap.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include "driver/dxgi/dxgi_common.h"
 #include "d3d12_command_list.h"
 #include "driver/dxgi/dxgi_common.h"
 

--- a/renderdoc/driver/d3d12/d3d12_msaa_array_conv.cpp
+++ b/renderdoc/driver/d3d12/d3d12_msaa_array_conv.cpp
@@ -419,7 +419,7 @@ void D3D12DebugManager::CopyArrayToTex2DMS(ID3D12Resource *destMS, ID3D12Resourc
     pipeDesc.PS.pShaderBytecode = m_DepthArray2MS->GetBufferPointer();
     pipeDesc.NumRenderTargets = 0;
     pipeDesc.RTVFormats[0] = DXGI_FORMAT_UNKNOWN;
-    pipeDesc.DSVFormat = rtvDesc.Format;
+    pipeDesc.DSVFormat = dsvDesc.Format;
     pipeDesc.DepthStencilState.DepthEnable = TRUE;
     pipeDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     pipeDesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
I've just found another issue with copying depth on D3D12, similar to the one that was fixed recently.
<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
