### PR TITLE
Keep DX12 descriptor heaps alive until deferred copy/write flush.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -2136,10 +2136,17 @@ void WrappedID3D12Device::FlushPendingDescriptorWrites()
   }
 
   for(size_t i = 0; i < writes.size(); i++)
+  {
     writes[i].dest->CopyFrom(writes[i].desc);
+    writes[i].dest->GetHeap()->Release();
+  }
 
   for(size_t i = 0; i < copies.size(); i++)
+  {
     copies[i].dst->CopyFrom(*copies[i].src);
+    copies[i].src->GetHeap()->Release();
+    copies[i].dst->GetHeap()->Release();
+  }
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -944,6 +944,7 @@ void WrappedID3D12Device::CreateConstantBufferView(const D3D12_CONSTANT_BUFFER_V
     {
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorWrites.push_back(write);
+      write.dest->GetHeap()->AddRef();
       m_DynamicDescriptorRefs.push_back(write.desc);
     }
 
@@ -986,6 +987,7 @@ void WrappedID3D12Device::CreateShaderResourceView(ID3D12Resource *pResource,
     {
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorWrites.push_back(write);
+      write.dest->GetHeap()->AddRef();
       if(pResource && pResource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
         m_DynamicDescriptorRefs.push_back(write.desc);
     }
@@ -1036,6 +1038,7 @@ void WrappedID3D12Device::CreateUnorderedAccessView(ID3D12Resource *pResource,
     {
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorWrites.push_back(write);
+      write.dest->GetHeap()->AddRef();
       if(pResource && pResource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
         m_DynamicDescriptorRefs.push_back(write.desc);
     }
@@ -1081,6 +1084,7 @@ void WrappedID3D12Device::CreateRenderTargetView(ID3D12Resource *pResource,
     {
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorWrites.push_back(write);
+      write.dest->GetHeap()->AddRef();
       if(pResource && pResource->GetDesc().Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
         m_DynamicDescriptorRefs.push_back(write.desc);
     }
@@ -1123,6 +1127,7 @@ void WrappedID3D12Device::CreateDepthStencilView(ID3D12Resource *pResource,
     {
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorWrites.push_back(write);
+      write.dest->GetHeap()->AddRef();
     }
 
     {
@@ -1161,6 +1166,7 @@ void WrappedID3D12Device::CreateSampler(const D3D12_SAMPLER_DESC *pDesc,
     {
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorWrites.push_back(write);
+      write.dest->GetHeap()->AddRef();
     }
 
     {
@@ -2072,7 +2078,11 @@ void WrappedID3D12Device::CopyDescriptors(
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorCopies.insert(m_DynamicDescriptorCopies.end(), copies.begin(), copies.end());
       for(size_t i = 0; i < copies.size(); i++)
+      {
+        copies[i].src->GetHeap()->AddRef();
+        copies[i].dst->GetHeap()->AddRef();
         m_DynamicDescriptorRefs.push_back(*copies[i].src);
+      }
     }
 
     {
@@ -2142,7 +2152,11 @@ void WrappedID3D12Device::CopyDescriptorsSimple(UINT NumDescriptors,
       SCOPED_LOCK(m_DynDescLock);
       m_DynamicDescriptorCopies.insert(m_DynamicDescriptorCopies.end(), copies.begin(), copies.end());
       for(size_t i = 0; i < copies.size(); i++)
+      {
+        copies[i].src->GetHeap()->AddRef();
+        copies[i].dst->GetHeap()->AddRef();
         m_DynamicDescriptorRefs.push_back(*copies[i].src);
+      }
     }
 
     {


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Currently RenderDoc specific metadata concerning DX12 descriptors is not copied immediately on respective API function calls but deferred to the end of a capture. However, the lifetime of involved descriptor objects might not be that long which is a potential source for undefined behavior when the copies actually occur.

To give a practical example, the current code creates sporadic crashes on capture end with our DX12 renderer because objects can be destroyed while a RenderDoc capture is still in flight if respective completion fences have already been signaled. Keeping the associated descriptor heaps alive until after the deferred flush prevents these crashes.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
