### PR TITLE
Fix Skia loop on Android 9

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_shader_funcs.cpp
@@ -1399,6 +1399,11 @@ void WrappedOpenGL::glProgramBinary(GLuint program, GLenum binaryFormat, const v
   {
     GL.glProgramBinary(program, binaryFormat, binary, length);
   }
+  else
+  {
+    // intentionally generate a GL_INVALID_OPERATION error to have an effect on the app
+    GL.glProgramBinary(0, binaryFormat, 0, 0);
+  }
 }
 
 #pragma endregion


### PR DESCRIPTION
## Description

Can’t start GLES application with RenderDoc on Android 9 because Skia causes an infinite loop.  
When glProgramBinary is called in capture mode, intentionally generate a GL_INVALID_OPERATION error to have an effect on the app, otherwise, Skia assumes that this function call was successful.
