### PR TITLE
 Optimize Apply_InitialState for VkDeviceMemory resources

### DIFF
--- a/renderdoc/core/intervals.h
+++ b/renderdoc/core/intervals.h
@@ -188,6 +188,8 @@ public:
   inline iterator begin() { return Wrap(StartPoints.begin()); }
   inline const_iterator begin() const { return Wrap(StartPoints.begin()); }
   inline const_iterator end() const { return Wrap(StartPoints.end()); }
+  typedef typename std::map<uint64_t, T>::size_type size_type;
+  inline size_type size() const { return StartPoints.size(); }
   // Find the interval containing `x`.
   iterator find(uint64_t x)
   {

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -787,7 +787,7 @@ FrameRefType GetRefType(VkDescriptorType descType)
     case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
     case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
     case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: return eFrameRef_PartialWrite; break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: return eFrameRef_ReadBeforeWrite; break;
     default: RDCERR("Unexpected descriptor type");
   }
 

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -702,6 +702,15 @@ void VulkanResourceManager::ClearReferencedMemory()
   m_MemFrameRefs.clear();
 }
 
+MemRefs *VulkanResourceManager::FindMemRefs(ResourceId mem)
+{
+  auto it = m_MemFrameRefs.find(mem);
+  if(it != m_MemFrameRefs.end())
+    return &it->second;
+  else
+    return NULL;
+}
+
 bool VulkanResourceManager::Force_InitialState(WrappedVkRes *res, bool prepare)
 {
   return false;

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -429,7 +429,9 @@ public:
 
   void MergeReferencedMemory(std::map<ResourceId, MemRefs> &memRefs);
   void ClearReferencedMemory();
+  MemRefs *FindMemRefs(ResourceId mem);
 
+  inline bool OptimizeInitialState() { return m_OptimizeInitialState; }
 private:
   bool ResourceTypeRelease(WrappedVkRes *res);
 
@@ -446,4 +448,5 @@ private:
   CaptureState m_State;
   WrappedVulkan *m_Core;
   std::map<ResourceId, MemRefs> m_MemFrameRefs;
+  bool m_OptimizeInitialState = false;
 };

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1006,8 +1006,10 @@ struct AttachmentInfo
 struct MemRefs
 {
   Intervals<FrameRefType> rangeRefs;
-  inline MemRefs() {}
+  WrappedVkRes *initializedLiveRes;
+  inline MemRefs() : initializedLiveRes(NULL) {}
   inline MemRefs(VkDeviceSize offset, VkDeviceSize size, FrameRefType refType)
+      : initializedLiveRes(NULL)
   {
     rangeRefs.update(offset, offset + size, refType, ComposeFrameRefs);
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1246,7 +1246,7 @@ void WrappedVulkan::vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
       if(att == NULL)
         break;
 
-      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_PartialWrite);
+      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_ReadBeforeWrite);
       if(att->baseResourceMem != ResourceId())
         record->MarkResourceFrameReferenced(att->baseResourceMem, eFrameRef_Read);
       if(att->resInfo)
@@ -1591,7 +1591,7 @@ void WrappedVulkan::vkCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
       if(att == NULL)
         break;
 
-      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_PartialWrite);
+      record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_ReadBeforeWrite);
       if(att->baseResourceMem != ResourceId())
         record->MarkResourceFrameReferenced(att->baseResourceMem, eFrameRef_Read);
       if(att->resInfo)


### PR DESCRIPTION
## Description

This change reduces the amount of data copied into `VkDeviceMemory` resources in `Apply_InitialState`; this uses the new (interval-based) reference tracking.

On a large capture from a recent game, this change reduces the amount of data copied into `VkDeviceMemory`s (*excluding* `VkImage`s) from 2.2GB to 720MB (plus 100MB cleared to 0). This reduces the time spent in `ApplyInitialContents` from 1800ms to 1500ms.

Because this optimization has the potential to break replays, it is currently disabled by default, and can be enabled by setting `m_OptimizeInitialState = true` at vk_manager.h:452.

Ranges of memory are initialized/reset by either clearing to 0, or copying in the initial state data, according to the `FrameRefType`, as follows:
- Read-only (`eFrameRef_Read`) regions of memory are initialized by copying once, before the first replay.
- Read-before-write (`eFrameRef_ReadBeforeWrite`) regions of memory are reset by copying before each replay.
- Write-only (`eFrameRef_PartialWrite` and `eFrameRef_CompleteWrite`) regions of memory are cleared to 0 before each replay. This is intended to avoid possible user confusion when inspecting these regions of memory, as they might otherwise show data written later in the frame.
- Unused (`eFrameRef_None`) regions of memory are cleared to 0 once, before the first replay.

There are potentially degenerate access patterns that could result in many small copies that might be slower than a single larger copy. This PR makes no attempt to handle such a situation, though it probably should be addressed eventually (particularly when we find an example of this a real application).