### PR TITLE
Fix textures not getting displayed when using GL_COMPARE_REF_TO_TEXTURE

### DIFF
--- a/renderdoc/driver/gl/gl_debug.cpp
+++ b/renderdoc/driver/gl/gl_debug.cpp
@@ -1168,6 +1168,11 @@ GLReplay::TextureSamplerState GLReplay::SetSamplerParams(GLenum target, GLuint t
   GL.glGetTextureParameterivEXT(texname, target, eGL_TEXTURE_MAG_FILTER, (GLint *)&ret.magFilter);
   GL.glGetTextureParameterivEXT(texname, target, eGL_TEXTURE_WRAP_S, (GLint *)&ret.wrapS);
   GL.glGetTextureParameterivEXT(texname, target, eGL_TEXTURE_WRAP_T, (GLint *)&ret.wrapT);
+  GL.glGetTextureParameterivEXT(texname, target, eGL_TEXTURE_COMPARE_MODE, (GLint *)&ret.compareMode);
+
+  // disable depth comparison
+  GLenum compareMode = eGL_NONE;
+  GL.glTextureParameterivEXT(texname, target, eGL_TEXTURE_COMPARE_MODE, (GLint *)&compareMode);
 
   // always want to clamp
   GLenum param = eGL_CLAMP_TO_EDGE;
@@ -1210,6 +1215,7 @@ void GLReplay::RestoreSamplerParams(GLenum target, GLuint texname, TextureSample
   GL.glTextureParameterivEXT(texname, target, eGL_TEXTURE_WRAP_T, (GLint *)&state.wrapT);
   GL.glTextureParameterivEXT(texname, target, eGL_TEXTURE_MIN_FILTER, (GLint *)&state.minFilter);
   GL.glTextureParameterivEXT(texname, target, eGL_TEXTURE_MAG_FILTER, (GLint *)&state.magFilter);
+  GL.glTextureParameterivEXT(texname, target, eGL_TEXTURE_COMPARE_MODE, (GLint *)&state.compareMode);
 }
 
 bool GLReplay::GetMinMax(ResourceId texid, uint32_t sliceFace, uint32_t mip, uint32_t sample,

--- a/renderdoc/driver/gl/gl_replay.h
+++ b/renderdoc/driver/gl/gl_replay.h
@@ -295,6 +295,7 @@ private:
     GLenum magFilter = eGL_NEAREST;
     GLenum wrapS = eGL_CLAMP_TO_EDGE;
     GLenum wrapT = eGL_CLAMP_TO_EDGE;
+    GLenum compareMode = eGL_NONE;
   };
 
   // sets the desired parameters, and returns the previous ones ready to restore


### PR DESCRIPTION
<!--
This commit adds the GL_TEXTURE_COMPARE_MODE parameter to the
TextureSamplerState struct, and sets its value to GL_NONE in
SetSamplerState. This fixes the issue of depth textures that use
GL_COMPARE_REF_TO_TEXTURE being displayed as solid black or white
in the texture viewer.
-->

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

`GL_TEXTURE_COMPARE_MODE` was not getting set to its default of `GL_NONE` in `SetSamplerParams`. Because of this, textures that use a `GL_TEXTURE_COMPARE_MODE` of `GL_COMPARE_REF_TO_TEXTURE` were being sampled incorrectly and were displayed as solid black or white in the texture viewer. This change makes it so that `SetSamplerParams` sets the `GL_TEXTURE_COMPARE_MODE` to `GL_NONE` (with `RestoreSamplerParams` restoring it), so that these textures are displayed correctly.