### PR TITLE
Change ref type for vkCmd(Fill|Update)Buffer to CompleteWrite

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -2375,7 +2375,7 @@ void WrappedVulkan::vkCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer de
     record->AddChunk(scope.Get());
 
     record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, dataSize,
-                                      eFrameRef_PartialWrite);
+                                      eFrameRef_CompleteWrite);
   }
 }
 
@@ -2437,7 +2437,7 @@ void WrappedVulkan::vkCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dest
     record->AddChunk(scope.Get());
 
     record->MarkBufferFrameReferenced(GetRecord(destBuffer), destOffset, fillSize,
-                                      eFrameRef_PartialWrite);
+                                      eFrameRef_CompleteWrite);
   }
 }
 


### PR DESCRIPTION
## Description

`vkCmdFillBuffer` and `vkCmdUpdateBuffer` each entirely overwrite the specified memory intervals; this change marks the memory intervals accessed by these commands as `CompleteWrite`, rather than the more conservative `PartialWrite`.