### PR TITLE
Fix MarkBufferViewFrameReferenced

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3058,11 +3058,12 @@ void VkResourceRecord::MarkBufferViewFrameReferenced(VkResourceRecord *bufView, 
 {
   // mark the VkBufferView and VkBuffer as read
   MarkResourceFrameReferenced(bufView->GetResourceID(), eFrameRef_Read);
-  MarkResourceFrameReferenced(bufView->baseResource, eFrameRef_Read);
+  if(bufView->baseResource != ResourceId())
+    MarkResourceFrameReferenced(bufView->baseResource, eFrameRef_Read);
 
   if(bufView->resInfo)
     cmdInfo->sparse.insert(bufView->resInfo);
-  if(bufView->baseResource != ResourceId())
+  if(bufView->baseResourceMem != ResourceId())
     MarkMemoryFrameReferenced(bufView->baseResourceMem, bufView->memOffset, bufView->memSize,
                               refType);
 }


### PR DESCRIPTION
## Description

The null resource guards in `VkResourceRecord::MarkBufferViewFrameReferenced` were incorrect; this change ensures that the underlying buffer and bound memory resources are only marked as referenced if they are non-null.