### PR TITLE
Add extended thumbnail section for .rdc conversion

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -1299,29 +1299,7 @@ void RenderDoc::FinishCaptureWriting(RDCFile *rdc, uint32_t frameNumber)
       delete w;
     }
 
-    const RDCThumb &thumb = rdc->GetThumbnail();
-    if(thumb.format != FileType::JPG && thumb.width > 0 && thumb.height > 0)
-    {
-      SectionProperties props = {};
-      props.type = SectionType::ExtendedThumbnail;
-      props.version = 1;
-      StreamWriter *w = rdc->WriteSection(props);
-
-      // if this file format ever changes, be sure to update the XML export which has a special
-      // handling for this case.
-
-      ExtThumbnailHeader header;
-      header.width = thumb.width;
-      header.height = thumb.height;
-      header.len = thumb.len;
-      header.format = thumb.format;
-      w->Write(header);
-      w->Write(thumb.pixels, thumb.len);
-
-      w->Finish();
-
-      delete w;
-    }
+    rdc->WriteExtendedThumbnailSection();
 
     RDCLOG("Written to disk: %s", m_CurrentLogFile.c_str());
 

--- a/renderdoc/replay/capture_file.cpp
+++ b/renderdoc/replay/capture_file.cpp
@@ -536,6 +536,7 @@ ReplayStatus CaptureFile::Convert(const char *filename, const char *filetype, co
       return ReplayStatus::FileIOFailed;
   }
 
+  output.WriteExtendedThumbnailSection();
   return ReplayStatus::Succeeded;
 }
 

--- a/renderdoc/serialise/rdcfile.cpp
+++ b/renderdoc/serialise/rdcfile.cpp
@@ -1220,3 +1220,30 @@ FILE *RDCFile::StealImageFileHandle(std::string &filename)
   m_File = NULL;
   return ret;
 }
+
+void RDCFile::WriteExtendedThumbnailSection()
+{
+  const RDCThumb &thumb = GetThumbnail();
+  if(thumb.format != FileType::JPG && thumb.width > 0 && thumb.height > 0)
+  {
+    SectionProperties props = {};
+    props.type = SectionType::ExtendedThumbnail;
+    props.version = 1;
+    StreamWriter *w = WriteSection(props);
+
+    // if this file format ever changes, be sure to update the XML export which has a special
+    // handling for this case.
+
+    ExtThumbnailHeader header;
+    header.width = thumb.width;
+    header.height = thumb.height;
+    header.len = thumb.len;
+    header.format = thumb.format;
+    w->Write(header);
+    w->Write(thumb.pixels, thumb.len);
+
+    w->Finish();
+
+    delete w;
+  }
+}

--- a/renderdoc/serialise/rdcfile.h
+++ b/renderdoc/serialise/rdcfile.h
@@ -94,6 +94,7 @@ public:
   const SectionProperties &GetSectionProperties(int index) const { return m_Sections[index]; }
   StreamReader *ReadSection(int index) const;
   StreamWriter *WriteSection(const SectionProperties &props);
+  void WriteExtendedThumbnailSection();
 
   // Only valid if GetDriver returns RDCDriver::Image, passes over the underlying FILE * for use
   // loading the image directly, since the RDC container isn't there to read from a section.


### PR DESCRIPTION
The extended (lossless) thumbnail section was only written to the end of
the file when saving a current capture. However, this wasn't done when
performing RDC file conversion in which case the lossless (e.g. PNG)
thumbnail was lost and only JPEG one was retained.
