### PR TITLE
Fix Vulkan mesh output for tessellated quads

### DIFF
--- a/qrenderdoc/Windows/BufferViewer.ui
+++ b/qrenderdoc/Windows/BufferViewer.ui
@@ -568,7 +568,7 @@
    </widget>
    <widget class="QWidget" name="gsoutTab">
     <attribute name="title">
-     <string>GS Out</string>
+     <string>GS/DS Out</string>
     </attribute>
     <layout class="QGridLayout" name="gridLayout_4">
      <property name="leftMargin">

--- a/renderdoc/driver/shaders/spirv/spirv_disassemble.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_disassemble.cpp
@@ -4659,6 +4659,10 @@ void SPVModule::MakeReflection(GraphicsAPI sourceAPI, ShaderStage stage, const s
         {
           patchData.outTopo = Topology::TriangleStrip;
         }
+        else if(mode.mode == spv::ExecutionModeQuads)
+        {
+          patchData.outTopo = Topology::TriangleList;
+        }
         else if(mode.mode == spv::ExecutionModeDepthGreater)
         {
           for(SigParameter &sig : outputs)

--- a/renderdoc/driver/vulkan/vk_postvs.cpp
+++ b/renderdoc/driver/vulkan/vk_postvs.cpp
@@ -2758,7 +2758,7 @@ void VulkanReplay::FetchTessGSOut(uint32_t eventId)
   if(!ObjDisp(m_Device)->CmdBeginTransformFeedbackEXT)
   {
     RDCLOG(
-        "VK_EXT_transform_feedback_extension not available, can't fetch tessellation/geometry "
+        "VK_EXT_transform_feedback extension not available, can't fetch tessellation/geometry "
         "output");
     return;
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -1173,12 +1173,12 @@ bool WrappedVulkan::Serialise_vkCreateDevice(SerialiserType &ser, VkPhysicalDevi
     if(supportedExtensions.find(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME) != supportedExtensions.end())
     {
       Extensions.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-      RDCLOG("Enabling VK_EXT_transform_feedback_extension");
+      RDCLOG("Enabling VK_EXT_transform_feedback extension");
     }
     else
     {
       RDCWARN(
-          "VK_EXT_transform_feedback_extension not available, mesh output from "
+          "VK_EXT_transform_feedback extension not available, mesh output from "
           "geometry/tessellation stages will not be available");
     }
 


### PR DESCRIPTION
## Description

When selecting a draw with a tessellation evaluation shader using
layout(quads), RenderDoc would emit an "Unexpected output topology"
error.

This change hooks up the SPIRV disassembly to the correct output
topology, and sets the post-VS rendering path to use triangle list
topology.

Additional changes:

* Fixes a typo in the VK_EXT_transform_feedback name in various debug
  prints.

* Renames the "GS Out" 3D View tab in the Mesh Viewer to "GS/DS Out",
  to match the corresponding table. This affects all APIs.

## Screenshot

This shows a torus rendered as tessellated subdivision surfaces rendering with the patch applied.

![image](https://user-images.githubusercontent.com/942582/55035123-7b8a1080-4fed-11e9-88d7-79a76039977b.png)
