### PR TITLE
Improve Vulkan byte range descriptions

### DIFF
--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.h
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.h
@@ -104,6 +104,7 @@ private:
   void setEmptyRow(RDTreeWidgetItem *node);
   void highlightIABind(int slot);
 
+  QString formatByteRange(const BufferDescription *buf, const VKPipe::BindingElement *descriptorBind);
   QString formatMembers(int indent, const QString &nameprefix, const rdcarray<ShaderConstant> &vars);
   const VKPipe::Shader *stageForSender(QWidget *widget);
 


### PR DESCRIPTION
## Description

Renames the "cont.d" column in the Pipeline State window to "Addendum".
This is a less confusing title then what I assume is a contraction of
"Continued".

Adds a "(whole size)" annotation after the range if VK_WHOLE_SIZE was
used, and an "(empty view)" annotation if the range is empty. These
annotations are intended to help diagnose incorrectly filled buffer
descriptors.

## Motivation

The desire to make this change came about when I was trying to get my first triangle on the screen using Vulkan. To keep the code less verbose, I decided to use the VulkanPP wrapper library, which provides default arguments for lots of descriptor constructors. In one such case, `vk::DescriptorBufferInfo`, the default argument for the size is 0.

I mistakenly assumed that this 0 value corresponds to the entire buffer - that would be a sensible default value for a constructor, but obviously it didn't work so I fired up RenderDoc. 

When examining the draw in RenderDoc, I was confused by the name of the `cont.d` column, and the "Viewing bytes 0 - 0". 

Not trusting RenderDoc yet, I checked the source code for the column in question and found that UINT64_MAX actually corresponds to VK_WHOLE_SIZE, and tracked backwards and discovered the problem with the C++ wrapper. 

Wanting to save someone the same troubleshooting effort, I made this patch to try to make the byte range clearer.

In addition to new Vulkan programmers, I think it might help people quickly differentiate empty buffer vs whole buffer vs partial buffer without having to mentally compare byte counts from different columns.

## Screenshot

![image](https://user-images.githubusercontent.com/942582/55035588-bfc9e080-4fee-11e9-869d-d5a35a7f8660.png)
