### PR TITLE
1.x/qt creator qmake

### DIFF
--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -1,7 +1,11 @@
 option(STATIC_QRENDERDOC "Compile qrenderdoc as static" OFF)
 option(QRENDERDOC_NO_CXX11_REGEX "Disable C++11 regex in scintilla" OFF)
 
-set(QMAKE_QT5_COMMAND qmake CACHE STRING "Command to run to invoke Qt5's qmake. Normally this is qmake, possibly with qtchooser, but might be qmake-qt5")
+if( NOT DEFINED QT_QMAKE_EXECUTABLE )
+    set( QT_QMAKE_EXECUTABLE "qmake" )
+endif()
+
+set(QMAKE_QT5_COMMAND ${QT_QMAKE_EXECUTABLE} CACHE STRING "Command to run to invoke Qt5's qmake. Normally this is qmake, possibly with qtchooser, but might be qmake-qt5")
 set(RENDERDOC_SWIG_PACKAGE https://github.com/baldurk/swig/archive/renderdoc-modified-6.zip CACHE STRING "The location where RenderDoc's swig fork source can be found. By default points to the URL on github but can be pointed to a local file.")
 
 set(QMAKE_CONFIG "debug")


### PR DESCRIPTION
## IMPORTANT
This PR is also bringing in another PR (https://github.com/baldurk/renderdoc/pull/1339).
If this is a problem I can split them, but I trust that they'll both get easily accepted since they're both trivial

## Description

When QtCreator is used to build a CMake script, it defaults to storing
the qmake to use in the variable "QT_QMAKE_EXECUTABLE"
(this is tweakable in Tools->Options->Kits->CMake generator)

Renderdoc now detects if QT_QMAKE_EXECUTABLE is already defined and if so, use that
setting. Otherwise use the previous default (which is "qmake")

Why this change? A user may have several Qt versions installed, and
QtCreator supports managing between them via the IDE.

Without this change the user will change between kits in the IDE but
Renderdoc will still use the default qmake.

This is problematic in Linux systems because the Qt version installed
via the Qt installer is often more up to date than the distro-provided
one