### PR TITLE
Allow Activity selection for Android

### DIFF
--- a/qrenderdoc/Code/Interface/QRDInterface.h
+++ b/qrenderdoc/Code/Interface/QRDInterface.h
@@ -418,6 +418,9 @@ struct ICaptureDialog
   DOCUMENT("Update the current state based on the current remote host, when that changes.");
   virtual void UpdateRemoteHost() = 0;
 
+  DOCUMENT("Called when a remote host is selected.");
+  virtual void OnRemoteHostSwitched() = 0;
+
 protected:
   ICaptureDialog() = default;
   ~ICaptureDialog() = default;

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.h
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.h
@@ -74,6 +74,7 @@ public:
   void SaveSettings(const rdcstr &filename) override;
   void UpdateGlobalHook() override;
   void UpdateRemoteHost() override;
+  void OnRemoteHostSwitched() override;
 
 public slots:
   bool checkAllowClose();
@@ -104,6 +105,8 @@ private slots:
   void vulkanLayerWarn_mouseClick();
   void androidWarn_mouseClick();
 
+  void on_activityBrowse_clicked();
+
 private:
   Ui::CaptureDialog *ui;
   ICaptureContext &m_Ctx;
@@ -126,4 +129,6 @@ private:
 
   void CheckAndroidSetup(QString &filename);
   AndroidFlags m_AndroidFlags;
+
+  std::map<std::string, rdcarray<rdcstr>> m_AndroidActivities;
 };

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>578</width>
-    <height>1025</height>
+    <height>1084</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,6 +50,33 @@
       <property name="topMargin">
        <number>4</number>
       </property>
+      <item row="0" column="3">
+       <widget class="QToolButton" name="exePathBrowse">
+        <property name="toolTip">
+         <string>Browse for an executable file</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="activityLabel">
+        <property name="text">
+         <string>Activity</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="cmdLineLabel">
+        <property name="toolTip">
+         <string>The command-line that will be passed to the executable on launch</string>
+        </property>
+        <property name="text">
+         <string>Command-line Arguments</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="2">
        <widget class="QLineEdit" name="exePath">
         <property name="minimumSize">
@@ -63,17 +90,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="3">
-       <widget class="QToolButton" name="exePathBrowse">
-        <property name="toolTip">
-         <string>Browse for an executable file</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="workDirLabel">
         <property name="toolTip">
          <string>Browse for a working directory</string>
@@ -83,27 +100,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="3">
-       <widget class="QToolButton" name="workDirBrowse">
-        <property name="toolTip">
-         <string>Browse for a working directory</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="cmdLineLabel">
-        <property name="toolTip">
-         <string>The command-line that will be passed to the executable on launch</string>
-        </property>
-        <property name="text">
-         <string>Command-line Arguments</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="envVarLabel">
         <property name="toolTip">
          <string>The environment variables for the executable</string>
@@ -113,13 +110,13 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
-       <widget class="QToolButton" name="envVarEdit">
+      <item row="4" column="2">
+       <widget class="QLineEdit" name="envVar">
         <property name="toolTip">
          <string>The environment variables for the executable</string>
         </property>
-        <property name="text">
-         <string>...</string>
+        <property name="readOnly">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -133,7 +130,17 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="2" column="3">
+       <widget class="QToolButton" name="workDirBrowse">
+        <property name="toolTip">
+         <string>Browse for a working directory</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
        <widget class="QLineEdit" name="workDirPath">
         <property name="minimumSize">
          <size>
@@ -146,7 +153,17 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2" colspan="2">
+      <item row="4" column="3">
+       <widget class="QToolButton" name="envVarEdit">
+        <property name="toolTip">
+         <string>The environment variables for the executable</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2" colspan="2">
        <widget class="QLineEdit" name="cmdline">
         <property name="minimumSize">
          <size>
@@ -159,13 +176,13 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
-       <widget class="QLineEdit" name="envVar">
-        <property name="toolTip">
-         <string>The environment variables for the executable</string>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="activity"/>
+      </item>
+      <item row="1" column="3">
+       <widget class="QToolButton" name="activityBrowse">
+        <property name="text">
+         <string>...</string>
         </property>
        </widget>
       </item>

--- a/qrenderdoc/Windows/Dialogs/VirtualFileDialog.h
+++ b/qrenderdoc/Windows/Dialogs/VirtualFileDialog.h
@@ -26,6 +26,7 @@
 
 #include <QDialog>
 #include <QItemSelection>
+#include "Code/Interface/QRDInterface.h"
 
 namespace Ui
 {
@@ -41,7 +42,8 @@ class VirtualFileDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit VirtualFileDialog(ICaptureContext &ctx, QString initialDirectory, QWidget *parent = 0);
+  explicit VirtualFileDialog(ICaptureContext &ctx, QString initialDirectory, QWidget *parent = 0,
+                             const rdcarray<rdcstr> &activityVector = rdcarray<rdcstr>());
   ~VirtualFileDialog();
 
   QString chosenPath() { return m_ChosenPath; }

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -1942,6 +1942,9 @@ void MainWindow::switchContext()
 
   if(ok)
     setRemoteHost(hostIdx);
+
+  if(m_Ctx.HasCaptureDialog())
+    m_Ctx.GetCaptureDialog()->OnRemoteHostSwitched();
 }
 
 void MainWindow::contextChooser_menuShowing()

--- a/renderdoc/android/android.h
+++ b/renderdoc/android/android.h
@@ -40,6 +40,7 @@ Process::ProcessResult adbExecCommand(const std::string &deviceID, const std::st
 void initAdb();
 void shutdownAdb();
 bool InjectWithJDWP(const std::string &deviceID, uint16_t jdwpport);
+std::string GetDefaultActivityForPackage(const std::string &deviceID, const std::string &packageName);
 
 struct LogcatThread
 {

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -2310,3 +2310,12 @@ extern "C" RENDERDOC_API int RENDERDOC_CC RENDERDOC_RunUnitTests(const rdcstr &c
 DOCUMENT("Internal function that runs functional tests.");
 extern "C" RENDERDOC_API int RENDERDOC_CC RENDERDOC_RunFunctionalTests(int pythonMinorVersion,
                                                                        const rdcarray<rdcstr> &args);
+DOCUMENT("Internal function for retrieving the launcher Activity for the Android application.");
+extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_GetDefaultActivity(const char *hostName,
+                                                                        const char *packageName,
+                                                                        rdcstr &activity);
+DOCUMENT(R"(Internal function for retrieving those Activities of a given Android application
+which can be launched by other applications.)");
+extern "C" RENDERDOC_API void RENDERDOC_CC RENDERDOC_GetActivities(const char *hostName,
+                                                                   const char *packageName,
+                                                                   rdcarray<rdcstr> &activities);


### PR DESCRIPTION
Make the Android Activities selectable by adding a new input filed listing the target application's Activities.
Activities can run on a process different from the default launcher Activity.  If these Activities are started directly, they can be captured with Renderdoc too.