### PR TITLE
Fix incorrect loop over d3d12 counters

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_counters.cpp
+++ b/renderdoc/driver/d3d12/d3d12_counters.cpp
@@ -628,14 +628,14 @@ vector<CounterResult> D3D12Replay::FetchCounters(const vector<GPUCounter> &count
       occlusion++;
     }
 
-    for(size_t c = 0; c < counters.size(); c++)
+    for(size_t c = 0; c < d3dCounters.size(); c++)
     {
       CounterResult result;
 
       result.eventId = cb.m_Results[i].first;
-      result.counter = counters[c];
+      result.counter = d3dCounters[c];
 
-      switch(counters[c])
+      switch(d3dCounters[c])
       {
         case GPUCounter::EventGPUDuration:
         {


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
* Incorrect loop over all the counters was causing additional entries to counter result data
leading to incorrect display in the performance counter viewer. This fix will ensure that it will only account d3d12 counters
