### PR TITLE
Vulkan: Add FormatImageAspects to get VkImageAspectFlags from VkFormat

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -2903,6 +2903,22 @@ VkFormat MakeVkFormat(ResourceFormat fmt)
   return ret;
 }
 
+VkImageAspectFlags FormatImageAspects(VkFormat fmt)
+{
+  if(IsStencilOnlyFormat(fmt))
+    return VK_IMAGE_ASPECT_STENCIL_BIT;
+  else if(IsDepthOnlyFormat(fmt))
+    return VK_IMAGE_ASPECT_DEPTH_BIT;
+  else if(IsDepthAndStencilFormat(fmt))
+    return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+  else if(GetYUVPlaneCount(fmt) == 3)
+    return VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
+  else if(GetYUVPlaneCount(fmt) == 2)
+    return VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
+  else
+    return VK_IMAGE_ASPECT_COLOR_BIT;
+}
+
 VkResourceRecord::~VkResourceRecord()
 {
   VkResourceType resType = Resource != NULL ? IdentifyTypeByPtr(Resource) : eResUnknown;

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1344,6 +1344,7 @@ bool IsUIntFormat(VkFormat f);
 bool IsDoubleFormat(VkFormat f);
 bool IsSIntFormat(VkFormat f);
 bool IsYUVFormat(VkFormat f);
+VkImageAspectFlags FormatImageAspects(VkFormat f);
 
 uint32_t GetYUVPlaneCount(VkFormat f);
 uint32_t GetYUVNumRows(VkFormat f, uint32_t height);


### PR DESCRIPTION
## Description

This function is used to determine the image aspects for an image format. This will be used by the per-subresource (aspect, mip level, array layer) image tracking code.

See https://github.com/bjoeris/renderdoc/tree/image-tracking-3 for context.