### PR TITLE
Vulkan: Add ImageLayouts::imageType

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1329,6 +1329,7 @@ struct ImageLayouts
   int layerCount, levelCount, sampleCount;
   VkExtent3D extent;
   VkFormat format;
+  VkImageType imageType;
 };
 
 DECLARE_REFLECTION_STRUCT(ImageLayouts);

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -1463,6 +1463,7 @@ bool WrappedVulkan::Serialise_vkCreateImage(SerialiserType &ser, VkDevice device
       layouts.levelCount = CreateInfo.mipLevels;
       layouts.extent = CreateInfo.extent;
       layouts.format = CreateInfo.format;
+      layouts.imageType = CreateInfo.imageType;
 
       range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
       if(IsDepthOnlyFormat(CreateInfo.format))
@@ -1758,6 +1759,7 @@ VkResult WrappedVulkan::vkCreateImage(VkDevice device, const VkImageCreateInfo *
     layout->sampleCount = (int)pCreateInfo->samples;
     layout->extent = pCreateInfo->extent;
     layout->format = pCreateInfo->format;
+    layout->imageType = pCreateInfo->imageType;
 
     layout->subresourceStates.clear();
 

--- a/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
@@ -448,6 +448,7 @@ bool WrappedVulkan::Serialise_vkCreateSwapchainKHR(SerialiserType &ser, VkDevice
 
       m_ImageLayouts[liveId].extent = iminfo.extent;
       m_ImageLayouts[liveId].format = iminfo.format;
+      m_ImageLayouts[liveId].imageType = iminfo.type;
 
       m_ImageLayouts[liveId].subresourceStates.clear();
       m_ImageLayouts[liveId].subresourceStates.push_back(ImageRegionState(
@@ -584,6 +585,7 @@ void WrappedVulkan::WrapAndProcessCreatedSwapchain(VkDevice device,
         {
           SCOPED_LOCK(m_ImageLayoutsLock);
           m_ImageLayouts[imid].format = pCreateInfo->imageFormat;
+          m_ImageLayouts[imid].imageType = VK_IMAGE_TYPE_2D;
 
           m_ImageLayouts[imid].subresourceStates.clear();
           m_ImageLayouts[imid].subresourceStates.push_back(ImageRegionState(


### PR DESCRIPTION
## Description

The image type is required to correctly handle 3D images accessed through 2D views.

See https://github.com/bjoeris/renderdoc/tree/image-tracking-3 for context.