### PR TITLE
Vulkan: Add ImgRefs to track usage of image subresorces

### DIFF
--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -37,6 +37,7 @@ set(sources
     vk_serialise.cpp
     vk_stringise.cpp
     vk_layer.cpp
+    imgrefs_tests.cpp
     official/vk_layer.h
     official/vk_layer_dispatch_table.h
     official/vk_platform.h

--- a/renderdoc/driver/vulkan/imgrefs_tests.cpp
+++ b/renderdoc/driver/vulkan/imgrefs_tests.cpp
@@ -1,0 +1,214 @@
+/******************************************************************************
+* The MIT License (MIT)
+*
+* Copyright (c) 2019 Baldur Karlsson
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+******************************************************************************/
+
+#include "common/globalconfig.h"
+
+#if ENABLED(ENABLE_UNIT_TESTS)
+
+#include "3rdparty/catch/catch.hpp"
+
+#include "vk_resources.h"
+
+#include <stdint.h>
+#include <vector>
+
+TEST_CASE("Test ImgRefs type", "[imgrefs]")
+{
+  SECTION("unsplit")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 0);
+  };
+  SECTION("split aspect")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(true, false, false);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 1);
+  };
+  SECTION("split levels")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(false, true, false);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 2);
+  };
+  SECTION("split layers")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(false, false, true);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 5);
+  };
+  SECTION("split aspect and levels")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(true, true, false);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 11 + 2);
+  };
+  SECTION("split aspect and layers")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(true, false, true);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 17 + 5);
+  };
+  SECTION("split levels and layers")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(false, true, true);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 2 * 17 + 5);
+  };
+  SECTION("split aspect and levels and layers")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    imgRefs.Split(true, true, true);
+    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 11 * 17 + 2 * 17 + 5);
+  };
+  SECTION("update unsplit")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    ImageRange range;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_Read};
+    CHECK(imgRefs.rangeRefs == expected);
+  };
+  SECTION("update split aspect")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    ImageRange range;
+    range.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_None, eFrameRef_Read};
+    CHECK(imgRefs.rangeRefs == expected);
+  };
+  SECTION("update split levels")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    ImageRange range;
+    range.baseMipLevel = 1;
+    range.levelCount = 3;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_None, eFrameRef_Read, eFrameRef_Read,
+                                          eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+                                          eFrameRef_None, eFrameRef_None, eFrameRef_None,
+                                          eFrameRef_None, eFrameRef_None};
+    CHECK(imgRefs.rangeRefs == expected);
+  };
+  SECTION("update split layers")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    ImageRange range;
+    range.baseArrayLayer = 7;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {
+        eFrameRef_None, eFrameRef_None, eFrameRef_None, eFrameRef_None, eFrameRef_None,
+        eFrameRef_None, eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_Read,
+        eFrameRef_Read, eFrameRef_Read, eFrameRef_Read, eFrameRef_Read, eFrameRef_Read,
+        eFrameRef_Read, eFrameRef_Read};
+    CHECK(imgRefs.rangeRefs == expected);
+  };
+  SECTION("update split aspect then levels")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
+                    17, {100, 100, 1});
+    ImageRange range0;
+    range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    imgRefs.Update(range0, eFrameRef_Read);
+    ImageRange range1;
+    range1.baseMipLevel = 5;
+    range1.levelCount = 2;
+    imgRefs.Update(range1, eFrameRef_PartialWrite);
+    std::vector<FrameRefType> expected = {
+        // VK_IMAGE_ASPECT_DEPTH_BIT
+        eFrameRef_None, eFrameRef_None, eFrameRef_None, eFrameRef_None, eFrameRef_None,
+        eFrameRef_PartialWrite, eFrameRef_PartialWrite, eFrameRef_None, eFrameRef_None,
+        eFrameRef_None, eFrameRef_None,
+        // VK_IMAGE_ASPECT_STENCIL_BIT
+        eFrameRef_Read, eFrameRef_Read, eFrameRef_Read, eFrameRef_Read, eFrameRef_Read,
+        eFrameRef_ReadBeforeWrite, eFrameRef_ReadBeforeWrite, eFrameRef_Read, eFrameRef_Read,
+        eFrameRef_Read, eFrameRef_Read,
+    };
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update split layers then aspects and levels")
+  {
+    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 7, 5,
+                    {100, 100, 1});
+    ImageRange range0;
+    range0.baseArrayLayer = 1;
+    range0.layerCount = 2;
+    imgRefs.Update(range0, eFrameRef_Read);
+    ImageRange range1;
+    range1.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    range1.baseMipLevel = 2;
+    range1.levelCount = 3;
+    imgRefs.Update(range1, eFrameRef_PartialWrite);
+    std::vector<FrameRefType> expected = {
+        // (Depth, level 0)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Depth, level 1)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Depth, level 2)
+        eFrameRef_PartialWrite, eFrameRef_ReadBeforeWrite, eFrameRef_ReadBeforeWrite,
+        eFrameRef_PartialWrite, eFrameRef_PartialWrite,
+        // (Depth, level 3)
+        eFrameRef_PartialWrite, eFrameRef_ReadBeforeWrite, eFrameRef_ReadBeforeWrite,
+        eFrameRef_PartialWrite, eFrameRef_PartialWrite,
+        // (Depth, level 4)
+        eFrameRef_PartialWrite, eFrameRef_ReadBeforeWrite, eFrameRef_ReadBeforeWrite,
+        eFrameRef_PartialWrite, eFrameRef_PartialWrite,
+        // (Depth, level 5)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Depth, level 6)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 0)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 1)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 2)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 3)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 4)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 5)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+        // (Stencil, level 6)
+        eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+
+    };
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+};
+
+#endif    // ENABLED(ENABLE_UNIT_TESTS)

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
@@ -99,6 +99,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="imgrefs_tests.cpp" />
     <ClCompile Include="precompiled.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
@@ -139,6 +139,9 @@
     <ClCompile Include="vk_bindless_feedback.cpp">
       <Filter>Replay</Filter>
     </ClCompile>
+    <ClCompile Include="imgrefs_tests.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vk_replay.h">

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -2919,6 +2919,91 @@ VkImageAspectFlags FormatImageAspects(VkFormat fmt)
     return VK_IMAGE_ASPECT_COLOR_BIT;
 }
 
+int ImgRefs::GetAspectCount() const
+{
+  int aspectCount = 0;
+  for(auto aspectIt = ImageAspectFlagIter::begin(aspectMask);
+      aspectIt != ImageAspectFlagIter::end(); ++aspectIt)
+  {
+    ++aspectCount;
+  }
+  return aspectCount;
+}
+
+int ImgRefs::SubresourceIndex(VkImageAspectFlagBits aspect, int level, int layer) const
+{
+  int aspectIndex = 0;
+  if(areAspectsSplit)
+  {
+    for(auto aspectIt = ImageAspectFlagIter::begin(aspectMask);
+        aspectIt != ImageAspectFlagIter::end(); ++aspectIt)
+    {
+      if(*aspectIt == aspect)
+        break;
+      ++aspectIndex;
+    }
+  }
+  return SubresourceIndex(aspectIndex, level, layer);
+}
+
+int ImgRefs::SubresourceIndex(int aspectIndex, int level, int layer) const
+{
+  if(!areAspectsSplit)
+    aspectIndex = 0;
+  int splitLevelCount = 1;
+  if(areLevelsSplit)
+    splitLevelCount = levelCount;
+  else
+    level = 0;
+  int splitLayerCount = 1;
+  if(areLayersSplit)
+    splitLayerCount = layerCount;
+  else
+    layer = 0;
+  return (aspectIndex * splitLevelCount + level) * splitLayerCount + layer;
+}
+
+void ImgRefs::Split(bool splitAspects, bool splitLevels, bool splitLayers)
+{
+  int newSplitAspectCount = 1;
+  if(splitAspects || areAspectsSplit)
+  {
+    newSplitAspectCount = GetAspectCount();
+  }
+
+  int oldSplitLevelCount = areLevelsSplit ? levelCount : 1;
+  int newSplitLevelCount = splitLevels ? levelCount : oldSplitLevelCount;
+
+  int oldSplitLayerCount = areLayersSplit ? layerCount : 1;
+  int newSplitLayerCount = splitLayers ? layerCount : oldSplitLayerCount;
+
+  int newSize = newSplitAspectCount * newSplitLevelCount * newSplitLayerCount;
+  if(newSize == (int)rangeRefs.size())
+    return;
+  rangeRefs.resize(newSize);
+
+  for(int newAspectIndex = newSplitAspectCount - 1; newAspectIndex >= 0; --newAspectIndex)
+  {
+    int oldAspectIndex = areAspectsSplit ? newAspectIndex : 0;
+    for(int newLevel = newSplitLevelCount - 1; newLevel >= 0; --newLevel)
+    {
+      int oldLevel = areLevelsSplit ? newLevel : 0;
+      for(int newLayer = newSplitLayerCount - 1; newLayer >= 0; --newLayer)
+      {
+        int oldLayer = areLayersSplit ? newLayer : 0;
+        int oldIndex =
+            (oldAspectIndex * oldSplitLevelCount + oldLevel) * oldSplitLayerCount + oldLayer;
+        int newIndex =
+            (newAspectIndex * newSplitLevelCount + newLevel) * newSplitLayerCount + newLayer;
+        rangeRefs[newIndex] = rangeRefs[oldIndex];
+      }
+    }
+  }
+  areAspectsSplit = newSplitAspectCount > 1;
+  areLevelsSplit = newSplitLevelCount > 1;
+  areLayersSplit = newSplitLayerCount > 1;
+}
+
 VkResourceRecord::~VkResourceRecord()
 {
   VkResourceType resType = Resource != NULL ? IdentifyTypeByPtr(Resource) : eResUnknown;


### PR DESCRIPTION
## Description

This adds a new data structure `ImgRefs` to track usage of image subresources (aspect, mip level, array layer). `ImgRefs` initially has a single `FrameRefType` for the entire image, and splits this out into separate `FrameRefType`s for ecah aspect, mip levels and/or array layers as necessary.

This also adds `ImageRange`, which is used as a common structure to specify the portion image which was accessed.