### PR TITLE
Make image info available through `ResourceInfo`

### DIFF
--- a/renderdoc/driver/vulkan/imgrefs_tests.cpp
+++ b/renderdoc/driver/vulkan/imgrefs_tests.cpp
@@ -37,63 +37,63 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
 {
   SECTION("unsplit")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 0);
   };
   SECTION("split aspect")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, false, false);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 1);
   };
   SECTION("split levels")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(false, true, false);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 2);
   };
   SECTION("split layers")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(false, false, true);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 5);
   };
   SECTION("split aspect and levels")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, true, false);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 11 + 2);
   };
   SECTION("split aspect and layers")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, false, true);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 17 + 5);
   };
   SECTION("split levels and layers")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(false, true, true);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 2 * 17 + 5);
   };
   SECTION("split aspect and levels and layers")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, true, true);
     CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 11 * 17 + 2 * 17 + 5);
   };
   SECTION("update unsplit")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     ImageRange range;
     imgRefs.Update(range, eFrameRef_Read);
     std::vector<FrameRefType> expected = {eFrameRef_Read};
@@ -101,8 +101,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split aspect")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     ImageRange range;
     range.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
     imgRefs.Update(range, eFrameRef_Read);
@@ -111,8 +111,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split levels")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     ImageRange range;
     range.baseMipLevel = 1;
     range.levelCount = 3;
@@ -125,8 +125,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split layers")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     ImageRange range;
     range.baseArrayLayer = 7;
     imgRefs.Update(range, eFrameRef_Read);
@@ -139,8 +139,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split aspect then levels")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 11,
-                    17, {100, 100, 1});
+    ImgRefs imgRefs(
+        ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     ImageRange range0;
     range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
     imgRefs.Update(range0, eFrameRef_Read);
@@ -162,8 +162,7 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update split layers then aspects and levels")
   {
-    ImgRefs imgRefs(VK_IMAGE_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 7, 5,
-                    {100, 100, 1});
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_2D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 7, 5, 1));
     ImageRange range0;
     range0.baseArrayLayer = 1;
     range0.layerCount = 2;
@@ -207,6 +206,66 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
         eFrameRef_None, eFrameRef_Read, eFrameRef_Read, eFrameRef_None, eFrameRef_None,
 
     };
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update 3D image default view")
+  {
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_3D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImageRange range;
+    range.layerCount = 1;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_Read};
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update 3D image 3D view")
+  {
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_3D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImageRange range;
+    range.layerCount = 1;
+    range.viewType = VK_IMAGE_VIEW_TYPE_3D;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_Read};
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update 3D image 2D view")
+  {
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_3D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImageRange range;
+    range.layerCount = 1;
+    range.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_Read, eFrameRef_None, eFrameRef_None,
+                                          eFrameRef_None, eFrameRef_None};
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update 3D image 2D array view")
+  {
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_3D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImageRange range;
+    range.baseArrayLayer = 1;
+    range.layerCount = 2;
+    range.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_None, eFrameRef_Read, eFrameRef_Read,
+                                          eFrameRef_None, eFrameRef_None};
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update 3D image 2D array view full")
+  {
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_3D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImageRange range;
+    range.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_Read};
+    CHECK(imgRefs.rangeRefs == expected);
+  }
+  SECTION("update 3D image 3D view full")
+  {
+    ImgRefs imgRefs(ImageInfo(VK_IMAGE_TYPE_3D, VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImageRange range;
+    range.viewType = VK_IMAGE_VIEW_TYPE_3D;
+    imgRefs.Update(range, eFrameRef_Read);
+    std::vector<FrameRefType> expected = {eFrameRef_Read};
     CHECK(imgRefs.rangeRefs == expected);
   }
 };

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -920,7 +920,8 @@ void DescriptorSetBindingElement::AddBindRefs(VkResourceRecord *record, FrameRef
   if(texelBufferView != VK_NULL_HANDLE)
   {
     VkResourceRecord *bufView = GetRecord(texelBufferView);
-    record->AddBindFrameRef(bufView->GetResourceID(), eFrameRef_Read, bufView->resInfo != NULL);
+    record->AddBindFrameRef(bufView->GetResourceID(), eFrameRef_Read,
+                            bufView->resInfo && bufView->resInfo->IsSparse());
     if(bufView->baseResource != ResourceId())
       record->AddBindFrameRef(bufView->baseResource, eFrameRef_Read);
     if(bufView->baseResourceMem != ResourceId())
@@ -941,7 +942,8 @@ void DescriptorSetBindingElement::AddBindRefs(VkResourceRecord *record, FrameRef
   if(bufferInfo.buffer != VK_NULL_HANDLE)
   {
     VkResourceRecord *buf = GetRecord(bufferInfo.buffer);
-    record->AddBindFrameRef(GetResID(bufferInfo.buffer), eFrameRef_Read, buf->resInfo != NULL);
+    record->AddBindFrameRef(GetResID(bufferInfo.buffer), eFrameRef_Read,
+                            buf->resInfo && buf->resInfo->IsSparse());
     if(buf->baseResource != ResourceId())
       record->AddMemFrameRef(buf->baseResource, buf->memOffset, buf->memSize, ref);
   }

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -210,7 +210,7 @@ void VulkanResourceManager::RecordBarriers(std::vector<rdcpair<ResourceId, Image
     if(nummips == VK_REMAINING_MIP_LEVELS)
     {
       if(it != layouts.end())
-        nummips = it->second.levelCount - t.subresourceRange.baseMipLevel;
+        nummips = it->second.imageInfo.levelCount - t.subresourceRange.baseMipLevel;
       else
         nummips = 1;
     }
@@ -218,7 +218,7 @@ void VulkanResourceManager::RecordBarriers(std::vector<rdcpair<ResourceId, Image
     if(numslices == VK_REMAINING_ARRAY_LAYERS)
     {
       if(it != layouts.end())
-        numslices = it->second.layerCount - t.subresourceRange.baseArrayLayer;
+        numslices = it->second.imageInfo.layerCount - t.subresourceRange.baseArrayLayer;
       else
         numslices = 1;
     }
@@ -370,9 +370,10 @@ void VulkanResourceManager::SerialiseImageStates(SerialiserType &ser,
   for(auto it = states.begin(); it != states.end(); ++it)
   {
     ImageLayouts &layouts = it->second;
+    const ImageInfo &imageInfo = layouts.imageInfo;
 
     if(layouts.subresourceStates.size() > 1 &&
-       layouts.subresourceStates.size() == size_t(layouts.layerCount * layouts.levelCount))
+       layouts.subresourceStates.size() == size_t(imageInfo.layerCount * imageInfo.levelCount))
     {
       VkImageLayout layout = layouts.subresourceStates[0].newLayout;
 
@@ -393,8 +394,8 @@ void VulkanResourceManager::SerialiseImageStates(SerialiserType &ser,
                                         layouts.subresourceStates.end());
         layouts.subresourceStates[0].subresourceRange.baseArrayLayer = 0;
         layouts.subresourceStates[0].subresourceRange.baseMipLevel = 0;
-        layouts.subresourceStates[0].subresourceRange.layerCount = layouts.layerCount;
-        layouts.subresourceStates[0].subresourceRange.levelCount = layouts.levelCount;
+        layouts.subresourceStates[0].subresourceRange.layerCount = imageInfo.layerCount;
+        layouts.subresourceStates[0].subresourceRange.levelCount = imageInfo.levelCount;
       }
     }
   }
@@ -538,12 +539,14 @@ void VulkanResourceManager::ApplyBarriers(uint32_t queueFamilyIndex,
     if(t.dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
       stit->second.queueFamilyIndex = queueFamilyIndex;
 
+    const ImageInfo &imageInfo = stit->second.imageInfo;
+
     uint32_t nummips = t.subresourceRange.levelCount;
     uint32_t numslices = t.subresourceRange.layerCount;
     if(nummips == VK_REMAINING_MIP_LEVELS)
-      nummips = layouts[id].levelCount;
+      nummips = imageInfo.levelCount;
     if(numslices == VK_REMAINING_ARRAY_LAYERS)
-      numslices = layouts[id].layerCount;
+      numslices = imageInfo.layerCount;
 
     if(nummips == 0)
       nummips = 1;

--- a/renderdoc/driver/vulkan/vk_rendertexture.cpp
+++ b/renderdoc/driver/vulkan/vk_rendertexture.cpp
@@ -164,6 +164,7 @@ bool VulkanReplay::RenderTextureInternal(TextureDisplay cfg, VkRenderPassBeginIn
   VulkanCreationInfo::Image &iminfo = m_pDriver->m_CreationInfo.m_Image[cfg.resourceId];
   TextureDisplayViews &texviews = m_TexRender.TextureViews[cfg.resourceId];
   VkImage liveIm = m_pDriver->GetResourceManager()->GetCurrentHandle<VkImage>(cfg.resourceId);
+  const ImageInfo &imageInfo = layouts.imageInfo;
 
   CreateTexImageView(liveIm, iminfo, cfg.typeHint, texviews);
 
@@ -189,14 +190,14 @@ bool VulkanReplay::RenderTextureInternal(TextureDisplay cfg, VkRenderPassBeginIn
   int viewIndex = 0;
 
   // if we're displaying the stencil, set up for stencil display
-  if(layouts.format == VK_FORMAT_S8_UINT ||
-     (IsStencilFormat(layouts.format) && !cfg.red && cfg.green))
+  if(imageInfo.format == VK_FORMAT_S8_UINT ||
+     (IsStencilFormat(imageInfo.format) && !cfg.red && cfg.green))
   {
     descSetBinding = 10;
     displayformat |= TEXDISPLAY_UINT_TEX;
 
     // for stencil we use view 1 as long as it's a depth-stencil texture
-    if(IsDepthAndStencilFormat(layouts.format))
+    if(IsDepthAndStencilFormat(imageInfo.format))
       viewIndex = 1;
 
     // rescale the range so that stencil seems to fit to 0-1

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -1788,7 +1788,7 @@ bool VulkanReplay::GetMinMax(ResourceId texid, uint32_t sliceFace, uint32_t mip,
 {
   ImageLayouts &layouts = m_pDriver->m_ImageLayouts[texid];
 
-  if(IsDepthAndStencilFormat(layouts.format))
+  if(IsDepthAndStencilFormat(layouts.imageInfo.format))
   {
     // for depth/stencil we need to run the code twice - once to fetch depth and once to fetch
     // stencil - since we can't process float depth and int stencil at the same time

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -2952,12 +2952,12 @@ int ImgRefs::SubresourceIndex(int aspectIndex, int level, int layer) const
     aspectIndex = 0;
   int splitLevelCount = 1;
   if(areLevelsSplit)
-    splitLevelCount = levelCount;
+    splitLevelCount = imageInfo.levelCount;
   else
     level = 0;
   int splitLayerCount = 1;
   if(areLayersSplit)
-    splitLayerCount = layerCount;
+    splitLayerCount = imageInfo.layerCount;
   else
     layer = 0;
   return (aspectIndex * splitLevelCount + level) * splitLayerCount + layer;
@@ -2971,11 +2971,11 @@ void ImgRefs::Split(bool splitAspects, bool splitLevels, bool splitLayers)
     newSplitAspectCount = GetAspectCount();
   }
 
-  int oldSplitLevelCount = areLevelsSplit ? levelCount : 1;
-  int newSplitLevelCount = splitLevels ? levelCount : oldSplitLevelCount;
+  int oldSplitLevelCount = areLevelsSplit ? imageInfo.levelCount : 1;
+  int newSplitLevelCount = splitLevels ? imageInfo.levelCount : oldSplitLevelCount;
 
-  int oldSplitLayerCount = areLayersSplit ? layerCount : 1;
-  int newSplitLayerCount = splitLayers ? layerCount : oldSplitLayerCount;
+  int oldSplitLayerCount = areLayersSplit ? imageInfo.layerCount : 1;
+  int newSplitLayerCount = splitLayers ? imageInfo.layerCount : oldSplitLayerCount;
 
   int newSize = newSplitAspectCount * newSplitLevelCount * newSplitLayerCount;
   if(newSize == (int)rangeRefs.size())

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3069,7 +3069,7 @@ void VkResourceRecord::MarkBufferFrameReferenced(VkResourceRecord *buf, VkDevice
   {
     size = buf->memSize;
   }
-  if(buf->resInfo)
+  if(buf->resInfo && buf->resInfo->IsSparse())
     cmdInfo->sparse.insert(buf->resInfo);
   if(buf->baseResource != ResourceId())
     MarkMemoryFrameReferenced(buf->baseResource, buf->memOffset + offset, size, refType);
@@ -3179,7 +3179,7 @@ void VkResourceRecord::MarkBufferViewFrameReferenced(VkResourceRecord *bufView, 
   if(bufView->baseResource != ResourceId())
     MarkResourceFrameReferenced(bufView->baseResource, eFrameRef_Read);
 
-  if(bufView->resInfo)
+  if(bufView->resInfo && bufView->resInfo->IsSparse())
     cmdInfo->sparse.insert(bufView->resInfo);
   if(bufView->baseResourceMem != ResourceId())
     MarkMemoryFrameReferenced(bufView->baseResourceMem, bufView->memOffset, bufView->memSize,

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3075,9 +3075,11 @@ void VkResourceRecord::MarkBufferFrameReferenced(VkResourceRecord *buf, VkDevice
     MarkMemoryFrameReferenced(buf->baseResource, buf->memOffset + offset, size, refType);
 }
 
-void VkResourceRecord::MarkBufferImageCopyFrameReferenced(
-    VkResourceRecord *buf, VkResourceRecord *img, const ImageLayouts &layout, uint32_t regionCount,
-    const VkBufferImageCopy *regions, FrameRefType bufRefType, FrameRefType imgRefType)
+void VkResourceRecord::MarkBufferImageCopyFrameReferenced(VkResourceRecord *buf,
+                                                          VkResourceRecord *img, uint32_t regionCount,
+                                                          const VkBufferImageCopy *regions,
+                                                          FrameRefType bufRefType,
+                                                          FrameRefType imgRefType)
 {
   MarkResourceFrameReferenced(img->GetResourceID(), imgRefType);
   MarkResourceFrameReferenced(img->baseResource, imgRefType);
@@ -3088,16 +3090,18 @@ void VkResourceRecord::MarkBufferImageCopyFrameReferenced(
   // mark buffer just as read
   MarkResourceFrameReferenced(buf->GetResourceID(), eFrameRef_Read);
 
+  VkFormat imgFormat = img->resInfo->imageInfo.format;
+
   for(uint32_t ri = 0; ri < regionCount; ri++)
   {
     const VkBufferImageCopy &region = regions[ri];
 
-    VkFormat regionFormat = layout.format;
+    VkFormat regionFormat = imgFormat;
     uint32_t plane = 0;
     switch(region.imageSubresource.aspectMask)
     {
       case VK_IMAGE_ASPECT_STENCIL_BIT: regionFormat = VK_FORMAT_S8_UINT; break;
-      case VK_IMAGE_ASPECT_DEPTH_BIT: regionFormat = GetDepthOnlyFormat(layout.format); break;
+      case VK_IMAGE_ASPECT_DEPTH_BIT: regionFormat = GetDepthOnlyFormat(imgFormat); break;
       case VK_IMAGE_ASPECT_PLANE_1_BIT: plane = 1; break;
       case VK_IMAGE_ASPECT_PLANE_2_BIT: plane = 2; break;
       default: break;

--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -3418,6 +3418,12 @@ void DoSerialise(SerialiserType &ser, ImageLayouts &el)
     SERIALISE_MEMBER(queueFamilyIndex);
   }
   SERIALISE_MEMBER(subresourceStates);
+  SERIALISE_MEMBER(imageInfo);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, ImageInfo &el)
+{
   SERIALISE_MEMBER(layerCount);
   SERIALISE_MEMBER(levelCount);
   SERIALISE_MEMBER(sampleCount);

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1597,7 +1597,7 @@ void WrappedVulkan::vkCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
       record->MarkResourceFrameReferenced(att->baseResource, eFrameRef_ReadBeforeWrite);
       if(att->baseResourceMem != ResourceId())
         record->MarkResourceFrameReferenced(att->baseResourceMem, eFrameRef_Read);
-      if(att->resInfo)
+      if(att->resInfo && att->resInfo->IsSparse())
         record->cmdInfo->sparse.insert(att->resInfo);
       record->cmdInfo->dirtied.insert(att->baseResource);
     }

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -1770,8 +1770,8 @@ void WrappedVulkan::vkCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuff
 
     record->AddChunk(scope.Get());
     record->MarkBufferImageCopyFrameReferenced(GetRecord(srcBuffer), GetRecord(destImage),
-                                               m_ImageLayouts[GetResID(destImage)], regionCount,
-                                               pRegions, eFrameRef_Read, eFrameRef_PartialWrite);
+                                               regionCount, pRegions, eFrameRef_Read,
+                                               eFrameRef_PartialWrite);
   }
 }
 
@@ -1878,8 +1878,8 @@ void WrappedVulkan::vkCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImag
 
     record->AddChunk(scope.Get());
     record->MarkBufferImageCopyFrameReferenced(GetRecord(destBuffer), GetRecord(srcImage),
-                                               m_ImageLayouts[GetResID(srcImage)], regionCount,
-                                               pRegions, eFrameRef_CompleteWrite, eFrameRef_Read);
+                                               regionCount, pRegions, eFrameRef_CompleteWrite,
+                                               eFrameRef_Read);
   }
 }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -2099,8 +2099,9 @@ void WrappedVulkan::vkCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage 
     record->MarkResourceFrameReferenced(GetResID(image), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(image)->baseResource, eFrameRef_Read);
     record->cmdInfo->dirtied.insert(GetResID(image));
-    if(GetRecord(image)->resInfo)
-      record->cmdInfo->sparse.insert(GetRecord(image)->resInfo);
+    VkResourceRecord *imageRecord = GetRecord(image);
+    if(imageRecord->resInfo && imageRecord->resInfo->IsSparse())
+      record->cmdInfo->sparse.insert(imageRecord->resInfo);
   }
 }
 
@@ -2207,8 +2208,9 @@ void WrappedVulkan::vkCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, V
     record->MarkResourceFrameReferenced(GetResID(image), eFrameRef_PartialWrite);
     record->MarkResourceFrameReferenced(GetRecord(image)->baseResource, eFrameRef_Read);
     record->cmdInfo->dirtied.insert(GetResID(image));
-    if(GetRecord(image)->resInfo)
-      record->cmdInfo->sparse.insert(GetRecord(image)->resInfo);
+    VkResourceRecord *imageRecord = GetRecord(image);
+    if(imageRecord->resInfo && imageRecord->resInfo->IsSparse())
+      record->cmdInfo->sparse.insert(imageRecord->resInfo);
   }
 }
 


### PR DESCRIPTION

## Description

The image info (layerCount, levelCount, sampleCount, extent, format, type)  was previously only available through `ImageLayouts`. This info is now also stored in `ResourceInfo`.

Storing this in `ResourceInfo` makes this info easily accessible from `VkResourceRecord`s representing `VkImage`s and `VkImageView`s. This simplifies upcoming changes to the image tracking and avoids the lock protecting the `m_ImageLayouts` map.

To simplify this duplication, a new struct `ImageInfo` is added here to hold the image info in both `ResourceInfo` and `ImageLayouts`.

This PR also updates `ImgRefs` to use the new `ImageInfo` class.