### PR TITLE
Vulkan: Fix `EndFrameCapture` with null `wnd`

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -932,8 +932,6 @@ RDCFile *RenderDoc::CreateRDC(RDCDriver driver, uint32_t frameNum, const FramePi
     EncodePixelsPNG(outRaw, outPng);
   }
 
-  RDCASSERT(outPng.pixels != NULL);
-
   ret->SetData(driver, ToStr(driver).c_str(), OSUtility::GetMachineIdent(), &outPng);
 
   FileIO::CreateParentDirectory(m_CurrentLogFile);

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1580,7 +1580,7 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
   const uint32_t maxSize = 2048;
   RenderDoc::FramePixels fp;
 
-  if(swap != VK_NULL_HANDLE)
+  if(swaprecord != NULL)
   {
     VkDevice device = GetDev();
     VkCommandBuffer cmd = GetNextCmd();


### PR DESCRIPTION
## Description

Previously, when `EndFrameCapture` was called with a null `wnd` argument, `fp` was not initialized, and caused a crash in `CreateRDC`.