### PR TITLE
Set analytics APIs for remote capture file and replay

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -939,6 +939,11 @@ void CaptureContext::LoadCaptureThreaded(const QString &captureFile, const QStri
       bytebuf buf = access->GetSectionContents(idx);
       LoadNotes(QString::fromUtf8((const char *)buf.data(), buf.count()));
     }
+    QString driver = access->DriverName();
+    if(!driver.isEmpty())
+    {
+      ANALYTIC_ADDUNIQ(APIs, driver);
+    }
   }
 
   m_LoadInProgress = false;

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -663,7 +663,7 @@ void MainWindow::LoadCapture(const QString &filename, bool temporary, bool local
         return;
       }
 
-      driver = QString::fromUtf8(file->DriverName());
+      driver = file->DriverName();
       machineIdent = QString::fromUtf8(file->RecordedMachineIdent());
       support = file->LocalReplaySupport();
 
@@ -795,10 +795,6 @@ void MainWindow::LoadCapture(const QString &filename, bool temporary, bool local
       if(driver == lit("Image"))
       {
         ANALYTIC_SET(UIFeatures.ImageViewer, true);
-      }
-      else if(!driver.isEmpty())
-      {
-        ANALYTIC_ADDUNIQ(APIs, driver);
       }
 
       m_Ctx.LoadCapture(fileToLoad, origFilename, temporary, local);

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -1532,6 +1532,13 @@ Must only be called after :meth:`InitResolver` has returned ``True``.
 )");
   virtual rdcarray<rdcstr> GetResolve(const rdcarray<uint64_t> &callstack) = 0;
 
+  DOCUMENT(R"(Retrieves the name of the driver that was used to create this capture.
+
+:return: A simple string identifying the driver used to make the capture.
+:rtype: ``str``
+)");
+  virtual rdcstr DriverName() = 0;
+
 protected:
   ICaptureAccess() = default;
   ~ICaptureAccess() = default;
@@ -1796,13 +1803,6 @@ replay support.
 :rtype: ReplaySupport
 )");
   virtual ReplaySupport LocalReplaySupport() = 0;
-
-  DOCUMENT(R"(Retrieves the name of the driver that was used to create this capture.
-
-:return: A simple string identifying the driver used to make the capture.
-:rtype: ``str``
-)");
-  virtual const char *DriverName() = 0;
 
   DOCUMENT(R"(Retrieves the identifying string describing what type of machine created this capture.
 

--- a/renderdoc/replay/capture_file.cpp
+++ b/renderdoc/replay/capture_file.cpp
@@ -120,7 +120,7 @@ public:
   rdcstr ErrorString() { return m_ErrorString; }
   void Shutdown() { delete this; }
   ReplaySupport LocalReplaySupport() { return m_Support; }
-  const char *DriverName() { return m_DriverName.c_str(); }
+  rdcstr DriverName() { return m_DriverName; }
   const char *RecordedMachineIdent() { return m_Ident.c_str(); }
   rdcpair<ReplayStatus, IReplayController *> OpenCapture(RENDERDOC_ProgressCallback progress);
 


### PR DESCRIPTION
The API used was not populated for the case of remote
capture and replay.