### PR TITLE
Optimize Apply_InitialState using new image tracking

### DIFF
--- a/renderdoc/driver/vulkan/imgrefs_tests.cpp
+++ b/renderdoc/driver/vulkan/imgrefs_tests.cpp
@@ -38,49 +38,51 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   SECTION("unsplit")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 0);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 0);
   };
   SECTION("split aspect")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, false, false);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 1);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 1);
   };
   SECTION("split levels")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(false, true, false);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 2);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 2);
   };
   SECTION("split layers")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(false, false, true);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 5);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 5);
   };
   SECTION("split aspect and levels")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, true, false);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 11 + 2);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 11 + 2);
   };
   SECTION("split aspect and layers")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, false, true);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 17 + 5);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 17 + 5);
   };
   SECTION("split levels and layers")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(false, true, true);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 2 * 17 + 5);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) ==
+          2 * 17 + 5);
   };
   SECTION("split aspect and levels and layers")
   {
     ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
     imgRefs.Split(true, true, true);
-    CHECK(imgRefs.SubresourceIndex(VK_IMAGE_ASPECT_STENCIL_BIT, 2, 5) == 11 * 17 + 2 * 17 + 5);
+    CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) ==
+          11 * 17 + 2 * 17 + 5);
   };
   SECTION("update unsplit")
   {

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -407,7 +407,7 @@ int StageIndex(VkShaderStageFlagBits stageFlag)
   return 0;
 }
 
-void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkImageMemoryBarrier *barriers)
+void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, const VkImageMemoryBarrier *barriers)
 {
   RDCASSERT(cmd != VK_NULL_HANDLE);
   ObjDisp(cmd)->CmdPipelineBarrier(Unwrap(cmd), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
@@ -417,7 +417,7 @@ void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkImageMemoryBarrier
                                    count, barriers);    // image memory barriers
 }
 
-void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkBufferMemoryBarrier *barriers)
+void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, const VkBufferMemoryBarrier *barriers)
 {
   RDCASSERT(cmd != VK_NULL_HANDLE);
   ObjDisp(cmd)->CmdPipelineBarrier(Unwrap(cmd), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
@@ -427,7 +427,7 @@ void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkBufferMemoryBarrie
                                    0, NULL);           // image memory barriers
 }
 
-void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkMemoryBarrier *barriers)
+void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, const VkMemoryBarrier *barriers)
 {
   RDCASSERT(cmd != VK_NULL_HANDLE);
   ObjDisp(cmd)->CmdPipelineBarrier(Unwrap(cmd), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -105,9 +105,9 @@ VkAccessFlags MakeAccessMask(VkImageLayout layout);
 void SanitiseOldImageLayout(VkImageLayout &layout);
 void SanitiseNewImageLayout(VkImageLayout &layout);
 
-void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkImageMemoryBarrier *barriers);
-void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkBufferMemoryBarrier *barriers);
-void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, VkMemoryBarrier *barriers);
+void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, const VkImageMemoryBarrier *barriers);
+void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, const VkBufferMemoryBarrier *barriers);
+void DoPipelineBarrier(VkCommandBuffer cmd, uint32_t count, const VkMemoryBarrier *barriers);
 
 int SampleCount(VkSampleCountFlagBits countFlag);
 int SampleIndex(VkSampleCountFlagBits countFlag);

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -899,6 +899,10 @@ private:
                                                       int32_t messageCode, const char *pLayerPrefix,
                                                       const char *pMessage, void *pUserData);
   void AddFrameTerminator(uint64_t queueMarkerTag);
+  std::vector<VkImageMemoryBarrier> ImageInitializationBarriers(ResourceId id, WrappedVkRes *live,
+                                                                bool initialized,
+                                                                const ImgRefs *imgRefs) const;
+  void SubmitExtQBarriers(const std::map<uint32_t, std::vector<VkImageMemoryBarrier>> &extQBarriers);
 
 public:
   WrappedVulkan();

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -2930,7 +2930,7 @@ int ImgRefs::GetAspectCount() const
   return aspectCount;
 }
 
-int ImgRefs::SubresourceIndex(VkImageAspectFlagBits aspect, int level, int layer) const
+int ImgRefs::AspectIndex(VkImageAspectFlagBits aspect) const
 {
   int aspectIndex = 0;
   if(areAspectsSplit)
@@ -2943,7 +2943,7 @@ int ImgRefs::SubresourceIndex(VkImageAspectFlagBits aspect, int level, int layer
       ++aspectIndex;
     }
   }
-  return SubresourceIndex(aspectIndex, level, layer);
+  return aspectIndex;
 }
 
 int ImgRefs::SubresourceIndex(int aspectIndex, int level, int layer) const

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1143,6 +1143,8 @@ struct ImgRefs
   {
     return InitReq(SubresourceRef(aspectIndex, level, layer));
   }
+  std::vector<rdcpair<VkImageSubresourceRange, InitReqType> > SubresourceRangeInitReqs(
+      VkImageSubresourceRange range) const;
   void Split(bool splitAspects, bool splitLevels, bool splitLayers);
   template <typename Compose>
   FrameRefType Update(ImageRange range, FrameRefType refType, Compose comp);

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1078,6 +1078,20 @@ struct ImageRange
         layerCount(range.layerCount)
   {
   }
+  ImageRange(const VkBufferImageCopy &range)
+      : aspectMask(range.imageSubresource.aspectMask),
+        baseMipLevel(range.imageSubresource.mipLevel),
+        levelCount(1),
+        baseArrayLayer(range.imageSubresource.baseArrayLayer),
+        layerCount(range.imageSubresource.layerCount),
+        offset(range.imageOffset),
+        extent(range.imageExtent)
+  {
+  }
+  inline operator VkImageSubresourceRange() const
+  {
+    return {aspectMask, baseMipLevel, levelCount, baseArrayLayer, layerCount};
+  }
   VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM;
   uint32_t baseMipLevel = 0;
   uint32_t levelCount = VK_REMAINING_MIP_LEVELS;
@@ -1115,15 +1129,19 @@ struct ImgRefs
       // Depth slices of 3D views are treated as array layers
       this->imageInfo.layerCount = imageInfo.extent.depth;
   }
-  int SubresourceIndex(VkImageAspectFlagBits aspect, int level, int layer) const;
+  int AspectIndex(VkImageAspectFlagBits aspect) const;
   int SubresourceIndex(int aspectIndex, int level, int layer) const;
-  inline FrameRefType SubresourceRef(VkImageAspectFlagBits aspect, int level, int layer) const
-  {
-    return rangeRefs[SubresourceIndex(aspect, level, layer)];
-  }
   inline FrameRefType SubresourceRef(int aspectIndex, int level, int layer) const
   {
     return rangeRefs[SubresourceIndex(aspectIndex, level, layer)];
+  }
+  inline InitReqType SubresourceInitReq(int aspectIndex, int level, int layer) const
+  {
+    return InitReq(SubresourceRef(aspectIndex, level, layer));
+  }
+  inline InitReqType SubresourceInitReq(int aspectIndex, int level, int layer, bool initialized) const
+  {
+    return InitReq(SubresourceRef(aspectIndex, level, layer));
   }
   void Split(bool splitAspects, bool splitLevels, bool splitLayers);
   template <typename Compose>


### PR DESCRIPTION
## Description

This uses the new image tracking to avoid unnecessary image copies and barriers when applying the initial state.

This change only affects images when all of the following apply:
  - The image initial contents tag is `BufferCopy` (not `ClearColorImage` or `ClearDepthStencilImage`),
  - The image is single sample,
  - The image is non-sparse,
  - The image has `ImgRefs` data,
  - The image has been completely initialized at least once, and
  - VulkanResourceManager::OptimizeInitialState() is true (currently disabled by default).

When all of these conditions are met, data will only be copied for those image subresources which require reset according to the ImgRefs data.