### PR TITLE
Add support for WKPDID_D3DDebugObjectNameW

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_resources.h
+++ b/renderdoc/driver/d3d11/d3d11_resources.h
@@ -302,6 +302,13 @@ public:
         m_pDevice->SetResourceName(this, pStrData);
       }
     }
+    else if(guid == WKPDID_D3DDebugObjectNameW)
+    {
+      const wchar_t *pStrData = (const wchar_t *)pData;
+      std::wstring wName(pStrData, DataSize / 2);
+      std::string sName = StringFormat::Wide2UTF8(wName);
+      m_pDevice->SetResourceName(this, sName.c_str());
+    }
 
     return m_pReal->SetPrivateData(guid, DataSize, pData);
   }

--- a/renderdoc/driver/d3d12/d3d12_command_list.h
+++ b/renderdoc/driver/d3d12/d3d12_command_list.h
@@ -209,7 +209,15 @@ public:
   HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID guid, UINT DataSize, const void *pData)
   {
     if(guid == WKPDID_D3DDebugObjectName)
+    {
       m_pDevice->SetName(this, (const char *)pData);
+    }
+    else if(guid == WKPDID_D3DDebugObjectNameW)
+    {
+      std::wstring wName((const wchar_t *)pData, DataSize / 2);
+      std::string sName = StringFormat::Wide2UTF8(wName);
+      m_pDevice->SetName(this, sName.c_str());
+    }
 
     return m_pList->SetPrivateData(guid, DataSize, pData);
   }

--- a/renderdoc/driver/d3d12/d3d12_command_queue.h
+++ b/renderdoc/driver/d3d12/d3d12_command_queue.h
@@ -194,7 +194,15 @@ public:
   HRESULT STDMETHODCALLTYPE SetPrivateData(REFGUID guid, UINT DataSize, const void *pData)
   {
     if(guid == WKPDID_D3DDebugObjectName)
+    {
       m_pDevice->SetName(this, (const char *)pData);
+    }
+    else if(guid == WKPDID_D3DDebugObjectNameW)
+    {
+      std::wstring wName((const wchar_t *)pData, DataSize / 2);
+      std::string sName = StringFormat::Wide2UTF8(wName);
+      m_pDevice->SetName(this, sName.c_str());
+    }
 
     return m_pReal->SetPrivateData(guid, DataSize, pData);
   }

--- a/renderdoc/driver/d3d12/d3d12_resources.h
+++ b/renderdoc/driver/d3d12/d3d12_resources.h
@@ -295,7 +295,15 @@ public:
       return m_pDevice->SetShaderDebugPath(this, (const char *)pData);
 
     if(guid == WKPDID_D3DDebugObjectName)
+    {
       m_pDevice->SetName(this, (const char *)pData);
+    }
+    else if(guid == WKPDID_D3DDebugObjectNameW)
+    {
+      std::wstring wName((const wchar_t *)pData, DataSize / 2);
+      std::string sName = StringFormat::Wide2UTF8(wName);
+      m_pDevice->SetName(this, sName.c_str());
+    }
 
     if(!m_pReal)
       return S_OK;


### PR DESCRIPTION
## Description
This change allows D3D11/D3D12 object debug names set via SetPrivateData with WKPDID_D3DDebugObjectNameW to show up in RenderDoc.