### PR TITLE
Introduce Low-Memory mode

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -127,7 +127,7 @@ WrappedID3D11Device::WrappedID3D11Device(ID3D11Device *realDevice, D3D11InitPara
     m_State = CaptureState::BackgroundCapturing;
   }
 
-  m_ResourceManager = new D3D11ResourceManager(this);
+  m_ResourceManager = new D3D11ResourceManager(m_State, this);
 
   m_ShaderCache = new D3D11ShaderCache(this);
 

--- a/renderdoc/driver/d3d11/d3d11_manager.h
+++ b/renderdoc/driver/d3d11/d3d11_manager.h
@@ -289,7 +289,10 @@ struct D3D11ResourceManagerConfiguration
 class D3D11ResourceManager : public ResourceManager<D3D11ResourceManagerConfiguration>
 {
 public:
-  D3D11ResourceManager(WrappedID3D11Device *dev) : m_Device(dev) {}
+  D3D11ResourceManager(CaptureState &state, WrappedID3D11Device *dev)
+      : ResourceManager(state), m_Device(dev)
+  {
+  }
   ID3D11DeviceChild *UnwrapResource(ID3D11DeviceChild *res);
   ID3D11Resource *UnwrapResource(ID3D11Resource *res)
   {

--- a/renderdoc/driver/d3d12/d3d12_manager.h
+++ b/renderdoc/driver/d3d12/d3d12_manager.h
@@ -679,8 +679,8 @@ struct D3D12ResourceManagerConfiguration
 class D3D12ResourceManager : public ResourceManager<D3D12ResourceManagerConfiguration>
 {
 public:
-  D3D12ResourceManager(CaptureState state, WrappedID3D12Device *dev)
-      : ResourceManager(), m_State(state), m_Device(dev)
+  D3D12ResourceManager(CaptureState &state, WrappedID3D12Device *dev)
+      : ResourceManager(state), m_Device(dev)
   {
   }
   template <class T>
@@ -723,6 +723,5 @@ private:
   void Create_InitialState(ResourceId id, ID3D12DeviceChild *live, bool hasData);
   void Apply_InitialState(ID3D12DeviceChild *live, const D3D12InitialContents &data);
 
-  CaptureState m_State;
   WrappedID3D12Device *m_Device;
 };

--- a/renderdoc/driver/d3d8/d3d8_device.cpp
+++ b/renderdoc/driver/d3d8/d3d8_device.cpp
@@ -69,7 +69,7 @@ WrappedD3DDevice8::WrappedD3DDevice8(IDirect3DDevice8 *device, HWND wnd,
     m_Wnd = NULL;
   }
 
-  m_ResourceManager = new D3D8ResourceManager(this);
+  m_ResourceManager = new D3D8ResourceManager(m_State, this);
 }
 
 void WrappedD3DDevice8::CheckForDeath()

--- a/renderdoc/driver/d3d8/d3d8_manager.h
+++ b/renderdoc/driver/d3d8/d3d8_manager.h
@@ -67,7 +67,11 @@ struct D3D8ResourceManagerConfiguration
 class D3D8ResourceManager : public ResourceManager<D3D8ResourceManagerConfiguration>
 {
 public:
-  D3D8ResourceManager(WrappedD3DDevice8 *dev) : m_Device(dev) {}
+  D3D8ResourceManager(CaptureState &state, WrappedD3DDevice8 *dev)
+      : ResourceManager(state), m_Device(dev)
+  {
+  }
+
 private:
   bool AutoReferenceResource(ResourceId id, D3D8ResourceRecord *record);
   ResourceId GetID(IUnknown *res);

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -1907,6 +1907,8 @@ public:
   void Common_glNamedBufferStorageEXT(ResourceId id, GLsizeiptr size, const void *data,
                                       GLbitfield flags);
 
+  void MarkReferencedWhileCapturing(GLResourceRecord *record, FrameRefType refType);
+
   IMPLEMENT_FUNCTION_SERIALISED(GLenum, glCheckNamedFramebufferStatusEXT, GLuint framebuffer,
                                 GLenum target);
   IMPLEMENT_FUNCTION_SERIALISED(void, glCompressedTextureImage1DEXT, GLuint texture, GLenum target,

--- a/renderdoc/driver/gl/gl_manager.cpp
+++ b/renderdoc/driver/gl/gl_manager.cpp
@@ -27,10 +27,14 @@
 #include <algorithm>
 #include "driver/gl/gl_driver.h"
 
-GLResourceManager::GLResourceManager(WrappedOpenGL *driver)
-    : ResourceManager(), m_Driver(driver), m_SyncName(1)
+GLResourceManager::GLResourceManager(CaptureState &state, WrappedOpenGL *driver)
+    : ResourceManager(state), m_Driver(driver), m_SyncName(1)
 {
-  m_State = m_Driver->GetState();
+}
+
+bool GLResourceManager::IsResourceTrackedForPersistency(const GLResource &res)
+{
+  return res.Namespace == eResTexture || res.Namespace == eResBuffer;
 }
 
 void GLResourceManager::MarkVAOReferenced(GLResource res, FrameRefType ref, bool allowFake0)

--- a/renderdoc/driver/gl/gl_renderstate.cpp
+++ b/renderdoc/driver/gl/gl_renderstate.cpp
@@ -539,7 +539,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       GL.glGetIntegeri_v(eGL_TRANSFORM_FEEDBACK_BUFFER_BINDING, i, (GLint *)&name);
 
       if(name)
-        manager->MarkDirtyResource(BufferRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(BufferRes(ctx, name));
     }
   }
 
@@ -553,7 +553,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       GL.glGetIntegeri_v(eGL_IMAGE_BINDING_NAME, i, (GLint *)&name);
 
       if(name)
-        manager->MarkDirtyResource(TextureRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
     }
   }
 
@@ -567,7 +567,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       GL.glGetIntegeri_v(eGL_ATOMIC_COUNTER_BUFFER_BINDING, i, (GLint *)&name);
 
       if(name)
-        manager->MarkDirtyResource(BufferRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(BufferRes(ctx, name));
     }
   }
 
@@ -581,7 +581,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       GL.glGetIntegeri_v(eGL_SHADER_STORAGE_BUFFER_BINDING, i, (GLint *)&name);
 
       if(name)
-        manager->MarkDirtyResource(BufferRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(BufferRes(ctx, name));
     }
   }
 
@@ -606,7 +606,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
         if(type == eGL_RENDERBUFFER)
           manager->MarkDirtyResource(RenderbufferRes(ctx, name));
         else
-          manager->MarkDirtyResource(TextureRes(ctx, name));
+          manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
       }
     }
 
@@ -620,7 +620,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       if(type == eGL_RENDERBUFFER)
         manager->MarkDirtyResource(RenderbufferRes(ctx, name));
       else
-        manager->MarkDirtyResource(TextureRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
     }
 
     GL.glGetFramebufferAttachmentParameteriv(eGL_DRAW_FRAMEBUFFER, eGL_STENCIL_ATTACHMENT,
@@ -633,7 +633,7 @@ void GLRenderState::MarkDirty(WrappedOpenGL *driver) const
       if(type == eGL_RENDERBUFFER)
         manager->MarkDirtyResource(RenderbufferRes(ctx, name));
       else
-        manager->MarkDirtyResource(TextureRes(ctx, name));
+        manager->MarkDirtyWithWriteReference(TextureRes(ctx, name));
     }
   }
 }

--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -311,6 +311,18 @@ void WrappedOpenGL::glDispatchCompute(GLuint num_groups_x, GLuint num_groups_y, 
 {
   CoherentMapImplicitBarrier();
 
+  if(IsCaptureMode(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDispatchCompute(num_groups_x, num_groups_y, num_groups_z));
 
   if(IsActiveCapturing(m_State))
@@ -321,15 +333,6 @@ void WrappedOpenGL::glDispatchCompute(GLuint num_groups_x, GLuint num_groups_y, 
     Serialise_glDispatchCompute(ser, num_groups_x, num_groups_y, num_groups_z);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -419,6 +422,18 @@ void WrappedOpenGL::glDispatchComputeGroupSizeARB(GLuint num_groups_x, GLuint nu
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDispatchComputeGroupSizeARB(num_groups_x, num_groups_y, num_groups_z,
                                                        group_size_x, group_size_y, group_size_z));
 
@@ -431,15 +446,6 @@ void WrappedOpenGL::glDispatchComputeGroupSizeARB(GLuint num_groups_x, GLuint nu
                                             group_size_x, group_size_y, group_size_z);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -492,6 +498,18 @@ void WrappedOpenGL::glDispatchComputeIndirect(GLintptr indirect)
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDispatchComputeIndirect(indirect));
 
   if(IsActiveCapturing(m_State))
@@ -502,15 +520,6 @@ void WrappedOpenGL::glDispatchComputeIndirect(GLintptr indirect)
     Serialise_glDispatchComputeIndirect(ser, indirect);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -658,6 +667,18 @@ void WrappedOpenGL::glDrawTransformFeedback(GLenum mode, GLuint id)
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawTransformFeedback(mode, id));
 
   if(IsActiveCapturing(m_State))
@@ -669,15 +690,6 @@ void WrappedOpenGL::glDrawTransformFeedback(GLenum mode, GLuint id)
     Serialise_glDrawTransformFeedback(ser, mode, id);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -728,6 +740,18 @@ void WrappedOpenGL::glDrawTransformFeedbackInstanced(GLenum mode, GLuint id, GLs
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawTransformFeedbackInstanced(mode, id, instancecount));
 
   if(IsActiveCapturing(m_State))
@@ -739,15 +763,6 @@ void WrappedOpenGL::glDrawTransformFeedbackInstanced(GLenum mode, GLuint id, GLs
     Serialise_glDrawTransformFeedbackInstanced(ser, mode, id, instancecount);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -797,6 +812,18 @@ void WrappedOpenGL::glDrawTransformFeedbackStream(GLenum mode, GLuint id, GLuint
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawTransformFeedbackStream(mode, id, stream));
 
   if(IsActiveCapturing(m_State))
@@ -808,15 +835,6 @@ void WrappedOpenGL::glDrawTransformFeedbackStream(GLenum mode, GLuint id, GLuint
     Serialise_glDrawTransformFeedbackStream(ser, mode, id, stream);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -871,6 +889,18 @@ void WrappedOpenGL::glDrawTransformFeedbackStreamInstanced(GLenum mode, GLuint i
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawTransformFeedbackStreamInstanced(mode, id, stream, instancecount));
 
   if(IsActiveCapturing(m_State))
@@ -882,15 +912,6 @@ void WrappedOpenGL::glDrawTransformFeedbackStreamInstanced(GLenum mode, GLuint i
     Serialise_glDrawTransformFeedbackStreamInstanced(ser, mode, id, stream, instancecount);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1101,6 +1122,18 @@ void WrappedOpenGL::glDrawArrays(GLenum mode, GLint first, GLsizei count)
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawArrays(mode, first, count));
 
   if(IsActiveCapturing(m_State))
@@ -1116,16 +1149,7 @@ void WrappedOpenGL::glDrawArrays(GLenum mode, GLint first, GLsizei count)
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, eGL_NONE);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1183,6 +1207,18 @@ void WrappedOpenGL::glDrawArraysIndirect(GLenum mode, const void *indirect)
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawArraysIndirect(mode, indirect));
 
   if(IsActiveCapturing(m_State))
@@ -1194,15 +1230,6 @@ void WrappedOpenGL::glDrawArraysIndirect(GLenum mode, const void *indirect)
     Serialise_glDrawArraysIndirect(ser, mode, indirect);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1252,6 +1279,18 @@ void WrappedOpenGL::glDrawArraysInstanced(GLenum mode, GLint first, GLsizei coun
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawArraysInstanced(mode, first, count, instancecount));
 
   if(IsActiveCapturing(m_State))
@@ -1267,16 +1306,7 @@ void WrappedOpenGL::glDrawArraysInstanced(GLenum mode, GLint first, GLsizei coun
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, eGL_NONE);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1329,6 +1359,18 @@ void WrappedOpenGL::glDrawArraysInstancedBaseInstance(GLenum mode, GLint first, 
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(
       GL.glDrawArraysInstancedBaseInstance(mode, first, count, instancecount, baseinstance));
 
@@ -1345,16 +1387,7 @@ void WrappedOpenGL::glDrawArraysInstancedBaseInstance(GLenum mode, GLint first, 
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, eGL_NONE);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1406,6 +1439,18 @@ void WrappedOpenGL::glDrawElements(GLenum mode, GLsizei count, GLenum type, cons
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawElements(mode, count, type, indices));
 
   if(IsActiveCapturing(m_State))
@@ -1420,16 +1465,7 @@ void WrappedOpenGL::glDrawElements(GLenum mode, GLsizei count, GLenum type, cons
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1493,6 +1529,18 @@ void WrappedOpenGL::glDrawElementsIndirect(GLenum mode, GLenum type, const void 
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawElementsIndirect(mode, type, indirect));
 
   if(IsActiveCapturing(m_State))
@@ -1504,15 +1552,6 @@ void WrappedOpenGL::glDrawElementsIndirect(GLenum mode, GLenum type, const void 
     Serialise_glDrawElementsIndirect(ser, mode, type, indirect);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1568,6 +1607,18 @@ void WrappedOpenGL::glDrawRangeElements(GLenum mode, GLuint start, GLuint end, G
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawRangeElements(mode, start, end, count, type, indices));
 
   if(IsActiveCapturing(m_State))
@@ -1582,16 +1633,7 @@ void WrappedOpenGL::glDrawRangeElements(GLenum mode, GLuint start, GLuint end, G
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1651,6 +1693,18 @@ void WrappedOpenGL::glDrawRangeElementsBaseVertex(GLenum mode, GLuint start, GLu
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(
       GL.glDrawRangeElementsBaseVertex(mode, start, end, count, type, indices, basevertex));
 
@@ -1666,16 +1720,7 @@ void WrappedOpenGL::glDrawRangeElementsBaseVertex(GLenum mode, GLuint start, GLu
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1730,6 +1775,18 @@ void WrappedOpenGL::glDrawElementsBaseVertex(GLenum mode, GLsizei count, GLenum 
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawElementsBaseVertex(mode, count, type, indices, basevertex));
 
   if(IsActiveCapturing(m_State))
@@ -1744,16 +1801,7 @@ void WrappedOpenGL::glDrawElementsBaseVertex(GLenum mode, GLsizei count, GLenum 
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1808,6 +1856,18 @@ void WrappedOpenGL::glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum t
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawElementsInstanced(mode, count, type, indices, instancecount));
 
   if(IsActiveCapturing(m_State))
@@ -1822,16 +1882,7 @@ void WrappedOpenGL::glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum t
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1891,6 +1942,18 @@ void WrappedOpenGL::glDrawElementsInstancedBaseInstance(GLenum mode, GLsizei cou
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawElementsInstancedBaseInstance(mode, count, type, indices,
                                                              instancecount, baseinstance));
 
@@ -1907,16 +1970,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseInstance(GLenum mode, GLsizei cou
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -1976,6 +2030,18 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertex(GLenum mode, GLsizei count
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(
       GL.glDrawElementsInstancedBaseVertex(mode, count, type, indices, instancecount, basevertex));
 
@@ -1992,16 +2058,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertex(GLenum mode, GLsizei count
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -2062,6 +2119,18 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertexBaseInstance(GLenum mode, G
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glDrawElementsInstancedBaseVertexBaseInstance(
       mode, count, type, indices, instancecount, basevertex, baseinstance));
 
@@ -2078,16 +2147,7 @@ void WrappedOpenGL::glDrawElementsInstancedBaseVertexBaseInstance(GLenum mode, G
 
     GetContextRecord()->AddChunk(scope.Get());
 
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-
     RestoreClientMemoryArrays(clientMemory, type);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -2206,6 +2266,18 @@ void WrappedOpenGL::glMultiDrawArrays(GLenum mode, const GLint *first, const GLs
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glMultiDrawArrays(mode, first, count, drawcount));
 
   if(IsActiveCapturing(m_State))
@@ -2217,15 +2289,6 @@ void WrappedOpenGL::glMultiDrawArrays(GLenum mode, const GLint *first, const GLs
     Serialise_glMultiDrawArrays(ser, mode, first, count, drawcount);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -2370,6 +2433,18 @@ void WrappedOpenGL::glMultiDrawElements(GLenum mode, const GLsizei *count, GLenu
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glMultiDrawElements(mode, count, type, indices, drawcount));
 
   if(IsActiveCapturing(m_State))
@@ -2381,15 +2456,6 @@ void WrappedOpenGL::glMultiDrawElements(GLenum mode, const GLsizei *count, GLenu
     Serialise_glMultiDrawElements(ser, mode, count, type, indices, drawcount);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -2539,6 +2605,18 @@ void WrappedOpenGL::glMultiDrawElementsBaseVertex(GLenum mode, const GLsizei *co
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(
       GL.glMultiDrawElementsBaseVertex(mode, count, type, indices, drawcount, basevertex));
 
@@ -2551,15 +2629,6 @@ void WrappedOpenGL::glMultiDrawElementsBaseVertex(GLenum mode, const GLsizei *co
     Serialise_glMultiDrawElementsBaseVertex(ser, mode, count, type, indices, drawcount, basevertex);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -2753,6 +2822,18 @@ void WrappedOpenGL::glMultiDrawArraysIndirect(GLenum mode, const void *indirect,
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glMultiDrawArraysIndirect(mode, indirect, drawcount, stride));
 
   if(IsActiveCapturing(m_State))
@@ -2764,15 +2845,6 @@ void WrappedOpenGL::glMultiDrawArraysIndirect(GLenum mode, const void *indirect,
     Serialise_glMultiDrawArraysIndirect(ser, mode, indirect, drawcount, stride);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -2976,6 +3048,18 @@ void WrappedOpenGL::glMultiDrawElementsIndirect(GLenum mode, GLenum type, const 
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glMultiDrawElementsIndirect(mode, type, indirect, drawcount, stride));
 
   if(IsActiveCapturing(m_State))
@@ -2987,15 +3071,6 @@ void WrappedOpenGL::glMultiDrawElementsIndirect(GLenum mode, GLenum type, const 
     Serialise_glMultiDrawElementsIndirect(ser, mode, type, indirect, drawcount, stride);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -3200,6 +3275,18 @@ void WrappedOpenGL::glMultiDrawArraysIndirectCount(GLenum mode, const void *indi
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(
       GL.glMultiDrawArraysIndirectCount(mode, indirect, drawcount, maxdrawcount, stride));
 
@@ -3212,15 +3299,6 @@ void WrappedOpenGL::glMultiDrawArraysIndirectCount(GLenum mode, const void *indi
     Serialise_glMultiDrawArraysIndirectCount(ser, mode, indirect, drawcount, maxdrawcount, stride);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -3432,6 +3510,18 @@ void WrappedOpenGL::glMultiDrawElementsIndirectCount(GLenum mode, GLenum type, c
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(
       GL.glMultiDrawElementsIndirectCount(mode, type, indirect, drawcount, maxdrawcount, stride));
 
@@ -3445,15 +3535,6 @@ void WrappedOpenGL::glMultiDrawElementsIndirectCount(GLenum mode, GLenum type, c
                                                stride);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
@@ -3538,6 +3619,22 @@ void WrappedOpenGL::glClearNamedFramebufferfv(GLuint framebuffer, GLenum buffer,
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
+  }
+
   SERIALISE_TIME_CALL(GL.glClearNamedFramebufferfv(framebuffer, buffer, drawbuffer, value));
 
   if(IsActiveCapturing(m_State))
@@ -3549,21 +3646,24 @@ void WrappedOpenGL::glClearNamedFramebufferfv(GLuint framebuffer, GLenum buffer,
     Serialise_glClearNamedFramebufferfv(ser, framebuffer, buffer, drawbuffer, value);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    GLRenderState state;
-    state.FetchState(this);
-    state.MarkReferenced(this, false);
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GLRenderState state;
-    state.MarkDirty(this);
   }
 }
 
 void WrappedOpenGL::glClearBufferfv(GLenum buffer, GLint drawbuffer, const GLfloat *value)
 {
   CoherentMapImplicitBarrier();
+
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
 
   SERIALISE_TIME_CALL(GL.glClearBufferfv(buffer, drawbuffer, value));
 
@@ -3682,6 +3782,18 @@ void WrappedOpenGL::glClearBufferiv(GLenum buffer, GLint drawbuffer, const GLint
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glClearBufferiv(buffer, drawbuffer, value));
 
   if(IsActiveCapturing(m_State))
@@ -3786,6 +3898,18 @@ void WrappedOpenGL::glClearNamedFramebufferuiv(GLuint framebuffer, GLenum buffer
 void WrappedOpenGL::glClearBufferuiv(GLenum buffer, GLint drawbuffer, const GLuint *value)
 {
   CoherentMapImplicitBarrier();
+
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
 
   SERIALISE_TIME_CALL(GL.glClearBufferuiv(buffer, drawbuffer, value));
 
@@ -3910,6 +4034,18 @@ void WrappedOpenGL::glClearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat dep
 {
   CoherentMapImplicitBarrier();
 
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
+
   SERIALISE_TIME_CALL(GL.glClearBufferfi(buffer, drawbuffer, depth, stencil));
 
   if(IsActiveCapturing(m_State))
@@ -4014,6 +4150,11 @@ void WrappedOpenGL::glClearNamedBufferDataEXT(GLuint buffer, GLenum internalform
 {
   CoherentMapImplicitBarrier();
 
+  if(IsCaptureMode(m_State))
+  {
+    GetResourceManager()->MarkDirtyWithWriteReference(BufferRes(GetCtx(), buffer));
+  }
+
   SERIALISE_TIME_CALL(GL.glClearNamedBufferDataEXT(buffer, internalformat, format, type, data));
 
   if(IsActiveCapturing(m_State))
@@ -4026,16 +4167,24 @@ void WrappedOpenGL::glClearNamedBufferDataEXT(GLuint buffer, GLenum internalform
 
     GetContextRecord()->AddChunk(scope.Get());
   }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GetResourceManager()->MarkDirtyResource(BufferRes(GetCtx(), buffer));
-  }
 }
 
 void WrappedOpenGL::glClearBufferData(GLenum target, GLenum internalformat, GLenum format,
                                       GLenum type, const void *data)
 {
   CoherentMapImplicitBarrier();
+
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLRenderState state;
+    state.MarkDirty(this);
+  }
+  else if(IsActiveCapturing(m_State))
+  {
+    GLRenderState state;
+    state.FetchState(this);
+    state.MarkReferenced(this, false);
+  }
 
   SERIALISE_TIME_CALL(GL.glClearBufferData(target, internalformat, format, type, data));
 
@@ -4157,6 +4306,11 @@ void WrappedOpenGL::glClearNamedBufferSubDataEXT(GLuint buffer, GLenum internalf
 {
   CoherentMapImplicitBarrier();
 
+  if(IsCaptureMode(m_State))
+  {
+    GetResourceManager()->MarkDirtyWithWriteReference(BufferRes(GetCtx(), buffer));
+  }
+
   SERIALISE_TIME_CALL(
       GL.glClearNamedBufferSubDataEXT(buffer, internalformat, offset, size, format, type, data));
 
@@ -4170,10 +4324,6 @@ void WrappedOpenGL::glClearNamedBufferSubDataEXT(GLuint buffer, GLenum internalf
                                            data);
 
     GetContextRecord()->AddChunk(scope.Get());
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
-    GetResourceManager()->MarkDirtyResource(BufferRes(GetCtx(), buffer));
   }
 }
 
@@ -4190,6 +4340,14 @@ void WrappedOpenGL::glClearBufferSubData(GLenum target, GLenum internalformat, G
                                          const void *data)
 {
   CoherentMapImplicitBarrier();
+
+  if(IsCaptureMode(m_State))
+  {
+    GLResourceRecord *record = GetCtxData().m_BufferRecord[BufferIdx(target)];
+    RDCASSERTMSG("Couldn't identify implicit object at binding. Mismatched or bad GLuint?", record,
+                 target);
+    GetResourceManager()->MarkDirtyResource(record->GetResourceID());
+  }
 
   SERIALISE_TIME_CALL(
       GL.glClearBufferSubData(target, internalformat, offset, size, format, type, data));
@@ -4212,10 +4370,6 @@ void WrappedOpenGL::glClearBufferSubData(GLenum target, GLenum internalformat, G
                                                size, format, type, data);
 
         GetContextRecord()->AddChunk(scope.Get());
-      }
-      else if(IsBackgroundCapturing(m_State))
-      {
-        GetResourceManager()->MarkDirtyResource(record->GetResourceID());
       }
     }
   }
@@ -4458,6 +4612,11 @@ void WrappedOpenGL::glClearTexImage(GLuint texture, GLint level, GLenum format, 
 {
   CoherentMapImplicitBarrier();
 
+  if(IsCaptureMode(m_State))
+  {
+    GetResourceManager()->MarkDirtyWithWriteReference(TextureRes(GetCtx(), texture));
+  }
+
   SERIALISE_TIME_CALL(GL.glClearTexImage(texture, level, format, type, data));
 
   if(IsActiveCapturing(m_State))
@@ -4469,10 +4628,6 @@ void WrappedOpenGL::glClearTexImage(GLuint texture, GLint level, GLenum format, 
     Serialise_glClearTexImage(ser, texture, level, format, type, data);
 
     GetContextRecord()->AddChunk(scope.Get());
-    GetResourceManager()->MarkDirtyResource(TextureRes(GetCtx(), texture));
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
     GetResourceManager()->MarkDirtyResource(TextureRes(GetCtx(), texture));
   }
 }
@@ -4573,6 +4728,11 @@ void WrappedOpenGL::glClearTexSubImage(GLuint texture, GLint level, GLint xoffse
 {
   CoherentMapImplicitBarrier();
 
+  if(IsCaptureMode(m_State))
+  {
+    GetResourceManager()->MarkDirtyWithWriteReference(TextureRes(GetCtx(), texture));
+  }
+
   SERIALISE_TIME_CALL(GL.glClearTexSubImage(texture, level, xoffset, yoffset, zoffset, width,
                                             height, depth, format, type, data));
 
@@ -4586,10 +4746,6 @@ void WrappedOpenGL::glClearTexSubImage(GLuint texture, GLint level, GLint xoffse
                                  depth, format, type, data);
 
     GetContextRecord()->AddChunk(scope.Get());
-    GetResourceManager()->MarkDirtyResource(TextureRes(GetCtx(), texture));
-  }
-  else if(IsBackgroundCapturing(m_State))
-  {
     GetResourceManager()->MarkDirtyResource(TextureRes(GetCtx(), texture));
   }
 }

--- a/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_framebuffer_funcs.cpp
@@ -212,6 +212,7 @@ void WrappedOpenGL::glNamedFramebufferTextureEXT(GLuint framebuffer, GLenum atta
         m_HighTrafficResources.insert(record->GetResourceID());
         GetResourceManager()->MarkDirtyResource(record->GetResourceID());
       }
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
     }
     else
     {
@@ -258,6 +259,8 @@ void WrappedOpenGL::glFramebufferTexture(GLenum target, GLenum attachment, GLuin
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -341,6 +344,8 @@ void WrappedOpenGL::glNamedFramebufferTexture1DEXT(GLuint framebuffer, GLenum at
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -394,6 +399,8 @@ void WrappedOpenGL::glFramebufferTexture1D(GLenum target, GLenum attachment, GLe
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -477,6 +484,8 @@ void WrappedOpenGL::glNamedFramebufferTexture2DEXT(GLuint framebuffer, GLenum at
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -534,6 +543,8 @@ void WrappedOpenGL::glFramebufferTexture2D(GLenum target, GLenum attachment, GLe
       if(record != m_DeviceRecord)
       {
         record->UpdateCount++;
+
+        GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
         if(record->UpdateCount > 10)
         {
@@ -637,6 +648,8 @@ void WrappedOpenGL::glFramebufferTexture2DMultisampleEXT(GLenum target, GLenum a
     {
       record->AddChunk(scope.Get());
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record != m_DeviceRecord)
       {
         record->UpdateCount++;
@@ -724,6 +737,8 @@ void WrappedOpenGL::glNamedFramebufferTexture3DEXT(GLuint framebuffer, GLenum at
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -778,6 +793,8 @@ void WrappedOpenGL::glFramebufferTexture3D(GLenum target, GLenum attachment, GLe
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -859,6 +876,8 @@ void WrappedOpenGL::glNamedFramebufferRenderbufferEXT(GLuint framebuffer, GLenum
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -908,6 +927,8 @@ void WrappedOpenGL::glFramebufferRenderbuffer(GLenum target, GLenum attachment,
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -992,6 +1013,8 @@ void WrappedOpenGL::glNamedFramebufferTextureLayerEXT(GLuint framebuffer, GLenum
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 10)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -1045,6 +1068,8 @@ void WrappedOpenGL::glFramebufferTextureLayer(GLenum target, GLenum attachment, 
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -1161,6 +1186,8 @@ void WrappedOpenGL::glFramebufferTextureMultiviewOVR(GLenum target, GLenum attac
     {
       record->AddChunk(scope.Get());
 
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
+
       if(record != m_DeviceRecord)
       {
         record->UpdateCount++;
@@ -1274,6 +1301,8 @@ void WrappedOpenGL::glFramebufferTextureMultisampleMultiviewOVR(GLenum target, G
     if(IsBackgroundCapturing(m_State))
     {
       record->AddChunk(scope.Get());
+
+      GetResourceManager()->MarkFBOReferenced(record->Resource, eFrameRef_ReadBeforeWrite);
 
       if(record != m_DeviceRecord)
       {
@@ -1419,6 +1448,9 @@ void WrappedOpenGL::glFramebufferReadBufferEXT(GLuint framebuffer, GLenum buf)
     ResourceRecord *record =
         GetResourceManager()->GetResourceRecord(FramebufferRes(GetCtx(), framebuffer));
     record->AddChunk(scope.Get());
+
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -1442,7 +1474,10 @@ void WrappedOpenGL::glReadBuffer(GLenum mode)
     else
     {
       if(readrecord)
+      {
         GetResourceManager()->MarkDirtyResource(readrecord->GetResourceID());
+        GetResourceManager()->MarkFBOReferenced(readrecord->Resource, eFrameRef_ReadBeforeWrite);
+      }
     }
   }
 }
@@ -1478,6 +1513,10 @@ void WrappedOpenGL::glBindFramebuffer(GLenum target, GLuint framebuffer)
     Serialise_glBindFramebuffer(ser, target, framebuffer);
 
     GetContextRecord()->AddChunk(scope.Get());
+  }
+
+  if(IsCaptureMode(m_State))
+  {
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
                                             eFrameRef_ReadBeforeWrite);
   }
@@ -1542,6 +1581,8 @@ void WrappedOpenGL::glFramebufferDrawBufferEXT(GLuint framebuffer, GLenum buf)
     ResourceRecord *record =
         GetResourceManager()->GetResourceRecord(FramebufferRes(GetCtx(), framebuffer));
     record->AddChunk(scope.Get());
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -1565,7 +1606,10 @@ void WrappedOpenGL::glDrawBuffer(GLenum buf)
     else
     {
       if(drawrecord)
+      {
         GetResourceManager()->MarkDirtyResource(drawrecord->GetResourceID());
+        GetResourceManager()->MarkFBOReferenced(drawrecord->Resource, eFrameRef_ReadBeforeWrite);
+      }
     }
   }
 }
@@ -1628,6 +1672,8 @@ void WrappedOpenGL::glFramebufferDrawBuffersEXT(GLuint framebuffer, GLsizei n, c
     ResourceRecord *record =
         GetResourceManager()->GetResourceRecord(FramebufferRes(GetCtx(), framebuffer));
     record->AddChunk(scope.Get());
+    GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), framebuffer),
+                                            eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -1654,7 +1700,10 @@ void WrappedOpenGL::glDrawBuffers(GLsizei n, const GLenum *bufs)
     else
     {
       if(drawrecord)
+      {
         GetResourceManager()->MarkDirtyResource(drawrecord->GetResourceID());
+        GetResourceManager()->MarkFBOReferenced(drawrecord->Resource, eFrameRef_ReadBeforeWrite);
+      }
     }
   }
 }
@@ -1934,6 +1983,10 @@ void WrappedOpenGL::glBlitNamedFramebuffer(GLuint readFramebuffer, GLuint drawFr
                                      srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
     GetContextRecord()->AddChunk(scope.Get());
+  }
+
+  if(IsCaptureMode(m_State))
+  {
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), readFramebuffer),
                                             eFrameRef_ReadBeforeWrite);
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), drawFramebuffer),
@@ -1950,7 +2003,7 @@ void WrappedOpenGL::glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLi
   SERIALISE_TIME_CALL(
       GL.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
 
-  if(IsActiveCapturing(m_State))
+  if(IsCaptureMode(m_State))
   {
     GLuint readFramebuffer = 0, drawFramebuffer = 0;
 
@@ -1959,12 +2012,16 @@ void WrappedOpenGL::glBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLi
     if(GetCtxData().m_DrawFramebufferRecord)
       drawFramebuffer = GetCtxData().m_DrawFramebufferRecord->Resource.name;
 
-    USE_SCRATCH_SERIALISER();
-    SCOPED_SERIALISE_CHUNK(gl_CurChunk);
-    Serialise_glBlitNamedFramebuffer(ser, readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1,
-                                     srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    if(IsActiveCapturing(m_State))
+    {
+      USE_SCRATCH_SERIALISER();
+      SCOPED_SERIALISE_CHUNK(gl_CurChunk);
+      Serialise_glBlitNamedFramebuffer(ser, readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1,
+                                       srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
-    GetContextRecord()->AddChunk(scope.Get());
+      GetContextRecord()->AddChunk(scope.Get());
+    }
+
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), readFramebuffer),
                                             eFrameRef_ReadBeforeWrite);
     GetResourceManager()->MarkFBOReferenced(FramebufferRes(GetCtx(), drawFramebuffer),

--- a/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_sampler_funcs.cpp
@@ -288,6 +288,9 @@ void WrappedOpenGL::glSamplerParameteri(GLuint sampler, GLenum pname, GLint para
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 20)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -347,6 +350,9 @@ void WrappedOpenGL::glSamplerParameterf(GLuint sampler, GLenum pname, GLfloat pa
     {
       record->AddChunk(scope.Get());
       record->UpdateCount++;
+
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
 
       if(record->UpdateCount > 20)
       {
@@ -409,6 +415,9 @@ void WrappedOpenGL::glSamplerParameteriv(GLuint sampler, GLenum pname, const GLi
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 20)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -469,6 +478,9 @@ void WrappedOpenGL::glSamplerParameterfv(GLuint sampler, GLenum pname, const GLf
     {
       record->AddChunk(scope.Get());
       record->UpdateCount++;
+
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
 
       if(record->UpdateCount > 20)
       {
@@ -531,6 +543,9 @@ void WrappedOpenGL::glSamplerParameterIiv(GLuint sampler, GLenum pname, const GL
       record->AddChunk(scope.Get());
       record->UpdateCount++;
 
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
+
       if(record->UpdateCount > 20)
       {
         m_HighTrafficResources.insert(record->GetResourceID());
@@ -591,6 +606,9 @@ void WrappedOpenGL::glSamplerParameterIuiv(GLuint sampler, GLenum pname, const G
     {
       record->AddChunk(scope.Get());
       record->UpdateCount++;
+
+      GetResourceManager()->MarkResourceFrameReferenced(SamplerRes(GetCtx(), sampler),
+                                                        eFrameRef_ReadBeforeWrite);
 
       if(record->UpdateCount > 20)
       {

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -581,6 +581,12 @@ bool WrappedOpenGL::Serialise_glBindImageTexture(SerialiserType &ser, GLuint uni
 void WrappedOpenGL::glBindImageTexture(GLuint unit, GLuint texture, GLint level, GLboolean layered,
                                        GLint layer, GLenum access, GLenum format)
 {
+  if(IsCaptureMode(m_State))
+  {
+    GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
+                                                      eFrameRef_ReadBeforeWrite);
+  }
+
   SERIALISE_TIME_CALL(GL.glBindImageTexture(unit, texture, level, layered, layer, access, format));
 
   if(IsActiveCapturing(m_State))
@@ -596,8 +602,6 @@ void WrappedOpenGL::glBindImageTexture(GLuint unit, GLuint texture, GLint level,
     }
 
     GetContextRecord()->AddChunk(chunk);
-    GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), texture),
-                                                      eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -644,6 +648,14 @@ bool WrappedOpenGL::Serialise_glBindImageTextures(SerialiserType &ser, GLuint fi
 
 void WrappedOpenGL::glBindImageTextures(GLuint first, GLsizei count, const GLuint *textures)
 {
+  if(IsCaptureMode(m_State))
+  {
+    for(GLsizei i = 0; i < count; i++)
+      if(textures != NULL && textures[i] != 0)
+        GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), textures[i]),
+                                                          eFrameRef_ReadBeforeWrite);
+  }
+
   SERIALISE_TIME_CALL(GL.glBindImageTextures(first, count, textures));
 
   if(IsActiveCapturing(m_State))
@@ -653,11 +665,6 @@ void WrappedOpenGL::glBindImageTextures(GLuint first, GLsizei count, const GLuin
     Serialise_glBindImageTextures(ser, first, count, textures);
 
     GetContextRecord()->AddChunk(scope.Get());
-
-    for(GLsizei i = 0; i < count; i++)
-      if(textures != NULL && textures[i] != 0)
-        GetResourceManager()->MarkResourceFrameReferenced(TextureRes(GetCtx(), textures[i]),
-                                                          eFrameRef_ReadBeforeWrite);
   }
 }
 
@@ -851,6 +858,9 @@ void WrappedOpenGL::Common_glGenerateTextureMipmapEXT(GLResourceRecord *record, 
 
 void WrappedOpenGL::glGenerateTextureMipmapEXT(GLuint texture, GLenum target)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glGenerateTextureMipmapEXT(texture, target));
 
   if(IsCaptureMode(m_State))
@@ -860,6 +870,9 @@ void WrappedOpenGL::glGenerateTextureMipmapEXT(GLuint texture, GLenum target)
 
 void WrappedOpenGL::glGenerateTextureMipmap(GLuint texture)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glGenerateTextureMipmap(texture));
 
   if(IsCaptureMode(m_State))
@@ -869,6 +882,8 @@ void WrappedOpenGL::glGenerateTextureMipmap(GLuint texture)
 
 void WrappedOpenGL::glGenerateMipmap(GLenum target)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glGenerateMipmap(target));
 
   if(IsCaptureMode(m_State))
@@ -877,6 +892,9 @@ void WrappedOpenGL::glGenerateMipmap(GLenum target)
 
 void WrappedOpenGL::glGenerateMultiTexMipmapEXT(GLenum texunit, GLenum target)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glGenerateMultiTexMipmapEXT(texunit, target));
 
   if(IsCaptureMode(m_State))
@@ -972,6 +990,15 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
                                        GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth)
 {
   CoherentMapImplicitBarrier();
+
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLResourceRecord *dstrecord =
+        GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), dstName));
+
+    GetResourceManager()->MarkResourceFrameReferenced(dstrecord->GetResourceID(),
+                                                      eFrameRef_CompleteWrite);
+  }
 
   SERIALISE_TIME_CALL(GL.glCopyImageSubData(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName,
                                             dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth,
@@ -1106,6 +1133,9 @@ void WrappedOpenGL::Common_glCopyTextureSubImage1DEXT(GLResourceRecord *record, 
 void WrappedOpenGL::glCopyTextureSubImage1DEXT(GLuint texture, GLenum target, GLint level,
                                                GLint xoffset, GLint x, GLint y, GLsizei width)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTextureSubImage1DEXT(texture, target, level, xoffset, x, y, width));
 
   if(IsCaptureMode(m_State))
@@ -1117,6 +1147,9 @@ void WrappedOpenGL::glCopyTextureSubImage1DEXT(GLuint texture, GLenum target, GL
 void WrappedOpenGL::glCopyTextureSubImage1D(GLuint texture, GLint level, GLint xoffset, GLint x,
                                             GLint y, GLsizei width)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTextureSubImage1D(texture, level, xoffset, x, y, width));
 
   if(IsCaptureMode(m_State))
@@ -1128,6 +1161,9 @@ void WrappedOpenGL::glCopyTextureSubImage1D(GLuint texture, GLint level, GLint x
 void WrappedOpenGL::glCopyMultiTexSubImage1DEXT(GLenum texunit, GLenum target, GLint level,
                                                 GLint xoffset, GLint x, GLint y, GLsizei width)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyMultiTexSubImage1DEXT(texunit, target, level, xoffset, x, y, width));
 
   if(IsCaptureMode(m_State))
@@ -1138,6 +1174,8 @@ void WrappedOpenGL::glCopyMultiTexSubImage1DEXT(GLenum texunit, GLenum target, G
 void WrappedOpenGL::glCopyTexSubImage1D(GLenum target, GLint level, GLint xoffset, GLint x, GLint y,
                                         GLsizei width)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTexSubImage1D(target, level, xoffset, x, y, width));
 
   if(IsCaptureMode(m_State))
@@ -1212,6 +1250,9 @@ void WrappedOpenGL::glCopyTextureSubImage2DEXT(GLuint texture, GLenum target, GL
                                                GLint xoffset, GLint yoffset, GLint x, GLint y,
                                                GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCopyTextureSubImage2DEXT(texture, target, level, xoffset, yoffset, x, y, width, height));
 
@@ -1224,6 +1265,9 @@ void WrappedOpenGL::glCopyTextureSubImage2DEXT(GLuint texture, GLenum target, GL
 void WrappedOpenGL::glCopyTextureSubImage2D(GLuint texture, GLint level, GLint xoffset, GLint yoffset,
                                             GLint x, GLint y, GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCopyTextureSubImage2D(texture, level, xoffset, yoffset, x, y, width, height));
 
@@ -1237,6 +1281,9 @@ void WrappedOpenGL::glCopyMultiTexSubImage2DEXT(GLenum texunit, GLenum target, G
                                                 GLint xoffset, GLint yoffset, GLint x, GLint y,
                                                 GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyMultiTexSubImage2DEXT(texunit, target, level, xoffset, yoffset, x, y,
                                                      width, height));
 
@@ -1248,6 +1295,8 @@ void WrappedOpenGL::glCopyMultiTexSubImage2DEXT(GLenum texunit, GLenum target, G
 void WrappedOpenGL::glCopyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                         GLint x, GLint y, GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
 
   if(IsCaptureMode(m_State))
@@ -1324,6 +1373,9 @@ void WrappedOpenGL::glCopyTextureSubImage3DEXT(GLuint texture, GLenum target, GL
                                                GLint xoffset, GLint yoffset, GLint zoffset, GLint x,
                                                GLint y, GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTextureSubImage3DEXT(texture, target, level, xoffset, yoffset,
                                                     zoffset, x, y, width, height));
 
@@ -1337,6 +1389,9 @@ void WrappedOpenGL::glCopyTextureSubImage3D(GLuint texture, GLint level, GLint x
                                             GLint yoffset, GLint zoffset, GLint x, GLint y,
                                             GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCopyTextureSubImage3D(texture, level, xoffset, yoffset, zoffset, x, y, width, height));
 
@@ -1350,6 +1405,9 @@ void WrappedOpenGL::glCopyMultiTexSubImage3DEXT(GLenum texunit, GLenum target, G
                                                 GLint xoffset, GLint yoffset, GLint zoffset,
                                                 GLint x, GLint y, GLsizei width, GLsizei height)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyMultiTexSubImage3DEXT(texunit, target, level, xoffset, yoffset,
                                                      zoffset, x, y, width, height));
 
@@ -1362,6 +1420,8 @@ void WrappedOpenGL::glCopyTexSubImage3D(GLenum target, GLint level, GLint xoffse
                                         GLint zoffset, GLint x, GLint y, GLsizei width,
                                         GLsizei height)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
 
@@ -1454,6 +1514,9 @@ void WrappedOpenGL::Common_glTextureParameteriEXT(GLResourceRecord *record, GLen
 
 void WrappedOpenGL::glTextureParameteri(GLuint texture, GLenum pname, GLint param)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameteri(texture, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1464,6 +1527,9 @@ void WrappedOpenGL::glTextureParameteri(GLuint texture, GLenum pname, GLint para
 
 void WrappedOpenGL::glTextureParameteriEXT(GLuint texture, GLenum target, GLenum pname, GLint param)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameteriEXT(texture, target, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1473,6 +1539,8 @@ void WrappedOpenGL::glTextureParameteriEXT(GLuint texture, GLenum target, GLenum
 
 void WrappedOpenGL::glTexParameteri(GLenum target, GLenum pname, GLint param)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTexParameteri(target, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1481,6 +1549,9 @@ void WrappedOpenGL::glTexParameteri(GLenum target, GLenum pname, GLint param)
 
 void WrappedOpenGL::glMultiTexParameteriEXT(GLenum texunit, GLenum target, GLenum pname, GLint param)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexParameteriEXT(texunit, target, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1560,6 +1631,9 @@ void WrappedOpenGL::Common_glTextureParameterivEXT(GLResourceRecord *record, GLe
 void WrappedOpenGL::glTextureParameterivEXT(GLuint texture, GLenum target, GLenum pname,
                                             const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterivEXT(texture, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1570,6 +1644,9 @@ void WrappedOpenGL::glTextureParameterivEXT(GLuint texture, GLenum target, GLenu
 
 void WrappedOpenGL::glTextureParameteriv(GLuint texture, GLenum pname, const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameteriv(texture, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1580,6 +1657,8 @@ void WrappedOpenGL::glTextureParameteriv(GLuint texture, GLenum pname, const GLi
 
 void WrappedOpenGL::glTexParameteriv(GLenum target, GLenum pname, const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTexParameteriv(target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1589,6 +1668,9 @@ void WrappedOpenGL::glTexParameteriv(GLenum target, GLenum pname, const GLint *p
 void WrappedOpenGL::glMultiTexParameterivEXT(GLenum texunit, GLenum target, GLenum pname,
                                              const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexParameterivEXT(texunit, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1668,6 +1750,9 @@ void WrappedOpenGL::Common_glTextureParameterIivEXT(GLResourceRecord *record, GL
 void WrappedOpenGL::glTextureParameterIivEXT(GLuint texture, GLenum target, GLenum pname,
                                              const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterIivEXT(texture, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1678,6 +1763,9 @@ void WrappedOpenGL::glTextureParameterIivEXT(GLuint texture, GLenum target, GLen
 
 void WrappedOpenGL::glTextureParameterIiv(GLuint texture, GLenum pname, const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterIiv(texture, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1688,6 +1776,8 @@ void WrappedOpenGL::glTextureParameterIiv(GLuint texture, GLenum pname, const GL
 
 void WrappedOpenGL::glTexParameterIiv(GLenum target, GLenum pname, const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTexParameterIiv(target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1697,6 +1787,9 @@ void WrappedOpenGL::glTexParameterIiv(GLenum target, GLenum pname, const GLint *
 void WrappedOpenGL::glMultiTexParameterIivEXT(GLenum texunit, GLenum target, GLenum pname,
                                               const GLint *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexParameterIivEXT(texunit, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1776,6 +1869,9 @@ void WrappedOpenGL::Common_glTextureParameterIuivEXT(GLResourceRecord *record, G
 void WrappedOpenGL::glTextureParameterIuivEXT(GLuint texture, GLenum target, GLenum pname,
                                               const GLuint *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterIuivEXT(texture, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1786,6 +1882,9 @@ void WrappedOpenGL::glTextureParameterIuivEXT(GLuint texture, GLenum target, GLe
 
 void WrappedOpenGL::glTextureParameterIuiv(GLuint texture, GLenum pname, const GLuint *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterIuiv(texture, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1796,6 +1895,8 @@ void WrappedOpenGL::glTextureParameterIuiv(GLuint texture, GLenum pname, const G
 
 void WrappedOpenGL::glTexParameterIuiv(GLenum target, GLenum pname, const GLuint *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTexParameterIuiv(target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1805,6 +1906,9 @@ void WrappedOpenGL::glTexParameterIuiv(GLenum target, GLenum pname, const GLuint
 void WrappedOpenGL::glMultiTexParameterIuivEXT(GLenum texunit, GLenum target, GLenum pname,
                                                const GLuint *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexParameterIuivEXT(texunit, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1881,6 +1985,9 @@ void WrappedOpenGL::Common_glTextureParameterfEXT(GLResourceRecord *record, GLen
 
 void WrappedOpenGL::glTextureParameterfEXT(GLuint texture, GLenum target, GLenum pname, GLfloat param)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterfEXT(texture, target, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1890,6 +1997,9 @@ void WrappedOpenGL::glTextureParameterfEXT(GLuint texture, GLenum target, GLenum
 
 void WrappedOpenGL::glTextureParameterf(GLuint texture, GLenum pname, GLfloat param)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterf(texture, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1900,6 +2010,8 @@ void WrappedOpenGL::glTextureParameterf(GLuint texture, GLenum pname, GLfloat pa
 
 void WrappedOpenGL::glTexParameterf(GLenum target, GLenum pname, GLfloat param)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTexParameterf(target, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1908,6 +2020,9 @@ void WrappedOpenGL::glTexParameterf(GLenum target, GLenum pname, GLfloat param)
 
 void WrappedOpenGL::glMultiTexParameterfEXT(GLenum texunit, GLenum target, GLenum pname, GLfloat param)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexParameterfEXT(texunit, target, pname, param));
 
   if(IsCaptureMode(m_State))
@@ -1987,6 +2102,9 @@ void WrappedOpenGL::Common_glTextureParameterfvEXT(GLResourceRecord *record, GLe
 void WrappedOpenGL::glTextureParameterfvEXT(GLuint texture, GLenum target, GLenum pname,
                                             const GLfloat *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterfvEXT(texture, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -1997,6 +2115,9 @@ void WrappedOpenGL::glTextureParameterfvEXT(GLuint texture, GLenum target, GLenu
 
 void WrappedOpenGL::glTextureParameterfv(GLuint texture, GLenum pname, const GLfloat *params)
 {
+  MarkReferencedWhileCapturing(GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureParameterfv(texture, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -2007,6 +2128,8 @@ void WrappedOpenGL::glTextureParameterfv(GLuint texture, GLenum pname, const GLf
 
 void WrappedOpenGL::glTexParameterfv(GLenum target, GLenum pname, const GLfloat *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glTexParameterfv(target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -2016,6 +2139,9 @@ void WrappedOpenGL::glTexParameterfv(GLenum target, GLenum pname, const GLfloat 
 void WrappedOpenGL::glMultiTexParameterfvEXT(GLenum texunit, GLenum target, GLenum pname,
                                              const GLfloat *params)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_ReadBeforeWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexParameterfvEXT(texunit, target, pname, params));
 
   if(IsCaptureMode(m_State))
@@ -2280,6 +2406,8 @@ void WrappedOpenGL::glTexImage1D(GLenum target, GLint level, GLint internalforma
 {
   internalformat = RemapGenericCompressedFormat(internalformat);
 
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glTexImage1D(target, level, internalformat, width, border, format, type, pixels));
 
@@ -2525,6 +2653,8 @@ void WrappedOpenGL::glTexImage2D(GLenum target, GLint level, GLint internalforma
 {
   internalformat = RemapGenericCompressedFormat(internalformat);
 
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels));
 
@@ -2752,6 +2882,8 @@ void WrappedOpenGL::glTexImage3D(GLenum target, GLint level, GLint internalforma
                                  GLenum type, const GLvoid *pixels)
 {
   internalformat = RemapGenericCompressedFormat(internalformat);
+
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
 
   SERIALISE_TIME_CALL(GL.glTexImage3D(target, level, internalformat, width, height, depth, border,
                                       format, type, pixels));
@@ -3723,6 +3855,9 @@ void WrappedOpenGL::glCopyTextureImage1DEXT(GLuint texture, GLenum target, GLint
                                             GLenum internalformat, GLint x, GLint y, GLsizei width,
                                             GLint border)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCopyTextureImage1DEXT(texture, target, level, internalformat, x, y, width, border));
 
@@ -3735,6 +3870,9 @@ void WrappedOpenGL::glCopyMultiTexImage1DEXT(GLenum texunit, GLenum target, GLin
                                              GLenum internalformat, GLint x, GLint y, GLsizei width,
                                              GLint border)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCopyMultiTexImage1DEXT(texunit, target, level, internalformat, x, y, width, border));
 
@@ -3750,6 +3888,8 @@ void WrappedOpenGL::glCopyMultiTexImage1DEXT(GLenum texunit, GLenum target, GLin
 void WrappedOpenGL::glCopyTexImage1D(GLenum target, GLint level, GLenum internalformat, GLint x,
                                      GLint y, GLsizei width, GLint border)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTexImage1D(target, level, internalformat, x, y, width, border));
 
   // saves on queries of the currently bound texture to this target, as we don't have records on
@@ -3877,6 +4017,9 @@ void WrappedOpenGL::glCopyTextureImage2DEXT(GLuint texture, GLenum target, GLint
                                             GLenum internalformat, GLint x, GLint y, GLsizei width,
                                             GLsizei height, GLint border)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTextureImage2DEXT(texture, target, level, internalformat, x, y,
                                                  width, height, border));
 
@@ -3889,6 +4032,9 @@ void WrappedOpenGL::glCopyMultiTexImage2DEXT(GLenum texunit, GLenum target, GLin
                                              GLenum internalformat, GLint x, GLint y, GLsizei width,
                                              GLsizei height, GLint border)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyMultiTexImage2DEXT(texunit, target, level, internalformat, x, y,
                                                   width, height, border));
 
@@ -3904,6 +4050,8 @@ void WrappedOpenGL::glCopyMultiTexImage2DEXT(GLenum texunit, GLenum target, GLin
 void WrappedOpenGL::glCopyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x,
                                      GLint y, GLsizei width, GLsizei height, GLint border)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCopyTexImage2D(target, level, internalformat, x, y, width, height, border));
 
   // saves on queries of the currently bound texture to this target, as we don't have records on
@@ -4456,6 +4604,8 @@ void WrappedOpenGL::glTexImage2DMultisample(GLenum target, GLsizei samples, GLen
                                             GLsizei width, GLsizei height,
                                             GLboolean fixedsamplelocations)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTexImage2DMultisample(target, samples, internalformat, width, height,
                                                  fixedsamplelocations));
 
@@ -4634,6 +4784,8 @@ void WrappedOpenGL::glTexImage3DMultisample(GLenum target, GLsizei samples, GLen
                                             GLsizei width, GLsizei height, GLsizei depth,
                                             GLboolean fixedsamplelocations)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTexImage3DMultisample(target, samples, internalformat, width, height,
                                                  depth, fixedsamplelocations));
 
@@ -4829,6 +4981,9 @@ void WrappedOpenGL::glTextureSubImage1DEXT(GLuint texture, GLenum target, GLint 
                                            GLint xoffset, GLsizei width, GLenum format, GLenum type,
                                            const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glTextureSubImage1DEXT(texture, target, level, xoffset, width, format, type, pixels));
 
@@ -4841,6 +4996,9 @@ void WrappedOpenGL::glTextureSubImage1DEXT(GLuint texture, GLenum target, GLint 
 void WrappedOpenGL::glTextureSubImage1D(GLuint texture, GLint level, GLint xoffset, GLsizei width,
                                         GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureSubImage1D(texture, level, xoffset, width, format, type, pixels));
 
   if(IsCaptureMode(m_State))
@@ -4852,6 +5010,8 @@ void WrappedOpenGL::glTextureSubImage1D(GLuint texture, GLint level, GLint xoffs
 void WrappedOpenGL::glTexSubImage1D(GLenum target, GLint level, GLint xoffset, GLsizei width,
                                     GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTexSubImage1D(target, level, xoffset, width, format, type, pixels));
 
   if(IsCaptureMode(m_State))
@@ -4863,6 +5023,9 @@ void WrappedOpenGL::glMultiTexSubImage1DEXT(GLenum texunit, GLenum target, GLint
                                             GLint xoffset, GLsizei width, GLenum format,
                                             GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glMultiTexSubImage1DEXT(texunit, target, level, xoffset, width, format, type, pixels));
 
@@ -5042,6 +5205,9 @@ void WrappedOpenGL::glTextureSubImage2DEXT(GLuint texture, GLenum target, GLint 
                                            GLint yoffset, GLsizei width, GLsizei height,
                                            GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureSubImage2DEXT(texture, target, level, xoffset, yoffset, width,
                                                 height, format, type, pixels));
 
@@ -5055,6 +5221,9 @@ void WrappedOpenGL::glTextureSubImage2D(GLuint texture, GLint level, GLint xoffs
                                         GLsizei width, GLsizei height, GLenum format, GLenum type,
                                         const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureSubImage2D(texture, level, xoffset, yoffset, width, height,
                                              format, type, pixels));
 
@@ -5068,6 +5237,8 @@ void WrappedOpenGL::glTexSubImage2D(GLenum target, GLint level, GLint xoffset, G
                                     GLsizei width, GLsizei height, GLenum format, GLenum type,
                                     const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels));
 
@@ -5080,6 +5251,9 @@ void WrappedOpenGL::glMultiTexSubImage2DEXT(GLenum texunit, GLenum target, GLint
                                             GLint yoffset, GLsizei width, GLsizei height,
                                             GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexSubImage2DEXT(texunit, target, level, xoffset, yoffset, width,
                                                  height, format, type, pixels));
 
@@ -5264,6 +5438,9 @@ void WrappedOpenGL::glTextureSubImage3DEXT(GLuint texture, GLenum target, GLint 
                                            GLsizei width, GLsizei height, GLsizei depth,
                                            GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureSubImage3DEXT(texture, target, level, xoffset, yoffset, zoffset,
                                                 width, height, depth, format, type, pixels));
 
@@ -5277,6 +5454,9 @@ void WrappedOpenGL::glTextureSubImage3D(GLuint texture, GLint level, GLint xoffs
                                         GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                         GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTextureSubImage3D(texture, level, xoffset, yoffset, zoffset, width,
                                              height, depth, format, type, pixels));
 
@@ -5290,6 +5470,8 @@ void WrappedOpenGL::glTexSubImage3D(GLenum target, GLint level, GLint xoffset, G
                                     GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                     GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height,
                                          depth, format, type, pixels));
 
@@ -5303,6 +5485,9 @@ void WrappedOpenGL::glMultiTexSubImage3DEXT(GLenum texunit, GLenum target, GLint
                                             GLsizei width, GLsizei height, GLsizei depth,
                                             GLenum format, GLenum type, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glMultiTexSubImage3DEXT(texunit, target, level, xoffset, yoffset, zoffset,
                                                  width, height, depth, format, type, pixels));
 
@@ -5465,6 +5650,9 @@ void WrappedOpenGL::glCompressedTextureSubImage1DEXT(GLuint texture, GLenum targ
                                                      GLint xoffset, GLsizei width, GLenum format,
                                                      GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTextureSubImage1DEXT(texture, target, level, xoffset, width,
                                                           format, imageSize, pixels));
 
@@ -5478,6 +5666,9 @@ void WrappedOpenGL::glCompressedTextureSubImage1D(GLuint texture, GLint level, G
                                                   GLsizei width, GLenum format, GLsizei imageSize,
                                                   const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCompressedTextureSubImage1D(texture, level, xoffset, width, format, imageSize, pixels));
 
@@ -5491,6 +5682,8 @@ void WrappedOpenGL::glCompressedTexSubImage1D(GLenum target, GLint level, GLint 
                                               GLsizei width, GLenum format, GLsizei imageSize,
                                               const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(
       GL.glCompressedTexSubImage1D(target, level, xoffset, width, format, imageSize, pixels));
 
@@ -5503,6 +5696,9 @@ void WrappedOpenGL::glCompressedMultiTexSubImage1DEXT(GLenum texunit, GLenum tar
                                                       GLint xoffset, GLsizei width, GLenum format,
                                                       GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedMultiTexSubImage1DEXT(texunit, target, level, xoffset, width,
                                                            format, imageSize, pixels));
 
@@ -5680,6 +5876,9 @@ void WrappedOpenGL::glCompressedTextureSubImage2DEXT(GLuint texture, GLenum targ
                                                      GLsizei height, GLenum format,
                                                      GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTextureSubImage2DEXT(
       texture, target, level, xoffset, yoffset, width, height, format, imageSize, pixels));
 
@@ -5694,6 +5893,9 @@ void WrappedOpenGL::glCompressedTextureSubImage2D(GLuint texture, GLint level, G
                                                   GLenum format, GLsizei imageSize,
                                                   const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTextureSubImage2D(texture, level, xoffset, yoffset, width,
                                                        height, format, imageSize, pixels));
 
@@ -5707,6 +5909,8 @@ void WrappedOpenGL::glCompressedTexSubImage2D(GLenum target, GLint level, GLint 
                                               GLint yoffset, GLsizei width, GLsizei height,
                                               GLenum format, GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height,
                                                    format, imageSize, pixels));
 
@@ -5721,6 +5925,9 @@ void WrappedOpenGL::glCompressedMultiTexSubImage2DEXT(GLenum texunit, GLenum tar
                                                       GLsizei height, GLenum format,
                                                       GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedMultiTexSubImage2DEXT(
       texunit, target, level, xoffset, yoffset, width, height, format, imageSize, pixels));
 
@@ -5901,6 +6108,9 @@ void WrappedOpenGL::glCompressedTextureSubImage3DEXT(GLuint texture, GLenum targ
                                                      GLenum format, GLsizei imageSize,
                                                      const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTextureSubImage3DEXT(texture, target, level, xoffset, yoffset,
                                                           zoffset, width, height, depth, format,
                                                           imageSize, pixels));
@@ -5916,6 +6126,9 @@ void WrappedOpenGL::glCompressedTextureSubImage3D(GLuint texture, GLint level, G
                                                   GLsizei height, GLsizei depth, GLenum format,
                                                   GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(
+      GetResourceManager()->GetResourceRecord(TextureRes(GetCtx(), texture)), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTextureSubImage3D(
       texture, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, pixels));
 
@@ -5930,6 +6143,8 @@ void WrappedOpenGL::glCompressedTexSubImage3D(GLenum target, GLint level, GLint 
                                               GLsizei height, GLsizei depth, GLenum format,
                                               GLsizei imageSize, const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetActiveTexRecord(target), eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
                                                    height, depth, format, imageSize, pixels));
 
@@ -5945,6 +6160,9 @@ void WrappedOpenGL::glCompressedMultiTexSubImage3DEXT(GLenum texunit, GLenum tar
                                                       GLenum format, GLsizei imageSize,
                                                       const void *pixels)
 {
+  MarkReferencedWhileCapturing(GetCtxData().GetTexUnitRecord(target, texunit),
+                               eFrameRef_PartialWrite);
+
   SERIALISE_TIME_CALL(GL.glCompressedMultiTexSubImage3DEXT(texunit, target, level, xoffset, yoffset,
                                                            zoffset, width, height, depth, format,
                                                            imageSize, pixels));

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -186,8 +186,8 @@ DECLARE_REFLECTION_STRUCT(MemRefInterval);
 class VulkanResourceManager : public ResourceManager<VulkanResourceManagerConfiguration>
 {
 public:
-  VulkanResourceManager(CaptureState state, WrappedVulkan *core)
-      : ResourceManager(), m_State(state), m_Core(core)
+  VulkanResourceManager(CaptureState &state, WrappedVulkan *core)
+      : ResourceManager(state), m_Core(core)
   {
   }
   void SetState(CaptureState state) { m_State = state; }
@@ -453,7 +453,6 @@ private:
   void Apply_InitialState(WrappedVkRes *live, const VkInitialContents &initial);
   std::vector<ResourceId> InitialContentResources();
 
-  CaptureState m_State;
   WrappedVulkan *m_Core;
   std::map<ResourceId, MemRefs> m_MemFrameRefs;
   std::map<ResourceId, ImgRefs> m_ImgFrameRefs;


### PR DESCRIPTION
This introduces _Low-Memory_ mode for managing resources. Currently handles only GL, and can be extended for other drives as well.

**Problem:**

On memory-limited devices (mainly Android), Renderdoc crashes during active captured due to OOM. Memory spikes 2-3x times, trying to keep all the resources in memory until final serialization. Low-Memory mode solves it by postponing persistent resources, and unloading them once they are written to RDC file.

**Overall design approach:**

- We track which resources are _"persistent"_ and postpone their preparation until serialization to RDC file
- To identify persistent resources we measure their _age_, as the difference from current time, and the last write-reference in the frame. For this `MarkResourceFrameReferenced` with dirty refs is called in background capture as well, and updates the last write time
- Resources ages are tracked in `m_LastWriteTime`, with `PERSISTENT_RESOURCE_AGE` (currently 3000 ms as threshold)
- Only specific types of resources are tracked. This is controlled by the `IsResourceTrackedForPersistency`, which returns false in default implementation, with an override in GL to handle textures and buffers only
- On capture end, the `m_LastWriteTime` is updated for resources which were below the threshold on capture start (tracked by the `m_captureStartTime`)
- During the active capture if a resources was postponed, and is written after it, it's prepared right away
- After resource is serialized to RDC, it's unloaded by replacing with an empty contents 


This on average saves 18-30% of memory during active capturing.

Example of memory profiling of Robo Recall app on Oculus Quest, with Low-Memory mode disabled and enabled:

```
Robo Recal with no Renderdoc:

CPU memory: 723.9 MB
GPU memory: 576.0 MB
Total:      1.3 GB

------------------------

Robo Recal with Renderdoc in default mode:

CPU memory: 1.1 GB
GPU memory: 571.3 MB (Background)
Total:      1.7 GB

CPU memory: 1.1 GB
GPU memory: 1.0 GB (Active, spikes 2x)
Total:      2.1 GB

------------------------

Robo Recal with Renderdoc in LMM:

CPU memory: 1.1 GB
GPU memory: 569.6 MB (Background)
Total:      1.7 GB

CPU memory: 1.1 GB
GPU memory: 659.3 MB (Active, lower increase)
Total:      1.7 GB
```
