### PR TITLE
Update d3d12_command_list_wrap.cpp

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -1625,8 +1625,7 @@ void WrappedID3D12GraphicsCommandList::SetComputeRootDescriptorTable(
       {
         std::vector<D3D12Descriptor *> &descs = m_ListRecord->cmdInfo->boundDescs;
 
-        for(UINT d = 0; d < num; d++)
-          descs.push_back(rangeStart + d);
+        descs.insert(descs.end(), rangeStart, rangeStart + num);
       }
 
       prevTableOffset = offset + num;
@@ -2188,8 +2187,7 @@ void WrappedID3D12GraphicsCommandList::SetGraphicsRootDescriptorTable(
       {
         std::vector<D3D12Descriptor *> &descs = m_ListRecord->cmdInfo->boundDescs;
 
-        for(UINT d = 0; d < num; d++)
-          descs.push_back(rangeStart + d);
+        descs.insert(descs.end(), rangeStart, rangeStart + num);
       }
 
       prevTableOffset = offset + num;


### PR DESCRIPTION
Insert bound descriptors as a batch

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

Insert bound descriptors via a single call to std::vector::insert@end instead of a loop of repeated calls to std::vector::push_back.  Noticed this when debugging issues using bindless rendering with enormous bound descriptor tables.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
