### PR TITLE
Share m_D3DLock between all WrappedID3D11Devices.

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_resources.h
+++ b/renderdoc/driver/d3d11/d3d11_resources.h
@@ -448,18 +448,24 @@ public:
   WrappedID3D11Buffer(ID3D11Buffer *real, uint32_t byteLength, WrappedID3D11Device *device)
       : WrappedResource11(real, device)
   {
-    SCOPED_LOCK(m_pDevice->D3DLock());
+    if(RenderDoc::Inst().IsReplayApp())
+    {
+      SCOPED_LOCK(m_pDevice->D3DLock());
 
-    RDCASSERT(m_BufferList.find(GetResourceID()) == m_BufferList.end());
-    m_BufferList[GetResourceID()] = BufferEntry(this, byteLength);
+      RDCASSERT(m_BufferList.find(GetResourceID()) == m_BufferList.end());
+      m_BufferList[GetResourceID()] = BufferEntry(this, byteLength);
+    }
   }
 
   virtual ~WrappedID3D11Buffer()
   {
     SCOPED_LOCK(m_pDevice->D3DLock());
 
-    if(m_BufferList.find(GetResourceID()) != m_BufferList.end())
-      m_BufferList.erase(GetResourceID());
+    if(RenderDoc::Inst().IsReplayApp())
+    {
+      if(m_BufferList.find(GetResourceID()) != m_BufferList.end())
+        m_BufferList.erase(GetResourceID());
+    }
 
     Shutdown();
   }
@@ -492,10 +498,13 @@ public:
   {
     if(type != TEXDISPLAY_UNKNOWN)
     {
-      SCOPED_LOCK(m_pDevice->D3DLock());
+      if(RenderDoc::Inst().IsReplayApp())
+      {
+        SCOPED_LOCK(m_pDevice->D3DLock());
 
-      RDCASSERT(m_TextureList.find(GetResourceID()) == m_TextureList.end());
-      m_TextureList[GetResourceID()] = TextureEntry(this, type);
+        RDCASSERT(m_TextureList.find(GetResourceID()) == m_TextureList.end());
+        m_TextureList[GetResourceID()] = TextureEntry(this, type);
+      }
     }
   }
 
@@ -503,8 +512,11 @@ public:
   {
     SCOPED_LOCK(m_pDevice->D3DLock());
 
-    if(m_TextureList.find(GetResourceID()) != m_TextureList.end())
-      m_TextureList.erase(GetResourceID());
+    if(RenderDoc::Inst().IsReplayApp())
+    {
+      if(m_TextureList.find(GetResourceID()) != m_TextureList.end())
+        m_TextureList.erase(GetResourceID());
+    }
 
     Shutdown();
   }


### PR DESCRIPTION
This allows it to protect static data like WrappedTexture<>::m_TextureList when it is accessed from different device instances on different threads.

## Description

Attaching RenderDoc 1.4 causes my game to hang.  I found the game creates at least two ID3D11Devices, which RenderDoc wraps, and they simultaneously modify the static WrappedTexture<>::m_TextureList, each trying to protect their access with their m_D3DLock mutexes.  One of them would get a pair of iterators defining a range, the other one would modify the map, and the first would wait forever for its iterators to match because it was no longer possible to reach the second iterator by incrementing the first.  The simplest solution seemed to be to make m_D3DLock static as well, so that's what I did.  My game no longer hangs when RenderDoc is attached.