### PR TITLE
Updates to resource tracking

### DIFF
--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -117,12 +117,6 @@ FrameRefType ComposeFrameRefsUnordered(FrameRefType first, FrameRefType second)
   RDCASSERT(eFrameRef_Minimum <= first && first <= eFrameRef_Maximum);
   RDCASSERT(eFrameRef_Minimum <= second && second <= eFrameRef_Maximum);
 
-  // The order of the reference types is irrelevant, so put them in a
-  // consistent order (`first >= second`) to reduce the number of cases to
-  // consider.
-  if(first < second)
-    std::swap(first, second);
-
   if(first == eFrameRef_Read &&
      (second == eFrameRef_PartialWrite || second == eFrameRef_CompleteWrite))
     // The resource is referenced both read and write/clear;
@@ -139,6 +133,11 @@ FrameRefType ComposeFrameRefsUnordered(FrameRefType first, FrameRefType second)
   // stronger (re)initialization requirements, this is simply the maximum
   // reference type; note that `first >= second` by the earlier swap.
   return first;
+}
+
+FrameRefType ComposeFrameRefsDisjoint(FrameRefType x, FrameRefType y)
+{
+  return RDCMAX(x, y);
 }
 
 bool IsDirtyFrameRef(FrameRefType refType)

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -111,6 +111,11 @@ FrameRefType ComposeFrameRefs(FrameRefType first, FrameRefType second);
 // reset for replay.
 FrameRefType ComposeFrameRefsUnordered(FrameRefType first, FrameRefType second);
 
+// Compose frame refs for disjoint subresources.
+// This is used to compute the overall frame ref for images/memory from the
+// frame refs of their subresources.
+FrameRefType ComposeFrameRefsDisjoint(FrameRefType x, FrameRefType y);
+
 bool IsDirtyFrameRef(FrameRefType refType);
 
 // Captures the possible initialization/reset requirements for resources.

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -94,6 +94,10 @@ enum FrameRefType
   eFrameRef_ReadBeforeWrite = 4,
 };
 
+bool IncludesRead(FrameRefType refType);
+
+bool IncludesWrite(FrameRefType refType);
+
 const FrameRefType eFrameRef_Minimum = eFrameRef_None;
 const FrameRefType eFrameRef_Maximum = eFrameRef_ReadBeforeWrite;
 

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -900,7 +900,7 @@ private:
                                                       const char *pMessage, void *pUserData);
   void AddFrameTerminator(uint64_t queueMarkerTag);
   std::vector<VkImageMemoryBarrier> ImageInitializationBarriers(ResourceId id, WrappedVkRes *live,
-                                                                bool initialized,
+                                                                InitPolicy policy, bool initialized,
                                                                 const ImgRefs *imgRefs) const;
   void SubmitExtQBarriers(const std::map<uint32_t, std::vector<VkImageMemoryBarrier>> &extQBarriers);
 

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -781,8 +781,7 @@ void VulkanResourceManager::MarkImageFrameReferenced(ResourceId img, const Image
                                                      const ImageRange &range, FrameRefType refType)
 {
   FrameRefType maxRef = MarkImageReferenced(m_ImgFrameRefs, img, imageInfo, range, refType);
-  MarkResourceFrameReferenced(
-      img, maxRef, [](FrameRefType x, FrameRefType y) -> FrameRefType { return std::max(x, y); });
+  MarkResourceFrameReferenced(img, maxRef, ComposeFrameRefsDisjoint);
 }
 
 void VulkanResourceManager::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize offset,
@@ -791,8 +790,7 @@ void VulkanResourceManager::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSi
   SCOPED_LOCK(m_Lock);
 
   FrameRefType maxRef = MarkMemoryReferenced(m_MemFrameRefs, mem, offset, size, refType);
-  MarkResourceFrameReferenced(
-      mem, maxRef, [](FrameRefType x, FrameRefType y) -> FrameRefType { return std::max(x, y); });
+  MarkResourceFrameReferenced(mem, maxRef, ComposeFrameRefsDisjoint);
 }
 
 void VulkanResourceManager::MergeReferencedImages(std::map<ResourceId, ImgRefs> &imgRefs)

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -441,6 +441,7 @@ public:
   ImgRefs *FindImgRefs(ResourceId img);
 
   inline bool OptimizeInitialState() { return m_OptimizeInitialState; }
+  inline InitPolicy GetInitPolicy() { return m_InitPolicy; }
 private:
   bool ResourceTypeRelease(WrappedVkRes *res);
 
@@ -457,4 +458,5 @@ private:
   std::map<ResourceId, MemRefs> m_MemFrameRefs;
   std::map<ResourceId, ImgRefs> m_ImgFrameRefs;
   bool m_OptimizeInitialState = false;
+  InitPolicy m_InitPolicy = eInitPolicy_CopyAll;
 };

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3114,8 +3114,7 @@ void VkResourceRecord::MarkImageFrameReferenced(VkResourceRecord *img, const Ima
 
   // maintain the reference type of the image itself as the maximum reference type of any
   // subresource
-  MarkResourceFrameReferenced(
-      id, maxRef, [](FrameRefType x, FrameRefType y) -> FrameRefType { return std::max(x, y); });
+  MarkResourceFrameReferenced(id, maxRef, ComposeFrameRefsDisjoint);
 }
 
 void VkResourceRecord::MarkImageViewFrameReferenced(VkResourceRecord *view, const ImageRange &range,
@@ -3148,8 +3147,7 @@ void VkResourceRecord::MarkImageViewFrameReferenced(VkResourceRecord *view, cons
 
   // maintain the reference type of the image itself as the maximum reference type of any
   // subresource
-  MarkResourceFrameReferenced(
-      img, maxRef, [](FrameRefType x, FrameRefType y) -> FrameRefType { return std::max(x, y); });
+  MarkResourceFrameReferenced(img, maxRef, ComposeFrameRefsDisjoint);
 }
 
 void VkResourceRecord::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize offset,
@@ -3158,8 +3156,7 @@ void VkResourceRecord::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize of
   if(refType != eFrameRef_Read && refType != eFrameRef_None)
     cmdInfo->dirtied.insert(mem);
   FrameRefType maxRef = MarkMemoryReferenced(cmdInfo->memFrameRefs, mem, offset, size, refType);
-  MarkResourceFrameReferenced(
-      mem, maxRef, [](FrameRefType x, FrameRefType y) -> FrameRefType { return std::max(x, y); });
+  MarkResourceFrameReferenced(mem, maxRef, ComposeFrameRefsDisjoint);
 }
 
 void VkResourceRecord::MarkBufferFrameReferenced(VkResourceRecord *buf, VkDeviceSize offset,

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -2964,7 +2964,7 @@ int ImgRefs::SubresourceIndex(int aspectIndex, int level, int layer) const
 }
 
 std::vector<rdcpair<VkImageSubresourceRange, InitReqType> > ImgRefs::SubresourceRangeInitReqs(
-    VkImageSubresourceRange range) const
+    VkImageSubresourceRange range, InitPolicy policy, bool initialized) const
 {
   VkImageSubresourceRange out(range);
   std::vector<rdcpair<VkImageSubresourceRange, InitReqType> > res;
@@ -3004,7 +3004,8 @@ std::vector<rdcpair<VkImageSubresourceRange, InitReqType> > ImgRefs::Subresource
       for(int layer = range.baseArrayLayer; layer < splitLayerCount; ++layer)
       {
         out.baseArrayLayer = layer;
-        res.push_back(make_rdcpair(out, SubresourceInitReq(aspectIndex, level, layer)));
+        res.push_back(
+            make_rdcpair(out, SubresourceInitReq(aspectIndex, level, layer, policy, initialized)));
       }
     }
   }

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1136,16 +1136,13 @@ struct ImgRefs
   {
     return rangeRefs[SubresourceIndex(aspectIndex, level, layer)];
   }
-  inline InitReqType SubresourceInitReq(int aspectIndex, int level, int layer) const
+  inline InitReqType SubresourceInitReq(int aspectIndex, int level, int layer, InitPolicy policy,
+                                        bool initialized) const
   {
-    return InitReq(SubresourceRef(aspectIndex, level, layer));
-  }
-  inline InitReqType SubresourceInitReq(int aspectIndex, int level, int layer, bool initialized) const
-  {
-    return InitReq(SubresourceRef(aspectIndex, level, layer));
+    return InitReq(SubresourceRef(aspectIndex, level, layer), policy, initialized);
   }
   std::vector<rdcpair<VkImageSubresourceRange, InitReqType> > SubresourceRangeInitReqs(
-      VkImageSubresourceRange range) const;
+      VkImageSubresourceRange range, InitPolicy policy, bool initialized) const;
   void Split(bool splitAspects, bool splitLevels, bool splitLayers);
   template <typename Compose>
   FrameRefType Update(ImageRange range, FrameRefType refType, Compose comp);


### PR DESCRIPTION
## Description

This adds a `WriteBeforeRead` ref type, as well as adding `InitPolicy` to control the copy/clear behaviour based on the resource's `FrameRefType`.

The `WriteBeforeRead` ref type allows us to detect potentially confusing situations when the user observes at a point in time before the write, but sees the result of the future write due to the resource not being cleared. Depending on the `InitPolicy`, these situations can be avoided by resetting or clearing resources that are written.

This sets the default `InitPolicy` to `CopyUnused`--a very conservative policy that always copies the initial data at least once, and re-copies the data on each replay for resources that are written.