### PR TITLE
Check type hint for auto fit range button in texture viewer

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -3277,6 +3277,10 @@ void TextureViewer::AutoFitRange()
       {
         fmt.compType = CompType::Float;
       }
+      if(fmt.compType == CompType::Typeless && m_TexDisplay.typeHint == CompType::UInt)
+        fmt.compType = CompType::UInt;
+      if(fmt.compType == CompType::Typeless && m_TexDisplay.typeHint == CompType::SInt)
+        fmt.compType = CompType::SInt;
 
       for(int i = 0; i < 4; i++)
       {


### PR DESCRIPTION
Check type hint for auto fit range button in texture viewer

If a texture has a typeless format and is viewed as uint, the autofit button does not adjust to the proper min/max range.