### PR TITLE
Use type hint for format for D3D11Replay::GetMinMax

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_replay.cpp
+++ b/renderdoc/driver/d3d11/d3d11_replay.cpp
@@ -1682,7 +1682,7 @@ bool D3D11Replay::GetMinMax(ResourceId texid, uint32_t sliceFace, uint32_t mip, 
   int srvOffset = 0;
   int intIdx = 0;
 
-  DXGI_FORMAT fmt = GetTypedFormat(details.texFmt);
+  DXGI_FORMAT fmt = GetTypedFormat(details.texFmt, typeHint);
 
   if(IsUIntFormat(fmt))
   {


### PR DESCRIPTION
Use type hint for format for D3D11Replay::GetMinMax

This matches what D3D12 is doing, and produces correct formats for typeless buffers viewed as a different format.