### PR TITLE
Fixed Incorrect Tuple Usage in unpackData

### DIFF
--- a/docs/python_api/examples/renderdoc/decode_mesh.py
+++ b/docs/python_api/examples/renderdoc/decode_mesh.py
@@ -57,11 +57,11 @@ def unpackData(fmt, data):
 	# If the format needs post-processing such as normalisation, do that now
 	if fmt.compType == rd.CompType.UNorm:
 		divisor = float((1 << fmt.compByteWidth) - 1)
-		value = tuple(float(value[i]) / divisor for i in value)
+		value = tuple(float(i) / divisor for i in value)
 	elif fmt.compType == rd.CompType.SNorm:
 		maxNeg = -(1 << (fmt.compByteWidth - 1))
 		divisor = float(-(maxNeg-1))
-		value = tuple((float(value[i]) if (value[i] == maxNeg) else (float(value[i]) / divisor)) for i in value)
+		value = tuple((float(i) if (i == maxNeg) else (float(i) / divisor)) for i in value)
 
 	# If the format is BGRA, swap the two components
 	if fmt.BGRAOrder():


### PR DESCRIPTION
Fixed "IndexError: tuple index out of range"
`value = tuple(float(value[i]) / divisor for i in value)`
Was effectively attempting to access the value tuple using an element as an index.

`value = tuple(float(i) / divisor for i in value)`
Uses the elements from the tuple and modifies them.

Ex: (0,0,0,255) becomes: (0.0, 0.0, 0.0, 255.0)
Instead of throwing an error.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
