### PR TITLE
groupshared memory compute shader debugging

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -2230,7 +2230,6 @@ void WrappedID3D11Device::AddDeferredContext(WrappedID3D11DeviceContext *defctx)
 
 void WrappedID3D11Device::RemoveDeferredContext(WrappedID3D11DeviceContext *defctx)
 {
-  RDCASSERT(m_DeferredContexts.find(defctx) != m_DeferredContexts.end());
   m_DeferredContexts.erase(defctx);
 }
 

--- a/renderdoc/driver/d3d11/d3d11_hooks.cpp
+++ b/renderdoc/driver/d3d11/d3d11_hooks.cpp
@@ -200,6 +200,9 @@ private:
     else
       Flags &= ~D3D11_CREATE_DEVICE_DEBUG;
 
+    // deferred contexts are needed for debugging
+    Flags &= ~D3D11_CREATE_DEVICE_SINGLETHREADED;
+
     DXGI_SWAP_CHAIN_DESC swapDesc;
     DXGI_SWAP_CHAIN_DESC *pUsedSwapDesc = NULL;
 

--- a/renderdoc/driver/shaders/dxbc/dxbc_disassemble.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_disassemble.cpp
@@ -125,6 +125,26 @@ static MaskedElement<bool, 0x00000008> Sync_UAV_Global;
 static MaskedElement<bool, 0x00800000> HasOrderPreservingCounter;
 };    // Opcode
 
+bool Sync_UAV_Global(uint32_t syncFlags)
+{
+  return Opcode::Sync_UAV_Global.Get(syncFlags);
+}
+
+bool Sync_UAV_Group(uint32_t syncFlags)
+{
+  return Opcode::Sync_UAV_Group.Get(syncFlags);
+}
+
+bool Sync_TGSM(uint32_t syncFlags)
+{
+  return Opcode::Sync_TGSM.Get(syncFlags);
+}
+
+bool Sync_Threads(uint32_t syncFlags)
+{
+  return Opcode::Sync_Threads.Get(syncFlags);
+}
+
 // Declarations are Opcode tokens, but with their own particular definitions
 // of most of the bits (aside from the generice type/length/extended bits above)
 namespace Declaration

--- a/renderdoc/driver/shaders/dxbc/dxbc_disassemble.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_disassemble.h
@@ -989,4 +989,9 @@ struct ASMOperation
   std::vector<ASMOperand> operands;
 };
 
+bool Sync_UAV_Global(uint32_t syncFlags);
+bool Sync_UAV_Group(uint32_t syncFlags);
+bool Sync_TGSM(uint32_t syncFlags);
+bool Sync_Threads(uint32_t syncFlags);
+
 };    // DXBC

--- a/renderdoc/driver/shaders/dxbc/dxbc_inspect.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_inspect.h
@@ -219,7 +219,8 @@ struct ShaderStatistics
   uint32_t hsOutputPrim;
   uint32_t hsPartitioning;
   uint32_t tessellatorDomain;
-  uint32_t unknown_g[3];
+  uint32_t barrierInstructions;
+  uint32_t unknown_g[2];
 
   enum Version
   {


### PR DESCRIPTION
Simulates all threads in a thread group so that changes to groupshared memory from other threads are available in the thread of interest.

## Description

This is the implementation of simulating all the threads in a thread group across all available cpu cores that I mentioned in response to issue #1054 "Compute shader results from other threads".  I made it about a year ago when I needed to debug a compute shader with groupshared memory.  It can take a while with a large group size, but it's time well spent if you're trying to understand what your compute shader is doing!

If it detects group sync instructions, it will simulate all the threads in the thread group of the target thread until the point at which they no longer affect the target's results.  If threads in another group can write to a location that the simulated group reads then that won't be reflected.  Ideally it would detect cases that won't be simulated correctly, and either warn you or simulate everything it needs to, but it doesn't at the moment.

It works by blocking at each thread sync instruction until all threads have arrived.  Atomic instructions are inside critical sections.  It uses deferred contexts, which turns out to be a bit of nuisance because I have to turn off the single threaded device bit, but also nice, because I don't have to save and restore state on the immediate context.  I assume it's going to conflict with pull request #1457 "Move D3D11 API usage out of dxbc_debug.cpp".

It puts up the cancel dialog if it runs for a certain number of instructions.  Ideally I think it would have a cancel button next to the "thinking" indicator that you could press at any time, but I haven't done that.  It would also be nice if it indicated how many threads it's simulating, so you can get an idea of what you're in for.  I suppose it could also give you the option to override simulating everything it thinks you need.
