### PR TITLE
BufferViewer: fix primitive restart

### DIFF
--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -1425,10 +1425,10 @@ static void RT_FetchMeshData(IReplayController *r, ICaptureContext &ctx, Populat
 
       for(size_t i = 0; i < idata.size() && (uint32_t)i < draw->numIndices; i++)
       {
+        indices[i] = (uint32_t)idata[i];
         if(primRestart && idata[i] == primRestart)
           continue;
 
-        indices[i] = (uint32_t)idata[i];
         maxIndex = qMax(maxIndex, indices[i]);
       }
     }
@@ -1439,10 +1439,10 @@ static void RT_FetchMeshData(IReplayController *r, ICaptureContext &ctx, Populat
       uint16_t *src = (uint16_t *)idata.data();
       for(size_t i = 0; i < idata.size() / sizeof(uint16_t) && (uint32_t)i < draw->numIndices; i++)
       {
+        indices[i] = (uint32_t)src[i];
         if(primRestart && idata[i] == primRestart)
           continue;
 
-        indices[i] = (uint32_t)src[i];
         maxIndex = qMax(maxIndex, indices[i]);
       }
     }

--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -1426,7 +1426,7 @@ static void RT_FetchMeshData(IReplayController *r, ICaptureContext &ctx, Populat
       for(size_t i = 0; i < idata.size() && (uint32_t)i < draw->numIndices; i++)
       {
         indices[i] = (uint32_t)idata[i];
-        if(primRestart && idata[i] == primRestart)
+        if(primRestart && indices[i] == primRestart)
           continue;
 
         maxIndex = qMax(maxIndex, indices[i]);
@@ -1440,7 +1440,7 @@ static void RT_FetchMeshData(IReplayController *r, ICaptureContext &ctx, Populat
       for(size_t i = 0; i < idata.size() / sizeof(uint16_t) && (uint32_t)i < draw->numIndices; i++)
       {
         indices[i] = (uint32_t)src[i];
-        if(primRestart && idata[i] == primRestart)
+        if(primRestart && indices[i] == primRestart)
           continue;
 
         maxIndex = qMax(maxIndex, indices[i]);
@@ -1454,7 +1454,7 @@ static void RT_FetchMeshData(IReplayController *r, ICaptureContext &ctx, Populat
 
       for(uint32_t i = 0; i < draw->numIndices; i++)
       {
-        if(primRestart && idata[i] == primRestart)
+        if(primRestart && indices[i] == primRestart)
           continue;
 
         maxIndex = qMax(maxIndex, indices[i]);


### PR DESCRIPTION
I wrote these fixes last year while debugging some [Dolphin](https://github.com/dolphin-emu/dolphin) code, so it's been a while... If I remember correctly the buffer view was showing uninitialized memory and primitive restarts of larger-than-one-byte indices were not recognized as such. This should fix it. There was another issue related to primitive restarts in index buffers with a base vertex offset but it looks like you already fixed it in the meantime.