### PR TITLE
Fully init pQueueCreateInfo if requesting additional queues

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -2537,6 +2537,9 @@ VkResult WrappedVulkan::vkCreateDevice(VkPhysicalDevice physicalDevice,
     modQueues[createInfo.queueCreateInfoCount].queueFamilyIndex = qFamilyIdx;
     modQueues[createInfo.queueCreateInfoCount].queueCount = 1;
     modQueues[createInfo.queueCreateInfoCount].pQueuePriorities = &one;
+    modQueues[createInfo.queueCreateInfoCount].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    modQueues[createInfo.queueCreateInfoCount].pNext = NULL;
+    modQueues[createInfo.queueCreateInfoCount].flags = 0;
 
     createInfo.pQueueCreateInfos = modQueues;
     createInfo.queueCreateInfoCount++;


### PR DESCRIPTION
## Description
In a case where the application is not using a queue with (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT) i.e headless test/compute applications, renderdoc creates an additional queue. There is a bug here where the pQueueCreateInfo isn't fully initialised. This causes a driver crash on both AMD& Nvidia on windows 10. This PR adds the remaining values to fix this.
