### PR TITLE
Fix image resource tracking

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1480,12 +1480,7 @@ public:
       p.first++;
     }
 
-    ImageRange imgRange;
-    imgRange.aspectMask = view->viewRange.aspectMask;
-    imgRange.baseMipLevel = view->viewRange.baseMipLevel;
-    imgRange.levelCount = view->viewRange.levelCount;
-    imgRange.baseArrayLayer = view->viewRange.baseArrayLayer;
-    imgRange.layerCount = view->viewRange.layerCount;
+    ImageRange imgRange = ImageRange((VkImageSubresourceRange)view->viewRange);
     imgRange.viewType = view->viewRange.viewType();
 
     FrameRefType maxRef = MarkImageReferenced(descInfo->bindImgRefs, view->baseResource,


### PR DESCRIPTION
Currently if image range uses VK_REMAINING_MIP_LEVELS it gets
converted to MipMaxValue (63).
https://github.com/baldurk/renderdoc/blob/e17631a4cc7e036b12ca5dbe0d37a8bd15b4f8d9/renderdoc/driver/vulkan/vk_resources.h#L1625
Which is then written to ImageRange and used when updating
descriptor sets. The code downstream checks for VK_REMAINING_MIP_LEVELS
but because the value is 63, it is not adjusted to the actual value.
Also affects layer count.
