### PR TITLE
Fixed behaviour of some buttons by connecting functors to correct signals

### DIFF
--- a/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
+++ b/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
@@ -176,10 +176,10 @@ PerformanceCounterSelection::PerformanceCounterSelection(ICaptureContext &ctx,
             }
           });
 
-  connect(ui->save, &QPushButton::pressed, this, &PerformanceCounterSelection::Save);
-  connect(ui->load, &QPushButton::pressed, this, &PerformanceCounterSelection::Load);
-  connect(ui->sampleCounters, &QPushButton::pressed, this, &PerformanceCounterSelection::accept);
-  connect(ui->cancel, &QPushButton::pressed, this, &PerformanceCounterSelection::reject);
+  connect(ui->save, &QPushButton::clicked, this, &PerformanceCounterSelection::Save);
+  connect(ui->load, &QPushButton::clicked, this, &PerformanceCounterSelection::Load);
+  connect(ui->sampleCounters, &QPushButton::clicked, this, &PerformanceCounterSelection::accept);
+  connect(ui->cancel, &QPushButton::clicked, this, &PerformanceCounterSelection::reject);
 
   connect(ui->counterTree, &RDTreeWidget::itemChanged, [this](RDTreeWidgetItem *item, int) -> void {
     const QVariant d = item->data(0, CounterIdRole);


### PR DESCRIPTION
This PR fixes a few UI buttons reacting to incorrect signals. Previously, a few buttons did not follow the standard UI behaviour and instead of reacting to button **click** (press & release), they executed their actions on **press**. This led to a bit inconsistent experience.

Thankfully, the only affected window was a Performance Counter Selection window. I've tested it both before and after the changes and now behaviour seems to be correct.