### PR TITLE
fixed Vulkan in app api capture

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1309,7 +1309,7 @@ void WrappedVulkan::FirstFrame()
   // if we have to capture the first frame, begin capturing immediately
   if(IsBackgroundCapturing(m_State) && RenderDoc::Inst().ShouldTriggerCapture(0))
   {
-    RenderDoc::Inst().StartFrameCapture(LayerDisp(m_Instance), NULL);
+    RenderDoc::Inst().StartFrameCapture(m_Instance, NULL);
 
     m_AppControlledCapture = false;
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -680,7 +680,7 @@ VkResult WrappedVulkan::vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo
 
   InitInstanceExtensionTables(m_Instance, record->instDevInfo);
 
-  RenderDoc::Inst().AddDeviceFrameCapturer(LayerDisp(m_Instance), this);
+  RenderDoc::Inst().AddDeviceFrameCapturer(m_Instance, this);
 
   m_DbgReportCallback = VK_NULL_HANDLE;
   m_DbgUtilsCallback = VK_NULL_HANDLE;
@@ -846,7 +846,7 @@ void WrappedVulkan::vkDestroyInstance(VkInstance instance, const VkAllocationCal
   // application is well behaved. If not, we just leak.
 
   ObjDisp(m_Instance)->DestroyInstance(Unwrap(m_Instance), NULL);
-  RenderDoc::Inst().RemoveDeviceFrameCapturer(LayerDisp(m_Instance));
+  RenderDoc::Inst().RemoveDeviceFrameCapturer(m_Instance);
 
   GetResourceManager()->ReleaseWrappedResource(m_Instance);
   m_Instance = VK_NULL_HANDLE;

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -135,7 +135,7 @@ void WrappedVulkan::vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR obj,
   {
     SwapchainInfo &info = *GetRecord(obj)->swapInfo;
 
-    RenderDoc::Inst().RemoveFrameCapturer(LayerDisp(m_Instance), info.wndHandle);
+    RenderDoc::Inst().RemoveFrameCapturer(m_Instance, info.wndHandle);
 
     VkRenderPass unwrappedRP = Unwrap(info.rp);
     GetResourceManager()->ReleaseWrappedResource(info.rp, true);

--- a/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
@@ -498,7 +498,7 @@ void WrappedVulkan::WrapAndProcessCreatedSwapchain(VkDevice device,
       m_SwapLookup[swapInfo.wndHandle] = *pSwapChain;
     }
 
-    RenderDoc::Inst().AddFrameCapturer(LayerDisp(m_Instance), swapInfo.wndHandle, this);
+    RenderDoc::Inst().AddFrameCapturer(m_Instance, swapInfo.wndHandle, this);
 
     swapInfo.format = pCreateInfo->imageFormat;
     swapInfo.extent = pCreateInfo->imageExtent;
@@ -714,7 +714,7 @@ VkResult WrappedVulkan::vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR 
 
   SwapchainInfo &swapInfo = *swaprecord->swapInfo;
 
-  bool activeWindow = RenderDoc::Inst().IsActiveWindow(LayerDisp(m_Instance), swapInfo.wndHandle);
+  bool activeWindow = RenderDoc::Inst().IsActiveWindow(m_Instance, swapInfo.wndHandle);
 
   // need to record which image was last flipped so we can get the correct backbuffer
   // for a thumbnail in EndFrameCapture
@@ -832,7 +832,7 @@ VkResult WrappedVulkan::vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR 
 
   VkResult vkr = ObjDisp(queue)->QueuePresentKHR(Unwrap(queue), &unwrappedInfo);
 
-  Present(LayerDisp(m_Instance), swapInfo.wndHandle);
+  Present(m_Instance, swapInfo.wndHandle);
 
   return vkr;
 }


### PR DESCRIPTION
Hi I have started using Vulkan and noticed that the Unreal Engine Renderdoc plugin doesn't work. After a little bit of digging I think the problem is that Vulkan is registering the framecapturer using the internal values of VKInstance_T and therefore it would be difficult to do in-app API capture.

Is there a reason for passing in the internal values of VKInstance to StartFrameCapture?
