### PR TITLE
Check alignment when clearing VkDeviceMemory (#1510)

### DIFF
--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -2145,15 +2145,18 @@ void WrappedVulkan::Apply_InitialState(WrappedVkRes *live, const VkInitialConten
     {
       if(it->start() >= initial.mem.size)
         continue;
+      VkDeviceSize start = it->start();
       VkDeviceSize finish = RDCMIN(it->finish(), initial.mem.size);
-      VkDeviceSize size = finish - it->start();
+      VkDeviceSize size = finish - start;
       switch(it->value())
       {
         case eInitReq_Clear:
-          ObjDisp(cmd)->CmdFillBuffer(Unwrap(cmd), Unwrap(dstBuf), it->start(), size, 0);
+          if(finish >= initial.mem.size)
+            size = VK_WHOLE_SIZE;
+          ObjDisp(cmd)->CmdFillBuffer(Unwrap(cmd), Unwrap(dstBuf), start, size, 0);
           fillCount++;
           break;
-        case eInitReq_Copy: regions.push_back({it->start(), it->start(), size}); break;
+        case eInitReq_Copy: regions.push_back({start, start, size}); break;
         default: break;
       }
     }


### PR DESCRIPTION
When initializing VkDeviceMemory resources, some regions may be cleared
using vkCmdFillBuffer, rather than having initial data copied.
vkCmdFillBuffer requires that the interval offset and size are multiples
of 4. This change now checks the alginment of the interval before
calling vkCmdFillBuffer, and falls back on vkCmdCopyBuffer for
non-aligned intervals.

I was not easily able to find a capture with non-aligned intervals, so that code path has not been tested.