### PR TITLE
Allow hidden errors and warnings to be shown again

### DIFF
--- a/qrenderdoc/Windows/DebugMessageView.cpp
+++ b/qrenderdoc/Windows/DebugMessageView.cpp
@@ -319,14 +319,14 @@ void DebugMessageView::messages_toggled()
     else
       m_FilterModel->m_HiddenSeverities.push_back(m_ContextMessage.severity);
   }
-  else if(action == m_ToggleSeverity)
+  else if(action == m_ToggleCategory)
   {
     if(m_FilterModel->m_HiddenCategories.contains(m_ContextMessage.category))
       m_FilterModel->m_HiddenCategories.removeOne(m_ContextMessage.category);
     else
       m_FilterModel->m_HiddenCategories.push_back(m_ContextMessage.category);
   }
-  else if(action == m_ToggleSeverity)
+  else if(action == m_ToggleMessageType)
   {
     auto type = DebugMessageFilterModel::makeType(m_ContextMessage);
     if(m_FilterModel->m_HiddenTypes.contains(type))
@@ -349,6 +349,11 @@ void DebugMessageView::messages_contextMenu(const QPoint &pos)
   {
     index = m_FilterModel->mapToSource(index);
 
+    m_ToggleSource->setVisible(true);
+    m_ToggleSeverity->setVisible(true);
+    m_ToggleCategory->setVisible(true);
+    m_ToggleMessageType->setVisible(true);
+
     const DebugMessage &msg = m_Ctx.DebugMessages()[index.row()];
 
     QString hide = tr("Hide");
@@ -369,9 +374,21 @@ void DebugMessageView::messages_contextMenu(const QPoint &pos)
     m_ToggleMessageType->setText(tr("%1 Message Type").arg(hidden ? show : hide));
 
     m_ContextMessage = msg;
-
-    RDDialog::show(m_ContextMenu, ui->messages->viewport()->mapToGlobal(pos));
   }
+  else
+  {
+    m_ToggleSource->setVisible(false);
+    m_ToggleSeverity->setVisible(false);
+    m_ToggleCategory->setVisible(false);
+    m_ToggleMessageType->setVisible(false);
+  }
+
+  QString showHidden = tr("Show hidden rows");
+  QString hideHidden = tr("Stop showing hidden rows");
+
+  m_ShowHidden->setText(m_FilterModel->showHidden ? hideHidden : showHidden);
+
+  RDDialog::show(m_ContextMenu, ui->messages->viewport()->mapToGlobal(pos));
 }
 
 void DebugMessageView::paintEvent(QPaintEvent *e)

--- a/qrenderdoc/Windows/DebugMessageView.cpp
+++ b/qrenderdoc/Windows/DebugMessageView.cpp
@@ -349,10 +349,10 @@ void DebugMessageView::messages_contextMenu(const QPoint &pos)
   {
     index = m_FilterModel->mapToSource(index);
 
-    m_ToggleSource->setVisible(true);
-    m_ToggleSeverity->setVisible(true);
-    m_ToggleCategory->setVisible(true);
-    m_ToggleMessageType->setVisible(true);
+    m_ToggleSource->setEnabled(true);
+    m_ToggleSeverity->setEnabled(true);
+    m_ToggleCategory->setEnabled(true);
+    m_ToggleMessageType->setEnabled(true);
 
     const DebugMessage &msg = m_Ctx.DebugMessages()[index.row()];
 
@@ -377,10 +377,14 @@ void DebugMessageView::messages_contextMenu(const QPoint &pos)
   }
   else
   {
-    m_ToggleSource->setVisible(false);
-    m_ToggleSeverity->setVisible(false);
-    m_ToggleCategory->setVisible(false);
-    m_ToggleMessageType->setVisible(false);
+    m_ToggleSource->setEnabled(false);
+    m_ToggleSeverity->setEnabled(false);
+    m_ToggleCategory->setEnabled(false);
+    m_ToggleMessageType->setEnabled(false);
+    m_ToggleSource->setText(tr("Toggle by Source"));
+    m_ToggleSeverity->setText(tr("Toggle by Severity"));
+    m_ToggleCategory->setText(tr("Toggle by Category"));
+    m_ToggleMessageType->setText(tr("Toggle by Message Type"));
   }
 
   RDDialog::show(m_ContextMenu, ui->messages->viewport()->mapToGlobal(pos));

--- a/qrenderdoc/Windows/DebugMessageView.cpp
+++ b/qrenderdoc/Windows/DebugMessageView.cpp
@@ -383,11 +383,6 @@ void DebugMessageView::messages_contextMenu(const QPoint &pos)
     m_ToggleMessageType->setVisible(false);
   }
 
-  QString showHidden = tr("Show hidden rows");
-  QString hideHidden = tr("Stop showing hidden rows");
-
-  m_ShowHidden->setText(m_FilterModel->showHidden ? hideHidden : showHidden);
-
   RDDialog::show(m_ContextMenu, ui->messages->viewport()->mapToGlobal(pos));
 }
 


### PR DESCRIPTION
* Fix copy paste typos (lines 322, 329)
* Allow hidden rows in Errors and Warnings tab to be unhidden
    * Prior to this commit, if all errors and warnings are hidden (through the context menu), they can not be made visible again. This commit makes the "Show hidden rows" option appear in the context menu where previously no context menu would appear.