### PR TITLE
Add implicit resolve usage for renderpasses

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -800,6 +800,7 @@ private:
   bool CheckMemoryRequirements(const char *resourceName, ResourceId memId,
                                VkDeviceSize memoryOffset, VkMemoryRequirements mrq);
 
+  void AddImplicitResolveResourceUsage(uint32_t subpass = 0);
   std::vector<VkImageMemoryBarrier> GetImplicitRenderPassBarriers(uint32_t subpass = 0);
   std::string MakeRenderPassOpString(bool store);
 


### PR DESCRIPTION
According to vulkan spec moving to the next subpass automatically
performs any multisample resolve operations in the subpass being
ended.

