### PR TITLE
(q)renderdoc/CMakeLists.txt: remove flag unsupported by GCC

### DIFF
--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -165,7 +165,7 @@ file(WRITE
 if(CMAKE_COMPILER_IS_GNUCXX)
     file(APPEND
         ${CMAKE_BINARY_DIR}/qrenderdoc/qrenderdoc_cmake.pri
-        "QMAKE_CXXFLAGS+=-Wno-unknown-warning -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation\n")
+        "QMAKE_CXXFLAGS+=-Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation\n")
 endif()
 
 if(ENABLE_WAYLAND)

--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -338,10 +338,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR APPLE)
 
     if(CMAKE_COMPILER_IS_GNUCXX)
         set_property(SOURCE 3rdparty/jpeg-compressor/jpgd.cpp
-            APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-unknown-warning -Wno-implicit-fallthrough")
+            APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough")
 
         set_property(SOURCE strings/utf8printf.cpp
-            APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-unknown-warning -Wno-format-truncation")
+            APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-format-truncation")
     endif()
 
     # Need to add -Wno-unknown-warning-option since only newer clang versions have


### PR DESCRIPTION
-Wno-unknown-warning is not supported by GCC, only by Clang so we
remove it because newer GCC versions like 9.2.0 will complain, older
versions would just ignore it.