### PR TITLE
Disable missing capture file menu items

### DIFF
--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -164,8 +164,10 @@ private slots:
   void switchContext();
   void contextChooser_menuShowing();
 
-  void ClearRecentCaptureFiles();
-  void ClearRecentCaptureSettings();
+  void ClearAllRecentCaptureFiles();
+  void ClearMissingRecentCaptureFiles();
+  void ClearAllRecentCaptureSettings();
+  void ClearMissingRecentCaptureSettings();
 
 private:
   void closeEvent(QCloseEvent *event) override;

--- a/qrenderdoc/Windows/MainWindow.ui
+++ b/qrenderdoc/Windows/MainWindow.ui
@@ -72,14 +72,16 @@
       <string>&amp;Recent Captures</string>
      </property>
      <addaction name="separator"/>
-     <addaction name="action_Clear_Capture_Files_History"/>
+     <addaction name="action_Clear_All_Capture_Files_History"/>
+     <addaction name="action_Clear_Missing_Capture_Files_History"/>
     </widget>
     <widget class="QMenu" name="menu_Recent_Capture_Settings">
      <property name="title">
       <string>Recent Capture Settings</string>
      </property>
      <addaction name="separator"/>
-     <addaction name="action_Clear_Capture_Settings_History"/>
+     <addaction name="action_Clear_All_Capture_Settings_History"/>
+     <addaction name="action_Clear_Missing_Capture_Settings_History"/>
     </widget>
     <widget class="QMenu" name="menu_Export_As">
      <property name="title">
@@ -402,14 +404,24 @@
     <string>&amp;About</string>
    </property>
   </action>
-  <action name="action_Clear_Capture_Files_History">
+  <action name="action_Clear_All_Capture_Files_History">
    <property name="text">
-    <string>Clear History</string>
+    <string>Clear All</string>
    </property>
   </action>
-  <action name="action_Clear_Capture_Settings_History">
+  <action name="action_Clear_Missing_Capture_Files_History">
    <property name="text">
-    <string>Clear History</string>
+    <string>Clear Missing</string>
+   </property>
+  </action>
+  <action name="action_Clear_All_Capture_Settings_History">
+   <property name="text">
+    <string>Clear All</string>
+   </property>
+  </action>
+  <action name="action_Clear_Missing_Capture_Settings_History">
+   <property name="text">
+    <string>Clear Missing</string>
    </property>
   </action>
   <action name="action_Statistics_Viewer">


### PR DESCRIPTION
After this commit, recent capture and capture settings files which no longer exist are disabled (greyed out and marked "(missing)"). An option to clear the missing files from the recent lists was added, alongside the previous "clear all" actions.

I would have liked to get the file status to be updated each time the menu is opened, so it never displays incorrect information, however I wasn't able to find where that could be hooked into. The recent captures file status is currently updated on capture save/load, and the recent capture settings file status is updated on capture setting save (and, of course, both are updated on application startup).