### PR TITLE
VK pixel history: re-write shaders to remove side effects

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -70,6 +70,30 @@ enum class VkIndirectPatchType
   DrawIndirectByteCount,
 };
 
+enum class EventFlags : uint32_t
+{
+  NoFlags = 0x0,
+  VertexRWUsage = 1 << uint32_t(ShaderStage::Vertex),
+  TessControlRWUsage = 1 << uint32_t(ShaderStage::Tess_Control),
+  TessEvalRWUsage = 1 << uint32_t(ShaderStage::Tess_Eval),
+  GeometryRWUsage = 1 << uint32_t(ShaderStage::Geometry),
+};
+
+BITMASK_OPERATORS(EventFlags);
+
+constexpr inline EventFlags PipeStageRWEventFlags(ShaderStage stage)
+{
+  return EventFlags(1 << uint32_t(stage));
+}
+
+inline EventFlags PipeRWUsageEventFlags(ResourceUsage usage)
+{
+  if(usage >= ResourceUsage::VS_RWResource && usage <= ResourceUsage::GS_RWResource)
+    return PipeStageRWEventFlags(
+        ShaderStage(uint32_t(usage) - uint32_t(ResourceUsage::VS_RWResource)));
+  return EventFlags::NoFlags;
+}
+
 struct VkIndirectRecordData
 {
   VkBufferMemoryBarrier paramsBarrier, countBarrier;
@@ -755,6 +779,7 @@ private:
   VulkanCreationInfo m_CreationInfo;
 
   std::map<ResourceId, std::vector<EventUsage>> m_ResourceUses;
+  std::map<uint32_t, EventFlags> m_EventFlags;
 
   // returns thread-local temporary memory
   byte *GetTempMemory(size_t s);
@@ -955,6 +980,7 @@ public:
   uint32_t GetUploadMemoryIndex(uint32_t resourceRequiredBitmask);
   uint32_t GetGPULocalMemoryIndex(uint32_t resourceRequiredBitmask);
 
+  EventFlags GetEventFlags(uint32_t eid) { return m_EventFlags[eid]; }
   std::vector<EventUsage> GetUsage(ResourceId id) { return m_ResourceUses[id]; }
   // return the pre-selected device and queue
   VkDevice GetDev()

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -696,6 +696,7 @@ void WrappedVulkan::InsertDrawsAndRefreshIDs(BakedCmdBufferInfo &cmdBufInfo)
       EventUsage u = it->second;
       u.eventId += m_RootEventID;
       m_ResourceUses[it->first].push_back(u);
+      m_EventFlags[u.eventId] |= PipeRWUsageEventFlags(u.usage);
     }
 
     GetDrawcallStack().back()->children.push_back(n);


### PR DESCRIPTION
So that we can replay a draw multiple times.
Added m_EventResourceUsage that keeps track of resource usage
for an event, allows quickly figuring out if an event had any
shader RW resources, and only then doing an expensive part of
analyzing/rewriting a shader.

