### PR TITLE
added ID3D11Device5 checks + fixed QueryInterface calls

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device.h
+++ b/renderdoc/driver/d3d11/d3d11_device.h
@@ -469,7 +469,7 @@ public:
   {
     if(iid == __uuidof(ID3D11Device) || iid == __uuidof(ID3D11Device1) ||
        iid == __uuidof(ID3D11Device2) || iid == __uuidof(ID3D11Device3) ||
-       iid == __uuidof(ID3D11Device4))
+       iid == __uuidof(ID3D11Device4) || iid == __uuidof(ID3D11Device5))
       return true;
 
     return false;
@@ -486,6 +486,8 @@ public:
       return (ID3D11Device3 *)this;
     else if(iid == __uuidof(ID3D11Device4))
       return (ID3D11Device4 *)this;
+    else if(iid == __uuidof(ID3D11Device5))
+      return (ID3D11Device5 *)this;
 
     RDCERR("Requested unknown device interface %s", ToStr(iid).c_str());
 

--- a/renderdoc/driver/d3d11/d3d11_resources.h
+++ b/renderdoc/driver/d3d11/d3d11_resources.h
@@ -193,7 +193,7 @@ public:
        riid == __uuidof(IDXGIResource1) || riid == __uuidof(IDXGISurface2))
     {
       // ensure the real object has this interface
-      void *outObj;
+      void *outObj = NULL;
       HRESULT hr = m_pReal->QueryInterface(riid, &outObj);
 
       IUnknown *unk = (IUnknown *)outObj;

--- a/renderdoc/driver/dxgi/dxgi_wrapped.h
+++ b/renderdoc/driver/dxgi/dxgi_wrapped.h
@@ -228,7 +228,7 @@ public:
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject)
   {
     // ensure the real object has this interface
-    void *outObj;
+    void *outObj = NULL;
     HRESULT hr = m_pWrapped->QueryInterface(riid, &outObj);
 
     IUnknown *unk = (IUnknown *)outObj;


### PR DESCRIPTION
- ID3D11Device5 is supported but checks in IsDeviceUUID and GetDeviceInterface are missing
- fixed not initialized pointers passed to QueryInterface

Note, the second change fixes a crash. WrappedDXGIInterface::QueryInterface calls QueryInterface on the wrapped type. In my case the wrapped type is WrappedDeviceChild11 and the requested type is IDXGISurface2. The crash happens when the DXGI object does not implement IDXGISurface2. In this case  WrappedDeviceChild11::QueryInterface returns E_NOINTERFACE and WrappedDXGIInterface::QueryInterface calls SAFE_RELEASE on an un-initialized pointer.