### PR TITLE
Reset images when backing memory is Reset

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1382,7 +1382,7 @@ bool WrappedVulkan::Serialise_BeginCaptureFrame(SerialiserType &ser)
       // PREINIT as if it was GENERAL.
       for(auto it = m_ImageLayouts.begin(); it != m_ImageLayouts.end(); ++it)
       {
-        if(!it->second.memoryBound)
+        if(!it->second.isMemoryBound)
           continue;
 
         for(auto stit = it->second.subresourceStates.begin();

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -296,7 +296,7 @@ void VulkanResourceManager::SerialiseImageStates(SerialiserType &ser,
 
         auto stit = states.find(liveid);
 
-        if(stit == states.end() || stit->second.memoryBound)
+        if(stit == states.end() || stit->second.isMemoryBound)
         {
           barriers.push_back(t);
           vec.push_back(make_rdcpair(liveid, state));
@@ -339,7 +339,7 @@ void VulkanResourceManager::SerialiseImageStates(SerialiserType &ser,
 
           auto stit = states.find(liveid);
 
-          if(stit == states.end() || stit->second.memoryBound)
+          if(stit == states.end() || stit->second.isMemoryBound)
           {
             barriers.push_back(t);
             vec.push_back(make_rdcpair(liveid, state));

--- a/renderdoc/driver/vulkan/vk_rendertexture.cpp
+++ b/renderdoc/driver/vulkan/vk_rendertexture.cpp
@@ -166,7 +166,7 @@ bool VulkanReplay::RenderTextureInternal(TextureDisplay cfg, VkRenderPassBeginIn
   VkImage liveIm = m_pDriver->GetResourceManager()->GetCurrentHandle<VkImage>(cfg.resourceId);
   const ImageInfo &imageInfo = layouts.imageInfo;
 
-  if(!layouts.memoryBound)
+  if(!layouts.isMemoryBound)
     return false;
 
   CreateTexImageView(liveIm, iminfo, cfg.typeHint, texviews);

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -2172,7 +2172,7 @@ bool VulkanReplay::GetMinMax(ResourceId texid, uint32_t sliceFace, uint32_t mip,
   TextureDisplayViews &texviews = m_TexRender.TextureViews[texid];
   VkImage liveIm = m_pDriver->GetResourceManager()->GetCurrentHandle<VkImage>(texid);
 
-  if(!layouts.memoryBound)
+  if(!layouts.isMemoryBound)
     return false;
 
   if(!IsStencilFormat(iminfo.format))
@@ -2494,7 +2494,7 @@ bool VulkanReplay::GetHistogram(ResourceId texid, uint32_t sliceFace, uint32_t m
   TextureDisplayViews &texviews = m_TexRender.TextureViews[texid];
   VkImage liveIm = m_pDriver->GetResourceManager()->GetCurrentHandle<VkImage>(texid);
 
-  if(!layouts.memoryBound)
+  if(!layouts.isMemoryBound)
     return false;
 
   bool stencil = false;
@@ -2814,7 +2814,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, uint32_t arrayIdx, uint32_t mi
 
   ImageLayouts &layouts = m_pDriver->m_ImageLayouts[tex];
 
-  if(!layouts.memoryBound)
+  if(!layouts.isMemoryBound)
     return;
 
   VkImageCreateInfo imCreateInfo = {

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1701,7 +1701,10 @@ struct ImageLayouts
 {
   uint32_t queueFamilyIndex = 0;
   std::vector<ImageRegionState> subresourceStates;
-  bool memoryBound = false;
+  bool isMemoryBound = false;
+  ResourceId boundMemory = ResourceId();
+  VkDeviceSize boundMemoryOffset = 0ull;
+  VkDeviceSize boundMemorySize = 0ull;
   VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
   ImageInfo imageInfo;
 };

--- a/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
@@ -453,7 +453,7 @@ bool WrappedVulkan::Serialise_vkCreateSwapchainKHR(SerialiserType &ser, VkDevice
 
       layouts.imageInfo = ImageInfo(swapinfo);
 
-      layouts.memoryBound = true;
+      layouts.isMemoryBound = true;
       layouts.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
       layouts.subresourceStates.clear();
@@ -594,7 +594,7 @@ void WrappedVulkan::WrapAndProcessCreatedSwapchain(VkDevice device,
           layout = &m_ImageLayouts[imid];
         }
         layout->imageInfo = GetRecord(images[i])->resInfo->imageInfo;
-        layout->memoryBound = true;
+        layout->isMemoryBound = true;
         layout->initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
         layout->subresourceStates.clear();


### PR DESCRIPTION
There are some situations that cause us to reset the memory backing an image, but not the image itself--this puts the image in a corrupted state.

This fix updates the image initialization logic to check the bound memory. If the memory is written by any captured command, or if the memory is reset, then the entire is image is assumed to be uninitialized.