### PR TITLE
Add Img/MemRefs for resources with initial contents

### DIFF
--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -100,6 +100,9 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
     const ResourceInfo &resInfo = *im->record->resInfo;
     const ImageInfo &imageInfo = resInfo.imageInfo;
 
+    if(!GetResourceManager()->FindImgRefs(id))
+      GetResourceManager()->AddImageFrameRefs(id, imageInfo);
+
     if(resInfo.IsSparse())
     {
       // if the image is sparse we have to do a different kind of initial state prepare,
@@ -548,6 +551,9 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
     VkResourceRecord *record = GetResourceManager()->GetResourceRecord(id);
     VkDeviceMemory datamem = ToHandle<VkDeviceMemory>(res);
     VkDeviceSize datasize = record->Length;
+
+    if(!GetResourceManager()->FindMemRefs(id))
+      GetResourceManager()->AddMemoryFrameRefs(id);
 
     RDCASSERT(datamem != VK_NULL_HANDLE);
 

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -844,6 +844,16 @@ void VulkanResourceManager::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSi
   MarkResourceFrameReferenced(mem, maxRef, ComposeFrameRefsDisjoint);
 }
 
+void VulkanResourceManager::AddMemoryFrameRefs(ResourceId mem)
+{
+  m_MemFrameRefs.insert({mem, MemRefs()});
+}
+
+void VulkanResourceManager::AddImageFrameRefs(ResourceId img, const ImageInfo &imageInfo)
+{
+  m_ImgFrameRefs.insert({img, ImgRefs(imageInfo)});
+}
+
 void VulkanResourceManager::MergeReferencedImages(std::map<ResourceId, ImgRefs> &imgRefs)
 {
   for(auto j = imgRefs.begin(); j != imgRefs.end(); j++)

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -432,6 +432,8 @@ public:
                                 FrameRefType refType);
   void MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize start, VkDeviceSize end,
                                  FrameRefType refType);
+  void AddMemoryFrameRefs(ResourceId mem);
+  void AddImageFrameRefs(ResourceId img, const ImageInfo &imageInfo);
 
   void MergeReferencedMemory(std::map<ResourceId, MemRefs> &memRefs);
   void MergeReferencedImages(std::map<ResourceId, ImgRefs> &imgRefs);


### PR DESCRIPTION
This ensures that ImgRefs/MemRefs exist for images/memory with initial contents. Previously if the resource was never accessed, then no information was saved about the resource references; this lack of reference info is pesimistically interpreted at replay as requiring complete reset.

This change now explicitly inserts empty ImgRefs/MemRefs for each resource when preparing the initial contents.