### PR TITLE
Fix injecting on some Android 9 devices

### DIFF
--- a/renderdoc/android/jdwp.cpp
+++ b/renderdoc/android/jdwp.cpp
@@ -216,6 +216,15 @@ bool InjectLibraries(const std::string &deviceID, Network::Socket *sock)
       int32_t slotIdx =
           conn.GetLocalVariable(vulkanLoaderClass, vulkanLoaderMethod, "librarySearchPath");
 
+      // Android 9 doesn't return names and changed how slots are indexed, try an offset from this
+      if(slotIdx == -1)
+      {
+        slotIdx = conn.GetLocalVariable(vulkanLoaderClass, vulkanLoaderMethod, "this");
+
+        if(slotIdx != -1)
+          slotIdx += 4;
+      }
+
       // as a default, use the 4th slot as it's the 4th argument argument (0 is this), if symbols
       // weren't available we can't identify the variable by name
       if(slotIdx == -1)

--- a/renderdoc/android/jdwp.cpp
+++ b/renderdoc/android/jdwp.cpp
@@ -213,16 +213,30 @@ bool InjectLibraries(const std::string &deviceID, Network::Socket *sock)
 
     if(vulkanLoaderMethod)
     {
-      int32_t slotIdx =
-          conn.GetLocalVariable(vulkanLoaderClass, vulkanLoaderMethod, "librarySearchPath");
+      std::vector<VariableSlot> slots = conn.GetLocalVariables(vulkanLoaderClass, vulkanLoaderMethod);
+
+      int32_t slotIdx = -1;
+
+      for(const VariableSlot &s : slots)
+      {
+        if(s.name == "librarySearchPath")
+        {
+          slotIdx = s.slot;
+          break;
+        }
+      }
 
       // Android 9 doesn't return names and changed how slots are indexed, try an offset from this
       if(slotIdx == -1)
       {
-        slotIdx = conn.GetLocalVariable(vulkanLoaderClass, vulkanLoaderMethod, "this");
-
-        if(slotIdx != -1)
-          slotIdx += 4;
+        for(const VariableSlot &s : slots)
+        {
+          if(s.name == "this")
+          {
+              slotIdx = s.slot + 4;
+              break;
+          }
+        }
       }
 
       // as a default, use the 4th slot as it's the 4th argument argument (0 is this), if symbols

--- a/renderdoc/android/jdwp.h
+++ b/renderdoc/android/jdwp.h
@@ -516,10 +516,8 @@ public:
   methodID GetMethod(referenceTypeID type, const std::string &name,
                      const std::string &signature = "", referenceTypeID *methClass = NULL);
 
-  // get a local variable slot. If signature is empty, it's ignored for matching. Returns -1 if not
-  // found
-  int32_t GetLocalVariable(referenceTypeID type, methodID method, const std::string &name,
-                           const std::string &signature = "");
+  // get local variable slots
+  std::vector<VariableSlot> GetLocalVariables(referenceTypeID type, methodID method);
 
   // get a thread's stack frames
   std::vector<StackFrame> GetCallStack(threadID thread);

--- a/renderdoc/android/jdwp_connection.cpp
+++ b/renderdoc/android/jdwp_connection.cpp
@@ -267,14 +267,13 @@ methodID Connection::GetMethod(referenceTypeID type, const std::string &name,
   return {};
 }
 
-int32_t Connection::GetLocalVariable(referenceTypeID type, methodID method, const std::string &name,
-                                     const std::string &signature)
+std::vector<VariableSlot> Connection::GetLocalVariables(referenceTypeID type, methodID method)
 {
   Command cmd(CommandSet::Method, 2);
   cmd.GetData().Write(type).Write(method);
 
   if(!SendReceive(cmd))
-    return -1;
+    return {};
 
   int32_t argumentCount = 0;
   std::vector<VariableSlot> slots;
@@ -286,11 +285,7 @@ int32_t Connection::GetLocalVariable(referenceTypeID type, methodID method, cons
   });
   data.Done();
 
-  for(const VariableSlot &s : slots)
-    if(s.name == name && (signature == "" || signature == s.signature))
-      return s.slot;
-
-  return -1;
+  return slots;
 }
 
 fieldID Connection::GetField(referenceTypeID type, const std::string &name,


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Since updating to Android 9, I get `Couldn't get 'String librarySearchPath' local parameter!` errors and `vkCreateInstance` failing whenever I launch an app. It looks like this is because `GetLocalValue` is receiving error 35 (invalid slot).

Printing the results in `GetLocalVariable` looks like this:
```
name this sig Landroid/app/ApplicationLoaders; slot 9
name  sig Ljava/lang/String; slot 10
name  sig I slot 11
name  sig Z slot 12
name  sig Ljava/lang/String; slot 13
name  sig Ljava/lang/String; slot 14
name  sig Ljava/lang/ClassLoader; slot 15
name  sig Ljava/lang/String; slot 16
```

So, everything except `this` has no name and the slots don't start at zero. I'm not sure if this is the right fix, but it works.