### PR TITLE
Fall back to EGL for GL replay

### DIFF
--- a/renderdoc/driver/gl/egl_platform.cpp
+++ b/renderdoc/driver/gl/egl_platform.cpp
@@ -362,8 +362,8 @@ class EGLPlatform : public GLPlatform
     Display *xlibDisplay = RenderDoc::Inst().GetGlobalEnvironment().xlibDisplay;
     wl_display *waylandDisplay = RenderDoc::Inst().GetGlobalEnvironment().waylandDisplay;
 
-    // we only support replaying GLES through EGL, except if Wayland is enabled
-    RDCASSERT(api == RDCDriver::OpenGLES || waylandDisplay);
+    // we support replaying both GLES and GL through EGL
+    RDCASSERT(api == RDCDriver::OpenGLES || api == RDCDriver::OpenGL);
 
     m_API = api;
 

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -3607,7 +3607,18 @@ ReplayStatus GL_CreateReplayDevice(RDCFile *rdc, const ReplayOptions &opts, IRep
 #endif
   }
 
-  if(!gl_platform->CanCreateGLContext())
+  bool can_create_gl_context = gl_platform->CanCreateGLContext();
+
+#if defined(RENDERDOC_SUPPORT_EGL)
+  if(!can_create_gl_context && gl_platform == &GetGLPlatform())
+  {
+    RDCLOG("Cannot create GL context with GL platform, falling back to EGL");
+    gl_platform = &GetEGLPlatform();
+    can_create_gl_context = gl_platform->CanCreateGLContext();
+  }
+#endif
+
+  if(!can_create_gl_context)
   {
     RDCERR("Platform doesn't support GL contexts");
     return ReplayStatus::APIInitFailed;


### PR DESCRIPTION
## Description

We want to try to use the EGL platform as a fallback when the GL
platform can't create a GL context, since EGL_DEFAULT_DISPLAY might
still provide a workable EGLDisplay. This, for example, allows us to
replay traces when on-screen display is not required, by using the Mesa
surfaceless platform (by setting the "EGL_PLATFORM=surfaceless" Mesa
environment variable).

If we prefer to not have such an implicit fallback, an alternative would be to
provide an explicit option (e.g., in ReplayOptions or in an environment
variable?) to force a particular platform.
