### PR TITLE
Update Vulkan features with VK_EXT_debug_utils

### DIFF
--- a/docs/getting_started/features.rst
+++ b/docs/getting_started/features.rst
@@ -86,7 +86,7 @@ Vulkan
 ------
 
 * Support for Vulkan 1.1 on Windows, Linux, Android, and Stadia.
-* Event markers and object naming both come from ``VK_EXT_debug_marker``.
+* Event markers and object naming both come from ``VK_EXT_debug_utils`` or deprecated ``VK_EXT_debug_marker``.
 
 OpenGL & OpenGL ES
 ------------------


### PR DESCRIPTION
## Description

Just a simple docs update of Vulkan features to include `VK_EXT_debug_utils` as stated in https://github.com/baldurk/renderdoc/issues/1427#issuecomment-505799113 and mark `VK_EXT_debug_marker` as deprecated according to [vulkan specs](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_EXT_debug_marker.html).

I can update other parts of docs where `VK_EXT_debug_marker` is mentioned if that seems like a good idea.