### PR TITLE
Implemented PerformanceCounterViewer::OnEventChanged handling

### DIFF
--- a/qrenderdoc/Windows/PerformanceCounterViewer.cpp
+++ b/qrenderdoc/Windows/PerformanceCounterViewer.cpp
@@ -281,6 +281,24 @@ void PerformanceCounterViewer::OnCaptureLoaded()
   ui->saveCSV->setEnabled(true);
 }
 
+void PerformanceCounterViewer::OnEventChanged(uint32_t eventId)
+{
+  if(ui->syncViews->isChecked())
+  {
+    const int numItems = (int)ui->counterResults->rowCount();
+    for(int i = 0; i < numItems; ++i)
+    {
+      QTableWidgetItem *item = ui->counterResults->item(i, 0);
+      if(item->data(Qt::UserRole).toUInt() == eventId)
+      {
+        ui->counterResults->setCurrentItem(item);
+        ui->counterResults->scrollToItem(item);
+        break;
+      }
+    }
+  }
+}
+
 void PerformanceCounterViewer::on_counterResults_doubleClicked(const QModelIndex &index)
 {
   QTableWidgetItem *item = ui->counterResults->item(index.row(), 0);

--- a/qrenderdoc/Windows/PerformanceCounterViewer.h
+++ b/qrenderdoc/Windows/PerformanceCounterViewer.h
@@ -48,7 +48,7 @@ public:
   void OnCaptureLoaded() override;
   void OnCaptureClosed() override;
   void OnSelectedEventChanged(uint32_t eventId) override {}
-  void OnEventChanged(uint32_t eventId) override {}
+  void OnEventChanged(uint32_t eventId) override;
 private slots:
   // automatic slots
   void on_counterResults_doubleClicked(const QModelIndex &index);

--- a/qrenderdoc/Windows/PerformanceCounterViewer.ui
+++ b/qrenderdoc/Windows/PerformanceCounterViewer.ui
@@ -82,6 +82,39 @@
          </widget>
         </item>
         <item>
+         <widget class="QToolButton" name="syncViews">
+          <property name="toolTip">
+           <string>Sync Views</string>
+          </property>
+          <property name="text">
+           <string>Sync Views</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../Resources/resources.qrc">
+            <normaloff>:/arrow_join.png</normaloff>:/arrow_join.png</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="toolButtonStyle">
+           <enum>Qt::ToolButtonTextBesideIcon</enum>
+          </property>
+          <property name="autoRaise">
+           <bool>true</bool>
+          </property>
+          <property name="arrowType">
+           <enum>Qt::NoArrow</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="line_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QToolButton" name="saveCSV">
           <property name="toolTip">
            <string>Export to CSV</string>


### PR DESCRIPTION
Implemented PerformanceCounterViewer::OnEventChanged to handle global event changes.
Behaviour can be toggled on/off via a new 'Sync Views' button similar to the Mesh Viewer; the default is off.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
