### PR TITLE
gl: Require ARB_shader_bit_encoding in FS

### DIFF
--- a/renderdoc/data/glsl/texdisplay.frag
+++ b/renderdoc/data/glsl/texdisplay.frag
@@ -27,10 +27,6 @@
 #extension GL_EXT_texture_cube_map_array : enable
 #extension GL_EXT_texture_buffer : enable
 
-#else
-
-#extension GL_ARB_gpu_shader5 : enable
-
 #endif
 
 #define HEATMAP_UBO
@@ -151,7 +147,7 @@ void main(void)
 
   if(texdisplay.RawOutput != 0)
   {
-#ifdef GL_ARB_gpu_shader5
+#ifdef HAS_BIT_CONVERSION
     if(uintTex)
       color_out = uintBitsToFloat(ucol);
     else if(sintTex)

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -686,6 +686,7 @@ extern bool IsGLES;
   EXT_TO_CHECK(33, 30, ARB_texture_swizzle)                      \
   EXT_TO_CHECK(33, 99, ARB_occlusion_query2)                     \
   EXT_TO_CHECK(33, 99, ARB_timer_query)                          \
+  EXT_TO_CHECK(33, 30, ARB_shader_bit_encoding)                  \
   EXT_TO_CHECK(40, 32, ARB_draw_buffers_blend)                   \
   EXT_TO_CHECK(40, 31, ARB_draw_indirect)                        \
   EXT_TO_CHECK(40, 32, ARB_gpu_shader5)                          \

--- a/renderdoc/driver/gl/gl_debug.cpp
+++ b/renderdoc/driver/gl/gl_debug.cpp
@@ -394,6 +394,8 @@ void GLReplay::InitDebugData()
       texSampleDefines +=
           "#define TEXSAMPLE_BUFFER 1\n"
           "#extension GL_EXT_texture_buffer : require\n";
+
+    texSampleDefines += "#define HAS_BIT_CONVERSION 1\n";
   }
   else
   {
@@ -410,6 +412,11 @@ void GLReplay::InitDebugData()
       texSampleDefines +=
           "#define TEXSAMPLE_MULTISAMPLE 1\n"
           "#extension GL_ARB_texture_multisample : require\n";
+
+    if(HasExt[ARB_gpu_shader5])
+      texSampleDefines +=
+          "#define HAS_BIT_CONVERSION 1\n"
+          "#extension GL_ARB_gpu_shader5 : require\n";
   }
 
   vs = GenerateGLSLShader(GetEmbeddedResource(glsl_blit_vert), shaderType, glslBaseVer);

--- a/renderdoc/driver/gl/gl_debug.cpp
+++ b/renderdoc/driver/gl/gl_debug.cpp
@@ -417,6 +417,10 @@ void GLReplay::InitDebugData()
       texSampleDefines +=
           "#define HAS_BIT_CONVERSION 1\n"
           "#extension GL_ARB_gpu_shader5 : require\n";
+    else if(HasExt[ARB_shader_bit_encoding])
+      texSampleDefines +=
+          "#define HAS_BIT_CONVERSION 1\n"
+          "#extension GL_ARB_shader_bit_encoding : require\n";
   }
 
   vs = GenerateGLSLShader(GetEmbeddedResource(glsl_blit_vert), shaderType, glslBaseVer);


### PR DESCRIPTION
On drivers only supportinmg OpenGL 3.3, like llvmpipe, ARB_gpu_shader5 may
not be available, but (u)intBitsToFloat and floatBitsTo* functions are also
provided by ARB_shader_bit_encoding. By requiring this extension in the FS
shader traces that were captured with the llvmpipe driver can actually also
be replayed by using this driver.
