### PR TITLE
Move some functions to common locations for upcoming D3D12 usage.

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_debug.h
+++ b/renderdoc/driver/d3d11/d3d11_debug.h
@@ -119,9 +119,6 @@ public:
 
   void PixelHistoryCopyPixel(CopyPixelParams &params, uint32_t x, uint32_t y);
 
-  ShaderDebug::State CreateShaderDebugState(ShaderDebugTrace &trace, int quadIdx,
-                                            DXBC::DXBCContainer *dxbc, const ShaderReflection &refl,
-                                            bytebuf *cbufData);
   void CreateShaderGlobalState(ShaderDebug::GlobalState &global, DXBC::DXBCContainer *dxbc,
                                uint32_t UAVStartSlot, ID3D11UnorderedAccessView **UAVs,
                                ID3D11ShaderResourceView **SRVs);

--- a/renderdoc/driver/d3d12/d3d12_debug.h
+++ b/renderdoc/driver/d3d12/d3d12_debug.h
@@ -28,6 +28,7 @@
 #include "core/core.h"
 #include "replay/replay_driver.h"
 #include "d3d12_common.h"
+#include "d3d12_state.h"
 
 class WrappedID3D12Device;
 class D3D12ResourceManager;
@@ -165,9 +166,6 @@ public:
   void CopyTex2DMSToArray(ID3D12Resource *destArray, ID3D12Resource *srcMS);
   void CopyArrayToTex2DMS(ID3D12Resource *destMS, ID3D12Resource *srcArray, UINT selectedSlice);
 
-  ShaderDebug::State CreateShaderDebugState(ShaderDebugTrace &trace, int quadIdx,
-                                            DXBC::DXBCContainer *dxbc, const ShaderReflection &refl,
-                                            bytebuf *cbufData);
   void CreateShaderGlobalState(ShaderDebug::GlobalState &global, DXBC::DXBCContainer *dxbc);
 
 private:
@@ -215,3 +213,12 @@ private:
   ID3D12GraphicsCommandListX *m_DebugList = NULL;
   ID3D12CommandAllocator *m_DebugAlloc = NULL;
 };
+
+void MoveRootSignatureElementsToRegisterSpace(D3D12RootSignature &sig, uint32_t registerSpace,
+                                              D3D12DescriptorType type,
+                                              D3D12_SHADER_VISIBILITY visibility);
+
+void AddDebugDescriptorToRenderState(WrappedID3D12Device *pDevice, D3D12RenderState &rs,
+                                     const PortableHandle &handle,
+                                     D3D12_DESCRIPTOR_HEAP_TYPE heapType, uint32_t sigElem,
+                                     std::set<ResourceId> &copiedHeaps);

--- a/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
@@ -117,22 +117,6 @@ bool D3D12DebugAPIWrapper::CalculateSampleGather(
   return false;
 }
 
-ShaderDebug::State D3D12DebugManager::CreateShaderDebugState(ShaderDebugTrace &trace, int quadIdx,
-                                                             DXBC::DXBCContainer *dxbc,
-                                                             const ShaderReflection &refl,
-                                                             bytebuf *cbufData)
-{
-  RDCUNIMPLEMENTED("CreateShaderDebugState not yet implemented for D3D12");
-
-  using namespace DXBCBytecode;
-  using namespace ShaderDebug;
-
-  State initialState = State(quadIdx, &trace, dxbc->GetReflection(), dxbc->GetDXBCByteCode());
-
-  initialState.Init();
-  return initialState;
-}
-
 void D3D12DebugManager::CreateShaderGlobalState(ShaderDebug::GlobalState &global,
                                                 DXBC::DXBCContainer *dxbc)
 {

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -37,6 +37,7 @@ struct CBufferVariable;
 }
 
 class WrappedID3D11Device;
+enum DXGI_FORMAT;
 
 namespace ShaderDebug
 {
@@ -185,6 +186,11 @@ void FlattenVariables(const rdcarray<ShaderConstant> &constants,
 void FlattenVariables(const rdcarray<ShaderConstant> &constants,
                       const rdcarray<ShaderVariable> &invars, rdcarray<ShaderVariable> &outvars);
 
+void FillViewFmt(DXGI_FORMAT format, GlobalState::ViewFmt &viewFmt);
+
+void LookupSRVFormatFromShaderReflection(const DXBC::Reflection &reflection,
+                                         uint32_t shaderRegister, GlobalState::ViewFmt &viewFmt);
+
 struct SampleGatherResourceData
 {
   DXBCBytecode::ResourceDimension dim;
@@ -316,5 +322,9 @@ private:
   const DXBCBytecode::Program *program;
   const ShaderDebugTrace *trace;
 };
+
+void CreateShaderDebugStateAndTrace(ShaderDebug::State &initialState, ShaderDebugTrace &trace,
+                                    int quadIdx, DXBC::DXBCContainer *dxbc,
+                                    const ShaderReflection &refl, bytebuf *cbufData);
 
 };    // namespace ShaderDebug


### PR DESCRIPTION
Some work for shader debugging is identical to setting up the quad overlay, so I've moved that logic to their own functions. Some portions of creating a global shader debug state, and the entirety of the initial shader debug state were agnostic of D3D API, so they now exist in DXBC code.