### PR TITLE
Fix bugs in image initialization barriers

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -916,9 +916,10 @@ private:
                                                       int32_t messageCode, const char *pLayerPrefix,
                                                       const char *pMessage, void *pUserData);
   void AddFrameTerminator(uint64_t queueMarkerTag);
-  std::vector<VkImageMemoryBarrier> ImageInitializationBarriers(ResourceId id, WrappedVkRes *live,
-                                                                InitPolicy policy, bool initialized,
-                                                                const ImgRefs *imgRefs) const;
+  void ImageInitializationBarriers(ResourceId id, WrappedVkRes *live, InitPolicy policy,
+                                   bool initialized, const ImgRefs *imgRefs,
+                                   std::vector<VkImageMemoryBarrier> &setupBarriers,
+                                   std::vector<VkImageMemoryBarrier> &cleanupBarriers) const;
   void SubmitExtQBarriers(const std::map<uint32_t, std::vector<VkImageMemoryBarrier>> &extQBarriers);
 
 public:

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1146,6 +1146,8 @@ struct ImgRefs
   {
     return InitReq(SubresourceRef(aspectIndex, level, layer), policy, initialized);
   }
+  InitReqType SubresourceRangeMaxInitReq(VkImageSubresourceRange range, InitPolicy policy,
+                                         bool initialized) const;
   std::vector<rdcpair<VkImageSubresourceRange, InitReqType> > SubresourceRangeInitReqs(
       VkImageSubresourceRange range, InitPolicy policy, bool initialized) const;
   void Split(bool splitAspects, bool splitLevels, bool splitLayers);


### PR DESCRIPTION
## Description
This fixes a couple of bugs with the image barriers in Apply_InitialState:
- The `oldLayout` in these barriers was incorrect in some cases. This has been changed to always transition from `UNDEFINED`, because these barriers immediately precede a write.
- The depth/stencil aspects could have different reset requirements, which could cause a barrier to transition one of the aspects without the other--this is not allowed without the `VK_KHR_separate_depth_stencil_layouts` extension.