### PR TITLE
Add impl for creating a D3D12 global state for shader debugging.

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
+++ b/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
@@ -1690,34 +1690,7 @@ void D3D11DebugManager::CreateShaderGlobalState(ShaderDebug::GlobalState &global
     }
   }
 
-  for(size_t i = 0; i < dxbc->GetDXBCByteCode()->GetNumDeclarations(); i++)
-  {
-    const DXBCBytecode::Declaration &decl = dxbc->GetDXBCByteCode()->GetDeclaration(i);
-
-    if(decl.declaration == DXBCBytecode::OPCODE_DCL_THREAD_GROUP_SHARED_MEMORY_RAW ||
-       decl.declaration == DXBCBytecode::OPCODE_DCL_THREAD_GROUP_SHARED_MEMORY_STRUCTURED)
-    {
-      uint32_t slot = (uint32_t)decl.operand.indices[0].index;
-
-      if(global.groupshared.size() <= slot)
-      {
-        global.groupshared.resize(slot + 1);
-
-        ShaderDebug::GlobalState::groupsharedMem &mem = global.groupshared[slot];
-
-        mem.structured =
-            (decl.declaration == DXBCBytecode::OPCODE_DCL_THREAD_GROUP_SHARED_MEMORY_STRUCTURED);
-
-        mem.count = decl.count;
-        if(mem.structured)
-          mem.bytestride = decl.stride;
-        else
-          mem.bytestride = 4;    // raw groupshared is implicitly uint32s
-
-        mem.data.resize(mem.bytestride * mem.count);
-      }
-    }
-  }
+  global.PopulateGroupshared(dxbc->GetDXBCByteCode());
 }
 
 ShaderDebugTrace D3D11Replay::DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid,

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -57,6 +57,8 @@ public:
       srvs[i].firstElement = srvs[i].numElements = 0;
   }
 
+  void PopulateGroupshared(const DXBCBytecode::Program *pBytecode);
+
   struct ViewFmt
   {
     int byteWidth = 0;


### PR DESCRIPTION
Walk the root signature and collect info on the SRVs and UAVs bound. This sets up enough global state to get some correct results. There's some gaps in the logic where more care is needed to detangle the resources, descriptors, etc. I've marked ones that I've identified with TODOs.