### PR TITLE
add support for serialising invalidate framebuffer calls in GL

### DIFF
--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -709,6 +709,7 @@ extern bool IsGLES;
   EXT_TO_CHECK(43, 31, ARB_compute_shader)                       \
   EXT_TO_CHECK(43, 32, ARB_copy_image)                           \
   EXT_TO_CHECK(43, 30, ARB_ES3_compatibility)                    \
+  EXT_TO_CHECK(43, 30, ARB_invalidate_subdata)                   \
   EXT_TO_CHECK(43, 99, ARB_internalformat_query2)                \
   EXT_TO_CHECK(43, 31, ARB_program_interface_query)              \
   EXT_TO_CHECK(43, 31, ARB_shader_storage_buffer_object)         \
@@ -756,7 +757,8 @@ extern bool IsGLES;
   EXT_TO_CHECK(99, 99, NV_read_depth_stencil)                    \
   EXT_TO_CHECK(99, 99, EXT_disjoint_timer_query)                 \
   EXT_TO_CHECK(99, 99, EXT_multisampled_render_to_texture)       \
-  EXT_TO_CHECK(99, 99, OVR_multiview)
+  EXT_TO_CHECK(99, 99, OVR_multiview)                            \
+  EXT_TO_CHECK(99, 99, EXT_discard_framebuffer)
 
 // GL extensions equivalents
 // Either promoted extensions from EXT to ARB, or

--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -3687,6 +3687,10 @@ bool WrappedOpenGL::ProcessChunk(ReadSerialiser &ser, GLChunk chunk)
       return Serialise_glFramebufferReadBufferEXT(ser, 0, eGL_NONE);
     case GLChunk::glBindFramebufferEXT:
     case GLChunk::glBindFramebuffer: return Serialise_glBindFramebuffer(ser, eGL_NONE, 0);
+    case GLChunk::glDiscardFramebufferEXT:
+    case GLChunk::glInvalidateFramebuffer:
+    case GLChunk::glInvalidateNamedFramebufferData:
+      return Serialise_glInvalidateNamedFramebufferData(ser, 0, 0, 0);
     case GLChunk::glDrawBuffer:
     case GLChunk::glNamedFramebufferDrawBuffer:
     case GLChunk::glFramebufferDrawBufferEXT:
@@ -4669,11 +4673,8 @@ bool WrappedOpenGL::ProcessChunk(ReadSerialiser &ser, GLChunk chunk)
     case GLChunk::glProgramBinary:
     case GLChunk::glReleaseShaderCompiler:
     case GLChunk::glFrameTerminatorGREMEDY:
-    case GLChunk::glDiscardFramebufferEXT:
     case GLChunk::glInvalidateBufferData:
     case GLChunk::glInvalidateBufferSubData:
-    case GLChunk::glInvalidateFramebuffer:
-    case GLChunk::glInvalidateNamedFramebufferData:
     case GLChunk::glInvalidateNamedFramebufferSubData:
     case GLChunk::glInvalidateSubFramebuffer:
     case GLChunk::glInvalidateTexImage:

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -908,6 +908,8 @@ public:
   IMPLEMENT_FUNCTION_SERIALISED(void, glDrawBuffer, GLenum buf);
   IMPLEMENT_FUNCTION_SERIALISED(void, glDrawBuffers, GLsizei n, const GLenum *bufs);
   IMPLEMENT_FUNCTION_SERIALISED(void, glBindFramebuffer, GLenum target, GLuint framebuffer);
+  IMPLEMENT_FUNCTION_SERIALISED(void, glInvalidateNamedFramebufferData, GLuint framebufferHandle,
+                                GLsizei numAttachments, const GLenum *attachments);
   IMPLEMENT_FUNCTION_SERIALISED(void, glFramebufferTexture, GLenum target, GLenum attachment,
                                 GLuint texture, GLint level);
   IMPLEMENT_FUNCTION_SERIALISED(void, glFramebufferTexture1D, GLenum target, GLenum attachment,
@@ -2236,9 +2238,6 @@ public:
                                 GLuint buffer);
   IMPLEMENT_FUNCTION_SERIALISED(void, glTransformFeedbackBufferRange, GLuint xfb, GLuint index,
                                 GLuint buffer, GLintptr offset, GLsizeiptr size);
-
-  IMPLEMENT_FUNCTION_SERIALISED(void, glInvalidateNamedFramebufferData, GLuint framebuffer,
-                                GLsizei numAttachments, const GLenum *attachments);
   IMPLEMENT_FUNCTION_SERIALISED(void, glInvalidateNamedFramebufferSubData, GLuint framebuffer,
                                 GLsizei numAttachments, const GLenum *attachments, GLint x, GLint y,
                                 GLsizei width, GLsizei height);

--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -314,6 +314,25 @@ void APIENTRY _glNamedFramebufferRenderbufferEXT(GLuint framebuffer, GLenum atta
   GL.glFramebufferRenderbuffer(eGL_DRAW_FRAMEBUFFER, attachment, renderbuffertarget, renderbuffer);
 }
 
+void APIENTRY _glInvalidateNamedFramebufferData(GLuint framebuffer, GLsizei numAttachments,
+                                                const GLenum *attachments)
+{
+  if(HasExt[ARB_invalidate_subdata])
+  {
+    PushPopFramebuffer(eGL_DRAW_FRAMEBUFFER, framebuffer);
+    GL.glInvalidateFramebuffer(eGL_DRAW_FRAMEBUFFER, numAttachments, attachments);
+  }
+  else if(HasExt[EXT_discard_framebuffer])
+  {
+    PushPopFramebuffer(eGL_DRAW_FRAMEBUFFER, framebuffer);
+    GL.glDiscardFramebufferEXT(eGL_DRAW_FRAMEBUFFER, numAttachments, attachments);
+  }
+  else
+  {
+    RDCERR("No support for framebuffer invalidate on GL %d", GLCoreVersion);
+  }
+}
+
 #pragma endregion
 
 #pragma region Renderbuffers
@@ -3313,6 +3332,7 @@ void GLDispatchTable::EmulateRequiredExtensions()
     EMULATE_FUNC(glBlitNamedFramebuffer)
     EMULATE_FUNC(glVertexArrayElementBuffer);
     EMULATE_FUNC(glVertexArrayVertexBuffers)
+    EMULATE_FUNC(glInvalidateNamedFramebufferData);
   }
 }
 


### PR DESCRIPTION
## Description
Add support for serialising invalidate framebuffer calls in GL, due to it being important for perf and debugging (verifying it actually happens) on mobile VR platforms. 
Verified working on UE4.24 and Unity (beat saber).
