### PR TITLE
Export 32bit floating point textures to 32bit floating point EXR files

### DIFF
--- a/renderdoc/replay/replay_controller.cpp
+++ b/renderdoc/replay/replay_controller.cpp
@@ -1506,6 +1506,14 @@ bool ReplayController::SaveTexture(const TextureSave &saveData, const char *path
         int reqTypes[4] = {TINYEXR_PIXELTYPE_HALF, TINYEXR_PIXELTYPE_HALF, TINYEXR_PIXELTYPE_HALF,
                            TINYEXR_PIXELTYPE_HALF};
 
+        if(saveFmt.compByteWidth == 4)
+        {
+          for(size_t channel = 0; channel < 4; channel++)
+          {
+            reqTypes[channel] = TINYEXR_PIXELTYPE_FLOAT;
+          }
+        }
+
         // must be in this order as many viewers don't pay attention to channels and just assume
         // they are in this order
         EXRChannelInfo bgraChannels[4] = {


### PR DESCRIPTION
## Description

I was pretty surprised that my RGBA32F buffers/textures are not exported in the correct bit width when exporting to EXR. This patch will always export float32 to float32, I am not sure if this is desired or if we should add an option to export dialog.
