### PR TITLE
Fix overlap check in `rdcarray::insert`

### DIFF
--- a/renderdoc/api/replay/basic_types.h
+++ b/renderdoc/api/replay/basic_types.h
@@ -439,7 +439,7 @@ public:
 
   void insert(size_t offs, const T *el, size_t count)
   {
-    if(el + count >= begin() && end() >= el)
+    if(elems < el + count && el < elems + allocatedCount)
     {
       // we're inserting from ourselves, so if we did this blindly we'd potentially change the
       // contents of the inserted range while doing the insertion.


### PR DESCRIPTION
This fixes an infinite recursion when attempting to call `insert(0, NULL, 0)` on an empty `rdcarray`.

The new behaviour also triggers a copy when the inserted interval overlaps the `rdcarray`'s *allocated* memory (rather than just the currently used prefix).