### PR TITLE
Add tests for BitFlagIterater bit constructor

### DIFF
--- a/renderdoc/core/bit_flag_iterator_tests.cpp
+++ b/renderdoc/core/bit_flag_iterator_tests.cpp
@@ -83,6 +83,49 @@ TEST_CASE("Test BitFlagIterator type", "[bit_flag_iterator]")
       CHECK(get_bits(TestFlagIter::begin(b), TestFlagIter::end()) == expected);
     }
   };
+  SECTION("empty from bit")
+  {
+    std::vector<uint32_t> expected = {};
+    CHECK(get_bits(TestFlagIter(0x0, 0x4), TestFlagIter::end()) == expected);
+  };
+  SECTION("full from bit")
+  {
+    std::vector<uint32_t> expected = {
+        0x4,       0x8,       0x10,       0x20,       0x40,       0x80,      0x100,     0x200,
+        0x400,     0x800,     0x1000,     0x2000,     0x4000,     0x8000,    0x10000,   0x20000,
+        0x40000,   0x80000,   0x100000,   0x200000,   0x400000,   0x800000,  0x1000000, 0x2000000,
+        0x4000000, 0x8000000, 0x10000000, 0x20000000, 0x40000000, 0x80000000};
+    CHECK(get_bits(TestFlagIter(UINT32_MAX, 0x4), TestFlagIter::end()) == expected);
+  };
+  SECTION("even from bit")
+  {
+    std::vector<uint32_t> expected = {0x4,      0x10,      0x40,      0x100,      0x400,
+                                      0x1000,   0x4000,    0x10000,   0x40000,    0x100000,
+                                      0x400000, 0x1000000, 0x4000000, 0x10000000, 0x40000000};
+    CHECK(get_bits(TestFlagIter(0x55555555, 0x2), TestFlagIter::end()) == expected);
+    CHECK(get_bits(TestFlagIter(0x55555555, 0x4), TestFlagIter::end()) == expected);
+  };
+  SECTION("odd from bit")
+  {
+    std::vector<uint32_t> expected = {0x8,      0x20,      0x80,      0x200,      0x800,
+                                      0x2000,   0x8000,    0x20000,   0x80000,    0x200000,
+                                      0x800000, 0x2000000, 0x8000000, 0x20000000, 0x80000000};
+    CHECK(get_bits(TestFlagIter(0xAAAAAAAA, 0x4), TestFlagIter::end()) == expected);
+    CHECK(get_bits(TestFlagIter(0xAAAAAAAA, 0x8), TestFlagIter::end()) == expected);
+  };
+  SECTION("single from bit")
+  {
+    for(int i = 0; i < 32; i++)
+    {
+      uint32_t b = 1 << i;
+      std::vector<uint32_t> expected = {b};
+      if(i > 0)
+        CHECK(get_bits(TestFlagIter(b, 1 << (i - 1)), TestFlagIter::end()) == expected);
+      CHECK(get_bits(TestFlagIter(b, 1 << i), TestFlagIter::end()) == expected);
+      if(i < 31)
+        CHECK(get_bits(TestFlagIter(b, 1 << (i + 1)), TestFlagIter::end()) == std::vector<uint32_t>());
+    }
+  };
 };
 
 #endif    // ENABLED(ENABLE_UNIT_TESTS)


### PR DESCRIPTION
Add tests for recently added BitFlagIterator constructor that starts from a specified bit (#1639).