### PR TITLE
Update Vulkan environment variable on Linux

### DIFF
--- a/renderdoc/driver/vulkan/vk_posix.cpp
+++ b/renderdoc/driver/vulkan/vk_posix.cpp
@@ -283,6 +283,17 @@ static rdcstr GenerateJSON(const rdcstr &sopath)
     idx = json.find(minorString);
   }
 
+  const char enableVarString[] = "@VULKAN_ENABLE_VAR@";
+
+  idx = json.find(enableVarString);
+  while(idx >= 0)
+  {
+    json = json.substr(0, idx) + STRINGIZE(ENABLE_VULKAN_RENDERDOC_CAPTURE) +
+           json.substr(idx + sizeof(enableVarString) - 1);
+
+    idx = json.find(enableVarString);
+  }
+
   return json;
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

With d2aee67afeafc94e119736e790f107eef5515a4d in place, `renderdoc_capture.json` doesn't expose a variable for enabling vulkan capture on Linux anymore. The files created with `vulkanregister` command will still have `@VULKAN_ENABLE_VAR@` instead of a proper variable.