### PR TITLE
New image state (and VK_KHR_separate_depth_stencil_layouts)

### DIFF
--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -133,6 +133,11 @@ FrameRefType ComposeFrameRefsFirstKnown(FrameRefType first, FrameRefType second)
     return second;
 }
 
+FrameRefType KeepOldFrameRef(FrameRefType first, FrameRefType second)
+{
+  return first;
+}
+
 bool IncludesRead(FrameRefType refType)
 {
   switch(refType)

--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -125,6 +125,14 @@ FrameRefType ComposeFrameRefsDisjoint(FrameRefType x, FrameRefType y)
     return RDCMAX(x, y);
 }
 
+FrameRefType ComposeFrameRefsFirstKnown(FrameRefType first, FrameRefType second)
+{
+  if(eFrameRef_Minimum <= first && first <= eFrameRef_Maximum)
+    return first;
+  else
+    return second;
+}
+
 bool IncludesRead(FrameRefType refType)
 {
   switch(refType)

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -123,6 +123,8 @@ const double PERSISTENT_RESOURCE_AGE = 3000;
 
 DECLARE_REFLECTION_ENUM(FrameRefType);
 
+typedef FrameRefType (*FrameRefCompFunc)(FrameRefType, FrameRefType);
+
 // Compose frame refs that occur in a known order.
 // This can be thought of as a state (`first`) and a transition from that state
 // (`second`), returning the new state (see the state diagram for
@@ -142,6 +144,9 @@ FrameRefType ComposeFrameRefsDisjoint(FrameRefType x, FrameRefType y);
 
 // Returns whichever of `first` or `second` is valid.
 FrameRefType ComposeFrameRefsFirstKnown(FrameRefType first, FrameRefType second);
+
+// Dummy frame ref composition that always keeps the old ref.
+FrameRefType KeepOldFrameRef(FrameRefType first, FrameRefType second);
 
 bool IsDirtyFrameRef(FrameRefType refType);
 

--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -22,6 +22,7 @@ set(sources
     vk_dispatchtables.h
     vk_dispatch_defs.h
     vk_hookset_defs.h
+    vk_image_states.cpp
     vk_info.cpp
     vk_info.h
     vk_initstate.cpp

--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -40,6 +40,7 @@ set(sources
     vk_serialise.cpp
     vk_stringise.cpp
     vk_layer.cpp
+    imagestate_tests.cpp
     imgrefs_tests.cpp
     official/vk_layer.h
     official/vk_platform.h

--- a/renderdoc/driver/vulkan/imagestate_tests.cpp
+++ b/renderdoc/driver/vulkan/imagestate_tests.cpp
@@ -1,0 +1,735 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "common/globalconfig.h"
+
+#if ENABLED(ENABLE_UNIT_TESTS)
+
+#include "3rdparty/catch/catch.hpp"
+
+#include "vk_resources.h"
+
+#include <stdint.h>
+#include <vector>
+
+void CheckSubresourceRanges(const ImageState &state, bool expectAspectsSplit,
+                            bool expectLevelsSplit, bool expectLayersSplit, bool expectDepthSplit)
+{
+  std::vector<VkImageAspectFlags> splitAspects;
+  if(expectAspectsSplit)
+  {
+    for(auto it = ImageAspectFlagIter::begin(state.GetImageInfo().Aspects());
+        it != ImageAspectFlagIter::end(); ++it)
+    {
+      splitAspects.push_back(*it);
+    }
+  }
+  else
+  {
+    splitAspects.push_back(state.GetImageInfo().Aspects());
+  }
+  uint32_t splitLevelCount = expectLevelsSplit ? state.GetImageInfo().levelCount : 1;
+  uint32_t splitLayerCount = expectLayersSplit ? state.GetImageInfo().layerCount : 1;
+  uint32_t splitSliceCount = expectDepthSplit ? state.GetImageInfo().extent.depth : 1;
+  size_t splitSize = splitAspects.size() * (size_t)splitLevelCount * (size_t)splitLayerCount *
+                     (size_t)splitSliceCount;
+  CHECK(state.subresourceStates.size() == splitSize);
+
+  auto substateIt = state.subresourceStates.begin();
+  auto aspectIt = splitAspects.begin();
+  uint32_t level = 0;
+  uint32_t layer = 0;
+  uint32_t slice = 0;
+  uint32_t index = 0;
+  for(; aspectIt != splitAspects.end() && substateIt != state.subresourceStates.end();
+      ++substateIt, ++index)
+  {
+    const ImageSubresourceRange &range = substateIt->range();
+    CHECK(range.aspectMask == *aspectIt);
+
+    if(expectLevelsSplit)
+    {
+      CHECK(range.baseMipLevel == level);
+      CHECK(range.levelCount == 1);
+    }
+    else
+    {
+      CHECK(range.baseMipLevel == 0);
+      CHECK(range.levelCount == (uint32_t)state.GetImageInfo().levelCount);
+    }
+
+    if(expectLayersSplit)
+    {
+      CHECK(range.baseArrayLayer == layer);
+      CHECK(range.layerCount == 1);
+    }
+    else
+    {
+      CHECK(range.baseArrayLayer == 0);
+      CHECK(range.layerCount == (uint32_t)state.GetImageInfo().layerCount);
+    }
+
+    if(expectDepthSplit)
+    {
+      CHECK(range.baseDepthSlice == slice);
+      CHECK(range.sliceCount == 1);
+    }
+    else
+    {
+      CHECK(range.baseDepthSlice == 0);
+      CHECK(range.sliceCount == (uint32_t)state.GetImageInfo().extent.depth);
+    }
+
+    ++slice;
+    if(slice < splitSliceCount)
+      continue;
+    slice = 0;
+
+    ++layer;
+    if(layer < splitLayerCount)
+      continue;
+    layer = 0;
+
+    ++level;
+    if(level < splitLevelCount)
+      continue;
+    level = 0;
+
+    ++aspectIt;
+  }
+  CHECK(index == splitSize);
+}
+
+void CheckSubresourceState(const ImageSubresourceState &substate,
+                           const ImageSubresourceState &expected)
+{
+  CHECK(substate.oldQueueFamilyIndex == expected.oldQueueFamilyIndex);
+  CHECK(substate.newQueueFamilyIndex == expected.newQueueFamilyIndex);
+  CHECK(substate.oldLayout == expected.oldLayout);
+  CHECK(substate.newLayout == expected.newLayout);
+  CHECK(substate.refType == expected.refType);
+}
+
+TEST_CASE("Test ImageState type", "[imagestate]")
+{
+  ImageTransitionInfo transitionInfo(CaptureState::ActiveCapturing, 0);
+  VkImage image = (VkImage)123;
+  VkFormat format = VK_FORMAT_D16_UNORM_S8_UINT;
+  VkExtent3D extent = {100, 100, 13};
+  int levelCount = 11;
+  int layerCount = 17;
+  int sampleCount = 1;
+  ImageInfo imageInfo(format, extent, levelCount, layerCount, sampleCount,
+                      VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE);
+
+  ImageSubresourceState initSubstate(VK_QUEUE_FAMILY_IGNORED, UNKNOWN_PREV_IMG_LAYOUT,
+                                     eFrameRef_None);
+
+  ImageSubresourceState readSubstate(initSubstate);
+  readSubstate.oldQueueFamilyIndex = readSubstate.newQueueFamilyIndex = 0;
+  readSubstate.refType = eFrameRef_Read;
+
+  SECTION("Initial state")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    CheckSubresourceRanges(state, false, false, false, false);
+    CheckSubresourceState(state.subresourceStates.begin()->state(), initSubstate);
+  };
+
+  SECTION("Split aspects")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range = imageInfo.FullRange();
+    range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    state.RecordUse(range, eFrameRef_Read, 0);
+
+    CheckSubresourceRanges(state, true, false, false, false);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Split mip levels")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range = imageInfo.FullRange();
+    range.baseMipLevel = 1;
+    range.levelCount = 3;
+    state.RecordUse(range, eFrameRef_Read, 0);
+
+    CheckSubresourceRanges(state, false, true, false, false);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().baseMipLevel >= range.baseMipLevel &&
+         it->range().baseMipLevel - range.baseMipLevel < range.levelCount)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Split array layers")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range = imageInfo.FullRange();
+    range.baseArrayLayer = 3;
+    range.layerCount = 5;
+    state.RecordUse(range, eFrameRef_Read, 0);
+
+    CheckSubresourceRanges(state, false, false, true, false);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().baseArrayLayer >= range.baseArrayLayer &&
+         it->range().baseArrayLayer - range.baseArrayLayer < range.layerCount)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Split depth slices")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range = imageInfo.FullRange();
+    range.baseDepthSlice = 1;
+    range.sliceCount = 1;
+    state.RecordUse(range, eFrameRef_Read, 0);
+
+    CheckSubresourceRanges(state, false, false, false, true);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().baseDepthSlice >= range.baseDepthSlice &&
+         it->range().baseDepthSlice - range.baseDepthSlice < range.sliceCount)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Split aspect to depth")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    ImageSubresourceRange aspectRange(imageInfo.FullRange());
+    aspectRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    state.RecordUse(aspectRange, eFrameRef_Read, 0);
+    CheckSubresourceRanges(state, true, false, false, false);
+
+    ImageSubresourceRange levelRange(imageInfo.FullRange());
+    levelRange.baseMipLevel = 0;
+    levelRange.levelCount = 1;
+    state.RecordUse(levelRange, eFrameRef_PartialWrite, 1);
+    CheckSubresourceRanges(state, true, true, false, false);
+
+    ImageSubresourceRange layerRange(imageInfo.FullRange());
+    layerRange.baseArrayLayer = 0;
+    layerRange.layerCount = 1;
+    state.RecordUse(layerRange, eFrameRef_Read, 2);
+    CheckSubresourceRanges(state, true, true, true, false);
+
+    ImageSubresourceRange sliceRange(imageInfo.FullRange());
+    sliceRange.baseDepthSlice = 0;
+    sliceRange.sliceCount = 1;
+    state.RecordUse(sliceRange, eFrameRef_CompleteWrite, 3);
+    CheckSubresourceRanges(state, true, true, true, true);
+
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState substate(initSubstate);
+      if(it->range().aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_Read);
+        substate.newQueueFamilyIndex = 0;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+      if(levelRange.baseMipLevel <= it->range().baseMipLevel &&
+         it->range().baseMipLevel - levelRange.baseMipLevel < levelRange.levelCount)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_PartialWrite);
+        substate.newQueueFamilyIndex = 1;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+      if(layerRange.baseArrayLayer <= it->range().baseArrayLayer &&
+         it->range().baseArrayLayer - layerRange.baseArrayLayer < layerRange.layerCount)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_Read);
+        substate.newQueueFamilyIndex = 2;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+      if(sliceRange.baseDepthSlice <= it->range().baseDepthSlice &&
+         it->range().baseDepthSlice - sliceRange.baseDepthSlice < sliceRange.sliceCount)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_CompleteWrite);
+        substate.newQueueFamilyIndex = 3;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+
+      CheckSubresourceState(it->state(), substate);
+    }
+  };
+
+  SECTION("Split depth to aspect")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    ImageSubresourceRange sliceRange(imageInfo.FullRange());
+    sliceRange.baseDepthSlice = 0;
+    sliceRange.sliceCount = 1;
+    state.RecordUse(sliceRange, eFrameRef_CompleteWrite, 3);
+    CheckSubresourceRanges(state, false, false, false, true);
+
+    ImageSubresourceRange layerRange(imageInfo.FullRange());
+    layerRange.baseArrayLayer = 0;
+    layerRange.layerCount = 1;
+    state.RecordUse(layerRange, eFrameRef_Read, 2);
+    CheckSubresourceRanges(state, false, false, true, true);
+
+    ImageSubresourceRange levelRange(imageInfo.FullRange());
+    levelRange.baseMipLevel = 0;
+    levelRange.levelCount = 1;
+    state.RecordUse(levelRange, eFrameRef_PartialWrite, 1);
+    CheckSubresourceRanges(state, false, true, true, true);
+
+    ImageSubresourceRange aspectRange(imageInfo.FullRange());
+    aspectRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    state.RecordUse(aspectRange, eFrameRef_Read, 0);
+    CheckSubresourceRanges(state, true, true, true, true);
+
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState substate(initSubstate);
+      if(sliceRange.baseDepthSlice <= it->range().baseDepthSlice &&
+         it->range().baseDepthSlice - sliceRange.baseDepthSlice < sliceRange.sliceCount)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_CompleteWrite);
+        substate.newQueueFamilyIndex = 3;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+      if(layerRange.baseArrayLayer <= it->range().baseArrayLayer &&
+         it->range().baseArrayLayer - layerRange.baseArrayLayer < layerRange.layerCount)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_Read);
+        substate.newQueueFamilyIndex = 2;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+      if(levelRange.baseMipLevel <= it->range().baseMipLevel &&
+         it->range().baseMipLevel - levelRange.baseMipLevel < levelRange.levelCount)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_PartialWrite);
+        substate.newQueueFamilyIndex = 1;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+      if(it->range().aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT)
+      {
+        substate.refType = ComposeFrameRefs(substate.refType, eFrameRef_Read);
+        substate.newQueueFamilyIndex = 0;
+        if(substate.oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+          substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex;
+      }
+
+      CheckSubresourceState(it->state(), substate);
+    }
+  };
+
+  SECTION("Single barrier")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range(imageInfo.FullRange());
+    range.baseArrayLayer = 1;
+    range.layerCount = 1;
+
+    VkImageMemoryBarrier barrier = {
+        /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        /* pNext = */ NULL,
+        /* srcAccessMask = */ 0,
+        /* dstAccessMask = */ 0,
+        /* oldLayout = */ VK_IMAGE_LAYOUT_UNDEFINED,
+        /* newLayout = */ VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        /* srcQueueFamilyIndex = */ 0,
+        /* dstQueueFamilyIndex = */ 0,
+        /* image = */ image,
+        /* subresourceRange = */ range,
+    };
+    state.RecordBarrier(barrier, 0, transitionInfo);
+    CheckSubresourceRanges(state, false, false, true, false);
+
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState substate(initSubstate);
+      if(range.baseArrayLayer <= it->range().baseArrayLayer &&
+         it->range().baseArrayLayer - range.baseArrayLayer < range.layerCount)
+      {
+        substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex = 0;
+        substate.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        substate.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+      }
+
+      CheckSubresourceState(it->state(), substate);
+    }
+  };
+
+  SECTION("Layout barriers")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range(imageInfo.FullRange());
+    range.baseArrayLayer = 0;
+    range.layerCount = 1;
+
+    VkImageMemoryBarrier barrier = {
+        /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        /* pNext = */ NULL,
+        /* srcAccessMask = */ 0,
+        /* dstAccessMask = */ 0,
+        /* oldLayout = */ VK_IMAGE_LAYOUT_UNDEFINED,
+        /* newLayout = */ VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        /* srcQueueFamilyIndex = */ 0,
+        /* dstQueueFamilyIndex = */ 0,
+        /* image = */ image,
+        /* subresourceRange = */ range,
+    };
+    state.RecordBarrier(barrier, 0, transitionInfo);
+    CheckSubresourceRanges(state, false, false, true, false);
+
+    barrier.subresourceRange.baseArrayLayer = 1;
+    state.RecordBarrier(barrier, 0, transitionInfo);
+    CheckSubresourceRanges(state, false, false, true, false);
+
+    barrier.subresourceRange.baseArrayLayer = range.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = range.layerCount = 2;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    state.RecordBarrier(barrier, 0, transitionInfo);
+    CheckSubresourceRanges(state, false, false, true, false);
+
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState substate(initSubstate);
+      if(range.baseArrayLayer <= it->range().baseArrayLayer &&
+         it->range().baseArrayLayer - range.baseArrayLayer < range.layerCount)
+      {
+        substate.oldQueueFamilyIndex = substate.newQueueFamilyIndex = 0;
+        substate.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        substate.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+      }
+
+      CheckSubresourceState(it->state(), substate);
+    }
+  };
+
+  SECTION("Unmatched queue family acquire")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range(imageInfo.FullRange());
+    range.baseArrayLayer = 1;
+    range.layerCount = 2;
+
+    VkImageMemoryBarrier barrier = {
+        /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        /* pNext = */ NULL,
+        /* srcAccessMask = */ 0,
+        /* dstAccessMask = */ 0,
+        /* oldLayout = */ VK_IMAGE_LAYOUT_GENERAL,
+        /* newLayout = */ VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        /* srcQueueFamilyIndex = */ 0,
+        /* dstQueueFamilyIndex = */ 1,
+        /* image = */ image,
+        /* subresourceRange = */ range,
+    };
+    state.RecordBarrier(barrier, 1, transitionInfo);
+    CheckSubresourceRanges(state, false, false, true, false);
+
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState substate(initSubstate);
+      if(range.baseArrayLayer <= it->range().baseArrayLayer &&
+         it->range().baseArrayLayer - range.baseArrayLayer < range.layerCount)
+      {
+        substate.oldQueueFamilyIndex = 0;
+        substate.newQueueFamilyIndex = 1;
+        substate.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+        substate.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+      }
+
+      CheckSubresourceState(it->state(), substate);
+    }
+
+    REQUIRE(state.oldQueueFamilyTransfers.size() == 1);
+    CHECK(state.oldQueueFamilyTransfers[0].oldLayout == VK_IMAGE_LAYOUT_GENERAL);
+    CHECK(state.oldQueueFamilyTransfers[0].newLayout ==
+          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    CHECK(state.oldQueueFamilyTransfers[0].srcQueueFamilyIndex == 0);
+    CHECK(state.oldQueueFamilyTransfers[0].dstQueueFamilyIndex == 1);
+
+    CHECK(state.newQueueFamilyTransfers.size() == 0);
+  };
+
+  SECTION("Unmatched queue family release")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range(imageInfo.FullRange());
+    range.baseArrayLayer = 1;
+    range.layerCount = 2;
+
+    VkImageMemoryBarrier barrier = {
+        /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        /* pNext = */ NULL,
+        /* srcAccessMask = */ 0,
+        /* dstAccessMask = */ 0,
+        /* oldLayout = */ VK_IMAGE_LAYOUT_GENERAL,
+        /* newLayout = */ VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        /* srcQueueFamilyIndex = */ 0,
+        /* dstQueueFamilyIndex = */ 1,
+        /* image = */ image,
+        /* subresourceRange = */ range,
+    };
+    state.RecordBarrier(barrier, 0, transitionInfo);
+    CheckSubresourceRanges(state, false, false, false, false);
+    CheckSubresourceState(state.subresourceStates.begin()->state(), initSubstate);
+
+    REQUIRE(state.newQueueFamilyTransfers.size() == 1);
+    CHECK(state.newQueueFamilyTransfers[0].oldLayout == VK_IMAGE_LAYOUT_GENERAL);
+    CHECK(state.newQueueFamilyTransfers[0].newLayout ==
+          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    CHECK(state.newQueueFamilyTransfers[0].srcQueueFamilyIndex == 0);
+    CHECK(state.newQueueFamilyTransfers[0].dstQueueFamilyIndex == 1);
+
+    CHECK(state.oldQueueFamilyTransfers.size() == 0);
+  };
+
+  SECTION("Matched queue family transfer")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+    ImageSubresourceRange range(imageInfo.FullRange());
+    range.baseArrayLayer = 1;
+    range.layerCount = 2;
+
+    VkImageMemoryBarrier barrier = {
+        /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        /* pNext = */ NULL,
+        /* srcAccessMask = */ 0,
+        /* dstAccessMask = */ 0,
+        /* oldLayout = */ VK_IMAGE_LAYOUT_GENERAL,
+        /* newLayout = */ VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        /* srcQueueFamilyIndex = */ 0,
+        /* dstQueueFamilyIndex = */ 1,
+        /* image = */ image,
+        /* subresourceRange = */ range,
+    };
+    state.RecordBarrier(barrier, 0, transitionInfo);
+    CheckSubresourceRanges(state, false, false, false, false);
+    state.RecordBarrier(barrier, 1, transitionInfo);
+    CheckSubresourceRanges(state, false, false, true, false);
+
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState substate(initSubstate);
+      if(range.baseArrayLayer <= it->range().baseArrayLayer &&
+         it->range().baseArrayLayer - range.baseArrayLayer < range.layerCount)
+      {
+        substate.oldQueueFamilyIndex = 0;
+        substate.newQueueFamilyIndex = 1;
+        substate.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+        substate.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+      }
+
+      CheckSubresourceState(it->state(), substate);
+    }
+
+    CHECK(state.oldQueueFamilyTransfers.size() == 0);
+
+    CHECK(state.newQueueFamilyTransfers.size() == 0);
+  };
+
+  SECTION("Unsplit aspects")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    // read subresource, triggering a split in every dimension except depth
+    ImageSubresourceRange range0 = imageInfo.FullRange();
+    range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    range0.baseMipLevel = 1;
+    range0.levelCount = imageInfo.levelCount - 1;
+    range0.baseArrayLayer = 1;
+    range0.layerCount = imageInfo.layerCount - 1;
+    range0.baseDepthSlice = 0;
+    range0.sliceCount = imageInfo.extent.depth;
+    state.RecordUse(range0, eFrameRef_Read, 0);
+
+    // read all aspects
+    ImageSubresourceRange range1 = range0;
+    range1.aspectMask = imageInfo.Aspects();
+    state.RecordUse(range1, eFrameRef_Read, 0);
+
+    state.subresourceStates.Unsplit();
+
+    CheckSubresourceRanges(state, false, true, true, false);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().baseMipLevel > 0 && it->range().baseArrayLayer > 0)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Unsplit mip levels")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    // read subresource, triggering a split in every dimension except aspect
+    ImageSubresourceRange range0 = imageInfo.FullRange();
+    range0.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    range0.baseMipLevel = 1;
+    range0.levelCount = imageInfo.levelCount - 1;
+    range0.baseArrayLayer = 1;
+    range0.layerCount = imageInfo.layerCount - 1;
+    range0.baseDepthSlice = 1;
+    range0.sliceCount = imageInfo.extent.depth - 1;
+    state.RecordUse(range0, eFrameRef_Read, 0);
+
+    // read all mip levels
+    ImageSubresourceRange range1 = range0;
+    range1.baseMipLevel = 0;
+    range1.levelCount = imageInfo.levelCount;
+    state.RecordUse(range1, eFrameRef_Read, 0);
+
+    state.subresourceStates.Unsplit();
+
+    CheckSubresourceRanges(state, false, false, true, true);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().baseArrayLayer > 0 && it->range().baseDepthSlice > 0)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Unsplit array layers")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    // read subresource, triggering a split in every dimension except mip levels
+    ImageSubresourceRange range0 = imageInfo.FullRange();
+    range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    range0.baseMipLevel = 0;
+    range0.levelCount = imageInfo.levelCount;
+    range0.baseArrayLayer = 1;
+    range0.layerCount = imageInfo.layerCount - 1;
+    range0.baseDepthSlice = 1;
+    range0.sliceCount = imageInfo.extent.depth - 1;
+    state.RecordUse(range0, eFrameRef_Read, 0);
+
+    // read all array layers
+    ImageSubresourceRange range1 = range0;
+    range1.baseArrayLayer = 0;
+    range1.layerCount = imageInfo.layerCount;
+    state.RecordUse(range1, eFrameRef_Read, 0);
+
+    state.subresourceStates.Unsplit();
+
+    CheckSubresourceRanges(state, true, false, false, true);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT && it->range().baseDepthSlice > 0)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Unsplit depth slices")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    // read subresource, triggering a split in every dimension except array layers
+    ImageSubresourceRange range0 = imageInfo.FullRange();
+    range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    range0.baseMipLevel = 1;
+    range0.levelCount = imageInfo.levelCount - 1;
+    range0.baseArrayLayer = 0;
+    range0.layerCount = imageInfo.layerCount;
+    range0.baseDepthSlice = 1;
+    range0.sliceCount = imageInfo.extent.depth - 1;
+    state.RecordUse(range0, eFrameRef_Read, 0);
+
+    // read all depth slices
+    ImageSubresourceRange range1 = range0;
+    range1.baseDepthSlice = 0;
+    range1.sliceCount = imageInfo.extent.depth;
+    state.RecordUse(range1, eFrameRef_Read, 0);
+
+    state.subresourceStates.Unsplit();
+
+    CheckSubresourceRanges(state, true, true, false, false);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      if(it->range().aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT && it->range().baseMipLevel > 0)
+        CheckSubresourceState(it->state(), readSubstate);
+      else
+        CheckSubresourceState(it->state(), initSubstate);
+    }
+  };
+
+  SECTION("Unsplit all")
+  {
+    ImageState state(image, imageInfo, eFrameRef_None);
+
+    // read subresource, triggering a split in every dimension
+    ImageSubresourceRange range0 = imageInfo.FullRange();
+    range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    range0.baseMipLevel = 1;
+    range0.levelCount = imageInfo.levelCount - 1;
+    range0.baseArrayLayer = 1;
+    range0.layerCount = imageInfo.layerCount - 1;
+    range0.baseDepthSlice = 1;
+    range0.sliceCount = imageInfo.extent.depth - 1;
+    state.RecordUse(range0, eFrameRef_Read, 0);
+
+    // read all subresources
+    ImageSubresourceRange range1 = imageInfo.FullRange();
+    state.RecordUse(range1, eFrameRef_Read, 0);
+
+    state.subresourceStates.Unsplit();
+
+    CheckSubresourceRanges(state, false, false, false, false);
+    for(auto it = state.subresourceStates.begin(); it != state.subresourceStates.end(); ++it)
+    {
+      CheckSubresourceState(it->state(), readSubstate);
+    }
+  };
+};
+
+#endif    // ENABLED(ENABLE_UNIT_TESTS)

--- a/renderdoc/driver/vulkan/imagestate_tests.cpp
+++ b/renderdoc/driver/vulkan/imagestate_tests.cpp
@@ -133,7 +133,7 @@ void CheckSubresourceState(const ImageSubresourceState &substate,
 
 TEST_CASE("Test ImageState type", "[imagestate]")
 {
-  ImageTransitionInfo transitionInfo(CaptureState::ActiveCapturing, 0);
+  ImageTransitionInfo transitionInfo(CaptureState::ActiveCapturing, 0, true);
   VkImage image = (VkImage)123;
   VkFormat format = VK_FORMAT_D16_UNORM_S8_UINT;
   VkExtent3D extent = {100, 100, 13};

--- a/renderdoc/driver/vulkan/imgrefs_tests.cpp
+++ b/renderdoc/driver/vulkan/imgrefs_tests.cpp
@@ -36,56 +36,65 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
 {
   SECTION("unsplit")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 0);
   };
   SECTION("split aspect")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(true, false, false);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 1);
   };
   SECTION("split levels")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(false, true, false);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 2);
   };
   SECTION("split layers")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(false, false, true);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 5);
   };
   SECTION("split aspect and levels")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(true, true, false);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 11 + 2);
   };
   SECTION("split aspect and layers")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(true, false, true);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) == 17 + 5);
   };
   SECTION("split levels and layers")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(false, true, true);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) ==
           2 * 17 + 5);
   };
   SECTION("split aspect and levels and layers")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     imgRefs.Split(true, true, true);
     CHECK(imgRefs.SubresourceIndex(imgRefs.AspectIndex(VK_IMAGE_ASPECT_STENCIL_BIT), 2, 5) ==
           11 * 17 + 2 * 17 + 5);
   };
   SECTION("update unsplit")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     imgRefs.Update(range, eFrameRef_Read);
     rdcarray<FrameRefType> expected = {eFrameRef_Read};
@@ -93,7 +102,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split aspect")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
     imgRefs.Update(range, eFrameRef_Read);
@@ -102,7 +112,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split levels")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.baseMipLevel = 1;
     range.levelCount = 3;
@@ -115,7 +126,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split layers")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.baseArrayLayer = 7;
     imgRefs.Update(range, eFrameRef_Read);
@@ -128,7 +140,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   };
   SECTION("update split aspect then levels")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 11, 17, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range0;
     range0.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
     imgRefs.Update(range0, eFrameRef_Read);
@@ -150,7 +163,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update split layers then aspects and levels")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 7, 5, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 1}, 7, 5, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range0;
     range0.baseArrayLayer = 1;
     range0.layerCount = 2;
@@ -198,7 +212,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update 3D image default view")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.layerCount = 1;
     imgRefs.Update(range, eFrameRef_Read);
@@ -207,7 +222,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update 3D image 3D view")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.layerCount = 1;
     range.viewType = VK_IMAGE_VIEW_TYPE_3D;
@@ -217,7 +233,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update 3D image 2D view")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.layerCount = 1;
     range.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -228,7 +245,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update 3D image 2D array view")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.baseArrayLayer = 1;
     range.layerCount = 2;
@@ -240,7 +258,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update 3D image 2D array view full")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     imgRefs.Update(range, eFrameRef_Read);
@@ -249,7 +268,8 @@ TEST_CASE("Test ImgRefs type", "[imgrefs]")
   }
   SECTION("update 3D image 3D view full")
   {
-    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1));
+    ImgRefs imgRefs(ImageInfo(VK_FORMAT_D16_UNORM_S8_UINT, {100, 100, 5}, 11, 1, 1,
+                              VK_IMAGE_LAYOUT_UNDEFINED, VK_SHARING_MODE_EXCLUSIVE));
     ImageRange range;
     range.viewType = VK_IMAGE_VIEW_TYPE_3D;
     imgRefs.Update(range, eFrameRef_Read);

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
@@ -100,6 +100,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="imagestate_tests.cpp" />
     <ClCompile Include="imgrefs_tests.cpp" />
     <ClCompile Include="precompiled.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
@@ -108,6 +108,7 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="vk_bindless_feedback.cpp" />
+    <ClCompile Include="vk_image_states.cpp" />
     <ClCompile Include="vk_msaa_array_conv.cpp" />
     <ClCompile Include="vk_next_chains.cpp" />
     <ClCompile Include="vk_outputwindow.cpp" />

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="vk_pixelhistory.cpp">
       <Filter>Replay</Filter>
     </ClCompile>
+    <ClCompile Include="imagestate_tests.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
     <ClCompile Include="vk_image_states.cpp">
       <Filter>Util</Filter>
     </ClCompile>

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="vk_pixelhistory.cpp">
       <Filter>Replay</Filter>
     </ClCompile>
+    <ClCompile Include="vk_image_states.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vk_replay.h">

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -321,6 +321,10 @@ bool VkInitParams::IsSupportedVersion(uint64_t ver)
   if(ver == CurrentVersion)
     return true;
 
+  // 0x10 -> 0x11 - non-breaking changes to image state serialization
+  if(ver == 0x10)
+    return true;
+
   // 0xF -> 0x10 - added serialisation of VkPhysicalDeviceDriverPropertiesKHR into enumerated
   // physical devices
   if(ver == 0xF)

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -370,6 +370,13 @@ VkAccessFlags MakeAccessMask(VkImageLayout layout)
 
   return VkAccessFlags(0);
 }
+void SanitiseReplayImageLayout(VkImageLayout &layout)
+{
+  // we don't replay with present layouts since we don't create actual swapchains. So change any
+  // present layouts to general layouts
+  if(layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR || layout == VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)
+    layout = VK_IMAGE_LAYOUT_GENERAL;
+}
 
 void SanitiseOldImageLayout(VkImageLayout &layout)
 {

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -91,6 +91,7 @@ VkAccessFlags MakeAccessMask(VkImageLayout layout);
 
 void SanitiseOldImageLayout(VkImageLayout &layout);
 void SanitiseNewImageLayout(VkImageLayout &layout);
+void SanitiseReplayImageLayout(VkImageLayout &layout);
 
 void CombineDepthStencilLayouts(rdcarray<VkImageMemoryBarrier> &barriers);
 

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -360,89 +360,6 @@ void WrappedVulkan::FlushQ()
   }
 }
 
-void WrappedVulkan::TempTransition(VkImage image, VkImageLayout layout, VkAccessFlags access,
-                                   rdcarray<VkImageMemoryBarrier> &setupBarriers,
-                                   rdcarray<VkImageMemoryBarrier> &cleanupBarriers,
-                                   bool &extQCleanup) const
-{
-  ResourceId id = GetResID(image);
-
-  auto it = m_ImageLayouts.find(id);
-
-  if(it == m_ImageLayouts.end())
-  {
-    RDCERR("Can't find image layouts for image %s in TempTransition", ToStr(id).c_str());
-    return;
-  }
-
-  setupBarriers.clear();
-  cleanupBarriers.clear();
-
-  const ImageLayouts &layouts = it->second;
-
-  VkImageMemoryBarrier barrier = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-
-  barrier.image = Unwrap(image);
-  barrier.newLayout = layout;
-  barrier.srcQueueFamilyIndex = layouts.queueFamilyIndex;
-  barrier.dstQueueFamilyIndex = GetQueueFamilyIndex();
-
-  extQCleanup = true;
-
-  // if we're on the same queue, don't need to bother with queue acquire/release
-  if(barrier.srcQueueFamilyIndex == barrier.dstQueueFamilyIndex)
-  {
-    barrier.srcQueueFamilyIndex = barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    extQCleanup = false;
-  }
-
-  barrier.dstAccessMask = access;
-
-  for(const ImageRegionState &region : layouts.subresourceStates)
-  {
-    barrier.subresourceRange = region.subresourceRange;
-    barrier.oldLayout = region.newLayout;
-    barrier.srcAccessMask = VK_ACCESS_ALL_WRITE_BITS | MakeAccessMask(barrier.oldLayout);
-    SanitiseOldImageLayout(barrier.oldLayout);
-
-    setupBarriers.push_back(barrier);
-  }
-
-  if(SeparateDepthStencil())
-    CombineDepthStencilLayouts(setupBarriers);
-
-  cleanupBarriers = setupBarriers;
-  for(VkImageMemoryBarrier &b : cleanupBarriers)
-  {
-    std::swap(b.srcQueueFamilyIndex, b.dstQueueFamilyIndex);
-    std::swap(b.oldLayout, b.newLayout);
-    SanitiseNewImageLayout(b.newLayout);
-    b.srcAccessMask = access;
-    b.dstAccessMask = VK_ACCESS_ALL_READ_BITS | MakeAccessMask(b.newLayout);
-  }
-
-  // if we have some queue transfer to do, submit the release on the ext queue now (which is what we
-  // defined above). The user will have to check the bool themselves and submit cleanupBarriers as
-  // external after they're done and submitted on the main queue
-  if(extQCleanup)
-  {
-    VkCommandBuffer extQCmd = GetExtQueueCmd(barrier.srcQueueFamilyIndex);
-
-    VkCommandBufferBeginInfo beginInfo = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL,
-                                          VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
-
-    VkResult vkr = ObjDisp(extQCmd)->BeginCommandBuffer(Unwrap(extQCmd), &beginInfo);
-    RDCASSERTEQUAL(vkr, VK_SUCCESS);
-
-    DoPipelineBarrier(extQCmd, setupBarriers.size(), setupBarriers.data());
-
-    vkr = ObjDisp(extQCmd)->EndCommandBuffer(Unwrap(extQCmd));
-    RDCASSERTEQUAL(vkr, VK_SUCCESS);
-
-    SubmitAndFlushExtQueue(layouts.queueFamilyIndex);
-  }
-}
-
 VkCommandBuffer WrappedVulkan::GetExtQueueCmd(uint32_t queueFamilyIdx) const
 {
   if(queueFamilyIdx >= m_ExternalQueues.size())
@@ -2443,8 +2360,10 @@ ReplayStatus WrappedVulkan::ContextReplayLog(CaptureState readType, uint32_t sta
 
     ApplyInitialContents();
 
+    SubmitAndFlushImageStateBarriers(m_setupImageBarriers);
     SubmitCmds();
     FlushQ();
+    SubmitAndFlushImageStateBarriers(m_cleanupImageBarriers);
 
     SetDebugMessageSink(sink);
   }
@@ -2661,6 +2580,19 @@ void WrappedVulkan::ApplyInitialContents()
   // actually apply the initial contents here
   GetResourceManager()->ApplyInitialContents();
 
+  for(auto it = m_ImageStates.begin(); it != m_ImageStates.end(); ++it)
+  {
+    if(GetResourceManager()->HasCurrentResource(it->first))
+    {
+      it->second.LockWrite()->ResetToOldState(m_cleanupImageBarriers, GetImageTransitionInfo());
+    }
+    else
+    {
+      it = m_ImageStates.erase(it);
+      --it;
+    }
+  }
+
   // likewise again to make sure the initial states are all applied
   cmd = GetNextCmd();
 
@@ -2673,7 +2605,10 @@ void WrappedVulkan::ApplyInitialContents()
   RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
 #if ENABLED(SINGLE_FLUSH_VALIDATE)
+  SubmitAndFlushImageStateBarriers(m_setupImageBarriers);
   SubmitCmds();
+  FlushQ();
+  SubmitAndFlushImageStateBarriers(m_cleanupImageBarriers);
 #endif
 }
 
@@ -3168,8 +3103,10 @@ void WrappedVulkan::ReplayLog(uint32_t startEventID, uint32_t endEventID, Replay
     ApplyInitialContents();
     VkMarkerRegion::End();
 
+    SubmitAndFlushImageStateBarriers(m_setupImageBarriers);
     SubmitCmds();
     FlushQ();
+    SubmitAndFlushImageStateBarriers(m_cleanupImageBarriers);
   }
 
   m_State = CaptureState::ActiveReplaying;
@@ -3287,7 +3224,10 @@ void WrappedVulkan::ReplayLog(uint32_t startEventID, uint32_t endEventID, Replay
     }
 
 #if ENABLED(SINGLE_FLUSH_VALIDATE)
+    SubmitAndFlushImageStateBarriers(m_setupImageBarriers);
     SubmitCmds();
+    FlushQ();
+    SubmitAndFlushImageStateBarriers(m_cleanupImageBarriers);
 #endif
   }
 

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1711,6 +1711,7 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
   RDCLOG("Finished capture, Frame %u", m_CapturedFrames.back().frameNumber);
 
   VkImage backbuffer = VK_NULL_HANDLE;
+  const PresentInfo *presentInfo = NULL;
   VkResourceRecord *swaprecord = NULL;
 
   if(swap != VK_NULL_HANDLE)
@@ -1722,7 +1723,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
 
     const SwapchainInfo &swapInfo = *swaprecord->swapInfo;
 
-    backbuffer = swapInfo.images[swapInfo.lastPresent].im;
+    presentInfo = &swapInfo.lastPresent;
+    backbuffer = swapInfo.images[presentInfo->imageIndex].im;
 
     // mark all images referenced as well
     for(size_t i = 0; i < swapInfo.images.size(); i++)
@@ -1741,7 +1743,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
 
       const SwapchainInfo &swapInfo = *swaprecord->swapInfo;
 
-      backbuffer = swapInfo.images[swapInfo.lastPresent].im;
+      presentInfo = &swapInfo.lastPresent;
+      backbuffer = swapInfo.images[presentInfo->imageIndex].im;
 
       // mark all images referenced as well
       for(size_t i = 0; i < swapInfo.images.size(); i++)
@@ -1833,7 +1836,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
         {swapInfo.imageInfo.extent.width, swapInfo.imageInfo.extent.height, 1},
     };
 
-    uint32_t swapQueueIndex = m_ImageLayouts[GetResID(backbuffer)].queueFamilyIndex;
+    VkResourceRecord *queueRecord = GetRecord(swapInfo.lastPresent.presentQueue);
+    uint32_t swapQueueIndex = queueRecord->queueFamilyIndex;
 
     VkImageMemoryBarrier bbBarrier = {
         VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1795,10 +1795,9 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
 
     // create readback buffer
     VkBufferCreateInfo bufInfo = {
-        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-        NULL,
-        0,
-        GetByteSize(swapInfo.extent.width, swapInfo.extent.height, 1, swapInfo.format, 0),
+        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, NULL, 0,
+        GetByteSize(swapInfo.imageInfo.extent.width, swapInfo.imageInfo.extent.height, 1,
+                    swapInfo.imageInfo.format, 0),
         VK_BUFFER_USAGE_TRANSFER_DST_BIT,
     };
     vt->CreateBuffer(Unwrap(device), &bufInfo, NULL, &readbackBuf);
@@ -1820,7 +1819,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
     vkr = vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-    uint32_t rowPitch = GetByteSize(swapInfo.extent.width, 1, 1, swapInfo.format, 0);
+    uint32_t rowPitch =
+        GetByteSize(swapInfo.imageInfo.extent.width, 1, 1, swapInfo.imageInfo.format, 0);
 
     VkBufferImageCopy cpy = {
         0,
@@ -1830,7 +1830,7 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
         {
             0, 0, 0,
         },
-        {swapInfo.extent.width, swapInfo.extent.height, 1},
+        {swapInfo.imageInfo.extent.width, swapInfo.imageInfo.extent.height, 1},
     };
 
     uint32_t swapQueueIndex = m_ImageLayouts[GetResID(backbuffer)].queueFamilyIndex;
@@ -1938,9 +1938,9 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
     vt->DestroyBuffer(Unwrap(device), Unwrap(readbackBuf), NULL);
     GetResourceManager()->ReleaseWrappedResource(readbackBuf);
 
-    ResourceFormat fmt = MakeResourceFormat(swapInfo.format);
-    fp.width = swapInfo.extent.width;
-    fp.height = swapInfo.extent.height;
+    ResourceFormat fmt = MakeResourceFormat(swapInfo.imageInfo.format);
+    fp.width = swapInfo.imageInfo.extent.width;
+    fp.height = swapInfo.imageInfo.extent.height;
     fp.pitch = rowPitch;
     fp.stride = fmt.compByteWidth * fmt.compCount;
     fp.bpc = fmt.compByteWidth;

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -4056,6 +4056,22 @@ const DrawcallDescription *WrappedVulkan::GetDrawcall(uint32_t eventId)
   return m_Drawcalls[eventId];
 }
 
+uint32_t WrappedVulkan::FindCommandQueueFamily(ResourceId cmdId)
+{
+  auto it = m_commandQueueFamilies.find(cmdId);
+  if(it == m_commandQueueFamilies.end())
+  {
+    RDCERR("Unknown queue family for %s", ToStr(cmdId).c_str());
+    return m_QueueFamilyIdx;
+  }
+  return it->second;
+}
+
+void WrappedVulkan::InsertCommandQueueFamily(ResourceId cmdId, uint32_t queueFamilyIndex)
+{
+  m_commandQueueFamilies[cmdId] = queueFamilyIndex;
+}
+
 #if ENABLED(ENABLE_UNIT_TESTS)
 
 #undef None

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1056,7 +1056,7 @@ public:
 
   inline ImageTransitionInfo GetImageTransitionInfo() const
   {
-    return ImageTransitionInfo(m_State, m_QueueFamilyIdx);
+    return ImageTransitionInfo(m_State, m_QueueFamilyIdx, SeparateDepthStencil());
   }
 
   // Device initialization

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -53,7 +53,7 @@ struct VkInitParams
   uint64_t GetSerialiseSize();
 
   // check if a frame capture section version is supported
-  static const uint64_t CurrentVersion = 0x10;
+  static const uint64_t CurrentVersion = 0x11;
   static bool IsSupportedVersion(uint64_t ver);
 };
 

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -747,6 +747,9 @@ private:
     m_ForcedReferences.push_back(record);
   }
 
+  // used on replay side to track the queue family of command buffers and pools
+  std::map<ResourceId, uint32_t> m_commandQueueFamilies;
+
   // used both on capture and replay side to track image layouts. Only locked
   // in capture
   std::map<ResourceId, ImageLayouts> m_ImageLayouts;
@@ -1043,6 +1046,8 @@ public:
     return m_PhysicalDeviceData.performanceQueryFeatures;
   }
   VkDriverInfo GetDriverInfo() { return m_PhysicalDeviceData.driverInfo; }
+  uint32_t FindCommandQueueFamily(ResourceId cmdId);
+  void InsertCommandQueueFamily(ResourceId cmdId, uint32_t queueFamilyIndex);
   // Device initialization
 
   IMPLEMENT_FUNCTION_SERIALISED(VkResult, vkCreateInstance, const VkInstanceCreateInfo *pCreateInfo,

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -422,6 +422,9 @@ private:
   rdcarray<uint32_t> m_QueueFamilyCounts;
   rdcarray<uint32_t> m_QueueFamilyIndices;
 
+  ImageBarrierSequence m_setupImageBarriers;
+  ImageBarrierSequence m_cleanupImageBarriers;
+
   // a small amount of helper code during capture for handling resources on different queues in init
   // states
   struct ExternalQueue
@@ -573,6 +576,7 @@ private:
       uint32_t subpass = 0;
     } state;
 
+    std::map<ResourceId, ImageState> imageStates;
     rdcarray<rdcpair<ResourceId, ImageRegionState>> imgbarriers;
 
     ResourceId pushDescriptorID[2][64];
@@ -754,8 +758,11 @@ private:
   // used on replay side to track the queue family of command buffers and pools
   std::map<ResourceId, uint32_t> m_commandQueueFamilies;
 
-  // used both on capture and replay side to track image layouts. Only locked
+  // used both on capture and replay side to track image state. Only locked
   // in capture
+  std::map<ResourceId, LockingImageState> m_ImageStates;
+  Threading::CriticalSection m_ImageStatesLock;
+
   std::map<ResourceId, ImageLayouts> m_ImageLayouts;
   Threading::CriticalSection m_ImageLayoutsLock;
 
@@ -1052,6 +1059,18 @@ public:
   VkDriverInfo GetDriverInfo() { return m_PhysicalDeviceData.driverInfo; }
   uint32_t FindCommandQueueFamily(ResourceId cmdId);
   void InsertCommandQueueFamily(ResourceId cmdId, uint32_t queueFamilyIndex);
+  LockedImageStateRef FindImageState(ResourceId id);
+  LockedConstImageStateRef FindConstImageState(ResourceId id);
+  LockedImageStateRef InsertImageState(VkImage wrappedHandle, ResourceId id, const ImageInfo &info,
+                                       FrameRefType refType, bool *inserted = NULL);
+  bool EraseImageState(ResourceId id);
+  void UpdateImageStates(const std::map<ResourceId, ImageState> &dstStates);
+
+  inline ImageTransitionInfo GetImageTransitionInfo() const
+  {
+    return ImageTransitionInfo(m_State, m_QueueFamilyIdx);
+  }
+
   // Device initialization
 
   IMPLEMENT_FUNCTION_SERIALISED(VkResult, vkCreateInstance, const VkInstanceCreateInfo *pCreateInfo,

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -577,7 +577,6 @@ private:
     } state;
 
     std::map<ResourceId, ImageState> imageStates;
-    rdcarray<rdcpair<ResourceId, ImageRegionState>> imgbarriers;
 
     ResourceId pushDescriptorID[2][64];
 
@@ -763,9 +762,6 @@ private:
   std::map<ResourceId, LockingImageState> m_ImageStates;
   Threading::CriticalSection m_ImageStatesLock;
 
-  std::map<ResourceId, ImageLayouts> m_ImageLayouts;
-  Threading::CriticalSection m_ImageLayoutsLock;
-
   // find swapchain for an image
   std::map<RENDERDOC_WindowHandle, VkSwapchainKHR> m_SwapLookup;
   Threading::CriticalSection m_SwapLookupLock;
@@ -931,10 +927,6 @@ private:
                                                       int32_t messageCode, const char *pLayerPrefix,
                                                       const char *pMessage, void *pUserData);
   void AddFrameTerminator(uint64_t queueMarkerTag);
-  void ImageInitializationBarriers(ResourceId id, WrappedVkRes *live, InitPolicy policy,
-                                   bool initialized, const ImgRefs *imgRefs,
-                                   rdcarray<VkImageMemoryBarrier> &setupBarriers,
-                                   rdcarray<VkImageMemoryBarrier> &cleanupBarriers) const;
   void SubmitExtQBarriers(const std::map<uint32_t, rdcarray<VkImageMemoryBarrier>> &extQBarriers);
   void SubmitExtQBarriers(uint32_t queueFamilyIndex,
                           const rdcarray<VkImageMemoryBarrier> &queueFamilyBarriers);
@@ -1027,10 +1019,6 @@ public:
   VkSemaphore GetNextSemaphore();
   void SubmitSemaphores();
   void FlushQ();
-
-  void TempTransition(VkImage image, VkImageLayout layout, VkAccessFlags access,
-                      rdcarray<VkImageMemoryBarrier> &setupBarriers,
-                      rdcarray<VkImageMemoryBarrier> &cleanupBarriers, bool &extQCleanup) const;
 
   bool SeparateDepthStencil() const { return m_SeparateDepthStencil; }
   VulkanRenderState &GetRenderState() { return m_RenderState; }

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -435,6 +435,10 @@ private:
   VkCommandBuffer GetExtQueueCmd(uint32_t queueFamilyIdx) const;
   void SubmitAndFlushExtQueue(uint32_t queueFamilyIdx) const;
 
+  void SubmitAndFlushImageStateBarriers(ImageBarrierSequence &barriers);
+  void InlineSetupImageBarriers(VkCommandBuffer cmd, ImageBarrierSequence &batches);
+  void InlineCleanupImageBarriers(VkCommandBuffer cmd, ImageBarrierSequence &batches);
+
   struct QueueRemap
   {
     uint32_t family;

--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -86,7 +86,8 @@ public:
 
   void PixelHistoryCopyPixel(VkCommandBuffer cmd, CopyPixelParams &p, size_t offset);
 
-  VkImageLayout GetImageLayout(ResourceId image, VkImageAspectFlags aspect, uint32_t mip);
+  VkImageLayout GetImageLayout(ResourceId image, VkImageAspectFlagBits aspect, uint32_t mip,
+                               uint32_t slice);
 
   const VulkanCreationInfo::Image &GetImageInfo(ResourceId img);
 

--- a/renderdoc/driver/vulkan/vk_image_states.cpp
+++ b/renderdoc/driver/vulkan/vk_image_states.cpp
@@ -24,6 +24,655 @@
 
 #include "vk_resources.h"
 
+ImageSubresourceRange ImageInfo::FullRange() const
+{
+  return ImageSubresourceRange(
+      /* aspectMask = */ Aspects(),
+      /* baseMipLevel = */ 0u,
+      /* levelCount = */ (uint32_t)levelCount,
+      /* baseArrayLayer = */ 0u,
+      /* layerCount = */ (uint32_t)layerCount,
+      /* baseDepthSlice = */ 0u,
+      /* sliceCount = */ extent.depth);
+}
+
+void ImageSubresourceState::Update(const ImageSubresourceState &other, FrameRefCompFunc compose)
+{
+  if(oldQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+    oldQueueFamilyIndex = other.oldQueueFamilyIndex;
+
+  if(other.newQueueFamilyIndex != VK_QUEUE_FAMILY_IGNORED)
+    newQueueFamilyIndex = other.newQueueFamilyIndex;
+
+  if(oldLayout == UNKNOWN_PREV_IMG_LAYOUT)
+    oldLayout = other.oldLayout;
+
+  if(other.newLayout != UNKNOWN_PREV_IMG_LAYOUT)
+    newLayout = other.newLayout;
+
+  refType = compose(refType, other.refType);
+}
+
+bool ImageSubresourceState::Update(const ImageSubresourceState &other,
+                                   ImageSubresourceState &result, FrameRefCompFunc compose) const
+{
+  result = *this;
+  result.Update(other, compose);
+
+  return result != *this;
+}
+
+template <typename Map, typename Pair>
+typename ImageSubresourceMap::SubresourceRangeIterTemplate<Map, Pair>
+    &ImageSubresourceMap::SubresourceRangeIterTemplate<Map, Pair>::operator++()
+{
+  if(!IsValid())
+    return *this;
+  FixSubRange();
+
+  ++m_slice;
+  if(IsDepthSplit(m_splitFlags) && m_slice < m_range.baseDepthSlice + m_range.sliceCount)
+  {
+    m_value.m_range.baseDepthSlice = m_slice;
+    return *this;
+  }
+  m_value.m_range.baseDepthSlice = m_slice = m_range.baseDepthSlice;
+
+  ++m_layer;
+  if(AreLayersSplit(m_splitFlags) && m_layer < m_range.baseArrayLayer + m_range.layerCount)
+  {
+    m_value.m_range.baseArrayLayer = m_layer;
+    return *this;
+  }
+  m_value.m_range.baseArrayLayer = m_layer = m_range.baseArrayLayer;
+
+  ++m_level;
+  if(AreLevelsSplit(m_splitFlags) && m_level < m_range.baseMipLevel + m_range.levelCount)
+  {
+    m_value.m_range.baseMipLevel = m_level;
+    return *this;
+  }
+  m_value.m_range.baseMipLevel = m_level = m_range.baseMipLevel;
+
+  if(AreAspectsSplit(m_splitFlags))
+  {
+    auto aspectIt = ImageAspectFlagIter(m_map->GetImageInfo().Aspects(),
+                                        (VkImageAspectFlagBits)m_value.m_range.aspectMask);
+    while(true)
+    {
+      ++m_aspectIndex;
+      ++aspectIt;
+      if(aspectIt == ImageAspectFlagIter::end())
+      {
+        break;
+      }
+      else if(m_range.aspectMask & *aspectIt)
+      {
+        m_value.m_range.aspectMask = *aspectIt;
+        return *this;
+      }
+    }
+  }
+
+  // iterator is at the end.
+  // make `m_aspectIndex` out of range to mark this.
+  m_aspectIndex = m_map->m_aspectCount;
+  return *this;
+}
+template
+    typename ImageSubresourceMap::SubresourceRangeIterTemplate<ImageSubresourceMap,
+                                                               ImageSubresourceMap::SubresourcePairRef>
+        &ImageSubresourceMap::SubresourceRangeIterTemplate<
+            ImageSubresourceMap, ImageSubresourceMap::SubresourcePairRef>::operator++();
+template typename ImageSubresourceMap::SubresourceRangeIterTemplate<
+    const ImageSubresourceMap, ImageSubresourceMap::ConstSubresourcePairRef>
+    &ImageSubresourceMap::SubresourceRangeIterTemplate<
+        const ImageSubresourceMap, ImageSubresourceMap::ConstSubresourcePairRef>::operator++();
+
+void ImageSubresourceMap::Split(bool splitAspects, bool splitLevels, bool splitLayers, bool splitDepth)
+{
+  uint16_t newFlags = m_flags;
+  if(splitAspects)
+    newFlags |= (uint16_t)FlagBits::AreAspectsSplit;
+  else
+    splitAspects = AreAspectsSplit();
+
+  if(splitLevels)
+    newFlags |= (uint16_t)FlagBits::AreLevelsSplit;
+  else
+    splitLevels = AreLevelsSplit();
+
+  if(splitLayers)
+    newFlags |= (uint16_t)FlagBits::AreLayersSplit;
+  else
+    splitLayers = AreLayersSplit();
+
+  if(splitDepth)
+    newFlags |= (uint16_t)FlagBits::IsDepthSplit;
+  else
+    splitDepth = IsDepthSplit();
+
+  if(newFlags == m_flags)
+    // not splitting anything new
+    return;
+
+  uint32_t oldSplitAspectCount = AreAspectsSplit() ? m_aspectCount : 1;
+  uint32_t newSplitAspectCount = splitAspects ? m_aspectCount : oldSplitAspectCount;
+
+  uint32_t oldSplitLevelCount = AreLevelsSplit() ? GetImageInfo().levelCount : 1;
+  uint32_t newSplitLevelCount = splitLevels ? GetImageInfo().levelCount : oldSplitLevelCount;
+
+  uint32_t oldSplitLayerCount = AreLayersSplit() ? GetImageInfo().layerCount : 1;
+  uint32_t newSplitLayerCount = splitLayers ? GetImageInfo().layerCount : oldSplitLayerCount;
+
+  uint32_t oldSplitSliceCount = IsDepthSplit() ? GetImageInfo().extent.depth : 1;
+  uint32_t newSplitSliceCount = splitDepth ? GetImageInfo().extent.depth : oldSplitSliceCount;
+
+  uint32_t oldSize = (uint32_t)m_values.size();
+  RDCASSERT(oldSize > 0);
+
+  uint32_t newSize =
+      newSplitAspectCount * newSplitLevelCount * newSplitLayerCount * newSplitSliceCount;
+  RDCASSERT(newSize > oldSize);
+
+  m_values.resize(newSize);
+
+  uint32_t newAspectIndex = newSplitAspectCount - 1;
+  uint32_t oldAspectIndex = AreAspectsSplit() ? newAspectIndex : 0;
+  uint32_t newLevel = newSplitLevelCount - 1;
+  uint32_t oldLevel = AreLevelsSplit() ? newLevel : 0;
+  uint32_t newLayer = newSplitLayerCount - 1;
+  uint32_t oldLayer = AreLayersSplit() ? newLayer : 0;
+  uint32_t newSlice = newSplitSliceCount - 1;
+  uint32_t oldSlice = IsDepthSplit() ? newSlice : 0;
+  uint32_t newIndex = newSize - 1;
+  while(true)
+  {
+    uint32_t oldIndex =
+        ((oldAspectIndex * oldSplitLevelCount + oldLevel) * oldSplitLayerCount + oldLayer) *
+            oldSplitSliceCount +
+        oldSlice;
+    m_values[newIndex] = m_values[oldIndex];
+
+    if(newIndex == 0)
+    {
+      RDCASSERT(oldIndex == 0);
+      break;
+    }
+    --newIndex;
+
+    if(newSlice > 0)
+    {
+      --newSlice;
+      oldSlice = IsDepthSplit() ? newSlice : 0;
+      continue;
+    }
+    newSlice = newSplitSliceCount - 1;
+    oldSlice = oldSplitSliceCount - 1;
+
+    if(newLayer > 0)
+    {
+      --newLayer;
+      oldLayer = AreLayersSplit() ? newLayer : 0;
+      continue;
+    }
+    newLayer = newSplitLayerCount - 1;
+    oldLayer = oldSplitLayerCount - 1;
+
+    if(newLevel > 0)
+    {
+      --newLevel;
+      oldLevel = AreLevelsSplit() ? newLevel : 0;
+      continue;
+    }
+    newLevel = newSplitLevelCount - 1;
+    oldLevel = oldSplitLevelCount - 1;
+
+    if(newAspectIndex > 0)
+    {
+      --newAspectIndex;
+      oldAspectIndex = AreAspectsSplit() ? newAspectIndex : 0;
+      continue;
+    }
+    RDCERR("Too many subresources in ImageSubresourceMap::Split");
+    break;
+  }
+
+  m_flags = newFlags;
+}
+
+void ImageSubresourceMap::Unsplit(bool unsplitAspects, bool unsplitLevels, bool unsplitLayers,
+                                  bool unsplitDepth)
+{
+  uint16_t newFlags = m_flags;
+  if(unsplitAspects)
+    newFlags &= ~(uint16_t)FlagBits::AreAspectsSplit;
+
+  if(unsplitLevels)
+    newFlags &= ~(uint16_t)FlagBits::AreLevelsSplit;
+
+  if(unsplitLayers)
+    newFlags &= ~(uint16_t)FlagBits::AreLayersSplit;
+
+  if(unsplitDepth)
+    newFlags &= ~(uint16_t)FlagBits::IsDepthSplit;
+
+  if(newFlags == m_flags)
+    // not splitting anything new
+    return;
+
+  uint32_t oldSplitAspectCount = AreAspectsSplit() ? m_aspectCount : 1;
+  uint32_t newSplitAspectCount = unsplitAspects ? 1 : oldSplitAspectCount;
+
+  uint32_t oldSplitLevelCount = AreLevelsSplit() ? GetImageInfo().levelCount : 1;
+  uint32_t newSplitLevelCount = unsplitLevels ? 1 : oldSplitLevelCount;
+
+  uint32_t oldSplitLayerCount = AreLayersSplit() ? GetImageInfo().layerCount : 1;
+  uint32_t newSplitLayerCount = unsplitLayers ? 1 : oldSplitLayerCount;
+
+  uint32_t oldSplitSliceCount = IsDepthSplit() ? GetImageInfo().extent.depth : 1;
+  uint32_t newSplitSliceCount = unsplitDepth ? 1 : oldSplitSliceCount;
+
+  uint32_t oldSize = (uint32_t)m_values.size();
+  RDCASSERT(oldSize > 0);
+
+  uint32_t newSize =
+      newSplitAspectCount * newSplitLevelCount * newSplitLayerCount * newSplitSliceCount;
+  RDCASSERT(newSize < oldSize);
+
+  rdcarray<ImageSubresourceState> newValues;
+  newValues.resize(newSize);
+
+  uint32_t aspectIndex = 0;
+  uint32_t level = 0;
+  uint32_t layer = 0;
+  uint32_t slice = 0;
+  uint32_t newIndex = 0;
+
+  while(newIndex < newValues.size())
+  {
+    uint32_t oldIndex = ((aspectIndex * oldSplitLevelCount + level) * oldSplitLayerCount + layer) *
+                            oldSplitSliceCount +
+                        slice;
+    newValues[newIndex] = m_values[oldIndex];
+
+    ++newIndex;
+
+    ++slice;
+    if(slice < newSplitSliceCount)
+      continue;
+    slice = 0;
+
+    ++layer;
+    if(layer < newSplitLayerCount)
+      continue;
+    layer = 0;
+
+    ++level;
+    if(level < newSplitLevelCount)
+      continue;
+    level = 0;
+
+    ++aspectIndex;
+  }
+
+  newValues.swap(m_values);
+  m_flags = newFlags;
+}
+
+void ImageSubresourceMap::Unsplit()
+{
+  if(m_values.size() == 1)
+    return;
+
+  uint32_t aspectCount = AreAspectsSplit() ? m_aspectCount : 1;
+  uint32_t aspectIndex = 0;
+  uint32_t levelCount = AreLevelsSplit() ? m_imageInfo.levelCount : 1;
+  uint32_t level = 0;
+  uint32_t layerCount = AreLayersSplit() ? m_imageInfo.layerCount : 1;
+  uint32_t layer = 0;
+  uint32_t sliceCount = IsDepthSplit() ? m_imageInfo.extent.depth : 1;
+  uint32_t slice = 0;
+  uint32_t index = 0;
+
+  bool canUnsplitAspects = aspectCount > 1;
+  bool canUnsplitLevels = levelCount > 1;
+  bool canUnsplitLayers = layerCount > 1;
+  bool canUnsplitDepth = sliceCount > 1;
+
+  RDCASSERT(aspectCount * levelCount * layerCount * sliceCount == m_values.size());
+#define UNSPLIT_INDEX(ASPECT, LEVEL, LAYER, SLICE) \
+  (((ASPECT * levelCount + LEVEL) * layerCount + LAYER) * sliceCount + SLICE)
+  while(index < m_values.size() &&
+        (canUnsplitAspects || canUnsplitLevels || canUnsplitLayers || canUnsplitDepth))
+  {
+    if(canUnsplitAspects && aspectIndex > 0)
+    {
+      uint32_t index0 = UNSPLIT_INDEX(0, level, layer, slice);
+      if(m_values[index] != m_values[index0])
+        canUnsplitAspects = false;
+    }
+    if(canUnsplitLevels && level > 0)
+    {
+      uint32_t index0 = UNSPLIT_INDEX(aspectIndex, 0, layer, slice);
+      if(m_values[index] != m_values[index0])
+        canUnsplitLevels = false;
+    }
+    if(canUnsplitLayers && layer > 0)
+    {
+      uint32_t index0 = UNSPLIT_INDEX(aspectIndex, level, 0, slice);
+      if(m_values[index] != m_values[index0])
+        canUnsplitLayers = false;
+    }
+    if(canUnsplitDepth && slice > 0)
+    {
+      uint32_t index0 = UNSPLIT_INDEX(aspectIndex, level, layer, 0);
+      if(m_values[index] != m_values[index0])
+        canUnsplitDepth = false;
+    }
+
+    ++index;
+
+    ++slice;
+    if(slice < sliceCount)
+      continue;
+    slice = 0;
+
+    ++layer;
+    if(layer < layerCount)
+      continue;
+    layer = 0;
+
+    ++level;
+    if(level < levelCount)
+      continue;
+    level = 0;
+
+    ++aspectIndex;
+    if(aspectIndex >= aspectCount)
+      break;
+  }
+#undef UNSPLIT_INDEX
+
+  Unsplit(canUnsplitAspects, canUnsplitLevels, canUnsplitLayers, canUnsplitDepth);
+}
+
+inline FrameRefType ImageSubresourceMap::Merge(const ImageSubresourceMap &other,
+                                               FrameRefCompFunc compose)
+{
+  FrameRefType maxRefType = eFrameRef_None;
+  bool didSplit = false;
+  for(auto oIt = other.begin(); oIt != other.end(); ++oIt)
+  {
+    for(auto it = RangeBegin(oIt->range()); it != end(); ++it)
+    {
+      ImageSubresourceState subState;
+      if(it->state().Update(oIt->state(), subState, compose))
+      {
+        if(!didSplit)
+        {
+          Split(oIt->range());
+          didSplit = true;
+        }
+        RDCASSERT(it->range().ContainedIn(oIt->range()));
+        it->SetState(subState);
+        maxRefType = ComposeFrameRefsDisjoint(maxRefType, subState.refType);
+      }
+    }
+  }
+  return maxRefType;
+}
+
+size_t ImageSubresourceMap::SubresourceIndex(uint32_t aspectIndex, uint32_t level, uint32_t layer,
+                                             uint32_t slice) const
+{
+  if(!AreAspectsSplit())
+    aspectIndex = 0;
+  int splitLevelCount = 1;
+  if(AreLevelsSplit())
+    splitLevelCount = GetImageInfo().levelCount;
+  else
+    level = 0;
+  int splitLayerCount = 1;
+  if(AreLayersSplit())
+    splitLayerCount = GetImageInfo().layerCount;
+  else
+    layer = 0;
+  int splitSliceCount = 1;
+  if(IsDepthSplit())
+    splitSliceCount = GetImageInfo().extent.depth;
+  else
+    slice = 0;
+  return ((aspectIndex * splitLevelCount + level) * splitLayerCount + layer) * splitSliceCount +
+         slice;
+}
+
+bool IntervalsOverlap(uint32_t base1, uint32_t count1, uint32_t base2, uint32_t count2)
+{
+  if((base1 + count1) < base1)
+  {
+    // integer overflow
+    if(count1 != VK_REMAINING_MIP_LEVELS)
+      RDCWARN("Integer overflow in interval: base=%u, count=%u", base1, count1);
+    count1 = UINT32_MAX - base1;
+  }
+  if((base2 + count2) < base2)
+  {
+    // integer overflow
+    if(count2 != VK_REMAINING_MIP_LEVELS)
+      RDCWARN("Integer overflow in interval: base=%u, count=%u", base2, count2);
+    count2 = UINT32_MAX - base2;
+  }
+  if(count1 == 0 || count2 == 0)
+    return false;    // one of the intervals is empty, so no overlap
+  if(base1 > base2)
+  {
+    std::swap(base1, base2);
+    std::swap(count1, count2);
+  }
+  return base2 < base1 + count1;
+}
+
+bool IntervalContainedIn(uint32_t base1, uint32_t count1, uint32_t base2, uint32_t count2)
+{
+  if((base1 + count1) < base1)
+  {
+    // integer overflow
+    if(count1 != VK_REMAINING_MIP_LEVELS)
+      RDCWARN("Integer overflow in interval: base=%u, count=%u", base1, count1);
+    count1 = UINT32_MAX - base1;
+  }
+  if((base2 + count2) < base2)
+  {
+    // integer overflow
+    if(count2 != VK_REMAINING_MIP_LEVELS)
+      RDCWARN("Integer overflow in interval: base=%u, count=%u", base2, count2);
+    count2 = UINT32_MAX - base2;
+  }
+  return base1 >= base2 && base1 + count1 <= base2 + count2;
+}
+
+bool SanitiseLevelRange(uint32_t &baseMipLevel, uint32_t &levelCount, uint32_t imageLevelCount)
+{
+  bool res = true;
+  if(baseMipLevel > imageLevelCount)
+  {
+    RDCWARN("baseMipLevel (%u) is greater than image levelCount (%u)", baseMipLevel, imageLevelCount);
+    baseMipLevel = imageLevelCount;
+    res = false;
+  }
+  if(levelCount == VK_REMAINING_MIP_LEVELS)
+  {
+    levelCount = imageLevelCount - baseMipLevel;
+  }
+  else if(levelCount > imageLevelCount - baseMipLevel)
+  {
+    RDCWARN("baseMipLevel (%u) + levelCount (%u) is greater than the image levelCount (%u)",
+            baseMipLevel, levelCount, imageLevelCount);
+    levelCount = imageLevelCount - baseMipLevel;
+    res = false;
+  }
+  return res;
+}
+
+bool SanitiseLayerRange(uint32_t &baseArrayLayer, uint32_t &layerCount, uint32_t imageLayerCount)
+{
+  bool res = true;
+  if(baseArrayLayer > imageLayerCount)
+  {
+    RDCWARN("baseArrayLayer (%u) is greater than image layerCount (%u)", baseArrayLayer,
+            imageLayerCount);
+    baseArrayLayer = imageLayerCount;
+    res = false;
+  }
+  if(layerCount == VK_REMAINING_ARRAY_LAYERS)
+  {
+    layerCount = imageLayerCount - baseArrayLayer;
+  }
+  else if(layerCount > imageLayerCount - baseArrayLayer)
+  {
+    RDCWARN("baseArrayLayer (%u) + layerCount (%u) is greater than the image layerCount (%u)",
+            baseArrayLayer, layerCount, imageLayerCount);
+    layerCount = imageLayerCount - baseArrayLayer;
+    res = false;
+  }
+  return res;
+}
+
+bool SanitiseSliceRange(uint32_t &baseSlice, uint32_t &sliceCount, uint32_t imageSliceCount)
+{
+  bool res = true;
+  if(baseSlice > imageSliceCount)
+  {
+    RDCWARN("baseSlice (%u) is greater than image sliceCount (%u)", baseSlice, imageSliceCount);
+    baseSlice = imageSliceCount;
+    res = false;
+  }
+  if(sliceCount == VK_REMAINING_ARRAY_LAYERS)
+  {
+    sliceCount = imageSliceCount - baseSlice;
+  }
+  else if(sliceCount > imageSliceCount - baseSlice)
+  {
+    RDCWARN("baseSlice (%u) + sliceCount (%u) is greater than the image sliceCount (%u)", baseSlice,
+            sliceCount, imageSliceCount);
+    sliceCount = imageSliceCount - baseSlice;
+    res = false;
+  }
+  return res;
+}
+
+template <typename Map, typename Pair>
+ImageSubresourceMap::SubresourceRangeIterTemplate<Map, Pair>::SubresourceRangeIterTemplate(
+    Map &map, const ImageSubresourceRange &range)
+    : m_map(&map),
+      m_range(range),
+      m_level(range.baseMipLevel),
+      m_layer(range.baseArrayLayer),
+      m_slice(range.baseDepthSlice)
+{
+  m_range.Sanitise(m_map->GetImageInfo());
+  m_splitFlags = (uint16_t)ImageSubresourceMap::FlagBits::IsUninitialized;
+  FixSubRange();
+}
+template ImageSubresourceMap::SubresourceRangeIterTemplate<ImageSubresourceMap,
+                                                           ImageSubresourceMap::SubresourcePairRef>::
+    SubresourceRangeIterTemplate(ImageSubresourceMap &map, const ImageSubresourceRange &range);
+template ImageSubresourceMap::SubresourceRangeIterTemplate<
+    const ImageSubresourceMap, ImageSubresourceMap::ConstSubresourcePairRef>::
+    SubresourceRangeIterTemplate(const ImageSubresourceMap &map, const ImageSubresourceRange &range);
+
+template <typename Map, typename Pair>
+void ImageSubresourceMap::SubresourceRangeIterTemplate<Map, Pair>::FixSubRange()
+{
+  if(m_splitFlags == m_map->m_flags)
+    return;
+  uint16_t oldFlags = m_splitFlags;
+  m_splitFlags = m_map->m_flags;
+
+  if(IsDepthSplit(m_splitFlags))
+  {
+    m_value.m_range.baseDepthSlice = m_slice;
+    m_value.m_range.sliceCount = 1u;
+  }
+  else
+  {
+    m_value.m_range.baseDepthSlice = 0u;
+    m_value.m_range.sliceCount = m_map->GetImageInfo().extent.depth;
+  }
+
+  if(AreLayersSplit(m_splitFlags))
+  {
+    m_value.m_range.baseArrayLayer = m_layer;
+    m_value.m_range.layerCount = 1u;
+  }
+  else
+  {
+    m_value.m_range.baseArrayLayer = 0u;
+    m_value.m_range.layerCount = m_map->GetImageInfo().layerCount;
+  }
+
+  if(AreLevelsSplit(m_splitFlags))
+  {
+    m_value.m_range.baseMipLevel = m_level;
+    m_value.m_range.levelCount = 1u;
+  }
+  else
+  {
+    m_value.m_range.baseMipLevel = 0u;
+    m_value.m_range.levelCount = m_map->GetImageInfo().levelCount;
+  }
+
+  if(!AreAspectsSplit(m_splitFlags))
+  {
+    m_value.m_range.aspectMask = m_map->GetImageInfo().Aspects();
+  }
+  else if(!AreAspectsSplit(oldFlags))
+  {
+    // aspects are split in the map, but are not yet split in this iterator.
+    // We need to find the aspectMask.
+    uint32_t i = 0;
+    for(auto it = ImageAspectFlagIter::begin(m_map->GetImageInfo().Aspects());
+        it != ImageAspectFlagIter::end(); ++it, ++i)
+    {
+      if(i >= m_aspectIndex && (((*it) & m_range.aspectMask) != 0))
+      {
+        m_value.m_range.aspectMask = *it;
+        break;
+      }
+    }
+    m_aspectIndex = i;
+  }
+}
+template void ImageSubresourceMap::SubresourceRangeIterTemplate<
+    ImageSubresourceMap, ImageSubresourceMap::SubresourcePairRef>::FixSubRange();
+template void ImageSubresourceMap::SubresourceRangeIterTemplate<
+    const ImageSubresourceMap, ImageSubresourceMap::ConstSubresourcePairRef>::FixSubRange();
+
+template <typename Map, typename Pair>
+Pair *ImageSubresourceMap::SubresourceRangeIterTemplate<Map, Pair>::operator->()
+{
+  FixSubRange();
+  m_value.m_state = &m_map->SubresourceValue(m_aspectIndex, m_level, m_layer, m_slice);
+  return &m_value;
+}
+template ImageSubresourceMap::SubresourcePairRef *ImageSubresourceMap::SubresourceRangeIterTemplate<
+    ImageSubresourceMap, ImageSubresourceMap::SubresourcePairRef>::operator->();
+template ImageSubresourceMap::ConstSubresourcePairRef *ImageSubresourceMap::SubresourceRangeIterTemplate<
+    const ImageSubresourceMap, ImageSubresourceMap::ConstSubresourcePairRef>::operator->();
+
+template <typename Map, typename Pair>
+Pair &ImageSubresourceMap::SubresourceRangeIterTemplate<Map, Pair>::operator*()
+{
+  FixSubRange();
+  m_value.m_state = &m_map->SubresourceValue(m_aspectIndex, m_level, m_layer, m_slice);
+  return m_value;
+}
+template ImageSubresourceMap::SubresourcePairRef &ImageSubresourceMap::SubresourceRangeIterTemplate<
+    ImageSubresourceMap, ImageSubresourceMap::SubresourcePairRef>::operator*();
+template ImageSubresourceMap::ConstSubresourcePairRef &ImageSubresourceMap::SubresourceRangeIterTemplate<
+    const ImageSubresourceMap, ImageSubresourceMap::ConstSubresourcePairRef>::operator*();
+
 template <typename Barrier>
 void BarrierSequence<Barrier>::AddWrapped(uint32_t batchIndex, uint32_t queueFamilyIndex,
                                           const Barrier &barrier)
@@ -132,3 +781,655 @@ void BarrierSequence<Barrier>::ExtractLastUnwrappedBatchForQueue(uint32_t queueF
 }
 template void BarrierSequence<VkImageMemoryBarrier>::ExtractLastUnwrappedBatchForQueue(
     uint32_t queueFamilyIndex, rdcarray<VkImageMemoryBarrier> &result);
+
+ImageState ImageState::InitialState() const
+{
+  ImageState result(wrappedHandle, GetImageInfo(), eFrameRef_Unknown);
+  InitialState(result);
+  return result;
+}
+
+void ImageState::InitialState(ImageState &result) const
+{
+  result.subresourceStates = subresourceStates;
+  for(auto it = result.subresourceStates.begin(); it != result.subresourceStates.end(); ++it)
+  {
+    ImageSubresourceState &sub = it->state();
+    sub.newLayout = sub.oldLayout = GetImageInfo().initialLayout;
+    sub.newQueueFamilyIndex = sub.oldQueueFamilyIndex;
+    sub.refType = eFrameRef_Unknown;
+  }
+}
+
+ImageState ImageState::CommandBufferInitialState() const
+{
+  ImageSubresourceState sub;
+  sub.oldLayout = sub.newLayout = UNKNOWN_PREV_IMG_LAYOUT;
+  return UniformState(sub);
+}
+
+ImageState ImageState::UniformState(const ImageSubresourceState &sub) const
+{
+  ImageState result(wrappedHandle, GetImageInfo(), eFrameRef_None);
+  result.subresourceStates.begin()->SetState(sub);
+  return result;
+}
+
+ImageState ImageState::ContentInitializationState(InitPolicy policy, bool initialized,
+                                                  uint32_t queueFamilyIndex, VkImageLayout copyLayout,
+                                                  VkImageLayout clearLayout) const
+{
+  ImageState result = *this;
+  for(auto it = result.subresourceStates.begin(); it != result.subresourceStates.end(); ++it)
+  {
+    ImageSubresourceState &sub = it->state();
+    InitReqType initReq = InitReq(sub.refType, policy, initialized);
+    if(initReq == eInitReq_None)
+      continue;
+    sub.newQueueFamilyIndex = queueFamilyIndex;
+    if(initReq == eInitReq_Copy)
+      sub.newLayout = copyLayout;
+    else if(initReq == eInitReq_Clear)
+      sub.newLayout = clearLayout;
+  }
+  return result;
+}
+
+void ImageState::RemoveQueueFamilyTransfer(VkImageMemoryBarrier *it)
+{
+  if(it < newQueueFamilyTransfers.begin() || it >= newQueueFamilyTransfers.end())
+    RDCERR("Attempting to remove queue family transfer at invalid address");
+  std::swap(*it, newQueueFamilyTransfers.back());
+  newQueueFamilyTransfers.erase(newQueueFamilyTransfers.size() - 1);
+}
+
+void ImageState::Update(ImageSubresourceRange range, const ImageSubresourceState &dst,
+                        FrameRefCompFunc compose)
+{
+  range.Sanitise(GetImageInfo());
+
+  bool didSplit = false;
+  for(auto it = subresourceStates.RangeBegin(range); it != subresourceStates.end(); ++it)
+  {
+    ImageSubresourceState subState;
+    if(it->state().Update(dst, subState, compose))
+    {
+      if(!didSplit)
+      {
+        subresourceStates.Split(range);
+        didSplit = true;
+      }
+      RDCASSERT(it->range().ContainedIn(range));
+      it->SetState(subState);
+      maxRefType = ComposeFrameRefsDisjoint(maxRefType, subState.refType);
+    }
+  }
+}
+
+void ImageState::Merge(const ImageState &other, ImageTransitionInfo info)
+{
+  if(wrappedHandle == VK_NULL_HANDLE)
+    wrappedHandle = other.wrappedHandle;
+  for(auto it = other.oldQueueFamilyTransfers.begin(); it != other.oldQueueFamilyTransfers.end(); ++it)
+  {
+    RecordQueueFamilyAcquire(*it);
+  }
+  maxRefType = subresourceStates.Merge(other.subresourceStates, info.GetFrameRefCompFunc());
+  for(auto it = other.newQueueFamilyTransfers.begin(); it != other.newQueueFamilyTransfers.end(); ++it)
+  {
+    RecordQueueFamilyRelease(*it);
+  }
+}
+
+void ImageState::MergeCaptureBeginState(const ImageState &initialState)
+{
+  oldQueueFamilyTransfers = initialState.oldQueueFamilyTransfers;
+  subresourceStates = initialState.subresourceStates;
+  maxRefType = initialState.maxRefType;
+}
+
+void ImageState::Merge(std::map<ResourceId, ImageState> &states,
+                       const std::map<ResourceId, ImageState> &dstStates, ImageTransitionInfo info)
+{
+  auto it = states.begin();
+  auto dstIt = dstStates.begin();
+  while(dstIt != dstStates.end())
+  {
+    if(it == states.end() || dstIt->first < it->first)
+    {
+      it = states.insert(it, {dstIt->first, dstIt->second.InitialState()});
+    }
+    else if(it->first < dstIt->first)
+    {
+      ++it;
+      continue;
+    }
+
+    it->second.Merge(dstIt->second, info);
+    ++it;
+    ++dstIt;
+  }
+}
+
+void ImageState::DiscardContents(const ImageSubresourceRange &range)
+{
+  Update(range, ImageSubresourceState(VK_QUEUE_FAMILY_IGNORED, VK_IMAGE_LAYOUT_UNDEFINED),
+         KeepOldFrameRef);
+}
+
+void ImageState::RecordQueueFamilyRelease(const VkImageMemoryBarrier &barrier)
+{
+  for(auto it = newQueueFamilyTransfers.begin(); it != newQueueFamilyTransfers.end(); ++it)
+  {
+    if(ImageSubresourceRange(barrier.subresourceRange).Overlaps(it->subresourceRange))
+    {
+      RDCWARN("Queue family release barriers overlap");
+      RemoveQueueFamilyTransfer(it);
+      --it;
+    }
+  }
+  newQueueFamilyTransfers.push_back(barrier);
+}
+
+void ImageState::RecordQueueFamilyAcquire(const VkImageMemoryBarrier &barrier)
+{
+  bool foundRelease = false;
+  ImageSubresourceRange acquireRange(barrier.subresourceRange);
+  for(auto it = newQueueFamilyTransfers.begin(); it != newQueueFamilyTransfers.end(); ++it)
+  {
+    ImageSubresourceRange releaseRange(it->subresourceRange);
+    if(acquireRange.Overlaps(releaseRange))
+    {
+      if(acquireRange != releaseRange)
+        RDCWARN(
+            "Overlapping queue family release and acquire barriers have different "
+            "subresourceRange");
+      if(barrier.srcQueueFamilyIndex != it->srcQueueFamilyIndex ||
+         barrier.dstQueueFamilyIndex != it->dstQueueFamilyIndex)
+        RDCWARN("Queue family mismatch between release and acquire barriers");
+      if(barrier.oldLayout != it->oldLayout || barrier.newLayout != it->newLayout)
+        RDCWARN("Image layouts mismatch between release and acquire barriers");
+      if(foundRelease)
+        RDCWARN("Found multiple release barriers for acquire barrier");
+      RemoveQueueFamilyTransfer(it);
+      --it;
+      foundRelease = true;
+    }
+  }
+  if(!foundRelease)
+  {
+    oldQueueFamilyTransfers.push_back(barrier);
+  }
+}
+
+void ImageState::RecordBarrier(VkImageMemoryBarrier barrier, uint32_t queueFamilyIndex,
+                               ImageTransitionInfo info)
+{
+  if(barrier.srcQueueFamilyIndex == VK_QUEUE_FAMILY_EXTERNAL ||
+     barrier.srcQueueFamilyIndex == VK_QUEUE_FAMILY_FOREIGN_EXT ||
+     barrier.dstQueueFamilyIndex == VK_QUEUE_FAMILY_EXTERNAL ||
+     barrier.dstQueueFamilyIndex == VK_QUEUE_FAMILY_FOREIGN_EXT)
+  {
+    RDCERR("External/foreign queue families are not supported");
+    return;
+  }
+  if(GetImageInfo().sharingMode == VK_SHARING_MODE_CONCURRENT)
+  {
+    if(!(barrier.srcQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED &&
+         barrier.dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED))
+    {
+      RDCWARN("Barrier contains invalid queue families for VK_SHARING_MODE_CONCURRENT");
+    }
+    barrier.srcQueueFamilyIndex = barrier.dstQueueFamilyIndex = queueFamilyIndex;
+  }
+  else if(GetImageInfo().sharingMode == VK_SHARING_MODE_EXCLUSIVE)
+  {
+    if(barrier.srcQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED ||
+       barrier.dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+    {
+      if(barrier.srcQueueFamilyIndex != VK_QUEUE_FAMILY_IGNORED ||
+         barrier.dstQueueFamilyIndex != VK_QUEUE_FAMILY_IGNORED)
+      {
+        RDCERR("Barrier contains invalid queue families for VK_SHARING_MODE_EXCLUSIVE: (%s, %s)",
+               ToStr(barrier.srcQueueFamilyIndex).c_str(),
+               ToStr(barrier.dstQueueFamilyIndex).c_str());
+        return;
+      }
+      barrier.srcQueueFamilyIndex = queueFamilyIndex;
+      barrier.dstQueueFamilyIndex = queueFamilyIndex;
+    }
+    else if(barrier.srcQueueFamilyIndex == queueFamilyIndex)
+    {
+      if(barrier.dstQueueFamilyIndex != queueFamilyIndex)
+      {
+        RecordQueueFamilyRelease(barrier);
+        // Skip the updates to the subresource states.
+        // These will be updated by the acquire.
+        // This allows us to restore a released-but-not-acquired state by first transitioning to the
+        // subresource states (which will match the srcQueueFamilyIndex/oldLayout), and then
+        // applying the release barrier.
+        return;
+      }
+    }
+    else if(barrier.dstQueueFamilyIndex == queueFamilyIndex)
+    {
+      RecordQueueFamilyAcquire(barrier);
+    }
+    else
+    {
+      RDCERR("Ownership transfer from queue family %u to %u submitted to queue family %u",
+             barrier.srcQueueFamilyIndex, barrier.dstAccessMask, queueFamilyIndex);
+    }
+  }
+
+  Update(barrier.subresourceRange, ImageSubresourceState(barrier), info.GetFrameRefCompFunc());
+}
+
+bool ImageState::CloseTransfers(uint32_t batchIndex, VkAccessFlags dstAccessMask,
+                                ImageBarrierSequence &barriers, ImageTransitionInfo info)
+{
+  if(newQueueFamilyTransfers.empty())
+    return false;
+  FrameRefCompFunc compose = info.GetFrameRefCompFunc();
+  for(auto it = newQueueFamilyTransfers.begin(); it != newQueueFamilyTransfers.end(); ++it)
+  {
+    Update(it->subresourceRange, ImageSubresourceState(it->dstQueueFamilyIndex, it->newLayout),
+           compose);
+
+    it->dstAccessMask = dstAccessMask;
+    it->image = wrappedHandle;
+    barriers.AddWrapped(batchIndex, it->dstQueueFamilyIndex, *it);
+  }
+  newQueueFamilyTransfers.clear();
+  return true;
+}
+
+bool ImageState::RestoreTransfers(uint32_t batchIndex,
+                                  const rdcarray<VkImageMemoryBarrier> &transfers,
+                                  VkAccessFlags srcAccessMask, ImageBarrierSequence &barriers,
+                                  ImageTransitionInfo info)
+{
+  // TODO: figure out why `transfers` has duplicate entries
+  if(transfers.empty())
+    return false;
+  for(auto it = transfers.begin(); it != transfers.end(); ++it)
+  {
+    VkImageMemoryBarrier barrier = *it;
+    barrier.srcAccessMask = srcAccessMask;
+    barrier.image = wrappedHandle;
+    barriers.AddWrapped(batchIndex, barrier.srcQueueFamilyIndex, barrier);
+    RecordQueueFamilyRelease(barrier);
+  }
+  return true;
+}
+
+void ImageState::ResetToOldState(ImageBarrierSequence &barriers, ImageTransitionInfo info)
+{
+  VkAccessFlags srcAccessMask = VK_ACCESS_ALL_WRITE_BITS;
+  VkAccessFlags dstAccessMask = VK_ACCESS_ALL_READ_BITS;
+  const uint32_t CLOSE_TRANSFERS_BATCH_INDEX = 0;
+  const uint32_t MAIN_BATCH_INDEX = 1;
+  const uint32_t ACQUIRE_BATCH_INDEX = 2;
+  const uint32_t RESTORE_TRANSFERS_BATCH_INDEX = 3;
+  CloseTransfers(CLOSE_TRANSFERS_BATCH_INDEX, dstAccessMask, barriers, info);
+
+  for(auto subIt = subresourceStates.begin(); subIt != subresourceStates.end(); ++subIt)
+  {
+    VkImageLayout oldLayout = subIt->state().newLayout;
+    if(oldLayout == UNKNOWN_PREV_IMG_LAYOUT)
+      oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    VkImageLayout newLayout = subIt->state().oldLayout;
+    subIt->state().newLayout = subIt->state().oldLayout;
+    if(newLayout == UNKNOWN_PREV_IMG_LAYOUT || newLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+    {
+      // contents discarded, no barrier necessary
+      continue;
+    }
+    SanitiseReplayImageLayout(oldLayout);
+    SanitiseReplayImageLayout(newLayout);
+    if(oldLayout != VK_IMAGE_LAYOUT_PREINITIALIZED && newLayout == VK_IMAGE_LAYOUT_PREINITIALIZED)
+    {
+      // Transitioning back to PREINITIALIZED; this is impossible, so transition to GENERAL instead.
+      newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    }
+
+    uint32_t srcQueueFamilyIndex = subIt->state().newQueueFamilyIndex;
+    uint32_t dstQueueFamilyIndex = subIt->state().oldQueueFamilyIndex;
+
+    if(srcQueueFamilyIndex == VK_QUEUE_FAMILY_EXTERNAL ||
+       srcQueueFamilyIndex == VK_QUEUE_FAMILY_FOREIGN_EXT)
+    {
+      srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    }
+    if(dstQueueFamilyIndex == VK_QUEUE_FAMILY_EXTERNAL ||
+       dstQueueFamilyIndex == VK_QUEUE_FAMILY_FOREIGN_EXT)
+    {
+      dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    }
+
+    uint32_t submitQueueFamilyIndex = srcQueueFamilyIndex;
+
+    if(GetImageInfo().sharingMode == VK_SHARING_MODE_EXCLUSIVE)
+    {
+      if(srcQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+      {
+        submitQueueFamilyIndex = dstQueueFamilyIndex;
+        dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+      }
+      else if(dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+      {
+        srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+      }
+    }
+    else
+    {
+      if(submitQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+        submitQueueFamilyIndex = dstQueueFamilyIndex;
+      srcQueueFamilyIndex = dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    }
+
+    if(srcQueueFamilyIndex == dstQueueFamilyIndex && oldLayout == newLayout)
+    {
+      subIt->state().newQueueFamilyIndex = subIt->state().oldQueueFamilyIndex;
+      continue;
+    }
+
+    if(submitQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+    {
+      RDCWARN(
+          "ResetToOldState: barrier submitted to VK_QUEUE_FAMILY_IGNORED; defaulting to queue "
+          "family %u",
+          info.defaultQueueFamilyIndex);
+      submitQueueFamilyIndex = info.defaultQueueFamilyIndex;
+    }
+    subIt->state().newQueueFamilyIndex = subIt->state().oldQueueFamilyIndex;
+
+    ImageSubresourceRange subRange = subIt->range();
+
+    if(subRange.baseDepthSlice != 0)
+    {
+      // We can't issue barriers per depth slice, so skip the barriers for non-zero depth slices.
+      // The zero depth slice barrier will implicitly cover the non-zerp depth slices.
+      continue;
+    }
+
+    if((GetImageInfo().Aspects() & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) ==
+       (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+    {
+      // This is a subresource of a depth and stencil image, and
+      // VK_KHR_separate_depth_stencil_layouts is not enabled, so the barrier needs to include both
+      // depth and stencil aspects. We skip the stencil-only aspect and expand the barrier for the
+      // depth-only aspect to include both depth and stencil aspects.
+      if(subRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT)
+        continue;
+      if(subRange.aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT)
+        subRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+    }
+
+    VkImageMemoryBarrier barrier = {
+        /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        /* pNext = */ NULL,
+        /* srcAccessMask = */ srcAccessMask,
+        /* dstAccessMask = */ dstAccessMask,
+        /* oldLayout = */ oldLayout,
+        /* newLayout = */ newLayout,
+        /* srcQueueFamilyIndex = */ srcQueueFamilyIndex,
+        /* dstQueueFamilyIndex = */ dstQueueFamilyIndex,
+        /* image = */ wrappedHandle,
+        /* subresourceRange = */ subRange,
+    };
+    barriers.AddWrapped(MAIN_BATCH_INDEX, submitQueueFamilyIndex, barrier);
+
+    // acquire the subresource in the dstQueueFamily, if necessary
+    if(barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex)
+    {
+      barriers.AddWrapped(ACQUIRE_BATCH_INDEX, barrier.dstQueueFamilyIndex, barrier);
+    }
+  }
+  RestoreTransfers(RESTORE_TRANSFERS_BATCH_INDEX, oldQueueFamilyTransfers, srcAccessMask, barriers,
+                   info);
+}
+
+void ImageState::Transition(const ImageState &dstState, VkAccessFlags srcAccessMask,
+                            VkAccessFlags dstAccessMask, ImageBarrierSequence &barriers,
+                            ImageTransitionInfo info)
+{
+  const uint32_t CLOSE_TRANSFERS_BATCH_INDEX = 0;
+  const uint32_t MAIN_BATCH_INDEX = 1;
+  const uint32_t ACQUIRE_BATCH_INDEX = 2;
+  const uint32_t RESTORE_TRANSFERS_BATCH_INDEX = 3;
+  CloseTransfers(CLOSE_TRANSFERS_BATCH_INDEX, dstAccessMask, barriers, info);
+
+  for(auto dstIt = dstState.subresourceStates.begin(); dstIt != dstState.subresourceStates.end();
+      ++dstIt)
+  {
+    const ImageSubresourceRange &dstRng = dstIt->range();
+    const ImageSubresourceState &dstSub = dstIt->state();
+    for(auto it = subresourceStates.RangeBegin(dstRng); it != subresourceStates.end(); ++it)
+    {
+      ImageSubresourceState srcSub;
+      if(!it->state().Update(dstSub, srcSub, info.GetFrameRefCompFunc()))
+        // subresource state did not change, so no need for a barrier
+        continue;
+
+      subresourceStates.Split(dstRng);
+      std::swap(it->state(), srcSub);
+
+      ImageSubresourceRange srcRng = it->range();
+
+      VkImageLayout oldLayout = srcSub.newLayout;
+      if(oldLayout == UNKNOWN_PREV_IMG_LAYOUT)
+        oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      VkImageLayout newLayout = dstSub.newLayout;
+      if(newLayout == UNKNOWN_PREV_IMG_LAYOUT || newLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+        // ignore transitions to undefined
+        continue;
+      uint32_t srcQueueFamilyIndex = srcSub.newQueueFamilyIndex;
+      uint32_t dstQueueFamilyIndex = dstSub.newQueueFamilyIndex;
+
+      if(oldLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+        // transitions from undefined discard the contents anyway, so no queue family ownership
+        // transfer is necessary
+        srcQueueFamilyIndex = dstQueueFamilyIndex;
+
+      if(newLayout == VK_IMAGE_LAYOUT_PREINITIALIZED && oldLayout != VK_IMAGE_LAYOUT_PREINITIALIZED)
+      {
+        // Transitioning to PREINITIALIZED, which is invalid. This happens when we are resetting to
+        // an earlier image state.
+        // Instead, we transition to GENERAL, and make the image owned by oldQueueFamilyIndex.
+        newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        dstQueueFamilyIndex = srcSub.oldQueueFamilyIndex;
+        RDCASSERT(dstQueueFamilyIndex != VK_QUEUE_FAMILY_IGNORED);
+      }
+
+      if(IsReplayMode(info.capState))
+      {
+        // Get rid of PRESENT layouts
+        SanitiseReplayImageLayout(oldLayout);
+        SanitiseReplayImageLayout(newLayout);
+      }
+
+      uint32_t submitQueueFamilyIndex = (srcQueueFamilyIndex != VK_QUEUE_FAMILY_IGNORED)
+                                            ? srcQueueFamilyIndex
+                                            : dstQueueFamilyIndex;
+      if(submitQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED ||
+         submitQueueFamilyIndex == VK_QUEUE_FAMILY_EXTERNAL ||
+         submitQueueFamilyIndex == VK_QUEUE_FAMILY_FOREIGN_EXT)
+      {
+        RDCERR("Ignoring state transition submitted to invalid queue family %u",
+               submitQueueFamilyIndex);
+        continue;
+      }
+      if(GetImageInfo().sharingMode == VK_SHARING_MODE_CONCURRENT)
+      {
+        srcQueueFamilyIndex = dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+      }
+      else
+      {
+        if(srcQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+        {
+          RDCWARN("ImageState::Transition: src queue family == VK_QUEUE_FAMILY_IGNORED.");
+          srcQueueFamilyIndex = dstQueueFamilyIndex;
+        }
+        if(dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED)
+        {
+          RDCWARN("ImageState::Transition: dst queue family == VK_QUEUE_FAMILY_IGNORED.");
+          dstQueueFamilyIndex = srcQueueFamilyIndex;
+        }
+      }
+
+      if(srcQueueFamilyIndex == dstQueueFamilyIndex && oldLayout == newLayout)
+        // Skip the barriers, because it would do nothing
+        continue;
+
+      if(srcRng.baseDepthSlice != 0 || dstRng.baseDepthSlice != 0)
+      {
+        // We can't issue barriers per depth slice, so skip the barriers for non-zero depth slices.
+        // The zero depth slice barrier will implicitly cover the non-zerp depth slices.
+        continue;
+      }
+
+      VkImageAspectFlags aspectMask = srcRng.aspectMask & dstRng.aspectMask;
+      if((GetImageInfo().Aspects() & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) ==
+         (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+      {
+        // This is a subresource of a depth and stencil image, and
+        // VK_KHR_separate_depth_stencil_layouts is not enabled, so the barrier needs to include
+        // both depth and stencil aspects. We skip the stencil-only aspect and expand the barrier
+        // for the depth-only aspect to include both depth and stencil aspects.
+        if(aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT)
+          continue;
+        if(aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT)
+          aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+      }
+      uint32_t baseMipLevel = RDCMAX(dstRng.baseMipLevel, srcRng.baseMipLevel);
+      uint32_t endMipLevel =
+          RDCMIN(dstRng.baseMipLevel + dstRng.levelCount, srcRng.baseMipLevel + srcRng.levelCount);
+      uint32_t baseArrayLayer = RDCMAX(dstRng.baseArrayLayer, srcRng.baseArrayLayer);
+      uint32_t endArrayLayer = RDCMIN(dstRng.baseArrayLayer + dstRng.layerCount,
+                                      srcRng.baseArrayLayer + srcRng.layerCount);
+      VkImageMemoryBarrier barrier = {
+          /* sType = */ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          /* pNext = */ NULL,
+          /* srcAccessMask = */ srcAccessMask,
+          /* dstAccessMask = */ dstAccessMask,
+          /* oldLayout = */ oldLayout,
+          /* newLayout = */ newLayout,
+          /* srcQueueFamilyIndex = */ srcQueueFamilyIndex,
+          /* dstQueueFamilyIndex = */ dstQueueFamilyIndex,
+          /* image = */ wrappedHandle,
+          /* subresourceRange = */
+          {
+              /* aspectMask = */ aspectMask,
+              /* baseMipLevel = */ baseMipLevel,
+              /* levelCount = */ endMipLevel - baseMipLevel,
+              /* baseArrayLayer = */ baseArrayLayer,
+              /* layerCount = */ endArrayLayer - baseArrayLayer,
+          },
+      };
+      barriers.AddWrapped(MAIN_BATCH_INDEX, submitQueueFamilyIndex, barrier);
+
+      // acquire the subresource in the dstQueueFamily, if necessary
+      if(barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex)
+      {
+        barriers.AddWrapped(ACQUIRE_BATCH_INDEX, barrier.dstQueueFamilyIndex, barrier);
+      }
+    }
+  }
+  RestoreTransfers(RESTORE_TRANSFERS_BATCH_INDEX, dstState.newQueueFamilyTransfers, srcAccessMask,
+                   barriers, info);
+}
+
+void ImageState::Transition(uint32_t queueFamilyIndex, VkImageLayout layout,
+                            VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
+                            ImageBarrierSequence &barriers, ImageTransitionInfo info)
+{
+  Transition(UniformState(ImageSubresourceState(queueFamilyIndex, layout)), srcAccessMask,
+             dstAccessMask, barriers, info);
+}
+
+void ImageState::TempTransition(const ImageState &dstState, VkAccessFlags preSrcAccessMask,
+                                VkAccessFlags preDstAccessMask, VkAccessFlags postSrcAccessmask,
+                                VkAccessFlags postDstAccessMask, ImageBarrierSequence &setupBarriers,
+                                ImageBarrierSequence &cleanupBarriers, ImageTransitionInfo info) const
+{
+  ImageState temp(*this);
+  temp.Transition(dstState, preSrcAccessMask, preDstAccessMask, setupBarriers, info);
+  temp.Transition(*this, postSrcAccessmask, postDstAccessMask, cleanupBarriers, info);
+}
+
+void ImageState::TempTransition(uint32_t queueFamilyIndex, VkImageLayout layout,
+                                VkAccessFlags accessMask, ImageBarrierSequence &setupBarriers,
+                                ImageBarrierSequence &cleanupBarriers, ImageTransitionInfo info) const
+{
+  TempTransition(UniformState(ImageSubresourceState(queueFamilyIndex, layout)),
+                 VK_ACCESS_ALL_WRITE_BITS, accessMask, accessMask, VK_ACCESS_ALL_READ_BITS,
+                 setupBarriers, cleanupBarriers, info);
+}
+
+void ImageState::InlineTransition(VkCommandBuffer cmd, uint32_t queueFamilyIndex,
+                                  const ImageState &dstState, VkAccessFlags srcAccessMask,
+                                  VkAccessFlags dstAccessMask, ImageTransitionInfo info)
+{
+  ImageBarrierSequence barriers;
+  Transition(dstState, srcAccessMask, dstAccessMask, barriers, info);
+  if(barriers.empty())
+    return;
+  rdcarray<VkImageMemoryBarrier> barriersArray;
+  barriers.ExtractFirstUnwrappedBatchForQueue(queueFamilyIndex, barriersArray);
+  if(!barriersArray.empty())
+    DoPipelineBarrier(cmd, (uint32_t)barriersArray.size(), barriersArray.data());
+  if(!barriers.empty())
+  {
+    RDCERR("Could not inline all image state transition barriers");
+  }
+}
+
+void ImageState::InlineTransition(VkCommandBuffer cmd, uint32_t queueFamilyIndex,
+                                  VkImageLayout layout, VkAccessFlags srcAccessMask,
+                                  VkAccessFlags dstAccessMask, ImageTransitionInfo info)
+{
+  InlineTransition(cmd, queueFamilyIndex,
+                   UniformState(ImageSubresourceState(queueFamilyIndex, layout)), srcAccessMask,
+                   dstAccessMask, info);
+}
+
+InitReqType ImageState::MaxInitReq(const ImageSubresourceRange &range, InitPolicy policy,
+                                   bool initialized) const
+{
+  FrameRefType refType = eFrameRef_None;
+  for(auto it = subresourceStates.RangeBegin(range); it != subresourceStates.end(); ++it)
+  {
+    refType = ComposeFrameRefsDisjoint(refType, it->state().refType);
+  }
+  return InitReq(refType, policy, initialized);
+}
+
+VkImageLayout ImageState::GetImageLayout(VkImageAspectFlagBits aspect, uint32_t mipLevel,
+                                         uint32_t arrayLayer) const
+{
+  return subresourceStates.SubresourceValue(aspect, mipLevel, arrayLayer, 0).newLayout;
+}
+
+void ImageState::BeginCapture()
+{
+  maxRefType = eFrameRef_None;
+
+  // Forget any pending queue family release operations.
+  // If the matching queue family acquire operation happens during the frame,
+  // an implicit release operation will be put into `oldQueueFamilyTransfers`.
+  newQueueFamilyTransfers.clear();
+
+  // Also clear implicit queue family acquire operations because these correspond to release
+  // operations already submitted (and therefore not part of the capture).
+  oldQueueFamilyTransfers.clear();
+
+  for(auto it = subresourceStates.begin(); it != subresourceStates.end(); ++it)
+  {
+    ImageSubresourceState state = it->state();
+    state.oldLayout = state.newLayout;
+    state.oldQueueFamilyIndex = state.newQueueFamilyIndex;
+    state.refType = eFrameRef_None;
+    it->SetState(state);
+  }
+}

--- a/renderdoc/driver/vulkan/vk_image_states.cpp
+++ b/renderdoc/driver/vulkan/vk_image_states.cpp
@@ -1,0 +1,134 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "vk_resources.h"
+
+template <typename Barrier>
+void BarrierSequence<Barrier>::AddWrapped(uint32_t batchIndex, uint32_t queueFamilyIndex,
+                                          const Barrier &barrier)
+{
+  RDCASSERT(batchIndex < MAX_BATCH_COUNT);
+  RDCASSERT(queueFamilyIndex < MAX_QUEUE_FAMILY_COUNT);
+  batches[batchIndex][queueFamilyIndex].push_back(barrier);
+  ++barrierCount;
+}
+template void BarrierSequence<VkImageMemoryBarrier>::AddWrapped(uint32_t batchIndex,
+                                                                uint32_t queueFamilyIndex,
+                                                                const VkImageMemoryBarrier &barrier);
+
+template <typename Barrier>
+void BarrierSequence<Barrier>::Merge(const BarrierSequence<Barrier> &other)
+{
+  for(uint32_t batchIndex = 0; batchIndex < MAX_BATCH_COUNT; ++batchIndex)
+  {
+    rdcarray<Barrier> *batch = batches[batchIndex];
+    const rdcarray<Barrier> *otherBatch = other.batches[batchIndex];
+    for(uint32_t queueFamilyIndex = 0; queueFamilyIndex < MAX_QUEUE_FAMILY_COUNT; ++queueFamilyIndex)
+    {
+      rdcarray<Barrier> &barriers = batch[queueFamilyIndex];
+      const rdcarray<Barrier> &otherBarriers = otherBatch[queueFamilyIndex];
+      barriers.insert(barriers.size(), otherBarriers.begin(), otherBarriers.size());
+      barrierCount += otherBarriers.size();
+    }
+  }
+}
+template void BarrierSequence<VkImageMemoryBarrier>::Merge(
+    const BarrierSequence<VkImageMemoryBarrier> &other);
+
+template <typename Barrier>
+bool BarrierSequence<Barrier>::IsBatchEmpty(uint32_t batchIndex) const
+{
+  if(batchIndex > MAX_BATCH_COUNT)
+    return true;
+  for(uint32_t queueFamilyIndex = 0; queueFamilyIndex < MAX_QUEUE_FAMILY_COUNT; ++queueFamilyIndex)
+  {
+    if(!batches[batchIndex][queueFamilyIndex].empty())
+      return false;
+  }
+  return true;
+}
+template bool BarrierSequence<VkImageMemoryBarrier>::IsBatchEmpty(uint32_t batchIndex) const;
+
+template <>
+void BarrierSequence<VkImageMemoryBarrier>::UnwrapBarriers(rdcarray<VkImageMemoryBarrier> &barriers)
+{
+  for(auto it = barriers.begin(); it != barriers.end(); ++it)
+  {
+    it->image = ::Unwrap(it->image);
+  }
+}
+
+template <typename Barrier>
+void BarrierSequence<Barrier>::ExtractUnwrappedBatch(uint32_t batchIndex, uint32_t queueFamilyIndex,
+                                                     rdcarray<Barrier> &result)
+{
+  if(batchIndex >= MAX_BATCH_COUNT || queueFamilyIndex >= MAX_QUEUE_FAMILY_COUNT)
+    return;
+  rdcarray<Barrier> &batch = batches[batchIndex][queueFamilyIndex];
+  batch.swap(result);
+  batch.clear();
+  barrierCount -= result.size();
+  UnwrapBarriers(result);
+}
+template void BarrierSequence<VkImageMemoryBarrier>::ExtractUnwrappedBatch(
+    uint32_t batchIndex, uint32_t queueFamilyIndex, rdcarray<VkImageMemoryBarrier> &result);
+
+template <typename Barrier>
+void BarrierSequence<Barrier>::ExtractFirstUnwrappedBatchForQueue(uint32_t queueFamilyIndex,
+                                                                  rdcarray<Barrier> &result)
+{
+  for(uint32_t batchIndex = 0; batchIndex < MAX_BATCH_COUNT; ++batchIndex)
+  {
+    if(!IsBatchEmpty(batchIndex))
+    {
+      batches[batchIndex][queueFamilyIndex].swap(result);
+      batches[batchIndex][queueFamilyIndex].clear();
+      barrierCount -= result.size();
+      UnwrapBarriers(result);
+      return;
+    }
+  }
+}
+template void BarrierSequence<VkImageMemoryBarrier>::ExtractFirstUnwrappedBatchForQueue(
+    uint32_t queueFamilyIndex, rdcarray<VkImageMemoryBarrier> &result);
+
+template <typename Barrier>
+void BarrierSequence<Barrier>::ExtractLastUnwrappedBatchForQueue(uint32_t queueFamilyIndex,
+                                                                 rdcarray<Barrier> &result)
+{
+  for(uint32_t batchIndex = MAX_BATCH_COUNT; batchIndex > 0;)
+  {
+    --batchIndex;
+    if(!IsBatchEmpty(batchIndex))
+    {
+      batches[batchIndex][queueFamilyIndex].swap(result);
+      batches[batchIndex][queueFamilyIndex].clear();
+      barrierCount -= result.size();
+      UnwrapBarriers(result);
+      return;
+    }
+  }
+}
+template void BarrierSequence<VkImageMemoryBarrier>::ExtractLastUnwrappedBatchForQueue(
+    uint32_t queueFamilyIndex, rdcarray<VkImageMemoryBarrier> &result);

--- a/renderdoc/driver/vulkan/vk_image_states.cpp
+++ b/renderdoc/driver/vulkan/vk_image_states.cpp
@@ -1211,7 +1211,8 @@ void ImageState::ResetToOldState(ImageBarrierSequence &barriers, ImageTransition
     }
 
     if((GetImageInfo().Aspects() & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) ==
-       (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+           (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT) &&
+       !info.separateDepthStencil)
     {
       // This is a subresource of a depth and stencil image, and
       // VK_KHR_separate_depth_stencil_layouts is not enabled, so the barrier needs to include both
@@ -1348,7 +1349,8 @@ void ImageState::Transition(const ImageState &dstState, VkAccessFlags srcAccessM
 
       VkImageAspectFlags aspectMask = srcRng.aspectMask & dstRng.aspectMask;
       if((GetImageInfo().Aspects() & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) ==
-         (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+             (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT) &&
+         !info.separateDepthStencil)
       {
         // This is a subresource of a depth and stencil image, and
         // VK_KHR_separate_depth_stencil_layouts is not enabled, so the barrier needs to include

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -460,6 +460,5 @@ private:
 
   WrappedVulkan *m_Core;
   std::map<ResourceId, MemRefs> m_MemFrameRefs;
-  std::map<ResourceId, ImgRefs> m_ImgFrameRefs;
   InitPolicy m_InitPolicy = eInitPolicy_CopyAll;
 };

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -264,18 +264,18 @@ public:
                      rdcarray<rdcpair<ResourceId, ImageRegionState> > &states,
                      std::map<ResourceId, ImageLayouts> &layouts);
 
+  void RecordBarriers(std::map<ResourceId, ImageState> &states, uint32_t queueFamilyIndex,
+                      uint32_t numBarriers, const VkImageMemoryBarrier *barriers);
+
   template <typename SerialiserType>
-  void SerialiseImageStates(SerialiserType &ser, std::map<ResourceId, ImageLayouts> &states,
-                            rdcarray<VkImageMemoryBarrier> &barriers);
+  void SerialiseImageStates(SerialiserType &ser, std::map<ResourceId, LockingImageState> &states);
 
   template <typename SerialiserType>
   bool Serialise_DeviceMemoryRefs(SerialiserType &ser, rdcarray<MemRefInterval> &data);
 
-  template <typename SerialiserType>
-  bool Serialise_ImageRefs(SerialiserType &ser, rdcarray<ImgRefsPair> &data);
+  bool Serialise_ImageRefs(ReadSerialiser &ser, std::map<ResourceId, LockingImageState> &states);
 
   void InsertDeviceMemoryRefs(WriteSerialiser &ser);
-  void InsertImageRefs(WriteSerialiser &ser);
 
   ResourceId GetID(WrappedVkRes *res)
   {
@@ -422,18 +422,11 @@ public:
 
   void SetInternalResource(ResourceId id);
 
-  void MarkImageFrameReferenced(const VkResourceRecord *img, const ImageRange &range,
-                                FrameRefType refType);
-  void MarkImageFrameReferenced(ResourceId img, const ImageInfo &imageInfo, const ImageRange &range,
-                                FrameRefType refType);
   void MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize start, VkDeviceSize end,
                                  FrameRefType refType);
   void AddMemoryFrameRefs(ResourceId mem);
-  void AddImageFrameRefs(ResourceId img, const ImageInfo &imageInfo);
 
   void MergeReferencedMemory(std::map<ResourceId, MemRefs> &memRefs);
-  void MergeReferencedImages(std::map<ResourceId, ImgRefs> &imgRefs);
-  void ClearReferencedImages();
   void ClearReferencedMemory();
   MemRefs *FindMemRefs(ResourceId mem);
   ImgRefs *FindImgRefs(ResourceId img);

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -296,7 +296,7 @@ rdcarray<ResourceId> VulkanReplay::GetTextures()
 {
   rdcarray<ResourceId> texs;
 
-  for(auto it = m_pDriver->m_ImageLayouts.begin(); it != m_pDriver->m_ImageLayouts.end(); ++it)
+  for(auto it = m_pDriver->m_ImageStates.begin(); it != m_pDriver->m_ImageStates.end(); ++it)
   {
     // skip textures that aren't from the capture
     if(m_pDriver->GetResourceManager()->GetOriginalID(it->first) == it->first)
@@ -1849,9 +1849,9 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
 
   // image layouts
   {
-    m_VulkanPipelineState.images.resize(m_pDriver->m_ImageLayouts.size());
     size_t i = 0;
-    for(auto it = m_pDriver->m_ImageLayouts.begin(); it != m_pDriver->m_ImageLayouts.end(); ++it)
+    m_VulkanPipelineState.images.resize(m_pDriver->m_ImageStates.size());
+    for(auto it = m_pDriver->m_ImageStates.begin(); it != m_pDriver->m_ImageStates.end(); ++it)
     {
       VKPipe::ImageData &img = m_VulkanPipelineState.images[i];
 
@@ -1860,14 +1860,16 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
 
       img.resourceId = rm->GetOriginalID(it->first);
 
-      img.layouts.resize(it->second.subresourceStates.size());
-      for(size_t l = 0; l < it->second.subresourceStates.size(); l++)
+      LockedConstImageStateRef imState = it->second.LockRead();
+      img.layouts.resize(imState->subresourceStates.size());
+      auto subIt = imState->subresourceStates.begin();
+      for(size_t l = 0; l < img.layouts.size(); ++l, ++subIt)
       {
-        img.layouts[l].name = ToStr(it->second.subresourceStates[l].newLayout);
-        img.layouts[l].baseMip = it->second.subresourceStates[l].subresourceRange.baseMipLevel;
-        img.layouts[l].baseLayer = it->second.subresourceStates[l].subresourceRange.baseArrayLayer;
-        img.layouts[l].numLayer = it->second.subresourceStates[l].subresourceRange.layerCount;
-        img.layouts[l].numMip = it->second.subresourceStates[l].subresourceRange.levelCount;
+        img.layouts[l].name = ToStr(subIt->state().newLayout);
+        img.layouts[l].baseMip = subIt->range().baseMipLevel;
+        img.layouts[l].numMip = subIt->range().levelCount;
+        img.layouts[l].baseLayer = subIt->range().baseArrayLayer;
+        img.layouts[l].numLayer = subIt->range().layerCount;
       }
 
       if(img.layouts.empty())
@@ -1965,6 +1967,14 @@ void VulkanReplay::PickPixel(ResourceId texture, uint32_t x, uint32_t y, const S
   m_DebugWidth = m_DebugHeight = 1;
 
   VulkanCreationInfo::Image &iminfo = m_pDriver->m_CreationInfo.m_Image[texture];
+  LockedConstImageStateRef imageState = m_pDriver->FindConstImageState(texture);
+  if(!imageState)
+  {
+    RDCWARN("Could not find image info for image %s", ToStr(texture).c_str());
+    return;
+  }
+  if(!imageState->isMemoryBound)
+    return;
 
   bool isStencil = IsStencilFormat(iminfo.format);
 
@@ -2012,7 +2022,8 @@ void VulkanReplay::PickPixel(ResourceId texture, uint32_t x, uint32_t y, const S
           &clearval,
       };
 
-      RenderTextureInternal(texDisplay, rpbegin, eTexDisplay_32Render | eTexDisplay_MipShift);
+      RenderTextureInternal(texDisplay, *imageState, rpbegin,
+                            eTexDisplay_32Render | eTexDisplay_MipShift);
     }
 
     VkDevice dev = m_pDriver->GetDev();
@@ -2114,9 +2125,15 @@ void VulkanReplay::PickPixel(ResourceId texture, uint32_t x, uint32_t y, const S
 bool VulkanReplay::GetMinMax(ResourceId texid, const Subresource &sub, CompType typeCast,
                              float *minval, float *maxval)
 {
-  ImageLayouts &layouts = m_pDriver->m_ImageLayouts[texid];
+  const ImageInfo *imageInfo = NULL;
+  {
+    LockedConstImageStateRef state = m_pDriver->FindConstImageState(texid);
+    if(!state)
+      return false;
+    imageInfo = &state->GetImageInfo();
+  }
 
-  if(IsDepthAndStencilFormat(layouts.imageInfo.format))
+  if(IsDepthAndStencilFormat(imageInfo->format))
   {
     // for depth/stencil we need to run the code twice - once to fetch depth and once to fetch
     // stencil - since we can't process float depth and int stencil at the same time
@@ -2154,12 +2171,15 @@ bool VulkanReplay::GetMinMax(ResourceId texid, const Subresource &sub, CompType 
   VkDevice dev = m_pDriver->GetDev();
   const VkDevDispatchTable *vt = ObjDisp(dev);
 
-  ImageLayouts &layouts = m_pDriver->m_ImageLayouts[texid];
+  LockedConstImageStateRef state = m_pDriver->FindConstImageState(texid);
+  if(!state)
+    return false;
+  bool isMemoryBound = state->isMemoryBound;
   VulkanCreationInfo::Image &iminfo = m_pDriver->m_CreationInfo.m_Image[texid];
   TextureDisplayViews &texviews = m_TexRender.TextureViews[texid];
   VkImage liveIm = m_pDriver->GetResourceManager()->GetCurrentHandle<VkImage>(texid);
 
-  if(!layouts.isMemoryBound)
+  if(!isMemoryBound)
     return false;
 
   if(!IsStencilFormat(iminfo.format))
@@ -2339,11 +2359,6 @@ bool VulkanReplay::GetMinMax(ResourceId texid, const Subresource &sub, CompType 
 
   m_Histogram.m_HistogramUBO.Unmap();
 
-  rdcarray<VkImageMemoryBarrier> setupBarriers, cleanupBarriers;
-  bool extQCleanup = false;
-  m_pDriver->TempTransition(liveIm, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                            VK_ACCESS_SHADER_READ_BIT, setupBarriers, cleanupBarriers, extQCleanup);
-
   VkCommandBufferBeginInfo beginInfo = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL,
                                         VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
 
@@ -2351,7 +2366,12 @@ bool VulkanReplay::GetMinMax(ResourceId texid, const Subresource &sub, CompType 
 
   vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
 
-  DoPipelineBarrier(cmd, setupBarriers.size(), setupBarriers.data());
+  ImageBarrierSequence setupBarriers, cleanupBarriers;
+  state->TempTransition(m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                        VK_ACCESS_SHADER_READ_BIT, setupBarriers, cleanupBarriers,
+                        m_pDriver->GetImageTransitionInfo());
+  m_pDriver->InlineSetupImageBarriers(cmd, setupBarriers);
+  m_pDriver->SubmitAndFlushImageStateBarriers(setupBarriers);
 
   int blocksX = (int)ceil(iminfo.extent.width / float(HGRAM_PIXELS_PER_TILE * HGRAM_TILES_PER_BLOCK));
   int blocksY =
@@ -2365,7 +2385,16 @@ bool VulkanReplay::GetMinMax(ResourceId texid, const Subresource &sub, CompType 
 
   vt->CmdDispatch(Unwrap(cmd), blocksX, blocksY, 1);
 
-  DoPipelineBarrier(cmd, cleanupBarriers.size(), cleanupBarriers.data());
+  m_pDriver->InlineCleanupImageBarriers(cmd, cleanupBarriers);
+  if(!cleanupBarriers.empty())
+  {
+    vt->EndCommandBuffer(Unwrap(cmd));
+    m_pDriver->SubmitCmds();
+    m_pDriver->FlushQ();
+    m_pDriver->SubmitAndFlushImageStateBarriers(cleanupBarriers);
+    cmd = m_pDriver->GetNextCmd();
+    vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
+  }
 
   VkBufferMemoryBarrier tilebarrier = {
       VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
@@ -2419,9 +2448,6 @@ bool VulkanReplay::GetMinMax(ResourceId texid, const Subresource &sub, CompType 
   m_pDriver->SubmitCmds();
   m_pDriver->FlushQ();
 
-  if(extQCleanup)
-    m_pDriver->SubmitExtQBarriers(~0U, cleanupBarriers);
-
   Vec4f *minmax = (Vec4f *)m_Histogram.m_MinMaxReadback.Map(NULL);
 
   minval[0] = minmax[0].x;
@@ -2449,13 +2475,12 @@ bool VulkanReplay::GetHistogram(ResourceId texid, const Subresource &sub, CompTy
   VkDevice dev = m_pDriver->GetDev();
   const VkDevDispatchTable *vt = ObjDisp(dev);
 
-  ImageLayouts &layouts = m_pDriver->m_ImageLayouts[texid];
+  LockedConstImageStateRef state = m_pDriver->FindConstImageState(texid);
+  if(!state->isMemoryBound)
+    return false;
   VulkanCreationInfo::Image &iminfo = m_pDriver->m_CreationInfo.m_Image[texid];
   TextureDisplayViews &texviews = m_TexRender.TextureViews[texid];
   VkImage liveIm = m_pDriver->GetResourceManager()->GetCurrentHandle<VkImage>(texid);
-
-  if(!layouts.isMemoryBound)
-    return false;
 
   bool stencil = false;
   // detect if stencil is selected
@@ -2655,11 +2680,12 @@ bool VulkanReplay::GetHistogram(ResourceId texid, const Subresource &sub, CompTy
 
   vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
 
-  rdcarray<VkImageMemoryBarrier> setupBarriers, cleanupBarriers;
-  bool extQCleanup = false;
-  m_pDriver->TempTransition(liveIm, VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_SHADER_READ_BIT,
-                            setupBarriers, cleanupBarriers, extQCleanup);
-  DoPipelineBarrier(cmd, setupBarriers.size(), setupBarriers.data());
+  ImageBarrierSequence setupBarriers, cleanupBarriers;
+  state->TempTransition(m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_GENERAL,
+                        VK_ACCESS_SHADER_READ_BIT, setupBarriers, cleanupBarriers,
+                        m_pDriver->GetImageTransitionInfo());
+  m_pDriver->InlineSetupImageBarriers(cmd, setupBarriers);
+  m_pDriver->SubmitAndFlushImageStateBarriers(setupBarriers);
 
   int blocksX = (int)ceil(iminfo.extent.width / float(HGRAM_PIXELS_PER_TILE * HGRAM_TILES_PER_BLOCK));
   int blocksY =
@@ -2676,7 +2702,16 @@ bool VulkanReplay::GetHistogram(ResourceId texid, const Subresource &sub, CompTy
 
   vt->CmdDispatch(Unwrap(cmd), blocksX, blocksY, 1);
 
-  DoPipelineBarrier(cmd, cleanupBarriers.size(), cleanupBarriers.data());
+  m_pDriver->InlineCleanupImageBarriers(cmd, cleanupBarriers);
+  if(!cleanupBarriers.empty())
+  {
+    vt->EndCommandBuffer(Unwrap(cmd));
+    m_pDriver->SubmitCmds();
+    m_pDriver->FlushQ();
+    m_pDriver->SubmitAndFlushImageStateBarriers(cleanupBarriers);
+    cmd = m_pDriver->GetNextCmd();
+    vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
+  }
 
   VkBufferMemoryBarrier tilebarrier = {
       VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
@@ -2714,9 +2749,6 @@ bool VulkanReplay::GetHistogram(ResourceId texid, const Subresource &sub, CompTy
   m_pDriver->SubmitCmds();
   m_pDriver->FlushQ();
 
-  if(extQCleanup)
-    m_pDriver->SubmitExtQBarriers(~0U, cleanupBarriers);
-
   uint32_t *buckets = (uint32_t *)m_Histogram.m_HistogramReadback.Map(NULL);
 
   histogram.assign(buckets, HGRAM_NUM_BUCKETS);
@@ -2745,10 +2777,11 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
   const VulkanCreationInfo::Image &imInfo = m_pDriver->m_CreationInfo.m_Image[tex];
 
-  ImageLayouts &layouts = m_pDriver->m_ImageLayouts[tex];
-
-  if(!layouts.isMemoryBound)
+  LockedConstImageStateRef lockedImage = m_pDriver->FindConstImageState(tex);
+  if(!lockedImage || !lockedImage->isMemoryBound)
     return;
+  const ImageState *srcImageState = &*lockedImage;
+  ImageState tmpImageState;
 
   VkMarkerRegion region(StringFormat::Fmt("GetTextureData(%u, %u, %u, remap=%d)", sub.mip,
                                           sub.slice, sub.sample, params.remap));
@@ -2781,9 +2814,8 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
   VkImage srcImage = Unwrap(liveWrappedImage);
   VkImage tmpImage = VK_NULL_HANDLE;
+  VkImage wrappedTmpImage = VK_NULL_HANDLE;
   VkDeviceMemory tmpMemory = VK_NULL_HANDLE;
-
-  uint32_t srcQueueIndex = layouts.queueFamilyIndex;
 
   VkFramebuffer *tmpFB = NULL;
   VkImageView *tmpView = NULL;
@@ -2811,9 +2843,6 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
   if(wasms && (isDepth || isStencil))
     resolve = false;
-
-  rdcarray<VkImageMemoryBarrier> setupBarriers, cleanupBarriers;
-  bool extQCleanup = false;
 
   if(params.remap != RemapTexture::NoRemap)
   {
@@ -2875,6 +2904,9 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
     // create render texture similar to readback texture
     vt->CreateImage(Unwrap(dev), &imCreateInfo, NULL, &tmpImage);
+    wrappedTmpImage = tmpImage;
+    GetResourceManager()->WrapResource(Unwrap(dev), wrappedTmpImage);
+    tmpImageState = ImageState(wrappedTmpImage, ImageInfo(imCreateInfo), eFrameRef_None);
 
     VkMemoryRequirements mrq = {0};
     vt->GetImageMemoryRequirements(Unwrap(dev), tmpImage, &mrq);
@@ -2890,21 +2922,9 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     vkr = vt->BindImageMemory(Unwrap(dev), tmpImage, tmpMemory, 0);
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-    VkImageMemoryBarrier dstimBarrier = {
-        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        NULL,
-        0,
-        0,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-        VK_QUEUE_FAMILY_IGNORED,
-        VK_QUEUE_FAMILY_IGNORED,
-        tmpImage,
-        {VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS},
-    };
-
-    // move tmp image into transfer destination layout
-    DoPipelineBarrier(cmd, 1, &dstimBarrier);
+    tmpImageState.InlineTransition(
+        cmd, m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 0,
+        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, m_pDriver->GetImageTransitionInfo());
 
     // end this command buffer, the rendertexture below will use its own and we want to ensure
     // ordering
@@ -3046,7 +3066,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
           &clearval,
       };
 
-      RenderTextureInternal(texDisplay, rpbegin, renderFlags);
+      RenderTextureInternal(texDisplay, *srcImageState, rpbegin, renderFlags);
       renderCount++;
 
       // for textures with stencil, do another draw to copy the stencil
@@ -3062,8 +3082,9 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
         rpbegin.framebuffer = tmpFB[i + numFBs];
 
         texDisplay.red = texDisplay.blue = texDisplay.alpha = false;
-        RenderTextureInternal(texDisplay, rpbegin, (renderFlags & ~eTexDisplay_RemapFloat) |
-                                                       eTexDisplay_RemapUInt | eTexDisplay_GreenOnly);
+        RenderTextureInternal(texDisplay, *srcImageState, rpbegin,
+                              (renderFlags & ~eTexDisplay_RemapFloat) | eTexDisplay_RemapUInt |
+                                  eTexDisplay_GreenOnly);
         renderCount++;
       }
     }
@@ -3072,7 +3093,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     m_DebugHeight = oldH;
 
     srcImage = tmpImage;
-    srcQueueIndex = m_pDriver->GetQueueFamilyIndex();
+    srcImageState = &tmpImageState;
 
     // fetch a new command buffer for copy & readback
     cmd = m_pDriver->GetNextCmd();
@@ -3080,13 +3101,10 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     vkr = vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-    // ensure all writes happen before copy & readback
-    dstimBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    dstimBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    dstimBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    dstimBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-
-    DoPipelineBarrier(cmd, 1, &dstimBarrier);
+    tmpImageState.InlineTransition(cmd, m_pDriver->m_QueueFamilyIdx,
+                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                   VK_ACCESS_TRANSFER_READ_BIT, m_pDriver->GetImageTransitionInfo());
 
     // these have already been selected, don't need to fetch that subresource
     // when copying back to readback buffer
@@ -3108,6 +3126,9 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
     // create resolve texture
     vt->CreateImage(Unwrap(dev), &imCreateInfo, NULL, &tmpImage);
+    wrappedTmpImage = tmpImage;
+    GetResourceManager()->WrapResource(Unwrap(dev), wrappedTmpImage);
+    tmpImageState = ImageState(wrappedTmpImage, ImageInfo(imCreateInfo), eFrameRef_None);
 
     VkMemoryRequirements mrq = {0};
     vt->GetImageMemoryRequirements(Unwrap(dev), tmpImage, &mrq);
@@ -3133,43 +3154,27 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
         imCreateInfo.extent,
     };
 
-    m_pDriver->TempTransition(liveWrappedImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                              VK_ACCESS_TRANSFER_READ_BIT, setupBarriers, cleanupBarriers,
-                              extQCleanup);
-
-    VkImageMemoryBarrier dstimBarrier = {
-        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        NULL,
-        0,
-        0,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        VK_QUEUE_FAMILY_IGNORED,
-        VK_QUEUE_FAMILY_IGNORED,
-        tmpImage,
-        {imageAspects, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS},
-    };
-
-    // move tmp image into transfer destination layout as well
-    setupBarriers.push_back(dstimBarrier);
-
-    DoPipelineBarrier(cmd, setupBarriers.size(), setupBarriers.data());
+    tmpImageState.InlineTransition(
+        cmd, m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0,
+        VK_ACCESS_TRANSFER_WRITE_BIT, m_pDriver->GetImageTransitionInfo());
+    ImageBarrierSequence setupBarriers, cleanupBarriers;
+    srcImageState->TempTransition(m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                  VK_ACCESS_TRANSFER_READ_BIT, setupBarriers, cleanupBarriers,
+                                  m_pDriver->GetImageTransitionInfo());
+    m_pDriver->InlineSetupImageBarriers(cmd, setupBarriers);
+    m_pDriver->SubmitAndFlushImageStateBarriers(setupBarriers);
 
     // resolve from live texture to resolve texture
     vt->CmdResolveImage(Unwrap(cmd), srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, tmpImage,
                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &resolveRegion);
 
-    dstimBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-    dstimBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-    dstimBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-    dstimBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    tmpImageState.InlineTransition(cmd, m_pDriver->m_QueueFamilyIdx,
+                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT,
+                                   VK_ACCESS_TRANSFER_READ_BIT, m_pDriver->GetImageTransitionInfo());
 
-    // wait for resolve to finish before copy to buffer
-    cleanupBarriers.push_back(dstimBarrier);
+    m_pDriver->InlineCleanupImageBarriers(cmd, cleanupBarriers);
 
-    DoPipelineBarrier(cmd, cleanupBarriers.size(), cleanupBarriers.data());
-
-    if(extQCleanup)
+    if(!cleanupBarriers.empty())
     {
       // ensure this resolve happens before handing back the source image to the original queue
       vkr = vt->EndCommandBuffer(Unwrap(cmd));
@@ -3178,10 +3183,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
       m_pDriver->SubmitCmds();
       m_pDriver->FlushQ();
 
-      // don't do our dest image barrier on the external queue
-      cleanupBarriers.pop_back();
-
-      m_pDriver->SubmitExtQBarriers(~0U, cleanupBarriers);
+      m_pDriver->SubmitAndFlushImageStateBarriers(cleanupBarriers);
 
       // fetch a new command buffer for remaining work
       cmd = m_pDriver->GetNextCmd();
@@ -3189,9 +3191,9 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
       vkr = vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
       RDCASSERTEQUAL(vkr, VK_SUCCESS);
     }
+    srcImageState = &tmpImageState;
 
     srcImage = tmpImage;
-    srcQueueIndex = m_pDriver->GetQueueFamilyIndex();
 
     // these have already been selected, don't need to fetch that subresource
     // when copying back to readback buffer
@@ -3215,6 +3217,9 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
     // create resolve texture
     vt->CreateImage(Unwrap(dev), &imCreateInfo, NULL, &tmpImage);
+    wrappedTmpImage = tmpImage;
+    GetResourceManager()->WrapResource(Unwrap(dev), wrappedTmpImage);
+    tmpImageState = ImageState(wrappedTmpImage, ImageInfo(imCreateInfo), eFrameRef_None);
 
     VkMemoryRequirements mrq = {0};
     vt->GetImageMemoryRequirements(Unwrap(dev), tmpImage, &mrq);
@@ -3230,26 +3235,15 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     vkr = vt->BindImageMemory(Unwrap(dev), tmpImage, tmpMemory, 0);
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-    m_pDriver->TempTransition(liveWrappedImage, VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_SHADER_READ_BIT,
-                              setupBarriers, cleanupBarriers, extQCleanup);
-
-    VkImageMemoryBarrier dstimBarrier = {
-        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        NULL,
-        0,
-        0,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_GENERAL,
-        VK_QUEUE_FAMILY_IGNORED,
-        VK_QUEUE_FAMILY_IGNORED,
-        tmpImage,
-        {imageAspects, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS},
-    };
-
-    // move tmp image into transfer destination layout
-    setupBarriers.push_back(dstimBarrier);
-
-    DoPipelineBarrier(cmd, setupBarriers.size(), setupBarriers.data());
+    tmpImageState.InlineTransition(cmd, m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_GENERAL, 0,
+                                   VK_ACCESS_SHADER_WRITE_BIT, m_pDriver->GetImageTransitionInfo());
+    ImageBarrierSequence setupBarriers, cleanupBarriers;
+    srcImageState->TempTransition(m_pDriver->m_QueueFamilyIdx,
+                                  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                  VK_ACCESS_SHADER_READ_BIT, setupBarriers, cleanupBarriers,
+                                  m_pDriver->GetImageTransitionInfo());
+    m_pDriver->InlineSetupImageBarriers(cmd, setupBarriers);
+    m_pDriver->SubmitAndFlushImageStateBarriers(setupBarriers);
 
     vkr = vt->EndCommandBuffer(Unwrap(cmd));
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
@@ -3265,18 +3259,13 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     vkr = vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
     RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-    // wait for copy to finish before copy to buffer
-    dstimBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-    dstimBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-    dstimBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
-    dstimBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    tmpImageState.InlineTransition(cmd, m_pDriver->m_QueueFamilyIdx,
+                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_ACCESS_SHADER_WRITE_BIT,
+                                   VK_ACCESS_TRANSFER_READ_BIT, m_pDriver->GetImageTransitionInfo());
 
-    // wait for work to finish before copy to buffer
-    cleanupBarriers.push_back(dstimBarrier);
+    m_pDriver->InlineCleanupImageBarriers(cmd, cleanupBarriers);
 
-    DoPipelineBarrier(cmd, cleanupBarriers.size(), cleanupBarriers.data());
-
-    if(extQCleanup)
+    if(!cleanupBarriers.empty())
     {
       // ensure this resolve happens before handing back the source image to the original queue
       vkr = vt->EndCommandBuffer(Unwrap(cmd));
@@ -3285,10 +3274,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
       m_pDriver->SubmitCmds();
       m_pDriver->FlushQ();
 
-      // don't do our dest image barrier on the external queue
-      cleanupBarriers.pop_back();
-
-      m_pDriver->SubmitExtQBarriers(~0U, cleanupBarriers);
+      m_pDriver->SubmitAndFlushImageStateBarriers(cleanupBarriers);
 
       // fetch a new command buffer for remaining work
       cmd = m_pDriver->GetNextCmd();
@@ -3298,27 +3284,22 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     }
 
     srcImage = tmpImage;
-    srcQueueIndex = m_pDriver->GetQueueFamilyIndex();
-
+    srcImageState = &tmpImageState;
     s.slice = s.slice * numSamples + s.sample;
     s.sample = 0;
   }
 
+  ImageBarrierSequence cleanupBarriers;
+
   // if we have no tmpImage, we're copying directly from the real image
   if(tmpImage == VK_NULL_HANDLE)
   {
-    m_pDriver->TempTransition(liveWrappedImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                              VK_ACCESS_TRANSFER_READ_BIT, setupBarriers, cleanupBarriers,
-                              extQCleanup);
-
-    DoPipelineBarrier(cmd, setupBarriers.size(), setupBarriers.data());
-  }
-  else
-  {
-    // no more setup/cleanup to do, we read from the real image above
-    extQCleanup = false;
-    setupBarriers.clear();
-    cleanupBarriers.clear();
+    ImageBarrierSequence setupBarriers;
+    srcImageState->TempTransition(m_pDriver->m_QueueFamilyIdx, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                  VK_ACCESS_TRANSFER_READ_BIT, setupBarriers, cleanupBarriers,
+                                  m_pDriver->GetImageTransitionInfo());
+    m_pDriver->InlineSetupImageBarriers(cmd, setupBarriers);
+    m_pDriver->SubmitAndFlushImageStateBarriers(setupBarriers);
   }
 
   VkImageAspectFlags copyAspects = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -3435,6 +3416,30 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
                              readbackBuf, 1, copyregion);
   }
 
+  // if we have no tmpImage, we're copying directly from the real image
+  if(tmpImage == VK_NULL_HANDLE)
+  {
+    m_pDriver->InlineCleanupImageBarriers(cmd, cleanupBarriers);
+
+    if(!cleanupBarriers.empty())
+    {
+      // ensure this resolve happens before handing back the source image to the original queue
+      vkr = vt->EndCommandBuffer(Unwrap(cmd));
+      RDCASSERTEQUAL(vkr, VK_SUCCESS);
+
+      m_pDriver->SubmitCmds();
+      m_pDriver->FlushQ();
+
+      m_pDriver->SubmitAndFlushImageStateBarriers(cleanupBarriers);
+
+      // fetch a new command buffer for remaining work
+      cmd = m_pDriver->GetNextCmd();
+
+      vkr = vt->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
+      RDCASSERTEQUAL(vkr, VK_SUCCESS);
+    }
+  }
+
   VkBufferMemoryBarrier bufBarrier = {
       VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
       NULL,
@@ -3447,10 +3452,6 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
       dataSize,
   };
 
-  // do any cleanup needed
-  if(!cleanupBarriers.empty())
-    DoPipelineBarrier(cmd, cleanupBarriers.size(), cleanupBarriers.data());
-
   // wait for copy to finish before reading back to host
   DoPipelineBarrier(cmd, 1, &bufBarrier);
 
@@ -3458,9 +3459,6 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
   m_pDriver->SubmitCmds();
   m_pDriver->FlushQ();
-
-  if(extQCleanup)
-    m_pDriver->SubmitExtQBarriers(~0U, cleanupBarriers);
 
   // map the buffer and copy to return buffer
   byte *pData = NULL;
@@ -3577,6 +3575,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
 
   if(tmpImage != VK_NULL_HANDLE)
   {
+    GetResourceManager()->ReleaseWrappedResource(wrappedTmpImage, true);
     vt->DestroyImage(Unwrap(dev), tmpImage, NULL);
     vt->FreeMemory(Unwrap(dev), tmpMemory, NULL);
   }
@@ -3658,7 +3657,16 @@ ResourceId VulkanReplay::ApplyCustomShader(ResourceId shader, ResourceId texid,
       &clearval,
   };
 
-  RenderTextureInternal(disp, rpbegin, eTexDisplay_MipShift);
+  LockedConstImageStateRef imageState = m_pDriver->FindConstImageState(texid);
+  if(!imageState)
+  {
+    RDCWARN("Could not find image info for image %s", ToStr(texid).c_str());
+    return ResourceId();
+  }
+  if(!imageState->isMemoryBound)
+    return ResourceId();
+
+  RenderTextureInternal(disp, *imageState, rpbegin, eTexDisplay_MipShift);
 
   m_DebugWidth = oldW;
   m_DebugHeight = oldH;

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -426,7 +426,8 @@ private:
 
   void RefreshDerivedReplacements();
 
-  bool RenderTextureInternal(TextureDisplay cfg, VkRenderPassBeginInfo rpbegin, int flags);
+  bool RenderTextureInternal(TextureDisplay cfg, const ImageState &imageState,
+                             VkRenderPassBeginInfo rpbegin, int flags);
 
   bool GetMinMax(ResourceId texid, const Subresource &sub, CompType typeCast, bool stencil,
                  float *minval, float *maxval);

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3207,6 +3207,18 @@ VkImageAspectFlags FormatImageAspects(VkFormat fmt)
     return VK_IMAGE_ASPECT_COLOR_BIT;
 }
 
+ImageSubresourceRange ImageInfo::FullRange() const
+{
+  return ImageSubresourceRange(
+      /* aspectMask = */ Aspects(),
+      /* baseMipLevel = */ 0u,
+      /* levelCount = */ (uint32_t)levelCount,
+      /* baseArrayLayer = */ 0u,
+      /* layerCount = */ (uint32_t)layerCount,
+      /* baseDepthSlice = */ 0u,
+      /* sliceCount = */ extent.depth);
+}
+
 int ImgRefs::GetAspectCount() const
 {
   int aspectCount = 0;

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3207,18 +3207,6 @@ VkImageAspectFlags FormatImageAspects(VkFormat fmt)
     return VK_IMAGE_ASPECT_COLOR_BIT;
 }
 
-ImageSubresourceRange ImageInfo::FullRange() const
-{
-  return ImageSubresourceRange(
-      /* aspectMask = */ Aspects(),
-      /* baseMipLevel = */ 0u,
-      /* levelCount = */ (uint32_t)levelCount,
-      /* baseArrayLayer = */ 0u,
-      /* layerCount = */ (uint32_t)layerCount,
-      /* baseDepthSlice = */ 0u,
-      /* sliceCount = */ extent.depth);
-}
-
 int ImgRefs::GetAspectCount() const
 {
   int aspectCount = 0;

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3442,8 +3442,10 @@ void VkResourceRecord::MarkImageFrameReferenced(VkResourceRecord *img, const Ima
   if(img->resInfo && img->resInfo->IsSparse())
     cmdInfo->sparse.insert(img->resInfo);
 
-  FrameRefType maxRef =
-      MarkImageReferenced(cmdInfo->imgFrameRefs, id, img->resInfo->imageInfo, range, refType);
+  ImageSubresourceRange range2(range);
+
+  FrameRefType maxRef = MarkImageReferenced(cmdInfo->imageStates, id, img->resInfo->imageInfo,
+                                            range2, pool->queueFamilyIndex, refType);
 
   // maintain the reference type of the image itself as the maximum reference type of any
   // subresource
@@ -3465,18 +3467,33 @@ void VkResourceRecord::MarkImageViewFrameReferenced(VkResourceRecord *view, cons
   if(refType != eFrameRef_Read && refType != eFrameRef_None)
     cmdInfo->dirtied.insert(img);
 
-  ImageRange imgRange;
+  ImageSubresourceRange imgRange;
   imgRange.aspectMask = view->viewRange.aspectMask;
-  imgRange.baseMipLevel = view->viewRange.baseMipLevel + range.baseMipLevel;
-  imgRange.levelCount = range.levelCount;
-  imgRange.baseArrayLayer = view->viewRange.baseArrayLayer + range.baseArrayLayer;
-  imgRange.layerCount = range.layerCount;
-  imgRange.offset = range.offset;
-  imgRange.extent = range.extent;
-  imgRange.viewType = view->viewRange.viewType();
 
-  FrameRefType maxRef =
-      MarkImageReferenced(cmdInfo->imgFrameRefs, img, view->resInfo->imageInfo, imgRange, refType);
+  imgRange.baseMipLevel = range.baseMipLevel;
+  imgRange.levelCount = range.levelCount;
+  SanitiseLevelRange(imgRange.baseMipLevel, imgRange.levelCount, view->viewRange.levelCount());
+  imgRange.baseMipLevel += view->viewRange.baseMipLevel;
+
+  if(view->resInfo->imageInfo.imageType == VK_IMAGE_TYPE_3D &&
+     view->viewRange.viewType() != VK_IMAGE_VIEW_TYPE_3D)
+  {
+    imgRange.baseDepthSlice = range.baseArrayLayer;
+    imgRange.sliceCount = range.layerCount;
+    SanitiseLayerRange(imgRange.baseDepthSlice, imgRange.sliceCount, view->viewRange.layerCount());
+    imgRange.baseDepthSlice += view->viewRange.baseArrayLayer;
+  }
+  else
+  {
+    imgRange.baseArrayLayer = range.baseArrayLayer;
+    imgRange.layerCount = range.layerCount;
+    SanitiseLayerRange(imgRange.baseArrayLayer, imgRange.layerCount, view->viewRange.layerCount());
+    imgRange.baseArrayLayer += view->viewRange.baseArrayLayer;
+  }
+  imgRange.Sanitise(view->resInfo->imageInfo);
+
+  FrameRefType maxRef = MarkImageReferenced(cmdInfo->imageStates, img, view->resInfo->imageInfo,
+                                            imgRange, pool->queueFamilyIndex, refType);
 
   // maintain the reference type of the image itself as the maximum reference type of any
   // subresource
@@ -3852,6 +3869,20 @@ void ResourceInfo::Update(uint32_t numBindings, const VkSparseMemoryBind *pBindi
     if(!found)
       opaquemappings.push_back(newRange);
   }
+}
+
+FrameRefType MarkImageReferenced(std::map<ResourceId, ImageState> &imageStates, ResourceId img,
+                                 const ImageInfo &imageInfo, const ImageSubresourceRange &range,
+                                 uint32_t queueFamilyIndex, FrameRefType refType)
+{
+  if(refType == eFrameRef_None)
+    return refType;
+  auto it = imageStates.find(img);
+  if(it == imageStates.end())
+    it = imageStates.insert({img, ImageState(VK_NULL_HANDLE, imageInfo, refType)}).first;
+  it->second.Update(range, ImageSubresourceState(queueFamilyIndex, UNKNOWN_PREV_IMG_LAYOUT, refType),
+                    ComposeFrameRefs);
+  return it->second.maxRefType;
 }
 
 #if ENABLED(ENABLE_UNIT_TESTS)

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -929,6 +929,13 @@ struct ImageInfo
 
 DECLARE_REFLECTION_STRUCT(ImageInfo);
 
+struct PresentInfo
+{
+  VkQueue presentQueue;
+  rdcarray<VkSemaphore> waitSemaphores;
+  uint32_t imageIndex;
+};
+
 struct SwapchainInfo
 {
   ImageInfo imageInfo;
@@ -947,7 +954,7 @@ struct SwapchainInfo
     VkFramebuffer fb;
   };
   rdcarray<SwapImage> images;
-  uint32_t lastPresent;
+  PresentInfo lastPresent;
 };
 
 // these structs are allocated for images and buffers, then pointed to (non-owning) by views

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1267,6 +1267,8 @@ struct ImageSubresourceRange
   }
 };
 
+DECLARE_REFLECTION_STRUCT(ImageSubresourceRange);
+
 struct ImageSubresourceState
 {
   uint32_t oldQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -1303,6 +1305,18 @@ struct ImageSubresourceState
   bool Update(const ImageSubresourceState &other, ImageSubresourceState &result,
               FrameRefCompFunc compose) const;
 };
+
+DECLARE_REFLECTION_STRUCT(ImageSubresourceState);
+
+struct ImageSubresourceStateForRange
+{
+  ImageSubresourceRange range;
+  ImageSubresourceState state;
+};
+
+DECLARE_REFLECTION_STRUCT(ImageSubresourceStateForRange);
+
+struct ImgRefs;
 
 class ImageSubresourceMap
 {
@@ -1364,6 +1378,12 @@ public:
     m_values.push_back(
         ImageSubresourceState(VK_QUEUE_FAMILY_IGNORED, UNKNOWN_PREV_IMG_LAYOUT, refType));
   }
+
+  void ToArray(rdcarray<ImageSubresourceStateForRange> &arr);
+
+  void FromArray(const rdcarray<ImageSubresourceStateForRange> &arr);
+
+  void FromImgRefs(const ImgRefs &imgRefs);
 
   inline ImageSubresourceState &SubresourceValue(uint32_t aspectIndex, uint32_t level,
                                                  uint32_t layer, uint32_t slice)
@@ -1452,6 +1472,7 @@ public:
     inline const ImageSubresourceRange &range() const { return m_range; }
     inline State &state() { return *m_state; }
     inline const State &state() const { return *m_state; }
+    operator ImageSubresourceStateForRange() const { return {range(), state()}; }
     SubresourcePairRefTemplate &operator=(const SubresourcePairRefTemplate &other) = delete;
 
   protected:
@@ -1678,6 +1699,13 @@ private:
   ImageState m_state;
   Threading::SpinLock m_lock;
 };
+struct TaggedImageState
+{
+  ResourceId id;
+  ImageState state;
+};
+
+DECLARE_REFLECTION_STRUCT(TaggedImageState);
 
 struct ImgRefs
 {

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1260,6 +1260,30 @@ struct ImageSubresourceRange
   }
 };
 
+template <typename Barrier>
+struct BarrierSequence
+{
+  static const uint32_t MAX_BATCH_COUNT = 4;
+  static const uint32_t MAX_QUEUE_FAMILY_COUNT = 3;
+
+  // batches[batchIndex][queueFamilyIndex] = array of barriers to submit to queueFamilyIndex as part
+  // of batchIndex
+  rdcarray<Barrier> batches[MAX_BATCH_COUNT][MAX_QUEUE_FAMILY_COUNT];
+  size_t barrierCount = 0;
+  void AddWrapped(uint32_t batchIndex, uint32_t queueFamilyIndex, const Barrier &barrier);
+  void Merge(const BarrierSequence<Barrier> &other);
+  bool IsBatchEmpty(uint32_t batchIndex) const;
+  void ExtractUnwrappedBatch(uint32_t batchIndex, uint32_t queueFamilyIndex,
+                             rdcarray<Barrier> &result);
+  void ExtractFirstUnwrappedBatchForQueue(uint32_t queueFamilyIndex, rdcarray<Barrier> &result);
+  void ExtractLastUnwrappedBatchForQueue(uint32_t queueFamilyIndex, rdcarray<Barrier> &result);
+  inline bool empty() const { return barrierCount == 0; }
+  inline size_t size() const { return barrierCount; }
+  static void UnwrapBarriers(rdcarray<Barrier> &barriers);
+};
+
+using ImageBarrierSequence = BarrierSequence<VkImageMemoryBarrier>;
+
 struct ImgRefs
 {
   rdcarray<FrameRefType> rangeRefs;

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -925,6 +925,14 @@ struct ImageInfo
   }
   VkImageAspectFlags Aspects() const { return FormatImageAspects(format); }
   ImageSubresourceRange FullRange() const;
+  inline bool operator==(const ImageInfo &other) const
+  {
+    return layerCount == other.layerCount && levelCount == other.levelCount &&
+           sampleCount == other.sampleCount && extent.width == other.extent.width &&
+           extent.height == other.extent.height && extent.depth == other.extent.depth &&
+           imageType == other.imageType && format == other.format &&
+           initialLayout == other.initialLayout && sharingMode == other.sharingMode;
+  }
 };
 
 DECLARE_REFLECTION_STRUCT(ImageInfo);
@@ -1146,9 +1154,9 @@ bool IntervalsOverlap(uint32_t base1, uint32_t count1, uint32_t base2, uint32_t 
 
 bool IntervalContainedIn(uint32_t base1, uint32_t count1, uint32_t base2, uint32_t count2);
 
-bool ValidateLevelRange(uint32_t &baseMipLevel, uint32_t &levelCount, uint32_t imageLevelCount);
-bool ValidateLayerRange(uint32_t &baseArrayLayer, uint32_t &layerCount, uint32_t imageLayerCount);
-bool ValidateSliceRange(uint32_t &baseSlice, uint32_t &sliceCount, uint32_t imageSliceCount);
+bool SanitiseLevelRange(uint32_t &baseMipLevel, uint32_t &levelCount, uint32_t imageLevelCount);
+bool SanitiseLayerRange(uint32_t &baseArrayLayer, uint32_t &layerCount, uint32_t imageLayerCount);
+bool SanitiseSliceRange(uint32_t &baseSlice, uint32_t &sliceCount, uint32_t imageSliceCount);
 
 struct ImageSubresourceRange
 {
@@ -1242,7 +1250,7 @@ struct ImageSubresourceRange
   {
     return other.ContainedIn(*this);
   }
-  void Validate(const ImageInfo &info)
+  void Sanitise(const ImageInfo &info)
   {
     if(aspectMask & ~info.Aspects())
     {
@@ -1250,14 +1258,228 @@ struct ImageSubresourceRange
       {
         RDCERR("Invalid aspect mask (%s) in image with aspects (%s)", ToStr(aspectMask).c_str(),
                ToStr(info.Aspects()).c_str());
-        RDCDUMP();
       }
       aspectMask &= ~info.Aspects();
     }
-    ValidateLevelRange(baseMipLevel, levelCount, info.levelCount);
-    ValidateLayerRange(baseArrayLayer, layerCount, info.layerCount);
-    ValidateSliceRange(baseDepthSlice, sliceCount, info.extent.depth);
+    SanitiseLevelRange(baseMipLevel, levelCount, info.levelCount);
+    SanitiseLayerRange(baseArrayLayer, layerCount, info.layerCount);
+    SanitiseSliceRange(baseDepthSlice, sliceCount, info.extent.depth);
   }
+};
+
+struct ImageSubresourceState
+{
+  uint32_t oldQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  uint32_t newQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  VkImageLayout oldLayout = UNKNOWN_PREV_IMG_LAYOUT;
+  VkImageLayout newLayout = UNKNOWN_PREV_IMG_LAYOUT;
+  FrameRefType refType = eFrameRef_None;
+
+  inline ImageSubresourceState() {}
+  inline ImageSubresourceState(const VkImageMemoryBarrier &barrier)
+      : oldQueueFamilyIndex(barrier.srcQueueFamilyIndex),
+        newQueueFamilyIndex(barrier.dstQueueFamilyIndex),
+        oldLayout(barrier.oldLayout),
+        newLayout(barrier.newLayout)
+  {
+  }
+  inline ImageSubresourceState(uint32_t queueFamilyIndex, VkImageLayout layout,
+                               FrameRefType refType = eFrameRef_None)
+      : oldQueueFamilyIndex(queueFamilyIndex),
+        newQueueFamilyIndex(queueFamilyIndex),
+        oldLayout(layout),
+        newLayout(layout),
+        refType(refType)
+  {
+  }
+  inline bool operator==(const ImageSubresourceState &other) const
+  {
+    return oldQueueFamilyIndex == other.oldQueueFamilyIndex &&
+           newQueueFamilyIndex == other.newQueueFamilyIndex && oldLayout == other.oldLayout &&
+           newLayout == other.newLayout && refType == other.refType;
+  }
+  inline bool operator!=(const ImageSubresourceState &other) const { return !(*this == other); }
+  void Update(const ImageSubresourceState &other, FrameRefCompFunc compose);
+  bool Update(const ImageSubresourceState &other, ImageSubresourceState &result,
+              FrameRefCompFunc compose) const;
+};
+
+class ImageSubresourceMap
+{
+  friend class SubresourceRangeIterator;
+
+  ImageInfo m_imageInfo;
+
+  // The states of the subresources, without explicit ranges.
+  // The ranges associated with each state are determined by the index in
+  // `m_values` and the `*Split` flags in `m_flags`.
+  rdcarray<ImageSubresourceState> m_values;
+
+  // All aspects of the image. This is computed from `m_imageInfo.format`
+  VkImageAspectFlags m_aspectMask = 0u;
+
+  // The bit count of `m_aspectMask`
+  uint16_t m_aspectCount = 0;
+
+  enum class FlagBits : uint16_t
+  {
+    AreAspectsSplit = 0x1,
+    AreLevelsSplit = 0x2,
+    AreLayersSplit = 0x4,
+    IsDepthSplit = 0x8,
+    IsUninitialized = 0x8000,
+  };
+  uint16_t m_flags = 0;
+
+  inline static bool AreAspectsSplit(uint16_t flags)
+  {
+    return (flags & (uint16_t)FlagBits::AreAspectsSplit) != 0;
+  }
+  inline static bool AreLevelsSplit(uint16_t flags)
+  {
+    return (flags & (uint16_t)FlagBits::AreLevelsSplit) != 0;
+  }
+  inline static bool AreLayersSplit(uint16_t flags)
+  {
+    return (flags & (uint16_t)FlagBits::AreLayersSplit) != 0;
+  }
+  inline static bool IsDepthSplit(uint16_t flags)
+  {
+    return (flags & (uint16_t)FlagBits::IsDepthSplit) != 0;
+  }
+  inline bool AreAspectsSplit() const { return AreAspectsSplit(m_flags); }
+  inline bool AreLevelsSplit() const { return AreLevelsSplit(m_flags); }
+  inline bool AreLayersSplit() const { return AreLayersSplit(m_flags); }
+  inline bool IsDepthSplit() const { return IsDepthSplit(m_flags); }
+  void Split(bool splitAspects, bool splitLevels, bool splitLayers, bool splitDepth);
+  void Unsplit(bool unsplitAspects, bool unsplitLevels, bool unsplitLayers, bool unsplitDepth);
+  size_t SubresourceIndex(uint32_t aspectIndex, uint32_t level, uint32_t layer, uint32_t z) const;
+
+public:
+  inline const ImageInfo &GetImageInfo() const { return m_imageInfo; }
+  inline ImageSubresourceMap() {}
+  inline ImageSubresourceMap(const ImageInfo &imageInfo, FrameRefType refType)
+      : m_imageInfo(imageInfo), m_aspectMask(FormatImageAspects(imageInfo.format))
+  {
+    for(auto it = ImageAspectFlagIter::begin(m_aspectMask); it != ImageAspectFlagIter::end(); ++it)
+      ++m_aspectCount;
+    m_values.push_back(
+        ImageSubresourceState(VK_QUEUE_FAMILY_IGNORED, UNKNOWN_PREV_IMG_LAYOUT, refType));
+  }
+
+  inline ImageSubresourceState &SubresourceValue(uint32_t aspectIndex, uint32_t level,
+                                                 uint32_t layer, uint32_t slice)
+  {
+    return m_values[SubresourceIndex(aspectIndex, level, layer, slice)];
+  }
+  inline const ImageSubresourceState &SubresourceValue(uint32_t aspectIndex, uint32_t level,
+                                                       uint32_t layer, uint32_t slice) const
+  {
+    return m_values[SubresourceIndex(aspectIndex, level, layer, slice)];
+  }
+  inline void Split(const ImageSubresourceRange &range)
+  {
+    Split(range.aspectMask != m_aspectMask,
+          range.baseMipLevel != 0u || range.levelCount < (uint32_t)GetImageInfo().levelCount,
+          range.baseArrayLayer != 0u || range.layerCount < (uint32_t)GetImageInfo().layerCount,
+          range.baseDepthSlice != 0u || range.sliceCount < GetImageInfo().extent.depth);
+  }
+  void Unsplit();
+  inline void Clear()
+  {
+    m_values.clear();
+    m_values.resize(1);
+    m_flags = 0;
+  }
+  FrameRefType Merge(const ImageSubresourceMap &other, FrameRefCompFunc compose);
+
+  template <typename Map, typename Pair>
+  class SubresourceRangeIterTemplate
+  {
+  public:
+    inline bool operator==(const SubresourceRangeIterTemplate &other)
+    {
+      bool isValid = IsValid();
+      bool otherIsValid = other.IsValid();
+      return (!isValid && !otherIsValid) ||
+             (isValid && otherIsValid &&
+              (m_aspectIndex == other.m_aspectIndex || !m_map->AreAspectsSplit()) &&
+              (m_level == other.m_level || !m_map->AreLevelsSplit()) &&
+              (m_layer == other.m_layer || !m_map->AreLayersSplit()) &&
+              (m_slice == other.m_slice || !m_map->IsDepthSplit()));
+    }
+    inline bool operator!=(const SubresourceRangeIterTemplate &other) { return !(*this == other); }
+    SubresourceRangeIterTemplate &operator++();
+    Pair *operator->();
+    Pair &operator*();
+
+    friend class ImageSubresourceMap;
+
+  protected:
+    Map *m_map = NULL;
+    uint16_t m_splitFlags = 0u;
+    ImageSubresourceRange m_range = {};
+    uint32_t m_aspectIndex = 0u;
+    uint32_t m_level = 0u;
+    uint32_t m_layer = 0u;
+    uint32_t m_slice = 0u;
+    Pair m_value;
+    SubresourceRangeIterTemplate() {}
+    SubresourceRangeIterTemplate(Map &map, const ImageSubresourceRange &range);
+    inline bool IsValid() const
+    {
+      return m_map && m_aspectIndex < m_map->m_aspectCount &&
+             m_level < m_range.baseMipLevel + m_range.levelCount &&
+             m_layer < m_range.baseArrayLayer + m_range.layerCount &&
+             m_slice < m_range.baseDepthSlice + m_range.sliceCount;
+    }
+    void FixSubRange();
+  };
+
+  template <typename State>
+  class SubresourcePairRefTemplate
+  {
+  public:
+    inline const ImageSubresourceRange &range() const { return m_range; }
+    inline State &state() { return *m_state; }
+    inline const State &state() const { return *m_state; }
+    SubresourcePairRefTemplate &operator=(const SubresourcePairRefTemplate &other) = delete;
+
+  protected:
+    template <typename Map, typename Pair>
+    friend class SubresourceRangeIterTemplate;
+    ImageSubresourceRange m_range;
+    State *m_state;
+  };
+
+  class SubresourcePairRef : public SubresourcePairRefTemplate<ImageSubresourceState>
+  {
+  public:
+    inline SubresourcePairRef &SetState(const ImageSubresourceState &state)
+    {
+      *m_state = state;
+      return *this;
+    }
+  };
+  using ConstSubresourcePairRef = SubresourcePairRefTemplate<const ImageSubresourceState>;
+
+  using SubresourceRangeIter = SubresourceRangeIterTemplate<ImageSubresourceMap, SubresourcePairRef>;
+  using SubresourceRangeConstIter =
+      SubresourceRangeIterTemplate<const ImageSubresourceMap, ConstSubresourcePairRef>;
+
+  inline SubresourceRangeIter RangeBegin(const ImageSubresourceRange &range)
+  {
+    return SubresourceRangeIter(*this, range);
+  }
+  inline SubresourceRangeConstIter RangeBegin(const ImageSubresourceRange &range) const
+  {
+    return SubresourceRangeConstIter(*this, range);
+  }
+  inline SubresourceRangeIter begin() { return RangeBegin(GetImageInfo().FullRange()); }
+  inline SubresourceRangeConstIter begin() const { return RangeBegin(GetImageInfo().FullRange()); }
+  inline SubresourceRangeIter end() { return SubresourceRangeIter(); }
+  inline SubresourceRangeConstIter end() const { return SubresourceRangeConstIter(); }
+  inline size_t size() const { return m_values.size(); }
 };
 
 template <typename Barrier>
@@ -1283,6 +1505,114 @@ struct BarrierSequence
 };
 
 using ImageBarrierSequence = BarrierSequence<VkImageMemoryBarrier>;
+
+struct ImageTransitionInfo
+{
+  CaptureState capState;
+  uint32_t defaultQueueFamilyIndex;
+  inline ImageTransitionInfo(CaptureState capState, uint32_t defaultQueueFamilyIndex)
+      : capState(capState), defaultQueueFamilyIndex(defaultQueueFamilyIndex)
+  {
+  }
+  inline FrameRefCompFunc GetFrameRefCompFunc()
+  {
+    if(IsCaptureMode(capState))
+      return ComposeFrameRefs;
+    else
+      return KeepOldFrameRef;
+  }
+  inline FrameRefType GetDefaultRefType()
+  {
+    if(IsCaptureMode(capState))
+      return eFrameRef_None;
+    else
+      return eFrameRef_Unknown;
+  }
+};
+
+struct ImageState
+{
+  ImageSubresourceMap subresourceStates;
+  rdcarray<VkImageMemoryBarrier> oldQueueFamilyTransfers;
+  rdcarray<VkImageMemoryBarrier> newQueueFamilyTransfers;
+  bool isMemoryBound = false;
+  ResourceId boundMemory = ResourceId();
+  VkDeviceSize boundMemoryOffset = 0ull;
+  VkDeviceSize boundMemorySize = 0ull;
+  FrameRefType maxRefType = eFrameRef_None;
+  VkImage wrappedHandle = VK_NULL_HANDLE;
+
+  inline const ImageInfo &GetImageInfo() const { return subresourceStates.GetImageInfo(); }
+  inline ImageState() {}
+  inline ImageState(VkImage wrappedHandle, const ImageInfo &imageInfo, FrameRefType refType)
+      : wrappedHandle(wrappedHandle), subresourceStates(imageInfo, refType), maxRefType(refType)
+  {
+  }
+  ImageState InitialState() const;
+  void InitialState(ImageState &result) const;
+  ImageState CommandBufferInitialState() const;
+  ImageState UniformState(const ImageSubresourceState &sub) const;
+  ImageState ContentInitializationState(InitPolicy policy, bool initialized,
+                                        uint32_t queueFamilyIndex, VkImageLayout copyLayout,
+                                        VkImageLayout clearLayout) const;
+  void RemoveQueueFamilyTransfer(VkImageMemoryBarrier *it);
+  void Update(ImageSubresourceRange range, const ImageSubresourceState &dst,
+              FrameRefCompFunc compose);
+  void Merge(const ImageState &other, ImageTransitionInfo info);
+  void MergeCaptureBeginState(const ImageState &initialState);
+  static void Merge(std::map<ResourceId, ImageState> &states,
+                    const std::map<ResourceId, ImageState> &dstStates, ImageTransitionInfo info);
+  void DiscardContents(const ImageSubresourceRange &range);
+  inline void DiscardContents() { DiscardContents(GetImageInfo().FullRange()); }
+  inline void RecordUse(const ImageSubresourceRange &range, FrameRefType refType,
+                        uint32_t queueFamilyIndex)
+  {
+    Update(range, ImageSubresourceState(queueFamilyIndex, UNKNOWN_PREV_IMG_LAYOUT, refType),
+           ComposeFrameRefs);
+  }
+  void RecordQueueFamilyRelease(const VkImageMemoryBarrier &barrier);
+  void RecordQueueFamilyAcquire(const VkImageMemoryBarrier &barrier);
+  void RecordBarrier(VkImageMemoryBarrier barrier, uint32_t queueFamilyIndex,
+                     ImageTransitionInfo info);
+  bool CloseTransfers(uint32_t batchIndex, VkAccessFlags dstAccessMask,
+                      ImageBarrierSequence &barriers, ImageTransitionInfo info);
+  bool RestoreTransfers(uint32_t batchIndex, const rdcarray<VkImageMemoryBarrier> &transfers,
+                        VkAccessFlags srcAccessMask, ImageBarrierSequence &barriers,
+                        ImageTransitionInfo info);
+  void ResetToOldState(ImageBarrierSequence &barriers, ImageTransitionInfo info);
+  void Transition(const ImageState &dstState, VkAccessFlags srcAccessMask,
+                  VkAccessFlags dstAccessMask, ImageBarrierSequence &barriers,
+                  ImageTransitionInfo info);
+  void Transition(uint32_t queueFamilyIndex, VkImageLayout layout, VkAccessFlags srcAccessMask,
+                  VkAccessFlags dstAccessMask, ImageBarrierSequence &barriers,
+                  ImageTransitionInfo info);
+
+  // Transitions the image state to `dstState` (via `preBarriers`) and back to the current state
+  // (via `postBarriers`).
+  // It is not always possible to return exactly to the current state, e.g. if the image is
+  // VK_IMAGE_LAYOUT_PREINITIALIZED, it will be returned to VK_IMAGE_LAYOUT_GENERAL instead.
+  void TempTransition(const ImageState &dstState, VkAccessFlags preSrcAccessMask,
+                      VkAccessFlags preDstAccessMask, VkAccessFlags postSrcAccessmask,
+                      VkAccessFlags postDstAccessMask, ImageBarrierSequence &setupBarriers,
+                      ImageBarrierSequence &cleanupBarriers, ImageTransitionInfo info) const;
+  void TempTransition(uint32_t queueFamilyIndex, VkImageLayout layout, VkAccessFlags accessMask,
+                      ImageBarrierSequence &setupBarriers, ImageBarrierSequence &cleanupBarriers,
+                      ImageTransitionInfo info) const;
+
+  void InlineTransition(VkCommandBuffer cmd, uint32_t queueFamilyIndex, const ImageState &dstState,
+                        VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
+                        ImageTransitionInfo info);
+  void InlineTransition(VkCommandBuffer cmd, uint32_t queueFamilyIndex, VkImageLayout layout,
+                        VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
+                        ImageTransitionInfo info);
+
+  InitReqType MaxInitReq(const ImageSubresourceRange &range, InitPolicy policy,
+                         bool initialized) const;
+  VkImageLayout GetImageLayout(VkImageAspectFlagBits aspect, uint32_t mipLevel,
+                               uint32_t arrayLayer) const;
+
+  void BeginCapture();
+};
 
 struct ImgRefs
 {

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1724,7 +1724,7 @@ public:
     PipelineLayoutData *pipeLayoutInfo;      // only for pipeline layouts
     DescriptorSetData *descInfo;             // only for descriptor sets and descriptor set layouts
     DescUpdateTemplate *descTemplateInfo;    // only for descriptor update templates
-    uint32_t queueFamilyIndex;               // only for queues
+    uint32_t queueFamilyIndex;               // only for queues and command pools
   };
 
   VkResourceRecord *bakedCommands;

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1540,8 +1540,12 @@ struct ImageTransitionInfo
 {
   CaptureState capState;
   uint32_t defaultQueueFamilyIndex;
-  inline ImageTransitionInfo(CaptureState capState, uint32_t defaultQueueFamilyIndex)
-      : capState(capState), defaultQueueFamilyIndex(defaultQueueFamilyIndex)
+  bool separateDepthStencil;
+  inline ImageTransitionInfo(CaptureState capState, uint32_t defaultQueueFamilyIndex,
+                             bool separateDepthStencil)
+      : capState(capState),
+        defaultQueueFamilyIndex(defaultQueueFamilyIndex),
+        separateDepthStencil(separateDepthStencil)
   {
   }
   inline FrameRefCompFunc GetFrameRefCompFunc()

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -453,7 +453,7 @@ bool WrappedVulkan::Serialise_vkCreateCommandPool(SerialiserType &ser, VkDevice 
     // remap the queue family index
     CreateInfo.queueFamilyIndex = m_QueueRemapping[CreateInfo.queueFamilyIndex][0].family;
 
-    m_commandQueueFamilies[CmdPool] = CreateInfo.queueFamilyIndex;
+    InsertCommandQueueFamily(CmdPool, CreateInfo.queueFamilyIndex);
 
     VkResult ret = ObjDisp(device)->CreateCommandPool(Unwrap(device), &CreateInfo, NULL, &pool);
 
@@ -466,7 +466,7 @@ bool WrappedVulkan::Serialise_vkCreateCommandPool(SerialiserType &ser, VkDevice 
     {
       ResourceId live = GetResourceManager()->WrapResource(Unwrap(device), pool);
       GetResourceManager()->AddLiveResource(CmdPool, pool);
-      m_commandQueueFamilies[live] = CreateInfo.queueFamilyIndex;
+      InsertCommandQueueFamily(live, CreateInfo.queueFamilyIndex);
     }
 
     AddResource(CmdPool, ResourceType::Pool, "Command Pool");
@@ -561,12 +561,17 @@ bool WrappedVulkan::Serialise_vkAllocateCommandBuffers(SerialiserType &ser, VkDe
     {
       ResourceId live = GetResourceManager()->WrapResource(Unwrap(device), cmd);
       GetResourceManager()->AddLiveResource(CommandBuffer, cmd);
-
-      m_commandQueueFamilies[live] = m_commandQueueFamilies[GetResID(AllocateInfo.commandPool)];
+      auto cmdQueueFamilyIt = m_commandQueueFamilies.find(GetResID(AllocateInfo.commandPool));
+      if(cmdQueueFamilyIt == m_commandQueueFamilies.end())
+      {
+        RDCERR("Missing queue family for %s", ToStr(GetResID(AllocateInfo.commandPool)).c_str());
+      }
+      else
+      {
+        InsertCommandQueueFamily(CommandBuffer, cmdQueueFamilyIt->second);
+        InsertCommandQueueFamily(live, cmdQueueFamilyIt->second);
+      }
     }
-
-    m_commandQueueFamilies[CommandBuffer] =
-        m_commandQueueFamilies[GetResID(AllocateInfo.commandPool)];
 
     AddResource(CommandBuffer, ResourceType::CommandBuffer, "Command Buffer");
     DerivedResource(device, CommandBuffer);
@@ -695,6 +700,16 @@ bool WrappedVulkan::Serialise_vkBeginCommandBuffer(SerialiserType &ser, VkComman
 
   if(IsReplayingAndReading())
   {
+    auto cmdQueueFamilyIt = m_commandQueueFamilies.find(CommandBuffer);
+    if(cmdQueueFamilyIt == m_commandQueueFamilies.end())
+    {
+      RDCERR("Unknown queue family for %s", ToStr(CommandBuffer).c_str());
+    }
+    else
+    {
+      InsertCommandQueueFamily(BakedCommandBuffer, cmdQueueFamilyIt->second);
+    }
+
     m_LastCmdBufferID = CommandBuffer;
 
     // when loading, allocate a new resource ID for each push descriptor slot in this command buffer
@@ -827,6 +842,7 @@ bool WrappedVulkan::Serialise_vkBeginCommandBuffer(SerialiserType &ser, VkComman
         // there's no issue with clashes here.
         m_RerecordCmds[BakedCommandBuffer] = cmd;
         m_RerecordCmds[m_LastCmdBufferID] = cmd;
+        InsertCommandQueueFamily(GetResID(cmd), FindCommandQueueFamily(m_LastCmdBufferID));
 
         m_RerecordCmdList.push_back({AllocateInfo.commandPool, cmd});
 
@@ -921,6 +937,8 @@ bool WrappedVulkan::Serialise_vkBeginCommandBuffer(SerialiserType &ser, VkComman
       }
 
       ObjDisp(device)->BeginCommandBuffer(Unwrap(cmd), &unwrappedBeginInfo);
+      InsertCommandQueueFamily(GetResourceManager()->GetLiveID(BakedCommandBuffer),
+                               FindCommandQueueFamily(BakedCommandBuffer));
     }
   }
 
@@ -1050,7 +1068,7 @@ bool WrappedVulkan::Serialise_vkEndCommandBuffer(SerialiserType &ser, VkCommandB
           // subpass
           uint32_t &sub = m_BakedCmdBufferInfo[m_LastCmdBufferID].state.subpass;
 
-          rdcarray<rdcpair<ResourceId, ImageRegionState> > imgbarriers;
+          std::map<ResourceId, ImageState> renderPassEndStates;
 
           for(sub = m_RenderState.subpass + 1; sub < numSubpasses; sub++)
           {
@@ -1059,51 +1077,43 @@ bool WrappedVulkan::Serialise_vkEndCommandBuffer(SerialiserType &ser, VkCommandB
             rdcarray<VkImageMemoryBarrier> subpassBarriers = GetImplicitRenderPassBarriers();
 
             GetResourceManager()->RecordBarriers(
-                imgbarriers, m_ImageLayouts, (uint32_t)subpassBarriers.size(), &subpassBarriers[0]);
+                renderPassEndStates, FindCommandQueueFamily(m_LastCmdBufferID),
+                (uint32_t)subpassBarriers.size(), subpassBarriers.data());
           }
 
           rdcarray<VkImageMemoryBarrier> finalBarriers = GetImplicitRenderPassBarriers(~0U);
 
-          GetResourceManager()->RecordBarriers(imgbarriers, m_ImageLayouts,
-                                               (uint32_t)finalBarriers.size(), &finalBarriers[0]);
+          GetResourceManager()->RecordBarriers(renderPassEndStates,
+                                               FindCommandQueueFamily(m_LastCmdBufferID),
+                                               (uint32_t)finalBarriers.size(), finalBarriers.data());
 
           ObjDisp(commandBuffer)->CmdEndRenderPass(Unwrap(commandBuffer));
 
           // undo any implicit transitions we just went through, so that we can pretend that the
           // image stayed in the same layout as it was when we stopped partially replaying.
-          rdcarray<VkImageMemoryBarrier> revertBarriers;
 
-          for(auto it = imgbarriers.begin(); it != imgbarriers.end(); ++it)
+          for(auto it = renderPassEndStates.begin(); it != renderPassEndStates.end(); ++it)
           {
-            VkImageMemoryBarrier barrier = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-            barrier.srcAccessMask = VK_ACCESS_ALL_READ_BITS | VK_ACCESS_ALL_WRITE_BITS;
-            barrier.dstAccessMask = VK_ACCESS_ALL_READ_BITS | VK_ACCESS_ALL_WRITE_BITS;
-            barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.image = Unwrap(GetResourceManager()->GetCurrentHandle<VkImage>(it->first));
-
-            // go from the layout we ended up in, to the layout we started in
-            barrier.oldLayout = it->second.newLayout;
-            barrier.newLayout = it->second.oldLayout;
-
-            barrier.subresourceRange = it->second.subresourceRange;
-
-            if(barrier.oldLayout != barrier.newLayout &&
-               barrier.newLayout != VK_IMAGE_LAYOUT_UNDEFINED)
+            ResourceId id = it->first;
+            ImageState &endState = it->second;
+            LockedConstImageStateRef current = FindConstImageState(id);
+            if(!current)
             {
-              SanitiseOldImageLayout(barrier.oldLayout);
-              SanitiseNewImageLayout(barrier.newLayout);
-
-              revertBarriers.push_back(barrier);
+              RDCERR("Unknown image %s", ToStr(id).c_str());
             }
-          }
-
-          if(!revertBarriers.empty())
-          {
-            if(SeparateDepthStencil())
-              CombineDepthStencilLayouts(revertBarriers);
-
-            DoPipelineBarrier(commandBuffer, revertBarriers.size(), revertBarriers.data());
+            else
+            {
+              ImageBarrierSequence barriers;
+              endState.Transition(*current, VK_ACCESS_ALL_WRITE_BITS, VK_ACCESS_ALL_READ_BITS,
+                                  barriers, GetImageTransitionInfo());
+              InlineCleanupImageBarriers(commandBuffer, barriers);
+              if(!barriers.empty())
+              {
+                // This should not happen, because the cleanup barriers are just image layout
+                // transitions, no queue family transitions
+                RDCERR("Partial RenderPass replay cleanup barriers could not all be inlined");
+              }
+            }
           }
         }
 
@@ -1327,12 +1337,12 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass(SerialiserType &ser, VkComman
         }
 
         ResourceId cmd = GetResID(commandBuffer);
-        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                             FindCommandQueueFamily(m_LastCmdBufferID),
                                              (uint32_t)imgBarriers.size(), imgBarriers.data());
 
         if(m_FirstEventID == m_LastEventID)
-          GetResourceManager()->ApplyBarriers(
-              m_QueueFamilyIdx, m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts);
+          UpdateImageStates(m_BakedCmdBufferInfo[cmd].imageStates);
       }
     }
     else
@@ -1389,7 +1399,8 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass(SerialiserType &ser, VkComman
       rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers();
 
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       AddEvent();
@@ -1529,7 +1540,8 @@ bool WrappedVulkan::Serialise_vkCmdNextSubpass(SerialiserType &ser, VkCommandBuf
         rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers();
 
         ResourceId cmd = GetResID(commandBuffer);
-        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                             FindCommandQueueFamily(m_LastCmdBufferID),
                                              (uint32_t)imgBarriers.size(), imgBarriers.data());
       }
     }
@@ -1545,7 +1557,8 @@ bool WrappedVulkan::Serialise_vkCmdNextSubpass(SerialiserType &ser, VkCommandBuf
       rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers();
 
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       AddEvent();
@@ -1623,7 +1636,8 @@ bool WrappedVulkan::Serialise_vkCmdEndRenderPass(SerialiserType &ser, VkCommandB
         }
 
         ResourceId cmd = GetResID(commandBuffer);
-        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                             FindCommandQueueFamily(m_LastCmdBufferID),
                                              (uint32_t)imgBarriers.size(), imgBarriers.data());
       }
     }
@@ -1641,7 +1655,8 @@ bool WrappedVulkan::Serialise_vkCmdEndRenderPass(SerialiserType &ser, VkCommandB
       rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers(~0U);
 
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       AddImplicitResolveResourceUsage(~0U);
@@ -1801,12 +1816,12 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass2(SerialiserType &ser,
         }
 
         ResourceId cmd = GetResID(commandBuffer);
-        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                             FindCommandQueueFamily(m_LastCmdBufferID),
                                              (uint32_t)imgBarriers.size(), imgBarriers.data());
 
         if(m_FirstEventID == m_LastEventID)
-          GetResourceManager()->ApplyBarriers(
-              m_QueueFamilyIdx, m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts);
+          UpdateImageStates(m_BakedCmdBufferInfo[cmd].imageStates);
       }
     }
     else
@@ -1864,7 +1879,8 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass2(SerialiserType &ser,
       rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers();
 
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       AddEvent();
@@ -2021,7 +2037,8 @@ bool WrappedVulkan::Serialise_vkCmdNextSubpass2(SerialiserType &ser, VkCommandBu
         rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers();
 
         ResourceId cmd = GetResID(commandBuffer);
-        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                             FindCommandQueueFamily(m_LastCmdBufferID),
                                              (uint32_t)imgBarriers.size(), imgBarriers.data());
       }
     }
@@ -2038,7 +2055,8 @@ bool WrappedVulkan::Serialise_vkCmdNextSubpass2(SerialiserType &ser, VkCommandBu
       rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers();
 
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       AddEvent();
@@ -2135,7 +2153,8 @@ bool WrappedVulkan::Serialise_vkCmdEndRenderPass2(SerialiserType &ser, VkCommand
         }
 
         ResourceId cmd = GetResID(commandBuffer);
-        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+        GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                             FindCommandQueueFamily(m_LastCmdBufferID),
                                              (uint32_t)imgBarriers.size(), imgBarriers.data());
       }
     }
@@ -2146,7 +2165,8 @@ bool WrappedVulkan::Serialise_vkCmdEndRenderPass2(SerialiserType &ser, VkCommand
       rdcarray<VkImageMemoryBarrier> imgBarriers = GetImplicitRenderPassBarriers(~0U);
 
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       AddEvent();
@@ -2962,14 +2982,25 @@ bool WrappedVulkan::Serialise_vkCmdPipelineBarrier(
     if(commandBuffer != VK_NULL_HANDLE)
     {
       ResourceId cmd = GetResID(commandBuffer);
-      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
+      GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                           FindCommandQueueFamily(m_LastCmdBufferID),
                                            (uint32_t)imgBarriers.size(), imgBarriers.data());
 
       // now sanitise layouts before passing to vulkan
       for(VkImageMemoryBarrier &barrier : imgBarriers)
       {
-        SanitiseOldImageLayout(barrier.oldLayout);
-        SanitiseNewImageLayout(barrier.newLayout);
+        if(!IsLoading(m_State) && barrier.oldLayout == VK_IMAGE_LAYOUT_PREINITIALIZED)
+        {
+          // This is a transition from PRENITIALIZED, but we've already done this barrier once (when
+          // loading); Since we couldn't transition back to PREINITIALIZED, we instead left the
+          // image in GENERAL.
+          barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+        }
+        else
+        {
+          SanitiseReplayImageLayout(barrier.oldLayout);
+        }
+        SanitiseReplayImageLayout(barrier.newLayout);
       }
 
       ObjDisp(commandBuffer)
@@ -3372,9 +3403,9 @@ bool WrappedVulkan::Serialise_vkCmdExecuteCommands(SerialiserType &ser, VkComman
       // merge barriers into parent command buffer
       for(uint32_t i = 0; i < commandBufferCount; i++)
       {
-        GetResourceManager()->MergeBarriers(
-            m_BakedCmdBufferInfo[GetResID(commandBuffer)].imgbarriers,
-            m_BakedCmdBufferInfo[GetResID(pCommandBuffers[i])].imgbarriers);
+        ImageState::Merge(m_BakedCmdBufferInfo[GetResID(commandBuffer)].imageStates,
+                          m_BakedCmdBufferInfo[GetResID(pCommandBuffers[i])].imageStates,
+                          GetImageTransitionInfo());
       }
 
       // append deferred indirect copies
@@ -3588,9 +3619,8 @@ bool WrappedVulkan::Serialise_vkCmdExecuteCommands(SerialiserType &ser, VkComman
 #endif
               rerecordedCmds.push_back(Unwrap(cmd));
 
-              GetResourceManager()->MergeBarriers(
-                  m_BakedCmdBufferInfo[GetResID(commandBuffer)].imgbarriers,
-                  m_BakedCmdBufferInfo[rerecord].imgbarriers);
+              ImageState::Merge(m_BakedCmdBufferInfo[GetResID(commandBuffer)].imageStates,
+                                m_BakedCmdBufferInfo[rerecord].imageStates, GetImageTransitionInfo());
             }
             else
             {

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -561,6 +561,7 @@ bool WrappedVulkan::Serialise_vkAllocateCommandBuffers(SerialiserType &ser, VkDe
     {
       ResourceId live = GetResourceManager()->WrapResource(Unwrap(device), cmd);
       GetResourceManager()->AddLiveResource(CommandBuffer, cmd);
+
       m_commandQueueFamilies[live] = m_commandQueueFamilies[GetResID(AllocateInfo.commandPool)];
     }
 
@@ -1683,12 +1684,8 @@ void WrappedVulkan::vkCmdEndRenderPass(VkCommandBuffer commandBuffer)
     const rdcarray<VkImageMemoryBarrier> &barriers = record->cmdInfo->rpbarriers;
 
     // apply the implicit layout transitions here
-    {
-      SCOPED_LOCK(m_ImageLayoutsLock);
-      GetResourceManager()->RecordBarriers(GetRecord(commandBuffer)->cmdInfo->imgbarriers,
-                                           m_ImageLayouts, (uint32_t)barriers.size(),
-                                           barriers.data());
-    }
+    GetResourceManager()->RecordBarriers(record->cmdInfo->imageStates, record->pool->queueFamilyIndex,
+                                         (uint32_t)barriers.size(), barriers.data());
   }
 }
 
@@ -2197,12 +2194,8 @@ void WrappedVulkan::vkCmdEndRenderPass2(VkCommandBuffer commandBuffer,
     const rdcarray<VkImageMemoryBarrier> &barriers = record->cmdInfo->rpbarriers;
 
     // apply the implicit layout transitions here
-    {
-      SCOPED_LOCK(m_ImageLayoutsLock);
-      GetResourceManager()->RecordBarriers(GetRecord(commandBuffer)->cmdInfo->imgbarriers,
-                                           m_ImageLayouts, (uint32_t)barriers.size(),
-                                           barriers.data());
-    }
+    GetResourceManager()->RecordBarriers(record->cmdInfo->imageStates, record->pool->queueFamilyIndex,
+                                         (uint32_t)barriers.size(), barriers.data());
   }
 }
 
@@ -3040,9 +3033,8 @@ void WrappedVulkan::vkCmdPipelineBarrier(
 
     if(imageMemoryBarrierCount > 0)
     {
-      SCOPED_LOCK(m_ImageLayoutsLock);
-      GetResourceManager()->RecordBarriers(GetRecord(commandBuffer)->cmdInfo->imgbarriers,
-                                           m_ImageLayouts, imageMemoryBarrierCount,
+      GetResourceManager()->RecordBarriers(record->cmdInfo->imageStates,
+                                           record->pool->queueFamilyIndex, imageMemoryBarrierCount,
                                            pImageMemoryBarriers);
     }
   }
@@ -3661,8 +3653,8 @@ void WrappedVulkan::vkCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t
             execRecord->bakedCommands->cmdInfo->boundDescSets.end());
         record->cmdInfo->subcmds.push_back(execRecord);
 
-        GetResourceManager()->MergeBarriers(record->cmdInfo->imgbarriers,
-                                            execRecord->bakedCommands->cmdInfo->imgbarriers);
+        ImageState::Merge(record->cmdInfo->imageStates,
+                          execRecord->bakedCommands->cmdInfo->imageStates, GetImageTransitionInfo());
       }
     }
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -268,9 +268,7 @@ bool WrappedVulkan::Serialise_vkQueueSubmit(SerialiserType &ser, VkQueue queue, 
 
           BakedCmdBufferInfo &cmdBufInfo = m_BakedCmdBufferInfo[cmd];
 
-          GetResourceManager()->ApplyBarriers(m_CreationInfo.m_Queue[GetResID(queue)],
-                                              m_BakedCmdBufferInfo[liveCmd].imgbarriers,
-                                              m_ImageLayouts);
+          UpdateImageStates(m_BakedCmdBufferInfo[liveCmd].imageStates);
 
           rdcstr name = StringFormat::Fmt("=> %s[%u]: vkBeginCommandBuffer(%s)", basename.c_str(),
                                           c, ToStr(cmd).c_str());
@@ -400,9 +398,7 @@ bool WrappedVulkan::Serialise_vkQueueSubmit(SerialiserType &ser, VkQueue queue, 
 #endif
               rerecordedCmds.push_back(Unwrap(cmd));
 
-              GetResourceManager()->ApplyBarriers(m_CreationInfo.m_Queue[GetResID(queue)],
-                                                  m_BakedCmdBufferInfo[rerecord].imgbarriers,
-                                                  m_ImageLayouts);
+              UpdateImageStates(m_BakedCmdBufferInfo[rerecord].imageStates);
             }
             else
             {

--- a/renderdoc/driver/vulkan/wrappers/vk_sync_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_sync_funcs.cpp
@@ -917,9 +917,8 @@ void WrappedVulkan::vkCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t even
 
     if(imageMemoryBarrierCount > 0)
     {
-      SCOPED_LOCK(m_ImageLayoutsLock);
-      GetResourceManager()->RecordBarriers(GetRecord(commandBuffer)->cmdInfo->imgbarriers,
-                                           m_ImageLayouts, imageMemoryBarrierCount,
+      GetResourceManager()->RecordBarriers(record->cmdInfo->imageStates,
+                                           record->pool->queueFamilyIndex, imageMemoryBarrierCount,
                                            pImageMemoryBarriers);
     }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_sync_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_sync_funcs.cpp
@@ -841,8 +841,9 @@ bool WrappedVulkan::Serialise_vkCmdWaitEvents(
     }
 
     ResourceId cmd = GetResID(commandBuffer);
-    GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imgbarriers, m_ImageLayouts,
-                                         (uint32_t)imgBarriers.size(), &imgBarriers[0]);
+    GetResourceManager()->RecordBarriers(m_BakedCmdBufferInfo[cmd].imageStates,
+                                         m_commandQueueFamilies[cmd], (uint32_t)imgBarriers.size(),
+                                         &imgBarriers[0]);
 
     if(commandBuffer != VK_NULL_HANDLE)
     {

--- a/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
@@ -441,22 +441,11 @@ bool WrappedVulkan::Serialise_vkCreateSwapchainKHR(SerialiserType &ser, VkDevice
 
       m_CreationInfo.m_Names[liveId] = StringFormat::Fmt("Presentable Image %u", i);
 
-      VkImageSubresourceRange range;
-      range.baseMipLevel = range.baseArrayLayer = 0;
-      range.levelCount = 1;
-      range.layerCount = CreateInfo.imageArrayLayers;
-      range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-
-      ImageLayouts &layouts = m_ImageLayouts[liveId];
-
-      layouts.imageInfo = swapinfo.imageInfo;
-
-      layouts.isMemoryBound = true;
-      layouts.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-      layouts.subresourceStates.clear();
-      layouts.subresourceStates.push_back(ImageRegionState(
-          VK_QUEUE_FAMILY_IGNORED, range, UNKNOWN_PREV_IMG_LAYOUT, VK_IMAGE_LAYOUT_UNDEFINED));
+      {
+        LockedImageStateRef state =
+            InsertImageState(im, liveId, ImageInfo(swapinfo.imageInfo), eFrameRef_Unknown);
+        state->isMemoryBound = true;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR merges the `ImageLayouts` and `ImgRefs`, and additionally

- Adds support for the VK_KHR_separate_depth_stencil_layouts extension
- Adds correct image-subresource queue family tracking

Most of these changes are currently behind an off-by default compile time flag (RDOC_NEW_IMAGE_STATE).

I intend to do more testing, and I would like to add some more explanation for some of the changes here, but tests are passing (unit tests, python tests, and manual tests on games), and I don't expect to need any more big changes to this code. I wanted to get the PR rolling so that it can hopefully make it in time for the next release.