### PR TITLE
Fix a handling of dlsym(RTLD_NEXT) without loading libGL. Closes #1463

### DIFF
--- a/renderdoc/driver/gl/egl_hooks.cpp
+++ b/renderdoc/driver/gl/egl_hooks.cpp
@@ -143,7 +143,8 @@ static void EnsureRealLibraryLoaded()
     if(!handle)
       handle = Process::LoadModule("libEGL.so.1");
 
-    eglhook.handle = handle;
+    if(RenderDoc::Inst().IsReplayApp())
+      eglhook.handle = handle;
   }
 #endif
 }

--- a/renderdoc/driver/gl/glx_hooks.cpp
+++ b/renderdoc/driver/gl/glx_hooks.cpp
@@ -76,7 +76,8 @@ static void EnsureRealLibraryLoaded()
     if(!handle)
       handle = Process::LoadModule("libGLX.so.0");
 
-    glxhook.handle = handle;
+    if(RenderDoc::Inst().IsReplayApp())
+      glxhook.handle = handle;
   }
 }
 


### PR DESCRIPTION
* The original fix leads to infinite recursion in GLX, EGL hooks.
  Due to `dlopen` function override in `librenderdoc.so` library the
  `Process::LoadModule` function always returns a handle of
  `librenderdoc.so` instead of requested library. So instead of
  `real function` we receive an address of the `hook` that leads
  to the infinite recursion in this `hook`.

Fixes: 66869e ("Handle dlsym(RTLD_NEXT) without loading libGL")
Signed-off-by: Andrii Simiklit <andrii.simiklit@globallogic.com>
