### PR TITLE
Fix viewing sRGB with D3D12, and fix pixel history text with dark theme

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_rendertexture.cpp
+++ b/renderdoc/driver/d3d12/d3d12_rendertexture.cpp
@@ -476,7 +476,9 @@ bool D3D12Replay::RenderTextureInternal(D3D12_CPU_DESCRIPTOR_HANDLE rtv, Texture
   else if(IsIntFormat(resourceDesc.Format))
     pixelData.OutputDisplayFormat |= TEXDISPLAY_SINT_TEX;
 
-  if(!IsSRGBFormat(resourceDesc.Format) && cfg.linearDisplayAsGamma)
+  // Check both the resource format and view format for sRGB
+  if(!IsSRGBFormat(resourceDesc.Format) && cfg.typeCast != CompType::UNormSRGB &&
+     cfg.linearDisplayAsGamma)
     pixelData.OutputDisplayFormat |= TEXDISPLAY_GAMMA_CURVE;
 
   Vec4u YUVDownsampleRate = {}, YUVAChannels = {};


### PR DESCRIPTION
D3D12 only checked the resource format to determine if it should be displaying as sRGB, but not whether it is viewed as sRGB.

The pixel history view changes the background color for passed/failed fragments, but didn't ensure that the foreground color had enough contrast to be readable. With the dark theme, this caused it to be very hard to read.