### PR TITLE
Unwrap resource when the application calls AssertResourceState

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list.h
+++ b/renderdoc/driver/d3d12/d3d12_command_list.h
@@ -42,7 +42,7 @@ struct WrappedID3D12DebugCommandList : public ID3D12DebugCommandList2, public ID
   ID3D12DebugCommandList1 *m_pReal1;
   ID3D12DebugCommandList2 *m_pReal2;
 
-  WrappedID3D12DebugCommandList() : m_pList(NULL), m_pReal(NULL) {}
+  WrappedID3D12DebugCommandList() : m_pList(NULL), m_pReal(NULL), m_pReal1(NULL), m_pReal2(NULL) {}
   //////////////////////////////
   // implement IUnknown
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject)
@@ -50,6 +50,18 @@ struct WrappedID3D12DebugCommandList : public ID3D12DebugCommandList2, public ID
     if(riid == __uuidof(ID3D12DebugCommandList))
     {
       *ppvObject = (ID3D12DebugCommandList *)this;
+      AddRef();
+      return S_OK;
+    }
+    else if(riid == __uuidof(ID3D12DebugCommandList1))
+    {
+      *ppvObject = (ID3D12DebugCommandList1 *)this;
+      AddRef();
+      return S_OK;
+    }
+    else if(riid == __uuidof(ID3D12DebugCommandList2))
+    {
+      *ppvObject = (ID3D12DebugCommandList2 *)this;
       AddRef();
       return S_OK;
     }
@@ -67,14 +79,14 @@ struct WrappedID3D12DebugCommandList : public ID3D12DebugCommandList2, public ID
                                                      UINT State)
   {
     if(m_pReal)
-      m_pReal->AssertResourceState(pResource, Subresource, State);
+      return m_pReal->AssertResourceState(Unwrap(pResource), Subresource, State);
     return TRUE;
   }
 
   virtual HRESULT STDMETHODCALLTYPE SetFeatureMask(D3D12_DEBUG_FEATURE Mask)
   {
     if(m_pReal)
-      m_pReal->SetFeatureMask(Mask);
+      return m_pReal->SetFeatureMask(Mask);
     return S_OK;
   }
 

--- a/renderdoc/driver/d3d12/d3d12_command_queue.h
+++ b/renderdoc/driver/d3d12/d3d12_command_queue.h
@@ -62,7 +62,7 @@ struct WrappedID3D12DebugCommandQueue : public ID3D12DebugCommandQueue
                                                      UINT State)
   {
     if(m_pReal)
-      m_pReal->AssertResourceState(pResource, Subresource, State);
+      return m_pReal->AssertResourceState(Unwrap(pResource), Subresource, State);
     return TRUE;
   }
 };

--- a/renderdoc/driver/d3d12/d3d12_commands.cpp
+++ b/renderdoc/driver/d3d12/d3d12_commands.cpp
@@ -264,25 +264,29 @@ WrappedID3D12GraphicsCommandList *GetWrapped(ID3D12GraphicsCommandList5 *obj)
 
 ULONG STDMETHODCALLTYPE WrappedID3D12DebugCommandQueue::AddRef()
 {
-  m_pQueue->AddRef();
+  if(m_pQueue)
+    m_pQueue->AddRef();
   return 1;
 }
 
 ULONG STDMETHODCALLTYPE WrappedID3D12DebugCommandQueue::Release()
 {
-  m_pQueue->Release();
+  if(m_pQueue)
+    m_pQueue->Release();
   return 1;
 }
 
 ULONG STDMETHODCALLTYPE WrappedID3D12DebugCommandList::AddRef()
 {
-  m_pList->AddRef();
+  if(m_pList)
+    m_pList->AddRef();
   return 1;
 }
 
 ULONG STDMETHODCALLTYPE WrappedID3D12DebugCommandList::Release()
 {
-  m_pList->Release();
+  if(m_pList)
+    m_pList->Release();
   return 1;
 }
 
@@ -316,7 +320,7 @@ WrappedID3D12CommandQueue::WrappedID3D12CommandQueue(ID3D12CommandQueue *real,
     RenderDoc::Inst().GetCrashHandler()->RegisterMemoryRegion(this,
                                                               sizeof(WrappedID3D12CommandQueue));
 
-  m_WrappedDebug.m_pReal = NULL;
+  m_WrappedDebug.m_pQueue = this;
   m_pDownlevel = NULL;
   if(m_pReal)
   {
@@ -985,10 +989,7 @@ WrappedID3D12GraphicsCommandList::WrappedID3D12GraphicsCommandList(ID3D12Graphic
   m_pList4 = NULL;
   m_pList5 = NULL;
 
-  m_WrappedDebug.m_pReal = NULL;
-  m_WrappedDebug.m_pReal1 = NULL;
-  m_WrappedDebug.m_pReal2 = NULL;
-
+  m_WrappedDebug.m_pList = this;
   if(m_pList)
   {
     m_pList->QueryInterface(__uuidof(ID3D12DebugCommandList), (void **)&m_WrappedDebug.m_pReal);


### PR DESCRIPTION
An application I was testing calls AssertResourceState which crashed when attached to RenderDoc, as the resource wasn't unwrapped. Also fixed up a crash on release that I encountered.