### PR TITLE
Backdoor context for opengl resource retrieval

### DIFF
--- a/renderdoc/driver/gl/gl_initstate.cpp
+++ b/renderdoc/driver/gl/gl_initstate.cpp
@@ -566,15 +566,17 @@ bool GLResourceManager::Prepare_InitialState(GLResource res)
     GLWindowingData oldContextData = m_Driver->m_ActiveContexts[Threading::GetCurrentID()];
 
     ContextShareGroup *shareGroup = (ContextShareGroup *)res.ContextShareGroup;
+    
+    if(m_Driver->m_Platform.MakeContextCurrent(shareGroup->m_BackDoor))
+    {
+      m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = shareGroup->m_BackDoor;
 
-    m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = shareGroup->m_BackDoor;
-    m_Driver->m_Platform.MakeContextCurrent(shareGroup->m_BackDoor);
+      ContextPrepare_InitialState(res);
 
-    ContextPrepare_InitialState(res);
-
-    // restore the context
-    m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = oldContextData;
-    m_Driver->m_Platform.MakeContextCurrent(oldContextData);
+      // restore the context
+      m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = oldContextData;
+      m_Driver->m_Platform.MakeContextCurrent(oldContextData);
+    }
   }
   else
   {
@@ -1813,18 +1815,19 @@ bool GLResourceManager::Serialise_InitialState(WriteSerialiser &ser, ResourceId 
 
     GLWindowingData backdoor = ((ContextShareGroup *)res.ContextShareGroup)->m_BackDoor;
 
-    m_Driver->m_Platform.MakeContextCurrent(backdoor);
+    if(m_Driver->m_Platform.MakeContextCurrent(backdoor))
+    {
+      m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = backdoor;
 
-    m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = backdoor;
+      bool success = Serialise_InitialState<WriteSerialiser>(ser, id, record, initial);
 
-    bool success = Serialise_InitialState<WriteSerialiser>(ser, id, record, initial);
+      // restore the context
+      m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = oldContextData;
 
-    // restore the context
-    m_Driver->m_ActiveContexts[Threading::GetCurrentID()] = oldContextData;
-
-    m_Driver->m_Platform.MakeContextCurrent(oldContextData);
-
-    return success;
+      m_Driver->m_Platform.MakeContextCurrent(oldContextData);
+    
+      return success;
+    }
   }
 
   return Serialise_InitialState<WriteSerialiser>(ser, id, record, initial);

--- a/renderdoc/driver/gl/gl_manager.cpp
+++ b/renderdoc/driver/gl/gl_manager.cpp
@@ -145,12 +145,17 @@ bool GLResourceManager::ResourceTypeRelease(GLResource res)
     {
       ContextShareGroup *contextShareGroup = (ContextShareGroup *)res.ContextShareGroup;
 
-      m_Driver->m_Platform.MakeContextCurrent(contextShareGroup->m_BackDoor);
+      if(m_Driver->m_Platform.MakeContextCurrent(contextShareGroup->m_BackDoor))
+      {
+        m_Driver->ReleaseResource(res);
 
-      m_Driver->ReleaseResource(res);
-
-      // restore the context
-      m_Driver->m_Platform.MakeContextCurrent(m_Driver->m_ActiveContexts[Threading::GetCurrentID()]);
+        // restore the context
+        m_Driver->m_Platform.MakeContextCurrent(m_Driver->m_ActiveContexts[Threading::GetCurrentID()]);
+      }
+      else
+      {
+        m_Driver->QueueResourceRelease(res);
+      }
     }
     else
     {

--- a/renderdoc/driver/gl/gl_manager.h
+++ b/renderdoc/driver/gl/gl_manager.h
@@ -270,13 +270,10 @@ public:
   template <typename SerialiserType>
   bool Serialise_InitialState(SerialiserType &ser, ResourceId id, GLResourceRecord *record,
                               const GLInitialContents *initial);
+  bool Serialise_InitialState(WriteSerialiser &ser, ResourceId id, GLResourceRecord *record,
+                              const GLInitialContents *initial);
 
   void ContextPrepare_InitialState(GLResource res);
-  bool Serialise_InitialState(WriteSerialiser &ser, ResourceId id, GLResourceRecord *record,
-                              const GLInitialContents *initial)
-  {
-    return Serialise_InitialState<WriteSerialiser>(ser, id, record, initial);
-  }
 
   void SetInternalResource(GLResource res);
 

--- a/renderdoc/driver/gl/gl_postvs.cpp
+++ b/renderdoc/driver/gl/gl_postvs.cpp
@@ -1852,7 +1852,7 @@ MeshFormat GLReplay::GetPostVSBuffers(uint32_t eventId, uint32_t instID, uint32_
   // no multiview support
   (void)viewID;
 
-  ContextPair ctx = {m_ReplayCtx.ctx, m_pDriver->ShareCtx(m_ReplayCtx.ctx)};
+  ContextPair ctx = {m_ReplayCtx.ctx, m_pDriver->GetShareGroup(m_ReplayCtx.ctx)};
 
   if(m_PostVSData.find(eventId) != m_PostVSData.end())
     postvs = m_PostVSData[eventId];


### PR DESCRIPTION
This implements the backdoor context so that resources created by non-current contexts can be retrieved and serialised.