### PR TITLE
Add headers required to build windows files without precompiled header

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_sdbg.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_sdbg.cpp
@@ -25,6 +25,7 @@
 
 #include "dxbc_container.h"
 
+#include "os/os_specific.h"
 #include "dxbc_sdbg.h"
 
 namespace DXBC

--- a/renderdoc/driver/shaders/dxbc/dxbc_spdb.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_spdb.cpp
@@ -28,6 +28,7 @@
 #include "dxbc_container.h"
 
 #include "official/cvinfo.h"
+#include "os/os_specific.h"
 #include "dxbc_spdb.h"
 
 // uncomment the following to print (very verbose) debugging prints for SPDB processing

--- a/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include "common/common.h"
 #include "common/formatting.h"
+#include "os/os_specific.h"
 #include "llvm_decoder.h"
 
 // undef some annoying defines that might come from OS headers

--- a/renderdoc/driver/shaders/dxil/llvm_decoder.cpp
+++ b/renderdoc/driver/shaders/dxil/llvm_decoder.cpp
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include "llvm_decoder.h"
+#include "os/os_specific.h"
 
 namespace LLVMBC
 {

--- a/renderdoc/maths/formatpacking.cpp
+++ b/renderdoc/maths/formatpacking.cpp
@@ -28,6 +28,7 @@
 #include "api/replay/data_types.h"
 #include "api/replay/rdcpair.h"
 #include "common/common.h"
+#include "os/os_specific.h"
 
 //	for(int i=0; i < 256; i++)
 //	{

--- a/renderdoc/os/win32/win32_network.cpp
+++ b/renderdoc/os/win32/win32_network.cpp
@@ -25,6 +25,7 @@
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include "api/replay/stringise.h"
 #include "common/common.h"
 #include "common/formatting.h"
 #include "os/os_specific.h"


### PR DESCRIPTION
Precompiled headers per folder are not easily setup in our (proprietary) build system, it would be nice if we could build without them. Seems there are only minor changes required for this to work.