### PR TITLE
Add split depth/stencil layouts for input attachments

### DIFF
--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -690,10 +690,11 @@ void VulkanCreationInfo::RenderPass::Init(VulkanResourceManager *resourceMan,
 
     dst.inputAttachments.resize(src.inputAttachmentCount);
     dst.inputLayouts.resize(src.inputAttachmentCount);
+    dst.inputStencilLayouts.resize(src.inputAttachmentCount);
     for(uint32_t i = 0; i < src.inputAttachmentCount; i++)
     {
       dst.inputAttachments[i] = src.pInputAttachments[i].attachment;
-      dst.inputLayouts[i] = src.pInputAttachments[i].layout;
+      dst.inputStencilLayouts[i] = dst.inputLayouts[i] = src.pInputAttachments[i].layout;
     }
 
     dst.colorAttachments.resize(src.colorAttachmentCount);
@@ -786,10 +787,16 @@ void VulkanCreationInfo::RenderPass::Init(VulkanResourceManager *resourceMan,
 
     dst.inputAttachments.resize(src.inputAttachmentCount);
     dst.inputLayouts.resize(src.inputAttachmentCount);
+    dst.inputStencilLayouts.resize(src.inputAttachmentCount);
     for(uint32_t i = 0; i < src.inputAttachmentCount; i++)
     {
       dst.inputAttachments[i] = src.pInputAttachments[i].attachment;
-      dst.inputLayouts[i] = src.pInputAttachments[i].layout;
+      dst.inputStencilLayouts[i] = dst.inputLayouts[i] = src.pInputAttachments[i].layout;
+      const VkAttachmentReferenceStencilLayoutKHR *stencilLayout =
+          (const VkAttachmentReferenceStencilLayoutKHR *)FindNextStruct(
+              &src.pInputAttachments[i], VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT_KHR);
+      if(stencilLayout != NULL)
+        dst.inputStencilLayouts[i] = stencilLayout->stencilLayout;
     }
 
     dst.colorAttachments.resize(src.colorAttachmentCount);

--- a/renderdoc/driver/vulkan/vk_info.h
+++ b/renderdoc/driver/vulkan/vk_info.h
@@ -376,6 +376,7 @@ struct VulkanCreationInfo
       int32_t fragmentDensityAttachment;
 
       rdcarray<VkImageLayout> inputLayouts;
+      rdcarray<VkImageLayout> inputStencilLayouts;
       rdcarray<VkImageLayout> colorLayouts;
       VkImageLayout depthLayout;
       VkImageLayout stencilLayout;

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -146,6 +146,7 @@ rdcarray<VkImageMemoryBarrier> WrappedVulkan::GetImplicitRenderPassBarriers(uint
       atts.push_back({});
       atts.back().attachment = attIdx;
       atts.back().layout = rpinfo.subpasses[subpass].inputLayouts[i];
+      atts.back().stencilLayout = rpinfo.subpasses[subpass].inputStencilLayouts[i];
     }
 
     int32_t ds = rpinfo.subpasses[subpass].depthstencilAttachment;
@@ -252,6 +253,7 @@ rdcarray<VkImageMemoryBarrier> WrappedVulkan::GetImplicitRenderPassBarriers(uint
         if(rpinfo.subpasses[s - 1].inputAttachments[a] == idx)
         {
           barrier.oldLayout = rpinfo.subpasses[s - 1].inputLayouts[a];
+          barrierStencil.oldLayout = rpinfo.subpasses[s - 1].inputStencilLayouts[a];
           found = true;
           break;
         }

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -703,9 +703,9 @@ VkResult WrappedVulkan::vkCreateFramebuffer(VkDevice device,
       VkResourceRecord *rpRecord = GetRecord(pCreateInfo->renderPass);
       record->AddParent(rpRecord);
 
-      // +1 for the terminating null attachment info, +1 again in case we need two barriers for
-      // separate depth and stencil
-      uint32_t arrayCount = pCreateInfo->attachmentCount + 2;
+      // *2 in case we need separate barriers for depth and stencil, +1 for the terminating null
+      // attachment info
+      uint32_t arrayCount = pCreateInfo->attachmentCount * 2 + 1;
 
       record->imageAttachments = new AttachmentInfo[arrayCount];
       RDCEraseMem(record->imageAttachments, sizeof(AttachmentInfo) * arrayCount);
@@ -961,9 +961,10 @@ VkResult WrappedVulkan::vkCreateRenderPass(VkDevice device, const VkRenderPassCr
       VkResourceRecord *record = GetResourceManager()->AddResourceRecord(*pRenderPass);
       record->AddChunk(chunk);
 
-      // +1 for the terminating null attachment info, +1 again in case we need two barriers for
-      // separate depth and stencil (though that isn't needed here, we keep the array size the same)
-      uint32_t arrayCount = pCreateInfo->attachmentCount + 2;
+      // *2 in case we need separate barriers for depth and stencil, +1 for the terminating null
+      // attachment info (though separate depth/stencil buffers aren't needed here, we keep the
+      // array size the same)
+      uint32_t arrayCount = pCreateInfo->attachmentCount * 2 + 1;
 
       record->imageAttachments = new AttachmentInfo[arrayCount];
 
@@ -1190,9 +1191,9 @@ VkResult WrappedVulkan::vkCreateRenderPass2KHR(VkDevice device,
       VkResourceRecord *record = GetResourceManager()->AddResourceRecord(*pRenderPass);
       record->AddChunk(chunk);
 
-      // +1 for the terminating null attachment info, +1 again in case we need two barriers for
-      // separate depth and stencil
-      uint32_t arrayCount = pCreateInfo->attachmentCount + 2;
+      // *2 in case we need separate barriers for depth and stencil, +1 for the terminating null
+      // attachment info
+      uint32_t arrayCount = pCreateInfo->attachmentCount * 2 + 1;
 
       record->imageAttachments = new AttachmentInfo[arrayCount];
 


### PR DESCRIPTION
This should fix support for depth/stencil input attachments with separate layouts.

I also updated the vk_separate_depth_stencil_layouts demo to use the depth aspect as an input attachment in one of the subpasses. On my machine, captures of the demo replay a correct image with and without the patch, but without the patch there is at least one extra validation warning in the diagnostic log when replaying:

```
Warning - [UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout] Submitted command buffer expects VkImage 0x445cb4000000018a[] (subresource: aspectMask 0x4 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR--instead, current layout is VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR.
```