### PR TITLE
Add drawcall callbacks to end and next renderpass cmds

### DIFF
--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -399,13 +399,22 @@ struct VulkanAMDDrawCallback : public VulkanDrawcallCallback
   void PreDispatch(uint32_t eid, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
   bool PostDispatch(uint32_t eid, VkCommandBuffer cmd) override { return PostDraw(eid, cmd); }
   void PostRedispatch(uint32_t eid, VkCommandBuffer cmd) override { PostRedraw(eid, cmd); }
-  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
+  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
+  {
+    if(flags & DrawFlags::PassBoundary)
+      return;
+    PreDraw(eid, cmd);
+  }
   bool PostMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
+    if(flags & DrawFlags::PassBoundary)
+      return false;
     return PostDraw(eid, cmd);
   }
   void PostRemisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
+    if(flags & DrawFlags::PassBoundary)
+      return;
     PostRedraw(eid, cmd);
   }
 
@@ -547,13 +556,22 @@ struct VulkanKHRCallback : public VulkanDrawcallCallback
   void PreDispatch(uint32_t eid, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
   bool PostDispatch(uint32_t eid, VkCommandBuffer cmd) override { return PostDraw(eid, cmd); }
   void PostRedispatch(uint32_t eid, VkCommandBuffer cmd) override { PostRedraw(eid, cmd); }
-  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
+  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
+  {
+    if(flags & DrawFlags::PassBoundary)
+      return;
+    PreDraw(eid, cmd);
+  }
   bool PostMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
+    if(flags & DrawFlags::PassBoundary)
+      return false;
     return PostDraw(eid, cmd);
   }
   void PostRemisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
+    if(flags & DrawFlags::PassBoundary)
+      return;
     PostRedraw(eid, cmd);
   }
   void AliasEvent(uint32_t primary, uint32_t alias) override
@@ -740,13 +758,22 @@ struct VulkanGPUTimerCallback : public VulkanDrawcallCallback
   void PreDispatch(uint32_t eid, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
   bool PostDispatch(uint32_t eid, VkCommandBuffer cmd) override { return PostDraw(eid, cmd); }
   void PostRedispatch(uint32_t eid, VkCommandBuffer cmd) override { PostRedraw(eid, cmd); }
-  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
+  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
+  {
+    if(flags & DrawFlags::PassBoundary)
+      return;
+    PreDraw(eid, cmd);
+  }
   bool PostMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
+    if(flags & DrawFlags::PassBoundary)
+      return false;
     return PostDraw(eid, cmd);
   }
   void PostRemisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
+    if(flags & DrawFlags::PassBoundary)
+      return;
     PostRedraw(eid, cmd);
   }
   void AliasEvent(uint32_t primary, uint32_t alias) override


### PR DESCRIPTION
For Vulkan pixel history vkCmdEndRenderPass and vkCmdNextSubpass
can represent a modification, since it might be doing an implicit
image resolve. Pixel history is using drawcall callbacks to figure
out values pre- post- events, and vkCmdEndRenderPass and
vkCmdNextSubpass might be such events.

Also add clear image usage for images cleared during vkCmdBeginRenderPass(2).