### PR TITLE
Fix missing SAMPLER descriptor type

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -3871,7 +3871,8 @@ void WrappedVulkan::ApplyPushDescriptorWrites(VkPipelineBindPoint pipelineBindPo
         // ignore descriptors not part of the write, as they might not even point to a valid
         // object so trying to get their ID could crash
         if(layoutBinding->immutableSampler ||
-           writeDesc.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+           (writeDesc.descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER &&
+            writeDesc.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
           sampler = false;
         if(writeDesc.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER)
           imageView = false;

--- a/renderdoc/driver/vulkan/wrappers/vk_descriptor_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_descriptor_funcs.cpp
@@ -703,7 +703,8 @@ void WrappedVulkan::ReplayDescriptorSetWrite(VkDevice device, const VkWriteDescr
           // ignore descriptors not part of the write, as they might not even point to a valid
           // object so trying to get their ID could crash
           if(layoutBinding->immutableSampler ||
-             writeDesc.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+             (writeDesc.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER &&
+              writeDesc.descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER))
             sampler = false;
           if(writeDesc.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER)
             imageView = false;
@@ -1089,7 +1090,8 @@ void WrappedVulkan::vkUpdateDescriptorSets(VkDevice device, uint32_t writeCount,
           // ignore descriptors not part of the write, as they might not even point to a valid
           // object so trying to get their ID could crash
           if(layoutBinding->immutableSampler ||
-             descWrite.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+             (descWrite.descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER &&
+              descWrite.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
             sampler = false;
           if(descWrite.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER)
             imageView = false;
@@ -1462,7 +1464,8 @@ void WrappedVulkan::vkUpdateDescriptorSetWithTemplate(
           // ignore descriptors not part of the write, as they might not even point to a valid
           // object so trying to get their ID could crash
           if(layoutBinding->immutableSampler ||
-             entry.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+             (entry.descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER &&
+              entry.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
             sampler = false;
           if(entry.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER)
             imageView = false;


### PR DESCRIPTION
This fixes a few places that were checking for the presence of a sampler in a descriptor binding, but only accepting combined image/sampler descriptors, not sampler-only descriptors. This caused sampler-only descriptors to be missing initial contents.