### PR TITLE
Fix numerous compiler warnings and errors

### DIFF
--- a/renderdoc/common/dds_readwrite.h
+++ b/renderdoc/common/dds_readwrite.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <stdio.h>
 #include "api/replay/data_types.h"
 
 struct dds_data

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdio.h>
 #include <map>
 #include "api/app/renderdoc_app.h"
 #include "api/replay/apidefs.h"

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -34,6 +34,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <functional>
 #include "api/replay/rdcarray.h"
 #include "api/replay/rdcpair.h"

--- a/renderdoc/os/posix/linux/linux_stringio.cpp
+++ b/renderdoc/os/posix/linux/linux_stringio.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include <ctype.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <iconv.h>

--- a/renderdoc/strings/utf8printf.cpp
+++ b/renderdoc/strings/utf8printf.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include <wchar.h>
 #include "common/common.h"
 #include "os/os_specific.h"
 


### PR DESCRIPTION
## Description

Depending on OS and compiler, certain types may not be included
transitively by headers that were included previously. This commit
produces a clean build on the latest trunk versions of GCC, Clang,
and QT.