### PR TITLE
Fix build break on VS2019 due to implicit wchar_t->char conversion

### DIFF
--- a/renderdoccmd/renderdoccmd_win32.cpp
+++ b/renderdoccmd/renderdoccmd_win32.cpp
@@ -541,8 +541,7 @@ struct CrashHandlerCommand : public Command
         }
         else
         {
-          report += "  \"" + std::string(name.begin(), name.end()) + "\": \"" +
-                    std::string(val.begin(), val.end()) + "\",\n";
+          report += "  \"" + conv(name) + "\": \"" + conv(val) + "\",\n";
         }
       }
 


### PR DESCRIPTION
Converting std::wstring to std::string by constructing the latter with
wchar_t iterators result in implicit conversion of wchar_t to char which
trips Visual Studio 2019 compiler into throwing a warning of potential
data loss during conversion.

## Description

Use conv() helper function to do the conversion and please the compiler at the same time.

