### PR TITLE
Add SM 5.1 resource binding support to shader debugging

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_bytecode.cpp
@@ -88,7 +88,7 @@ DXBC::Reflection *Program::GuessReflection()
         DXBC::ShaderInputBind desc;
 
         RDCASSERT(dcl.operand.type == TYPE_RESOURCE);
-        RDCASSERT(dcl.operand.indices.size() == 1);
+        RDCASSERT(dcl.operand.indices.size() == 1 || dcl.operand.indices.size() == 3);
         RDCASSERT(dcl.operand.indices[0].absolute);
 
         uint32_t idx = (uint32_t)dcl.operand.indices[0].index;
@@ -159,7 +159,7 @@ DXBC::Reflection *Program::GuessReflection()
 
         RDCASSERT(dcl.operand.type == TYPE_RESOURCE ||
                   dcl.operand.type == TYPE_UNORDERED_ACCESS_VIEW);
-        RDCASSERT(dcl.operand.indices.size() == 1);
+        RDCASSERT(dcl.operand.indices.size() == 1 || dcl.operand.indices.size() == 3);
         RDCASSERT(dcl.operand.indices[0].absolute);
 
         uint32_t idx = (uint32_t)dcl.operand.indices[0].index;
@@ -196,7 +196,7 @@ DXBC::Reflection *Program::GuessReflection()
         DXBC::ShaderInputBind desc;
 
         RDCASSERT(dcl.operand.type == TYPE_RESOURCE);
-        RDCASSERT(dcl.operand.indices.size() == 1);
+        RDCASSERT(dcl.operand.indices.size() == 1 || dcl.operand.indices.size() == 3);
         RDCASSERT(dcl.operand.indices[0].absolute);
 
         uint32_t idx = (uint32_t)dcl.operand.indices[0].index;
@@ -227,7 +227,7 @@ DXBC::Reflection *Program::GuessReflection()
         DXBC::ShaderInputBind desc;
 
         RDCASSERT(dcl.operand.type == TYPE_UNORDERED_ACCESS_VIEW);
-        RDCASSERT(dcl.operand.indices.size() == 1);
+        RDCASSERT(dcl.operand.indices.size() == 1 || dcl.operand.indices.size() == 3);
         RDCASSERT(dcl.operand.indices[0].absolute);
 
         uint32_t idx = (uint32_t)dcl.operand.indices[0].index;
@@ -263,7 +263,7 @@ DXBC::Reflection *Program::GuessReflection()
         DXBC::ShaderInputBind desc;
 
         RDCASSERT(dcl.operand.type == TYPE_UNORDERED_ACCESS_VIEW);
-        RDCASSERT(dcl.operand.indices.size() == 1);
+        RDCASSERT(dcl.operand.indices.size() == 1 || dcl.operand.indices.size() == 3);
         RDCASSERT(dcl.operand.indices[0].absolute);
 
         uint32_t idx = (uint32_t)dcl.operand.indices[0].index;
@@ -326,7 +326,7 @@ DXBC::Reflection *Program::GuessReflection()
         DXBC::ShaderInputBind desc;
 
         RDCASSERT(dcl.operand.type == TYPE_CONSTANT_BUFFER);
-        RDCASSERT(dcl.operand.indices.size() == 2);
+        RDCASSERT(dcl.operand.indices.size() == 2 || dcl.operand.indices.size() == 3);
         RDCASSERT(dcl.operand.indices[0].absolute && dcl.operand.indices[1].absolute);
 
         uint32_t idx = (uint32_t)dcl.operand.indices[0].index;

--- a/renderdoc/driver/shaders/dxbc/dxbc_bytecode.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_bytecode.h
@@ -934,9 +934,10 @@ public:
 
   void SetReflection(const DXBC::Reflection *refl) { m_Reflection = refl; }
   void SetDebugInfo(const DXBC::IDebugInfo *debug) { m_DebugInfo = debug; }
-  DXBC::ShaderType GetShaderType() { return m_Type; }
-  uint32_t GetMajorVersion() { return m_Major; }
-  uint32_t GetMinorVersion() { return m_Minor; }
+  DXBC::ShaderType GetShaderType() const { return m_Type; }
+  uint32_t GetMajorVersion() const { return m_Major; }
+  uint32_t GetMinorVersion() const { return m_Minor; }
+  bool IsShaderModel51() const { return m_Major == 5 && m_Minor == 1; }
   D3D_PRIMITIVE_TOPOLOGY GetOutputTopology();
   const rdcstr &GetDisassembly()
   {
@@ -946,6 +947,7 @@ public:
   }
   size_t GetNumDeclarations() const { return m_Declarations.size(); }
   const Declaration &GetDeclaration(size_t i) const { return m_Declarations[i]; }
+  const Declaration *FindDeclaration(OperandType declType, uint32_t identifier) const;
   size_t GetNumInstructions() const { return m_Instructions.size(); }
   const Operation &GetInstruction(size_t i) const { return m_Instructions[i]; }
   const rdcarray<uint32_t> &GetImmediateConstantBuffer() const { return m_Immediate; }

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -35,6 +35,13 @@ class DXBCContainer;
 struct CBufferVariable;
 }
 
+namespace DXBCBytecode
+{
+struct Declaration;
+class Program;
+enum OperandType;
+}
+
 class WrappedID3D11Device;
 enum DXGI_FORMAT;
 
@@ -56,6 +63,12 @@ struct BindingSlot
   uint32_t shaderRegister;
   uint32_t registerSpace;
 };
+
+ShaderDebug::BindingSlot GetBindingSlotForDeclaration(const DXBCBytecode::Program &program,
+                                                      const DXBCBytecode::Declaration &decl);
+ShaderDebug::BindingSlot GetBindingSlotForIdentifier(const DXBCBytecode::Program &program,
+                                                     DXBCBytecode::OperandType declType,
+                                                     uint32_t identifier);
 
 struct GlobalState
 {
@@ -101,6 +114,7 @@ public:
     uint32_t hiddenCounter;
   };
   std::map<BindingSlot, UAVData> uavs;
+  typedef std::map<BindingSlot, UAVData>::iterator UAVIterator;
 
   struct SRVData
   {
@@ -112,6 +126,7 @@ public:
     ViewFmt format;
   };
   std::map<BindingSlot, SRVData> srvs;
+  typedef std::map<BindingSlot, SRVData>::iterator SRVIterator;
 
   struct groupsharedMem
   {

--- a/renderdoc/driver/shaders/dxbc/dxbc_disassemble.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_disassemble.cpp
@@ -2046,6 +2046,25 @@ bool Program::ExtractDecl(uint32_t *&tokenStream, Declaration &retDecl, bool fri
   return true;
 }
 
+const Declaration *Program::FindDeclaration(OperandType declType, uint32_t identifier) const
+{
+  // Given a declType and identifier (together defining a binding such as t0, s1, etc.),
+  // return the matching declaration if it exists. The logic for this is the same for all
+  // shader model versions.
+  size_t numDeclarations = m_Declarations.size();
+  for(size_t i = 0; i < numDeclarations; ++i)
+  {
+    const Declaration &decl = m_Declarations[i];
+    if(decl.operand.type == declType)
+    {
+      if(decl.operand.indices[0].index == identifier)
+        return &decl;
+    }
+  }
+
+  return NULL;
+}
+
 bool Program::ExtractOperation(uint32_t *&tokenStream, Operation &retOp, bool friendlyName)
 {
   uint32_t *begin = tokenStream;


### PR DESCRIPTION
With SM 5.1, instructions specify a resource by a logical identifier, but root signatures specify them with a base register and register space. Find the appropriate declaration and retrieve the data needed for resource lookup.