### PR TITLE
Change SRV/UAV fetching to be on-demand, when needed by an instruction

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_debug.h
+++ b/renderdoc/driver/d3d11/d3d11_debug.h
@@ -138,10 +138,6 @@ public:
 
   void PixelHistoryCopyPixel(CopyPixelParams &params, uint32_t x, uint32_t y);
 
-  void CreateShaderGlobalState(ShaderDebug::GlobalState &global, DXBC::DXBCContainer *dxbc,
-                               uint32_t UAVStartSlot, ID3D11UnorderedAccessView **UAVs,
-                               ID3D11ShaderResourceView **SRVs);
-
   struct CacheElem
   {
     CacheElem(ResourceId id_, CompType typeHint_, bool raw_)

--- a/renderdoc/driver/d3d12/d3d12_debug.h
+++ b/renderdoc/driver/d3d12/d3d12_debug.h
@@ -171,8 +171,6 @@ public:
   void CopyTex2DMSToArray(ID3D12Resource *destArray, ID3D12Resource *srcMS);
   void CopyArrayToTex2DMS(ID3D12Resource *destMS, ID3D12Resource *srcArray, UINT selectedSlice);
 
-  void CreateShaderGlobalState(ShaderDebug::GlobalState &global, DXBC::DXBCContainer *dxbc);
-
 private:
   bool CreateMathIntrinsicsResources();
 

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -218,7 +218,8 @@ void FlattenVariables(const rdcarray<ShaderConstant> &constants,
 void FillViewFmt(DXGI_FORMAT format, GlobalState::ViewFmt &viewFmt);
 
 void LookupSRVFormatFromShaderReflection(const DXBC::Reflection &reflection,
-                                         uint32_t shaderRegister, GlobalState::ViewFmt &viewFmt);
+                                         const ShaderDebug::BindingSlot &slot,
+                                         GlobalState::ViewFmt &viewFmt);
 
 void GatherPSInputDataForInitialValues(const DXBC::Reflection &psDxbc,
                                        const DXBC::Reflection &prevStageDxbc,
@@ -254,6 +255,12 @@ class DebugAPIWrapper
 public:
   virtual void SetCurrentInstruction(uint32_t instruction) = 0;
   virtual void AddDebugMessage(MessageCategory c, MessageSeverity sv, MessageSource src, rdcstr d) = 0;
+
+  // During shader debugging, when a new resource is encountered, this will be called to fetch the
+  // data on demand. Return true if the ShaderDebug::GlobalState data for the slot is populated,
+  // return false if the resource cannot be found.
+  virtual bool FetchSRV(const ShaderDebug::BindingSlot &slot) = 0;
+  virtual bool FetchUAV(const ShaderDebug::BindingSlot &slot) = 0;
 
   virtual bool CalculateMathIntrinsic(DXBCBytecode::OpcodeType opcode, const ShaderVariable &input,
                                       ShaderVariable &output1, ShaderVariable &output2) = 0;


### PR DESCRIPTION
Instead of fetching all SRVs/UAVs at the beginning of shader debugging, detect when an instruction needs a resource that hasn't been fetched yet and ask the API wrapper to do so. This will solve issues with large bindless descriptor tables with D3D12, and should generally improve debugging prep times for D3D11 as well.