### PR TITLE
Fix pixel pick value in D3D12 with a sRGB target

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -759,7 +759,7 @@ void TextureViewer::RT_FetchCurrentPixel(IReplayController *r, uint32_t x, uint3
     }
   }
 
-  realValue = r->PickPixel(id, x, y, sub, CompType::Typeless);
+  realValue = r->PickPixel(id, x, y, sub, typeCast);
 
   if(m_TexDisplay.customShaderId != ResourceId())
   {


### PR DESCRIPTION
D3D12 is provided the resource but not the view, so without the type cast info all picked colors were treated as linear color.