### PR TITLE
Change wireframe overlay to dim & draw identically to drawcall overlay

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_overlay.cpp
+++ b/renderdoc/driver/d3d11/d3d11_overlay.cpp
@@ -555,10 +555,10 @@ ResourceId D3D11Replay::RenderOverlay(ResourceId texid, CompType typeCast, Float
       }
     }
 
-    float overlayConsts[] = {200.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f, 0.0f};
-    m_pImmediateContext->ClearRenderTargetView(rtv, overlayConsts);
+    float clearColour[] = {0.0f, 0.0f, 0.0f, 0.5f};
+    m_pImmediateContext->ClearRenderTargetView(rtv, clearColour);
 
-    overlayConsts[3] = 1.0f;
+    float overlayConsts[] = {0.8f, 0.1f, 0.8f, 1.0f};
     ID3D11Buffer *buf = GetDebugManager()->MakeCBuffer(overlayConsts, sizeof(overlayConsts));
 
     m_pImmediateContext->PSSetConstantBuffers(0, 1, &buf);

--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -580,7 +580,7 @@ ResourceId D3D12Replay::RenderOverlay(ResourceId texid, CompType typeCast, Float
       D3D12_EXPANDED_PIPELINE_STATE_STREAM_DESC psoDesc;
       pipe->Fill(psoDesc);
 
-      float overlayConsts[] = {200.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f, 1.0f};
+      float overlayConsts[4] = {0.8f, 0.1f, 0.8f, 1.0f};
       ID3DBlob *ps = m_pDevice->GetShaderCache()->MakeFixedColShader(overlayConsts);
 
       psoDesc.PS.pShaderBytecode = ps->GetBufferPointer();
@@ -612,8 +612,8 @@ ResourceId D3D12Replay::RenderOverlay(ResourceId texid, CompType typeCast, Float
       psoDesc.RasterizerState.MultisampleEnable = FALSE;
       psoDesc.RasterizerState.AntialiasedLineEnable = FALSE;
 
-      overlayConsts[3] = 0.0f;
-      list->ClearRenderTargetView(rtv, overlayConsts, 0, NULL);
+      float clearColour[] = {0.0f, 0.0f, 0.0f, 0.5f};
+      list->ClearRenderTargetView(rtv, clearColour, 0, NULL);
 
       list->Close();
       list = NULL;

--- a/renderdoc/driver/gl/gl_overlay.cpp
+++ b/renderdoc/driver/gl/gl_overlay.cpp
@@ -454,11 +454,11 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, CompType typeCast, FloatVec
   }
   else if(overlay == DebugOverlay::Wireframe)
   {
-    float wireCol[] = {200.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f, 0.0f};
-    drv.glClearBufferfv(eGL_COLOR, 0, wireCol);
+    float black[] = {0.0f, 0.0f, 0.0f, 0.5f};
+    drv.glClearBufferfv(eGL_COLOR, 0, black);
 
-    wireCol[3] = 1.0f;
-    drv.glProgramUniform4fv(DebugData.overlayProg, overlayFixedColLocation, 1, wireCol);
+    float colVal[] = {0.8f, 0.1f, 0.8f, 1.0f};
+    drv.glProgramUniform4fv(DebugData.overlayProg, overlayFixedColLocation, 1, colVal);
 
     if(!IsGLES)
     {

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -658,18 +658,6 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, CompType typeCast, Floa
     float highlightCol[] = {0.8f, 0.1f, 0.8f, 1.0f};
     float bgclearCol[] = {0.0f, 0.0f, 0.0f, 0.5f};
 
-    if(overlay == DebugOverlay::Wireframe)
-    {
-      highlightCol[0] = 200 / 255.0f;
-      highlightCol[1] = 1.0f;
-      highlightCol[2] = 0.0f;
-
-      bgclearCol[0] = 200 / 255.0f;
-      bgclearCol[1] = 1.0f;
-      bgclearCol[2] = 0.0f;
-      bgclearCol[3] = 0.0f;
-    }
-
     VkImageMemoryBarrier barrier = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                     NULL,
                                     VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,


### PR DESCRIPTION
When debugging a R8G8 texture (such as a velocity buffer) that clears to "white", the wireframe overlay is not visible, as the texture appears yellow as well. This change adjusts the overlay's behavior to match the drawcall overlay - dim the texture, and draw with magenta - so that it is always visible.