### PR TITLE
Fix constant buffer lookups with SM5.1 shader debugging

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_bytecode.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_bytecode.h
@@ -754,6 +754,7 @@ struct Declaration
     resType[0] = resType[1] = resType[2] = resType[3] = DXBC::NUM_RETURN_TYPES;
     dim = RESOURCE_DIMENSION_UNKNOWN;
     sampleCount = 0;
+    float4size = 0;
     interpolation = INTERPOLATION_UNDEFINED;
     systemValue = DXBC::SVNAME_UNDEFINED;
     maxOut = 0;
@@ -827,6 +828,9 @@ struct Declaration
   DXBC::ResourceRetType resType[4];
   ResourceDimension dim;
   uint32_t sampleCount;
+
+  // OPCODE_DCL_CONSTANT_BUFFER
+  uint32_t float4size;
 
   // OPCODE_DCL_INPUT_PS
   InterpolationMode interpolation;

--- a/renderdoc/driver/shaders/dxbc/dxbc_common.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_common.h
@@ -319,6 +319,7 @@ struct CBuffer
 {
   rdcstr name;
 
+  uint32_t identifier;
   uint32_t space;
   uint32_t reg;
   uint32_t bindCount;

--- a/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
@@ -880,6 +880,10 @@ DXBCContainer::DXBCContainer(const void *ByteCode, size_t ByteCodeLength)
 
         cbuffernames.insert(cname);
 
+        // In addition to the register, store the identifier that we'll use to lookup during
+        // debugging. For SM5.1, this is the logical identifier that correlates to the CB order in
+        // the bytecode. For SM5 and earlier, it's the CB register.
+        cb.identifier = (h->targetVersion < 0x501) ? cbufferbinds[cname].reg : i;
         cb.space = cbufferbinds[cname].space;
         cb.reg = cbufferbinds[cname].reg;
         cb.bindCount = cbufferbinds[cname].bindCount;

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -365,6 +365,9 @@ private:
 
 void CreateShaderDebugStateAndTrace(ShaderDebug::State &initialState, ShaderDebugTrace &trace,
                                     int quadIdx, DXBC::DXBCContainer *dxbc,
-                                    const ShaderReflection &refl, bytebuf *cbufData);
+                                    const ShaderReflection &refl);
+void AddCBufferToDebugTrace(const DXBCBytecode::Program &program, ShaderDebugTrace &trace,
+                            const ShaderReflection &refl, const ShaderBindpointMapping &mapping,
+                            const ShaderDebug::BindingSlot &slot, bytebuf &cbufData);
 
 };    // namespace ShaderDebug

--- a/renderdoc/driver/shaders/dxbc/dxbc_disassemble.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_disassemble.cpp
@@ -1447,10 +1447,12 @@ bool Program::ExtractDecl(uint32_t *&tokenStream, Declaration &retDecl, bool fri
     retDecl.str += retDecl.operand.toString(m_Reflection, flags);
     if(sm51)
     {
-      uint32_t float4size = tokenStream[0];
+      // Store the size provided. If there's no reflection data, this will be
+      // necessary to guess the buffer size properly
+      retDecl.float4size = tokenStream[0];
       tokenStream++;
 
-      retDecl.str += StringFormat::Fmt("[%u]", float4size);
+      retDecl.str += StringFormat::Fmt("[%u]", retDecl.float4size);
     }
 
     retDecl.str += ", ";


### PR DESCRIPTION
This fixes several issues related to constant buffers that I found while capturing/debugging D3D12:

- Constant buffers were stored in a flat array, so overlapping registers with different register spaces didn't work. Adding a constant buffer to the ShaderDebugTrace now uses the ShaderBindpointMapping to convert from a register/space to the identifier used by the shader.
- Constant buffers as instruction operands differ with SM5.1 - the data lookup is shifted by one index since the shader register is also specified.
- Constant buffer declarations now store the identifier (correlated to the order presented in the bytecode) to aid finding the correct buffer.
- Without reflection info, constant buffers appeared incorrect in the pipeline state viewer with D3D12. The size in float4s is stored by the declaration so that when guessing the reflection we have the appropriate buffer size.