### PR TITLE
Improvements to the demo program

### DIFF
--- a/util/test/demos/d3d11/d3d11_test.cpp
+++ b/util/test/demos/d3d11/d3d11_test.cpp
@@ -132,7 +132,7 @@ void D3D11GraphicsTest::Prepare(int argc, char **argv)
   }
 }
 
-bool D3D11GraphicsTest::Init()
+bool D3D11GraphicsTest::Init(IDXGIAdapterPtr pAdapter)
 {
   if(!GraphicsTest::Init())
     return false;
@@ -148,7 +148,10 @@ bool D3D11GraphicsTest::Init()
 
   if(headless)
   {
-    hr = CreateDevice(adapters, NULL, features, flags);
+    if(pAdapter != NULL)
+      hr = CreateDevice({pAdapter}, NULL, features, flags);
+    else
+      hr = CreateDevice(adapters, NULL, features, flags);
 
     if(FAILED(hr))
     {
@@ -179,7 +182,10 @@ bool D3D11GraphicsTest::Init()
   swapDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
   swapDesc.Flags = 0;
 
-  hr = CreateDevice(adapters, &swapDesc, features, flags);
+  if(pAdapter != NULL)
+    hr = CreateDevice({pAdapter}, &swapDesc, features, flags);
+  else
+    hr = CreateDevice(adapters, &swapDesc, features, flags);
 
   if(FAILED(hr))
   {
@@ -216,7 +222,7 @@ GraphicsWindow *D3D11GraphicsTest::MakeWindow(int width, int height, const char 
   return new Win32Window(width, height, title);
 }
 
-HRESULT D3D11GraphicsTest::CreateDevice(std::vector<IDXGIAdapterPtr> &adaptersToTry,
+HRESULT D3D11GraphicsTest::CreateDevice(const std::vector<IDXGIAdapterPtr> &adaptersToTry,
                                         DXGI_SWAP_CHAIN_DESC *swapDesc, D3D_FEATURE_LEVEL *features,
                                         UINT flags)
 {

--- a/util/test/demos/d3d11/d3d11_test.h
+++ b/util/test/demos/d3d11/d3d11_test.h
@@ -46,12 +46,12 @@ struct D3D11GraphicsTest : public GraphicsTest
   static const TestAPI API = TestAPI::D3D11;
 
   void Prepare(int argc, char **argv);
-  bool Init();
+  bool Init(IDXGIAdapterPtr pAdapter = NULL);
   void Shutdown();
   GraphicsWindow *MakeWindow(int width, int height, const char *title);
 
-  HRESULT CreateDevice(std::vector<IDXGIAdapterPtr> &adaptersToTry, DXGI_SWAP_CHAIN_DESC *swapDesc,
-                       D3D_FEATURE_LEVEL *features, UINT flags);
+  HRESULT CreateDevice(const std::vector<IDXGIAdapterPtr> &adaptersToTry,
+                       DXGI_SWAP_CHAIN_DESC *swapDesc, D3D_FEATURE_LEVEL *features, UINT flags);
   void PostDeviceCreate();
 
   enum BufType

--- a/util/test/demos/d3d11/d3d11_test.h
+++ b/util/test/demos/d3d11/d3d11_test.h
@@ -50,6 +50,8 @@ struct D3D11GraphicsTest : public GraphicsTest
   void Shutdown();
   GraphicsWindow *MakeWindow(int width, int height, const char *title);
 
+  HRESULT CreateDevice(std::vector<IDXGIAdapterPtr> &adaptersToTry, DXGI_SWAP_CHAIN_DESC *swapDesc,
+                       D3D_FEATURE_LEVEL *features, UINT flags);
   void PostDeviceCreate();
 
   enum BufType

--- a/util/test/demos/d3d12/d3d12_sharing.cpp
+++ b/util/test/demos/d3d12/d3d12_sharing.cpp
@@ -62,11 +62,13 @@ RD_TEST(D3D12_Sharing, D3D12GraphicsTest)
 
       IDXGIAdapterPtr pDXGIAdapter;
       HRESULT hr = EnumAdapterByLuid(dev->GetAdapterLuid(), pDXGIAdapter);
+      std::vector<IDXGIAdapterPtr> adapters;
+      adapters.push_back(pDXGIAdapter);
 
       if(FAILED(hr))
         return 2;
 
-      dev2 = CreateDevice(pDXGIAdapter);
+      dev2 = CreateDevice(adapters, D3D_FEATURE_LEVEL_11_0);
 
       if(!dev2)
         return 2;

--- a/util/test/demos/d3d12/d3d12_test.cpp
+++ b/util/test/demos/d3d12/d3d12_test.cpp
@@ -425,7 +425,7 @@ HRESULT D3D12GraphicsTest::EnumAdapterByLuid(LUID luid, IDXGIAdapterPtr &pAdapte
   return E_FAIL;
 }
 
-ID3D12DevicePtr D3D12GraphicsTest::CreateDevice(std::vector<IDXGIAdapterPtr> &adaptersToTry,
+ID3D12DevicePtr D3D12GraphicsTest::CreateDevice(const std::vector<IDXGIAdapterPtr> &adaptersToTry,
                                                 D3D_FEATURE_LEVEL features)
 {
   HRESULT hr = S_OK;

--- a/util/test/demos/d3d12/d3d12_test.h
+++ b/util/test/demos/d3d12/d3d12_test.h
@@ -52,7 +52,7 @@ struct D3D12GraphicsTest : public GraphicsTest
   GraphicsWindow *MakeWindow(int width, int height, const char *title);
 
   HRESULT EnumAdapterByLuid(LUID luid, IDXGIAdapterPtr &pAdapter);
-  ID3D12DevicePtr CreateDevice(std::vector<IDXGIAdapterPtr> &adaptersToTry,
+  ID3D12DevicePtr CreateDevice(const std::vector<IDXGIAdapterPtr> &adaptersToTry,
                                D3D_FEATURE_LEVEL features);
 
   enum BufType

--- a/util/test/demos/d3d12/d3d12_test.h
+++ b/util/test/demos/d3d12/d3d12_test.h
@@ -52,7 +52,8 @@ struct D3D12GraphicsTest : public GraphicsTest
   GraphicsWindow *MakeWindow(int width, int height, const char *title);
 
   HRESULT EnumAdapterByLuid(LUID luid, IDXGIAdapterPtr &pAdapter);
-  ID3D12DevicePtr CreateDevice(IDXGIAdapterPtr adapter);
+  ID3D12DevicePtr CreateDevice(std::vector<IDXGIAdapterPtr> &adaptersToTry,
+                               D3D_FEATURE_LEVEL features);
 
   enum BufType
   {

--- a/util/test/demos/dx/d3d_helpers.h
+++ b/util/test/demos/dx/d3d_helpers.h
@@ -26,6 +26,7 @@
 
 #include <comdef.h>
 #include <string>
+#include <vector>
 #include "dx/official/dxgi1_4.h"
 
 extern std::string D3DFullscreenQuadVertex;
@@ -43,7 +44,8 @@ COM_SMARTPTR(IDXGIAdapter);
 COM_SMARTPTR(IDXGISurface);
 COM_SMARTPTR(IDXGIResource);
 
-IDXGIAdapterPtr ChooseD3DAdapter(IDXGIFactoryPtr factory, int argc, char **argv, bool &warp);
+std::vector<IDXGIAdapterPtr> FindD3DAdapters(IDXGIFactoryPtr factory, int argc, char **argv,
+                                             bool &warp);
 
 enum class ResourceType
 {


### PR DESCRIPTION
- On laptops with integrated+discrete adapters, adapter 0 may not support D3D12, so a default create device call will fail. Loop through adapters until one succeeds, allowing for overriding with a specific adapter or warp.
- The D3D12 sharing test crashes if the D3D11 adapter doesn't support D3D12. Pass in a specific adapter to use for D3D11, by giving the one that the D3D12 device was created with.
- Fix a memory leak in the D3D12 sharing test.
- Made the UI's API filters inclusive, so that if any are checked, only the selected ones are shown. If none are selected, then all tests are shown as before.
- Moved the test name filter to the UI's top pane, so that it is always visible - before if you scrolled down in the test list, it would be hidden.
- Added more room for test descriptions in the UI's bottom pane - long descriptions were previously truncated.
