### PR TITLE
Support launching android services 

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -1126,9 +1126,9 @@ ExecuteResult AndroidRemoteServer::ExecuteAndInject(const char *a, const char *w
       RDCLOG("Launching APK with no debugger or direct injection.");
 
       // start the activity in this package with debugging enabled and force-stop after starting
-      Android::adbExecCommand(m_deviceID,
-                              StringFormat::Fmt("shell am start -n %s/%s %s", packageName.c_str(),
-                                                activityName.c_str(), intentArgs.c_str()));
+      Android::adbExecCommand(
+          m_deviceID, StringFormat::Fmt("shell am start -S -n %s/%s %s", packageName.c_str(),
+                                        activityName.c_str(), intentArgs.c_str()));
 
       // don't connect JDWP
       jdwpPort = 0;


### PR DESCRIPTION
## Description
Grepping for the package name fails to find the correct process for activities that set `android:process`; use resolve-activity to get the correct name.

-S is necessary to force-stop the processes even on Android 10 at launch time, given that it might be restarted automatically after the force-stop but before the GPU layers get set.
