### PR TITLE
Add missing includes for gcc/libsdc++ 10

### DIFF
--- a/renderdoc/common/dds_readwrite.h
+++ b/renderdoc/common/dds_readwrite.h
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include "api/replay/data_types.h"
+#include <cstdio>
 
 struct dds_data
 {

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <cstdio>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/renderdoc/strings/utf8printf.cpp
+++ b/renderdoc/strings/utf8printf.cpp
@@ -25,6 +25,7 @@
 #include <wchar.h>
 #include "common/common.h"
 #include "os/os_specific.h"
+#include <cwchar>
 
 // grisu2 double-to-string function, returns number of digits written to digits array
 int grisu2(uint64_t mantissa, int exponent, char digits[18], int &kout);


### PR DESCRIPTION
When compiling with gcc & libstdc++ version 10, <cstdio> needs to be explicitly included for 'FILE', <cwchar> for 'wcslen'.

This plus commit 29403836c60fd8d61325e9972d3a56d8b0ff0178 fix #1712 
