### PR TITLE
Option to force stop existing remote targets

### DIFF
--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -559,11 +559,15 @@ void MainWindow::OnCaptureTrigger(const QString &exe, const QString &workingDir,
 
     if(isUnshareableDeviceInUse())
     {
-      RDDialog::warning(this, tr("RenderDoc is already capturing an app on this device"),
-                        tr("A running app on this device is already being captured with RenderDoc. "
-                           "First please close the app then try to launch again."),
-                        QMessageBox::Ok);
-      return;
+      QMessageBox::StandardButton result = RDDialog::warning(
+          this, tr("RenderDoc is already capturing an app on this device"),
+          tr("A running app on this device is already being captured with RenderDoc. "
+             "Proceeding will terminate this app."),
+          QMessageBox::Ok | QMessageBox::Cancel);
+      if(result == QMessageBox::Cancel)
+      {
+        return;
+      }
     }
 
     QString capturefile = m_Ctx.TempCaptureFilename(QFileInfo(exe).baseName());

--- a/renderdoc/android/android.h
+++ b/renderdoc/android/android.h
@@ -36,6 +36,7 @@ void ResetCaptureSettings(const rdcstr &deviceID);
 void ExtractDeviceIDAndIndex(const rdcstr &hostname, int &index, rdcstr &deviceID);
 Process::ProcessResult adbExecCommand(const rdcstr &deviceID, const rdcstr &args,
                                       const rdcstr &workDir = ".", bool silent = false);
+void ForceStopAllRemoteTargets(const rdcstr &protocolName, const rdcstr &deviceID);
 void initAdb();
 void shutdownAdb();
 bool InjectWithJDWP(const rdcstr &deviceID, uint16_t jdwpport);


### PR DESCRIPTION
Prompt to force stop existing remote targets when launching an app

## Description

When attempting to launch a new process on the device, instead of informing the user that they need to manually close an existing renderdoc target, this change prompts the user asking if they would like to terminate the running app. If accepted renderdoc will then automatically for close those apps when running ExecuteAndInject().