### PR TITLE
Add APIProperties for debugging and pixel history

### DIFF
--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -2200,7 +2200,7 @@ void BufferViewer::stageRowMenu(MeshDataStage stage, QMenu *menu, const QPoint &
 
   menu->clear();
 
-  if(m_MeshView && stage != MeshDataStage::GSOut && m_Ctx.CurPipelineState().IsCaptureD3D11())
+  if(m_MeshView && stage != MeshDataStage::GSOut && m_Ctx.APIProps().shaderDebugging)
   {
     menu->addAction(m_DebugVert);
     menu->addSeparator();

--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -486,9 +486,8 @@ void TextureViewer::UI_UpdateCachedTexture()
 
   m_CachedTexture = m_Ctx.GetTexture(id);
 
-  ui->debugPixelContext->setEnabled(m_Ctx.CurPipelineState().IsCaptureD3D11() &&
-                                    m_CachedTexture != NULL);
-  ui->pixelHistory->setEnabled(m_Ctx.CurPipelineState().IsCaptureD3D11() && m_CachedTexture != NULL);
+  ui->debugPixelContext->setEnabled(m_Ctx.APIProps().shaderDebugging && m_CachedTexture != NULL);
+  ui->pixelHistory->setEnabled(m_Ctx.APIProps().pixelHistory && m_CachedTexture != NULL);
 }
 
 TextureViewer::TextureViewer(ICaptureContext &ctx, QWidget *parent)
@@ -2767,7 +2766,7 @@ void TextureViewer::OnCaptureLoaded()
   ui->locationGoto->setEnabled(true);
   ui->viewTexBuffer->setEnabled(true);
 
-  if(m_Ctx.CurPipelineState().IsCaptureD3D11())
+  if(m_Ctx.APIProps().pixelHistory)
   {
     ui->pixelHistory->setEnabled(true);
     ui->pixelHistory->setToolTip(QString());
@@ -2778,7 +2777,7 @@ void TextureViewer::OnCaptureLoaded()
     ui->pixelHistory->setToolTip(tr("Pixel History not implemented on this API"));
   }
 
-  if(m_Ctx.CurPipelineState().IsCaptureD3D11())
+  if(m_Ctx.APIProps().shaderDebugging)
   {
     ui->debugPixelContext->setEnabled(true);
     ui->debugPixelContext->setToolTip(QString());

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -1423,6 +1423,12 @@ worked around by re-sorting bindings.
 )");
   bool shadersMutable = false;
 
+  DOCUMENT("(``True`` if the API supports shader debugging.");
+  bool shaderDebugging = false;
+
+  DOCUMENT("(``True`` if the API supports viewing pixel history.");
+  bool pixelHistory = false;
+
   DOCUMENT("``True`` if the driver and system are configured to allow creating RGP captures.");
   bool rgpCapture = false;
 

--- a/renderdoc/driver/d3d11/d3d11_replay.cpp
+++ b/renderdoc/driver/d3d11/d3d11_replay.cpp
@@ -561,6 +561,8 @@ APIProperties D3D11Replay::GetAPIProperties()
   ret.vendor = m_DriverInfo.vendor;
   ret.degraded = m_WARP;
   ret.shadersMutable = false;
+  ret.shaderDebugging = true;
+  ret.pixelHistory = true;
 
   return ret;
 }

--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -32,6 +32,7 @@
 #include "maths/formatpacking.h"
 #include "maths/matrix.h"
 #include "serialise/rdcfile.h"
+#include "strings/string_utils.h"
 #include "d3d12_command_queue.h"
 #include "d3d12_debug.h"
 #include "d3d12_device.h"
@@ -270,6 +271,11 @@ APIProperties D3D12Replay::GetAPIProperties()
   ret.shadersMutable = false;
   ret.rgpCapture =
       m_DriverInfo.vendor == GPUVendor::AMD && m_RGP != NULL && m_RGP->DriverSupportsInterop();
+
+  // Enable shader debugging if specified in the config
+  rdcstr setting = strlower(RenderDoc::Inst().GetConfigSetting("d3d12ShaderDebugging"));
+  if(!strcmp(setting.c_str(), "true") || setting == "1")
+    ret.shaderDebugging = true;
 
   return ret;
 }

--- a/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
@@ -30,9 +30,6 @@
 #include "d3d12_resources.h"
 #include "d3d12_shader_cache.h"
 
-#define D3D12SHADERDEBUG_PIXEL 0
-#define D3D12SHADERDEBUG_THREAD 0
-
 struct DebugHit
 {
   uint32_t numHits;
@@ -1144,20 +1141,15 @@ ShaderDebugTrace *D3D12Replay::DebugVertex(uint32_t eventId, uint32_t vertid, ui
   return new ShaderDebugTrace();
 }
 
-#if D3D12SHADERDEBUG_PIXEL == 0
-
 ShaderDebugTrace *D3D12Replay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
                                           uint32_t primitive)
 {
-  RDCUNIMPLEMENTED("Pixel debugging not yet implemented for D3D12");
-  return new ShaderDebugTrace();
-}
+  if(!GetAPIProperties().shaderDebugging)
+  {
+    RDCUNIMPLEMENTED("Pixel debugging not yet implemented for D3D12");
+    return new ShaderDebugTrace();
+  }
 
-#else
-
-ShaderDebugTrace *D3D12Replay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                          uint32_t primitive)
-{
   using namespace DXBC;
   using namespace DXBCBytecode;
   using namespace DXBCDebug;
@@ -1669,22 +1661,15 @@ void ExtractInputsPS(PSInput IN, float4 debug_pixelPos : SV_Position, uint prim 
   return ret;
 }
 
-#endif    // D3D12SHADERDEBUG_PIXEL
-
-#if D3D12SHADERDEBUG_THREAD == 0
-
 ShaderDebugTrace *D3D12Replay::DebugThread(uint32_t eventId, const uint32_t groupid[3],
                                            const uint32_t threadid[3])
 {
-  RDCUNIMPLEMENTED("Compute shader debugging not yet implemented for D3D12");
-  return new ShaderDebugTrace();
-}
+  if(!GetAPIProperties().shaderDebugging)
+  {
+    RDCUNIMPLEMENTED("Compute shader debugging not yet implemented for D3D12");
+    return new ShaderDebugTrace();
+  }
 
-#else
-
-ShaderDebugTrace *D3D12Replay::DebugThread(uint32_t eventId, const uint32_t groupid[3],
-                                           const uint32_t threadid[3])
-{
   using namespace DXBCBytecode;
   using namespace DXBCDebug;
 
@@ -1788,8 +1773,6 @@ ShaderDebugTrace *D3D12Replay::DebugThread(uint32_t eventId, const uint32_t grou
 
   return ret;
 }
-
-#endif    // D3D12SHADERDEBUG_THREAD
 
 rdcarray<ShaderDebugState> D3D12Replay::ContinueDebug(ShaderDebugger *debugger)
 {

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -486,13 +486,16 @@ void DoSerialise(SerialiserType &ser, APIProperties &el)
   SERIALISE_MEMBER(degraded);
   SERIALISE_MEMBER(shadersMutable);
 
+  SERIALISE_MEMBER(shaderDebugging);
+  SERIALISE_MEMBER(pixelHistory);
+
   SERIALISE_MEMBER(ShaderLinkage);
   SERIALISE_MEMBER(YUVTextures);
   SERIALISE_MEMBER(SparseResources);
   SERIALISE_MEMBER(MultiGPU);
   SERIALISE_MEMBER(D3D12Bundle);
 
-  SIZE_CHECK(20);
+  SIZE_CHECK(24);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
Checks to enable debugging and pixel history are gated by the APIProperties instead of whether the capture is D3D11. Shader debugging for D3D12 is gated on a config option, which can be enabled by adding "d3d12ShaderDebugging": "true" to the ConfigSettings