### PR TITLE
Migrate DebugAPIWrapper resource info functions to binding slots

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
+++ b/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
@@ -65,11 +65,12 @@ public:
   bool CalculateMathIntrinsic(DXBCBytecode::OpcodeType opcode, const ShaderVariable &input,
                               ShaderVariable &output1, ShaderVariable &output2);
 
-  ShaderVariable GetSampleInfo(DXBCBytecode::OperandType type, bool isAbsoluteResource, UINT slot,
+  ShaderVariable GetSampleInfo(DXBCBytecode::OperandType type, bool isAbsoluteResource,
+                               const DXBCDebug::BindingSlot &slot, const char *opString);
+  ShaderVariable GetBufferInfo(DXBCBytecode::OperandType type, const DXBCDebug::BindingSlot &slot,
                                const char *opString);
-  ShaderVariable GetBufferInfo(DXBCBytecode::OperandType type, UINT slot, const char *opString);
-  ShaderVariable GetResourceInfo(DXBCBytecode::OperandType type, UINT slot, uint32_t mipLevel,
-                                 int &dim);
+  ShaderVariable GetResourceInfo(DXBCBytecode::OperandType type, const DXBCDebug::BindingSlot &slot,
+                                 uint32_t mipLevel, int &dim);
 
   bool CalculateSampleGather(DXBCBytecode::OpcodeType opcode,
                              DXBCDebug::SampleGatherResourceData resourceData,
@@ -396,7 +397,8 @@ bool D3D11DebugAPIWrapper::FetchUAV(const DXBCDebug::BindingSlot &slot)
 }
 
 ShaderVariable D3D11DebugAPIWrapper::GetSampleInfo(DXBCBytecode::OperandType type,
-                                                   bool isAbsoluteResource, UINT slot,
+                                                   bool isAbsoluteResource,
+                                                   const DXBCDebug::BindingSlot &slot,
                                                    const char *opString)
 {
   ID3D11DeviceContext *context = NULL;
@@ -450,12 +452,24 @@ ShaderVariable D3D11DebugAPIWrapper::GetSampleInfo(DXBCBytecode::OperandType typ
     ID3D11ShaderResourceView *srv = NULL;
     switch(GetShaderType())
     {
-      case DXBC::ShaderType::Vertex: context->VSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Hull: context->HSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Domain: context->DSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Geometry: context->GSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Pixel: context->PSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Compute: context->CSGetShaderResources(slot, 1, &srv); break;
+      case DXBC::ShaderType::Vertex:
+        context->VSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Hull:
+        context->HSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Domain:
+        context->DSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Geometry:
+        context->GSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Pixel:
+        context->PSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Compute:
+        context->CSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
       default: RDCERR("Unhandled shader type %d", GetShaderType()); break;
     }
 
@@ -518,7 +532,8 @@ ShaderVariable D3D11DebugAPIWrapper::GetSampleInfo(DXBCBytecode::OperandType typ
   return result;
 }
 
-ShaderVariable D3D11DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType type, UINT slot,
+ShaderVariable D3D11DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType type,
+                                                   const DXBCDebug::BindingSlot &slot,
                                                    const char *opString)
 {
   ID3D11DeviceContext *context = NULL;
@@ -530,9 +545,9 @@ ShaderVariable D3D11DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType typ
   {
     ID3D11UnorderedAccessView *uav = NULL;
     if(GetShaderType() == DXBC::ShaderType::Compute)
-      context->CSGetUnorderedAccessViews(slot, 1, &uav);
+      context->CSGetUnorderedAccessViews(slot.shaderRegister, 1, &uav);
     else
-      context->OMGetRenderTargetsAndUnorderedAccessViews(0, NULL, NULL, slot, 1, &uav);
+      context->OMGetRenderTargetsAndUnorderedAccessViews(0, NULL, NULL, slot.shaderRegister, 1, &uav);
 
     if(uav)
     {
@@ -572,12 +587,24 @@ ShaderVariable D3D11DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType typ
     ID3D11ShaderResourceView *srv = NULL;
     switch(GetShaderType())
     {
-      case DXBC::ShaderType::Vertex: context->VSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Hull: context->HSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Domain: context->DSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Geometry: context->GSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Pixel: context->PSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Compute: context->CSGetShaderResources(slot, 1, &srv); break;
+      case DXBC::ShaderType::Vertex:
+        context->VSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Hull:
+        context->HSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Domain:
+        context->DSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Geometry:
+        context->GSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Pixel:
+        context->PSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Compute:
+        context->CSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
       default: RDCERR("Unhandled shader type %d", GetShaderType()); break;
     }
 
@@ -624,7 +651,8 @@ ShaderVariable D3D11DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType typ
   return result;
 }
 
-ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType type, UINT slot,
+ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType type,
+                                                     const DXBCDebug::BindingSlot &slot,
                                                      uint32_t mipLevel, int &dim)
 {
   ID3D11DeviceContext *context = NULL;
@@ -637,12 +665,24 @@ ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType t
     ID3D11ShaderResourceView *srv = NULL;
     switch(GetShaderType())
     {
-      case DXBC::ShaderType::Vertex: context->VSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Hull: context->HSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Domain: context->DSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Geometry: context->GSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Pixel: context->PSGetShaderResources(slot, 1, &srv); break;
-      case DXBC::ShaderType::Compute: context->CSGetShaderResources(slot, 1, &srv); break;
+      case DXBC::ShaderType::Vertex:
+        context->VSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Hull:
+        context->HSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Domain:
+        context->DSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Geometry:
+        context->GSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Pixel:
+        context->PSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
+      case DXBC::ShaderType::Compute:
+        context->CSGetShaderResources(slot.shaderRegister, 1, &srv);
+        break;
       default: RDCERR("Unhandled shader type %d", GetShaderType()); break;
     }
 
@@ -810,13 +850,13 @@ ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType t
     ID3D11UnorderedAccessView *uav = NULL;
     if(GetShaderType() == DXBC::ShaderType::Compute)
     {
-      context->CSGetUnorderedAccessViews(slot, 1, &uav);
+      context->CSGetUnorderedAccessViews(slot.shaderRegister, 1, &uav);
     }
     else
     {
       ID3D11RenderTargetView *rtvs[8] = {0};
       ID3D11DepthStencilView *dsv = NULL;
-      context->OMGetRenderTargetsAndUnorderedAccessViews(0, rtvs, &dsv, slot, 1, &uav);
+      context->OMGetRenderTargetsAndUnorderedAccessViews(0, rtvs, &dsv, slot.shaderRegister, 1, &uav);
 
       for(int i = 0; i < 8; i++)
         SAFE_RELEASE(rtvs[i]);

--- a/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
@@ -73,12 +73,12 @@ public:
   bool CalculateMathIntrinsic(DXBCBytecode::OpcodeType opcode, const ShaderVariable &input,
                               ShaderVariable &output1, ShaderVariable &output2);
 
-  ShaderVariable GetSampleInfo(DXBCBytecode::OperandType type, bool isAbsoluteResource, UINT slot,
+  ShaderVariable GetSampleInfo(DXBCBytecode::OperandType type, bool isAbsoluteResource,
+                               const DXBCDebug::BindingSlot &slot, const char *opString);
+  ShaderVariable GetBufferInfo(DXBCBytecode::OperandType type, const DXBCDebug::BindingSlot &slot,
                                const char *opString);
-
-  ShaderVariable GetBufferInfo(DXBCBytecode::OperandType type, UINT slot, const char *opString);
-  ShaderVariable GetResourceInfo(DXBCBytecode::OperandType type, UINT slot, uint32_t mipLevel,
-                                 int &dim);
+  ShaderVariable GetResourceInfo(DXBCBytecode::OperandType type, const DXBCDebug::BindingSlot &slot,
+                                 uint32_t mipLevel, int &dim);
 
   bool CalculateSampleGather(DXBCBytecode::OpcodeType opcode,
                              DXBCDebug::SampleGatherResourceData resourceData,
@@ -457,7 +457,8 @@ bool D3D12DebugAPIWrapper::CalculateMathIntrinsic(DXBCBytecode::OpcodeType opcod
 }
 
 ShaderVariable D3D12DebugAPIWrapper::GetSampleInfo(DXBCBytecode::OperandType type,
-                                                   bool isAbsoluteResource, UINT slot,
+                                                   bool isAbsoluteResource,
+                                                   const DXBCDebug::BindingSlot &slot,
                                                    const char *opString)
 {
   RDCUNIMPLEMENTED("GetSampleInfo not yet implemented for D3D12");
@@ -465,7 +466,8 @@ ShaderVariable D3D12DebugAPIWrapper::GetSampleInfo(DXBCBytecode::OperandType typ
   return result;
 }
 
-ShaderVariable D3D12DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType type, UINT slot,
+ShaderVariable D3D12DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType type,
+                                                   const DXBCDebug::BindingSlot &slot,
                                                    const char *opString)
 {
   RDCUNIMPLEMENTED("GetBufferInfo not yet implemented for D3D12");
@@ -473,7 +475,8 @@ ShaderVariable D3D12DebugAPIWrapper::GetBufferInfo(DXBCBytecode::OperandType typ
   return result;
 }
 
-ShaderVariable D3D12DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType type, UINT slot,
+ShaderVariable D3D12DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType type,
+                                                     const DXBCDebug::BindingSlot &slot,
                                                      uint32_t mipLevel, int &dim)
 {
   RDCUNIMPLEMENTED("GetResourceInfo not yet implemented for D3D12");

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
@@ -3359,10 +3359,12 @@ void ThreadState::StepNext(ShaderDebugState *state, DebugAPIWrapper *apiWrapper,
     case OPCODE_SAMPLE_INFO:
     case OPCODE_SAMPLE_POS:
     {
+      size_t numIndices = program->IsShaderModel51() ? 2 : 1;
       bool isAbsoluteResource =
-          (op.operands[1].indices.size() == 1 && op.operands[1].indices[0].absolute &&
+          (op.operands[1].indices.size() == numIndices && op.operands[1].indices[0].absolute &&
            !op.operands[1].indices[0].relative);
-      UINT slot = (UINT)(op.operands[1].indices[0].index & 0xffffffff);
+      UINT identifier = (UINT)(op.operands[1].indices[0].index & 0xffffffff);
+      BindingSlot slot = GetBindingSlotForIdentifier(*program, op.operands[1].type, identifier);
       ShaderVariable result =
           apiWrapper->GetSampleInfo(op.operands[1].type, isAbsoluteResource, slot, op.str.c_str());
 
@@ -3509,10 +3511,12 @@ void ThreadState::StepNext(ShaderDebugState *state, DebugAPIWrapper *apiWrapper,
 
     case OPCODE_BUFINFO:
     {
-      if(op.operands[1].indices.size() == 1 && op.operands[1].indices[0].absolute &&
+      size_t numIndices = program->IsShaderModel51() ? 2 : 1;
+      if(op.operands[1].indices.size() == numIndices && op.operands[1].indices[0].absolute &&
          !op.operands[1].indices[0].relative)
       {
-        UINT slot = (UINT)(op.operands[1].indices[0].index & 0xffffffff);
+        UINT identifier = (UINT)(op.operands[1].indices[0].index & 0xffffffff);
+        BindingSlot slot = GetBindingSlotForIdentifier(*program, op.operands[1].type, identifier);
         ShaderVariable result = apiWrapper->GetBufferInfo(op.operands[1].type, slot, op.str.c_str());
 
         // apply swizzle
@@ -3552,11 +3556,13 @@ void ThreadState::StepNext(ShaderDebugState *state, DebugAPIWrapper *apiWrapper,
       // spec says "srcMipLevel is read as an unsigned integer scalar"
       uint32_t mipLevel = srcOpers[0].value.u.x;
 
-      if(op.operands[2].indices.size() == 1 && op.operands[2].indices[0].absolute &&
+      size_t numIndices = program->IsShaderModel51() ? 2 : 1;
+      if(op.operands[2].indices.size() == numIndices && op.operands[2].indices[0].absolute &&
          !op.operands[2].indices[0].relative)
       {
         int dim = 0;
-        UINT slot = (UINT)(op.operands[2].indices[0].index & 0xffffffff);
+        UINT identifier = (UINT)(op.operands[2].indices[0].index & 0xffffffff);
+        BindingSlot slot = GetBindingSlotForIdentifier(*program, op.operands[2].type, identifier);
         ShaderVariable result = apiWrapper->GetResourceInfo(op.operands[2].type, slot, mipLevel, dim);
 
         // need a valid dimension even if the resource was unbound, so

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -252,11 +252,11 @@ public:
                                       ShaderVariable &output1, ShaderVariable &output2) = 0;
 
   virtual ShaderVariable GetSampleInfo(DXBCBytecode::OperandType type, bool isAbsoluteResource,
-                                       UINT slot, const char *opString) = 0;
+                                       const BindingSlot &slot, const char *opString) = 0;
 
-  virtual ShaderVariable GetBufferInfo(DXBCBytecode::OperandType type, UINT slot,
+  virtual ShaderVariable GetBufferInfo(DXBCBytecode::OperandType type, const BindingSlot &slot,
                                        const char *opString) = 0;
-  virtual ShaderVariable GetResourceInfo(DXBCBytecode::OperandType type, UINT slot,
+  virtual ShaderVariable GetResourceInfo(DXBCBytecode::OperandType type, const BindingSlot &slot,
                                          uint32_t mipLevel, int &dim) = 0;
 
   virtual bool CalculateSampleGather(DXBCBytecode::OpcodeType opcode,


### PR DESCRIPTION
With SM5.1, the operand for instructions like resinfo provide two indices - the logical identifier and the shader register. Fixup the logic and convert the identifier to binding slot.