### PR TITLE
Add impls of GetBuffer/ResourceInfo for D3D12 shader debugging

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
+++ b/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
@@ -696,12 +696,7 @@ ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType t
         case D3D11_SRV_DIMENSION_UNKNOWN:
         case D3D11_SRV_DIMENSION_BUFFER:
         {
-          dim = 1;
-
-          result.value.u.x = srvDesc.Buffer.NumElements;
-          result.value.u.y = 0;
-          result.value.u.z = 0;
-          result.value.u.w = 0;
+          RDCWARN("Invalid view dimension for GetResourceInfo");
           break;
         }
         case D3D11_SRV_DIMENSION_BUFFEREX:
@@ -819,7 +814,7 @@ ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType t
 
           if(tex)
           {
-            bool isarray = srvDesc.ViewDimension == D3D11_SRV_DIMENSION_TEXTURE1DARRAY;
+            bool isarray = srvDesc.ViewDimension == D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
 
             D3D11_TEXTURE2D_DESC desc;
             tex->GetDesc(&desc);
@@ -873,22 +868,7 @@ ShaderVariable D3D11DebugAPIWrapper::GetResourceInfo(DXBCBytecode::OperandType t
         case D3D11_UAV_DIMENSION_UNKNOWN:
         case D3D11_UAV_DIMENSION_BUFFER:
         {
-          ID3D11Buffer *buf = NULL;
-          uav->GetResource((ID3D11Resource **)&buf);
-
-          dim = 1;
-
-          if(buf)
-          {
-            D3D11_BUFFER_DESC desc;
-            buf->GetDesc(&desc);
-            result.value.u.x = desc.ByteWidth;
-            result.value.u.y = 0;
-            result.value.u.z = 0;
-            result.value.u.w = 0;
-
-            SAFE_RELEASE(buf);
-          }
+          RDCWARN("Invalid view dimension for GetResourceInfo");
           break;
         }
         case D3D11_UAV_DIMENSION_TEXTURE1D:

--- a/util/test/demos/d3d11/d3d11_shader_debug_zoo.cpp
+++ b/util/test/demos/d3d11/d3d11_shader_debug_zoo.cpp
@@ -550,6 +550,12 @@ float4 main(v2f IN) : SV_Target0
     dimtex.GetDimensions(z+10, width, height, numLevels);
     return float4(max(1,width), max(1,height), numLevels, 0.0f);
   }
+  if(IN.tri == 62)
+  {
+    uint width = 0;
+    test.GetDimensions(width);
+    return float4(max(1,width), 0.0f, 0.0f, 0.0f);
+  }
 
   return float4(0.4f, 0.4f, 0.4f, 0.4f);
 }

--- a/util/test/demos/d3d12/d3d12_shader_debug_zoo.cpp
+++ b/util/test/demos/d3d12/d3d12_shader_debug_zoo.cpp
@@ -566,6 +566,12 @@ float4 main(v2f IN) : SV_Target0
     dimtex.GetDimensions(z+10, width, height, numLevels);
     return float4(max(1,width), max(1,height), numLevels, 0.0f);
   }
+  if(IN.tri == 62)
+  {
+    uint width = 0;
+    test.GetDimensions(width);
+    return float4(max(1,width), 0.0f, 0.0f, 0.0f);
+  }
 
   return float4(0.4f, 0.4f, 0.4f, 0.4f);
 }
@@ -662,7 +668,7 @@ float4 main(v2f IN) : SV_Target0
     MakeSRV(srvBuf).Format(DXGI_FORMAT_R32_FLOAT).CreateGPU(0);
 
     ID3D12ResourcePtr testTex = MakeTexture(DXGI_FORMAT_R32G32B32A32_FLOAT, 16, 16).Mips(3);
-    MakeSRV(testTex).CreateGPU(3);
+    MakeSRV(testTex).NumMips(3).CreateGPU(3);
 
     ID3D12ResourcePtr rawBuf = MakeBuffer().Data(testdata);
     MakeSRV(rawBuf)


### PR DESCRIPTION
This traverses the root signature to find the buffer/resource and report the desired data. On reading the shader asm docs, "srcResource must be a t# or u# register that is not a Buffer, but is a Texture". As such, for both D3D11 and D3D12, a warning is emitted if GetResourceInfo finds a buffer view in the requested slot.