### PR TITLE
Record MemRefs for every VkDeviceMemory

### DIFF
--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -425,6 +425,8 @@ public:
   void MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSize start, VkDeviceSize end,
                                  FrameRefType refType);
   void AddMemoryFrameRefs(ResourceId mem);
+  void AddDeviceMemory(ResourceId mem);
+  void RemoveDeviceMemory(ResourceId mem);
 
   void MergeReferencedMemory(std::map<ResourceId, MemRefs> &memRefs);
   void ClearReferencedMemory();
@@ -460,5 +462,6 @@ private:
 
   WrappedVulkan *m_Core;
   std::map<ResourceId, MemRefs> m_MemFrameRefs;
+  std::set<ResourceId> m_DeviceMemories;
   InitPolicy m_InitPolicy = eInitPolicy_CopyAll;
 };

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -471,6 +471,8 @@ VkResult WrappedVulkan::vkAllocateMemory(VkDevice device, const VkMemoryAllocate
         record->memMapState->mapCoherent = (memProps & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) != 0;
         record->memMapState->refData = NULL;
       }
+
+      GetResourceManager()->AddDeviceMemory(id);
     }
     else
     {
@@ -539,6 +541,8 @@ void WrappedVulkan::vkFreeMemory(VkDevice device, VkDeviceMemory memory,
       SCOPED_LOCK(m_CoherentMapsLock);
       m_CoherentMaps.removeOne(wrapped->record);
     }
+
+    GetResourceManager()->RemoveDeviceMemory(wrapped->id);
   }
 
   m_CreationInfo.erase(GetResID(memory));


### PR DESCRIPTION
This fixes an ambiguity between old captures (where missing MemRefs indicates a lack of information, and we need to act pessimistically), vs new captures where the memory contents were not accessed (e.g. only bound to images). Now the latter case will have an explicit MemRefs entry indicating that the memory was not referenced.

I wasn't sure if there was a better way to get all the device memories without needing the new `m_DeviceMemories` set.

Testing:
- In a sample app with a device memory bound only to an image, this previously triggered the conservative image reset behaviour, and no longer does after this patch
- I ran the python test scripts, and saw no new failures