### PR TITLE
Refactor: Keep track of rendering state per command buffer

### DIFF
--- a/renderdoc/driver/vulkan/vk_bindless_feedback.cpp
+++ b/renderdoc/driver/vulkan/vk_bindless_feedback.cpp
@@ -820,14 +820,14 @@ void VulkanReplay::FetchShaderFeedback(uint32_t eventId)
 
     if(result.compute)
     {
-      modifiedstate.BindPipeline(cmd, VulkanRenderState::BindCompute, true);
+      modifiedstate.BindPipeline(m_pDriver, cmd, VulkanRenderState::BindCompute, true);
 
       ObjDisp(cmd)->CmdDispatch(Unwrap(cmd), drawcall->dispatchDimension[0],
                                 drawcall->dispatchDimension[1], drawcall->dispatchDimension[2]);
     }
     else
     {
-      modifiedstate.BeginRenderPassAndApplyState(cmd, VulkanRenderState::BindGraphics);
+      modifiedstate.BeginRenderPassAndApplyState(m_pDriver, cmd, VulkanRenderState::BindGraphics);
 
       if(drawcall->flags & DrawFlags::Indexed)
       {

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -668,6 +668,8 @@ private:
   bool ShouldUpdateRenderState(ResourceId cmdid, bool forcePrimary = false);
   VkCommandBuffer RerecordCmdBuf(ResourceId cmdid, PartialReplayIndex partialType = ePartialNum);
 
+  ResourceId GetPartialCommandBuffer();
+
   // this info is stored in the record on capture, but we
   // need it on replay too
   struct DescriptorSetInfo

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -551,29 +551,7 @@ private:
 
     rdcarray<rdcpair<ResourceId, EventUsage>> resourceUsage;
 
-    struct CmdBufferState
-    {
-      ResourceId pipeline;
-
-      struct DescriptorAndOffsets
-      {
-        ResourceId descSet;
-        rdcarray<uint32_t> offsets;
-      };
-      rdcarray<DescriptorAndOffsets> graphicsDescSets, computeDescSets;
-
-      uint32_t idxWidth = 0;
-      ResourceId ibuffer;
-      rdcarray<ResourceId> vbuffers;
-      rdcarray<ResourceId> xfbbuffers;
-      uint32_t xfbfirst = 0;
-      uint32_t xfbcount = 0;
-
-      ResourceId renderPass;
-      ResourceId framebuffer;
-      rdcarray<ResourceId> fbattachments;
-      uint32_t subpass = 0;
-    } state;
+    VulkanRenderState state;
 
     std::map<ResourceId, ImageState> imageStates;
 
@@ -939,6 +917,14 @@ public:
   const InstanceDeviceInfo &GetExtensions(VkResourceRecord *record) const
   {
     return record ? *record->instDevInfo : m_EnabledExtensions;
+  }
+
+  VulkanRenderState &GetCmdRenderState()
+  {
+    RDCASSERT(m_LastCmdBufferID != ResourceId());
+    auto it = m_BakedCmdBufferInfo.find(m_LastCmdBufferID);
+    RDCASSERT(it != m_BakedCmdBufferInfo.end());
+    return it->second.state;
   }
 
   static rdcstr GetChunkName(uint32_t idx);

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -1473,10 +1473,59 @@ uint32_t VulkanReplay::PickVertex(uint32_t eventId, int32_t w, int32_t h, const 
   return ret;
 }
 
-const VulkanCreationInfo::Image &VulkanDebugManager::GetImageInfo(ResourceId img)
+const VulkanCreationInfo::Image &VulkanDebugManager::GetImageInfo(ResourceId img) const
 {
   auto it = m_pDriver->m_CreationInfo.m_Image.find(img);
   RDCASSERT(it != m_pDriver->m_CreationInfo.m_Image.end());
+  return it->second;
+}
+
+const VulkanCreationInfo::Pipeline &VulkanDebugManager::GetPipelineInfo(ResourceId pipe) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_Pipeline.find(pipe);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_Pipeline.end());
+  return it->second;
+}
+
+const VulkanCreationInfo::ShaderModule &VulkanDebugManager::GetShaderInfo(ResourceId shader) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_ShaderModule.find(shader);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_ShaderModule.end());
+  return it->second;
+}
+
+const VulkanCreationInfo::Framebuffer &VulkanDebugManager::GetFramebufferInfo(ResourceId fb) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_Framebuffer.find(fb);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_Framebuffer.end());
+  return it->second;
+}
+
+const VulkanCreationInfo::RenderPass &VulkanDebugManager::GetRenderPassInfo(ResourceId rp) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_RenderPass.find(rp);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_RenderPass.end());
+  return it->second;
+}
+
+const VulkanCreationInfo::PipelineLayout &VulkanDebugManager::GetPipelineLayoutInfo(ResourceId rp) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_PipelineLayout.find(rp);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_PipelineLayout.end());
+  return it->second;
+}
+
+const DescSetLayout &VulkanDebugManager::GetDescSetLayout(ResourceId dsl) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_DescSetLayout.find(dsl);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_DescSetLayout.end());
+  return it->second;
+}
+
+const WrappedVulkan::DescriptorSetInfo &VulkanDebugManager::GetDescSetInfo(ResourceId ds) const
+{
+  auto it = m_pDriver->m_DescriptorSetState.find(ds);
+  RDCASSERT(it != m_pDriver->m_DescriptorSetState.end());
   return it->second;
 }
 

--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -89,7 +89,14 @@ public:
   VkImageLayout GetImageLayout(ResourceId image, VkImageAspectFlagBits aspect, uint32_t mip,
                                uint32_t slice);
 
-  const VulkanCreationInfo::Image &GetImageInfo(ResourceId img);
+  const VulkanCreationInfo::Image &GetImageInfo(ResourceId img) const;
+  const VulkanCreationInfo::Pipeline &GetPipelineInfo(ResourceId pipe) const;
+  const VulkanCreationInfo::ShaderModule &GetShaderInfo(ResourceId shader) const;
+  const VulkanCreationInfo::Framebuffer &GetFramebufferInfo(ResourceId fb) const;
+  const VulkanCreationInfo::RenderPass &GetRenderPassInfo(ResourceId rp) const;
+  const VulkanCreationInfo::PipelineLayout &GetPipelineLayoutInfo(ResourceId pp) const;
+  const DescSetLayout &GetDescSetLayout(ResourceId dsl) const;
+  const WrappedVulkan::DescriptorSetInfo &GetDescSetInfo(ResourceId ds) const;
 
 private:
   // GetBufferData

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -1653,11 +1653,11 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, CompType typeCast, Floa
       vkr = vt->EndCommandBuffer(Unwrap(cmd));
       RDCASSERTEQUAL(vkr, VK_SUCCESS);
 
-      for (size_t i = startEvent; i < events.size(); i++)
+      for(size_t i = startEvent; i < events.size(); i++)
       {
         m_pDriver->ReplayLog(events[i], events[i], eReplay_OnlyDraw);
 
-        if (overlay == DebugOverlay::ClearBeforePass && i + 1 < events.size())
+        if(overlay == DebugOverlay::ClearBeforePass && i + 1 < events.size())
           m_pDriver->ReplayLog(events[i] + 1, events[i + 1], eReplay_WithoutDraw);
       }
 

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -29,6 +29,7 @@
 #include "replay/replay_driver.h"
 #include "vk_common.h"
 #include "vk_info.h"
+#include "vk_state.h"
 
 #if ENABLED(RDOC_WIN32)
 
@@ -322,6 +323,7 @@ public:
                     float maxval, bool channels[4], rdcarray<uint32_t> &histogram);
 
   void InitPostVSBuffers(uint32_t eventId);
+  void InitPostVSBuffers(uint32_t eventId, VulkanRenderState &state);
   void InitPostVSBuffers(const rdcarray<uint32_t> &passEvents);
 
   // indicates that EID alias is the same as eventId
@@ -421,8 +423,8 @@ private:
                                 const VkDescriptorSetLayoutBinding *newBindings,
                                 size_t newBindingsCount);
 
-  void FetchVSOut(uint32_t eventId);
-  void FetchTessGSOut(uint32_t eventId);
+  void FetchVSOut(uint32_t eventId, VulkanRenderState &state);
+  void FetchTessGSOut(uint32_t eventId, VulkanRenderState &state);
   void ClearPostVSCache();
 
   void RefreshDerivedReplacements();

--- a/renderdoc/driver/vulkan/vk_state.h
+++ b/renderdoc/driver/vulkan/vk_state.h
@@ -53,23 +53,22 @@ struct VulkanRenderState
     BindCompute = 0x2,
   };
 
-  VulkanRenderState(WrappedVulkan *driver, VulkanCreationInfo *createInfo);
-  void BeginRenderPassAndApplyState(VkCommandBuffer cmd, PipelineBinding binding);
-  void EndRenderPass(VkCommandBuffer cmd);
+  VulkanRenderState();
+  bool IsConditionalRenderingEnabled();
+  void BeginRenderPassAndApplyState(WrappedVulkan *vk, VkCommandBuffer cmd, PipelineBinding binding);
+  void BindPipeline(WrappedVulkan *vk, VkCommandBuffer cmd, PipelineBinding binding, bool subpass0);
 
-  void EndTransformFeedback(VkCommandBuffer cmd);
-
-  void EndConditionalRendering(VkCommandBuffer cmd);
-
-  void BindPipeline(VkCommandBuffer cmd, PipelineBinding binding, bool subpass0);
-
-  void BindDescriptorSets(VkCommandBuffer cmd, VulkanStatePipeline &pipe,
+  void BindDescriptorSets(WrappedVulkan *vk, VkCommandBuffer cmd, VulkanStatePipeline &pipe,
                           VkPipelineBindPoint bindPoint);
 
-  void BindDescriptorSet(const DescSetLayout &descLayout, VkCommandBuffer cmd,
+  void BindDescriptorSet(WrappedVulkan *vk, const DescSetLayout &descLayout, VkCommandBuffer cmd,
                          VkPipelineBindPoint bindPoint, uint32_t setIndex, uint32_t *dynamicOffsets);
 
-  bool IsConditionalRenderingEnabled();
+  void EndRenderPass(VkCommandBuffer cmd);
+
+  void EndTransformFeedback(WrappedVulkan *vk, VkCommandBuffer cmd);
+
+  void EndConditionalRendering(VkCommandBuffer cmd);
 
   // dynamic state
   rdcarray<VkViewport> views;
@@ -113,7 +112,9 @@ struct VulkanRenderState
 
   // framebuffer accessors - to allow for imageless framebuffers and prevent accidentally changing
   // only the framebuffer without updating the attachments
-  void SetFramebuffer(ResourceId fb, const VkRenderPassAttachmentBeginInfo *attachmentsInfo = NULL);
+  void SetFramebuffer(WrappedVulkan *vk, ResourceId fb,
+                      const VkRenderPassAttachmentBeginInfo *attachmentsInfo = NULL);
+
   void SetFramebuffer(ResourceId fb, const rdcarray<ResourceId> &dynamicAttachments)
   {
     framebuffer = fb;
@@ -165,10 +166,6 @@ struct VulkanRenderState
 
     bool forceDisable = false;
   } conditionalRendering;
-
-  VulkanResourceManager *GetResourceManager();
-  VulkanCreationInfo *m_CreationInfo;
-  WrappedVulkan *m_pDriver;
 
 private:
   ResourceId framebuffer;

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1773,7 +1773,6 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass2(SerialiserType &ser,
         // be in subpass 0's layout
         if(m_FirstEventID == m_LastEventID)
         {
-          // VulkanCreationInfo::Framebuffer fbinfo = m_CreationInfo.m_Framebuffer[fb];
           VulkanCreationInfo::RenderPass rpinfo =
               m_CreationInfo.m_RenderPass[GetCmdRenderState().renderPass];
           unwrappedInfo.renderPass = Unwrap(rpinfo.loadRPs[0]);
@@ -3488,6 +3487,7 @@ bool WrappedVulkan::Serialise_vkCmdExecuteCommands(SerialiserType &ser, VkComman
           m_BakedCmdBufferInfo[cmd].state.SetFramebuffer(
               parentCmdBufInfo.state.GetFramebuffer(),
               parentCmdBufInfo.state.GetFramebufferAttachments());
+          m_BakedCmdBufferInfo[cmd].state.renderArea = parentCmdBufInfo.state.renderArea;
 
           // 2 extra for the virtual labels around the command buffer
           parentCmdBufInfo.curEventID += 2 + m_BakedCmdBufferInfo[cmd].eventCount;
@@ -4931,7 +4931,6 @@ bool WrappedVulkan::Serialise_vkCmdBeginTransformFeedbackEXT(
 
       // track while reading, for fetching the right set of outputs in AddDrawcall
       m_BakedCmdBufferInfo[m_LastCmdBufferID].state.firstxfbcounter = firstBuffer;
-      // TODO: should change the xfbcount, resize?
       m_BakedCmdBufferInfo[m_LastCmdBufferID].state.xfbcounters.resize(bufferCount);
     }
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -2421,10 +2421,9 @@ bool WrappedVulkan::Serialise_vkCmdClearAttachments(SerialiserType &ser,
         AddDrawcall(draw, true);
 
         VulkanDrawcallTreeNode &drawNode = GetDrawcallStack().back()->children.back();
-        const BakedCmdBufferInfo::CmdBufferState &state =
-            m_BakedCmdBufferInfo[m_LastCmdBufferID].state;
+        const VulkanRenderState &state = m_BakedCmdBufferInfo[m_LastCmdBufferID].state;
 
-        if(state.renderPass != ResourceId() && state.framebuffer != ResourceId())
+        if(state.renderPass != ResourceId() && state.GetFramebuffer() != ResourceId())
         {
           VulkanCreationInfo::RenderPass &rp = m_CreationInfo.m_RenderPass[state.renderPass];
 
@@ -2439,10 +2438,10 @@ bool WrappedVulkan::Serialise_vkCmdClearAttachments(SerialiserType &ser,
               if(att < (uint32_t)rp.subpasses[state.subpass].colorAttachments.size())
               {
                 att = rp.subpasses[state.subpass].colorAttachments[att];
-                drawNode.resourceUsage.push_back(
-                    make_rdcpair(m_CreationInfo.m_ImageView[state.fbattachments[att]].image,
-                                 EventUsage(drawNode.draw.eventId, ResourceUsage::Clear,
-                                            state.fbattachments[att])));
+                drawNode.resourceUsage.push_back(make_rdcpair(
+                    m_CreationInfo.m_ImageView[state.GetFramebufferAttachments()[att]].image,
+                    EventUsage(drawNode.draw.eventId, ResourceUsage::Clear,
+                               state.GetFramebufferAttachments()[att])));
               }
             }
             else if(pAttachments[a].aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT)
@@ -2450,10 +2449,10 @@ bool WrappedVulkan::Serialise_vkCmdClearAttachments(SerialiserType &ser,
               if(rp.subpasses[state.subpass].depthstencilAttachment >= 0)
               {
                 att = (uint32_t)rp.subpasses[state.subpass].depthstencilAttachment;
-                drawNode.resourceUsage.push_back(
-                    make_rdcpair(m_CreationInfo.m_ImageView[state.fbattachments[att]].image,
-                                 EventUsage(drawNode.draw.eventId, ResourceUsage::Clear,
-                                            state.fbattachments[att])));
+                drawNode.resourceUsage.push_back(make_rdcpair(
+                    m_CreationInfo.m_ImageView[state.GetFramebufferAttachments()[att]].image,
+                    EventUsage(drawNode.draw.eventId, ResourceUsage::Clear,
+                               state.GetFramebufferAttachments()[att])));
               }
             }
           }

--- a/renderdoc/driver/vulkan/wrappers/vk_dynamic_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_dynamic_funcs.cpp
@@ -48,13 +48,13 @@ bool WrappedVulkan::Serialise_vkCmdSetViewport(SerialiserType &ser, VkCommandBuf
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          if(m_RenderState.views.size() < firstViewport + viewportCount)
-            m_RenderState.views.resize(firstViewport + viewportCount);
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          if(renderstate.views.size() < firstViewport + viewportCount)
+            renderstate.views.resize(firstViewport + viewportCount);
 
           for(uint32_t i = 0; i < viewportCount; i++)
-            m_RenderState.views[firstViewport + i] = pViewports[i];
+            renderstate.views[firstViewport + i] = pViewports[i];
         }
       }
       else
@@ -117,13 +117,13 @@ bool WrappedVulkan::Serialise_vkCmdSetScissor(SerialiserType &ser, VkCommandBuff
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          if(m_RenderState.scissors.size() < firstScissor + scissorCount)
-            m_RenderState.scissors.resize(firstScissor + scissorCount);
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          if(renderstate.scissors.size() < firstScissor + scissorCount)
+            renderstate.scissors.resize(firstScissor + scissorCount);
 
           for(uint32_t i = 0; i < scissorCount; i++)
-            m_RenderState.scissors[firstScissor + i] = pScissors[i];
+            renderstate.scissors[firstScissor + i] = pScissors[i];
         }
       }
       else
@@ -182,8 +182,9 @@ bool WrappedVulkan::Serialise_vkCmdSetLineWidth(SerialiserType &ser, VkCommandBu
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
-          m_RenderState.lineWidth = lineWidth;
+        {
+          GetCmdRenderState().lineWidth = lineWidth;
+        }
       }
       else
       {
@@ -241,11 +242,11 @@ bool WrappedVulkan::Serialise_vkCmdSetDepthBias(SerialiserType &ser, VkCommandBu
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          m_RenderState.bias.depth = depthBias;
-          m_RenderState.bias.biasclamp = depthBiasClamp;
-          m_RenderState.bias.slope = slopeScaledDepthBias;
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          renderstate.bias.depth = depthBias;
+          renderstate.bias.biasclamp = depthBiasClamp;
+          renderstate.bias.slope = slopeScaledDepthBias;
         }
       }
       else
@@ -306,8 +307,10 @@ bool WrappedVulkan::Serialise_vkCmdSetBlendConstants(SerialiserType &ser,
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
-          memcpy(m_RenderState.blendConst, blendConst, sizeof(m_RenderState.blendConst));
+        {
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          memcpy(renderstate.blendConst, blendConst, sizeof(renderstate.blendConst));
+        }
       }
       else
       {
@@ -363,10 +366,10 @@ bool WrappedVulkan::Serialise_vkCmdSetDepthBounds(SerialiserType &ser, VkCommand
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          m_RenderState.mindepth = minDepthBounds;
-          m_RenderState.maxdepth = maxDepthBounds;
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          renderstate.mindepth = minDepthBounds;
+          renderstate.maxdepth = maxDepthBounds;
         }
       }
       else
@@ -427,12 +430,12 @@ bool WrappedVulkan::Serialise_vkCmdSetStencilCompareMask(SerialiserType &ser,
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
+          VulkanRenderState &renderstate = GetCmdRenderState();
           if(faceMask & VK_STENCIL_FACE_FRONT_BIT)
-            m_RenderState.front.compare = compareMask;
+            renderstate.front.compare = compareMask;
           if(faceMask & VK_STENCIL_FACE_BACK_BIT)
-            m_RenderState.back.compare = compareMask;
+            renderstate.back.compare = compareMask;
         }
       }
       else
@@ -493,12 +496,12 @@ bool WrappedVulkan::Serialise_vkCmdSetStencilWriteMask(SerialiserType &ser,
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
+          VulkanRenderState &renderstate = GetCmdRenderState();
           if(faceMask & VK_STENCIL_FACE_FRONT_BIT)
-            m_RenderState.front.write = writeMask;
+            renderstate.front.write = writeMask;
           if(faceMask & VK_STENCIL_FACE_BACK_BIT)
-            m_RenderState.back.write = writeMask;
+            renderstate.back.write = writeMask;
         }
       }
       else
@@ -559,12 +562,12 @@ bool WrappedVulkan::Serialise_vkCmdSetStencilReference(SerialiserType &ser,
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
+          VulkanRenderState &renderstate = GetCmdRenderState();
           if(faceMask & VK_STENCIL_FACE_FRONT_BIT)
-            m_RenderState.front.ref = reference;
+            renderstate.front.ref = reference;
           if(faceMask & VK_STENCIL_FACE_BACK_BIT)
-            m_RenderState.back.ref = reference;
+            renderstate.back.ref = reference;
         }
       }
       else
@@ -623,12 +626,12 @@ bool WrappedVulkan::Serialise_vkCmdSetSampleLocationsEXT(
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          m_RenderState.sampleLocations.locations.assign(sampleInfo.pSampleLocations,
-                                                         sampleInfo.sampleLocationsCount);
-          m_RenderState.sampleLocations.gridSize = sampleInfo.sampleLocationGridSize;
-          m_RenderState.sampleLocations.sampleCount = sampleInfo.sampleLocationsPerPixel;
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          renderstate.sampleLocations.locations.assign(sampleInfo.pSampleLocations,
+                                                       sampleInfo.sampleLocationsCount);
+          renderstate.sampleLocations.gridSize = sampleInfo.sampleLocationGridSize;
+          renderstate.sampleLocations.sampleCount = sampleInfo.sampleLocationsPerPixel;
         }
       }
       else
@@ -691,13 +694,13 @@ bool WrappedVulkan::Serialise_vkCmdSetDiscardRectangleEXT(SerialiserType &ser,
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          if(m_RenderState.discardRectangles.size() < firstDiscardRectangle + discardRectangleCount)
-            m_RenderState.discardRectangles.resize(firstDiscardRectangle + discardRectangleCount);
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          if(renderstate.discardRectangles.size() < firstDiscardRectangle + discardRectangleCount)
+            renderstate.discardRectangles.resize(firstDiscardRectangle + discardRectangleCount);
 
           for(uint32_t i = 0; i < discardRectangleCount; i++)
-            m_RenderState.discardRectangles[firstDiscardRectangle + i] = pDiscardRectangles[i];
+            renderstate.discardRectangles[firstDiscardRectangle + i] = pDiscardRectangles[i];
         }
       }
       else
@@ -764,10 +767,10 @@ bool WrappedVulkan::Serialise_vkCmdSetLineStippleEXT(SerialiserType &ser,
       {
         commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
 
-        if(ShouldUpdateRenderState(m_LastCmdBufferID))
         {
-          m_RenderState.stippleFactor = lineStippleFactor;
-          m_RenderState.stipplePattern = lineStipplePattern;
+          VulkanRenderState &renderstate = GetCmdRenderState();
+          renderstate.stippleFactor = lineStippleFactor;
+          renderstate.stipplePattern = lineStipplePattern;
         }
       }
       else


### PR DESCRIPTION
This is needed for Vulkan Pixel history, where we need to know render
state at current point of time for a command buffer during callback
replay.

Modifications:
- Removed m_pDriver and m_CreationInfo members from VulkanRenderState,
instead these are accepted as arguments to member functions.
- BakedCmdBufferInfo state is now full VulkanRenderState

