### PR TITLE
Fix Qt deprecation warning

### DIFF
--- a/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
+++ b/qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp
@@ -438,7 +438,7 @@ void PerformanceCounterSelection::Load()
         selectedCounters.insert(m_UuidToCounter[uuid]);
       }
 
-      SetSelectedCounters(selectedCounters.toList());
+      SetSelectedCounters(selectedCounters.values());
     }
     else
     {


### PR DESCRIPTION
## Description

On Qt 5.14.1, fixes this warning:
```c++
qrenderdoc/Windows/Dialogs/PerformanceCounterSelection.cpp:441:51: warning: ‘QList<T> QSet<T>::toList() const [with T = GPUCounter]’ is deprecated: Use values() instead. [-Wdeprecated-declarations]
```