### PR TITLE
Respect the XDG base directory specification

### DIFF
--- a/renderdoc/common/shader_cache.h
+++ b/renderdoc/common/shader_cache.h
@@ -32,7 +32,7 @@ template <typename ResultType, typename ShaderCallbacks>
 bool LoadShaderCache(const char *filename, const uint32_t magicNumber, const uint32_t versionNumber,
                      std::map<uint32_t, ResultType> &resultCache, const ShaderCallbacks &callbacks)
 {
-  rdcstr shadercache = FileIO::GetAppFolderFilename(filename);
+  rdcstr shadercache = FileIO::GetCacheFolderFilename(filename);
 
   FILE *f = FileIO::fopen(shadercache.c_str(), "rb");
 
@@ -154,7 +154,7 @@ template <typename ResultType, typename ShaderCallbacks>
 void SaveShaderCache(const char *filename, uint32_t magicNumber, uint32_t versionNumber,
                      const std::map<uint32_t, ResultType> &cache, const ShaderCallbacks &callbacks)
 {
-  rdcstr shadercache = FileIO::GetAppFolderFilename(filename);
+  rdcstr shadercache = FileIO::GetCacheFolderFilename(filename);
 
   FILE *f = FileIO::fopen(shadercache.c_str(), "wb");
 

--- a/renderdoc/core/remote_server.cpp
+++ b/renderdoc/core/remote_server.cpp
@@ -910,7 +910,7 @@ void RenderDoc::BecomeRemoteServer(const char *listenhost, uint16_t port,
   rdcarray<rdcpair<uint32_t, uint32_t> > listenRanges;
   bool allowExecution = true;
 
-  FILE *f = FileIO::fopen(FileIO::GetAppFolderFilename("remoteserver.conf").c_str(), "r");
+  FILE *f = FileIO::fopen(FileIO::GetConfigFolderFilename("remoteserver.conf").c_str(), "r");
 
   rdcstr configFile;
 

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -277,7 +277,8 @@ namespace FileIO
 void GetDefaultFiles(const char *logBaseName, rdcstr &capture_filename, rdcstr &logging_filename,
                      rdcstr &target);
 rdcstr GetHomeFolderFilename();
-rdcstr GetAppFolderFilename(const rdcstr &filename);
+rdcstr GetConfigFolderFilename(const rdcstr &filename);
+rdcstr GetCacheFolderFilename(const rdcstr &filename);
 rdcstr GetTempFolderFilename();
 rdcstr GetReplayAppFilename();
 

--- a/renderdoc/os/posix/android/android_stringio.cpp
+++ b/renderdoc/os/posix/android/android_stringio.cpp
@@ -69,7 +69,12 @@ rdcstr GetTempRootPath()
   return "/sdcard/Android/data/" + package + "/files";
 }
 
-rdcstr GetAppFolderFilename(const rdcstr &filename)
+rdcstr GetConfigFolderFilename(const rdcstr &filename)
+{
+  return GetTempRootPath() + rdcstr("/") + filename;
+}
+
+rdcstr GetCacheFolderFilename(const rdcstr &filename)
 {
   return GetTempRootPath() + rdcstr("/") + filename;
 }

--- a/renderdoc/os/posix/apple/apple_stringio.cpp
+++ b/renderdoc/os/posix/apple/apple_stringio.cpp
@@ -67,12 +67,42 @@ rdcstr GetTempRootPath()
   return "/tmp";
 }
 
-rdcstr GetAppFolderFilename(const rdcstr &filename)
+rdcstr GetConfigFolderFilename(const rdcstr &filename)
 {
+  const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
   passwd *pw = getpwuid(getuid());
   const char *homedir = pw->pw_dir;
 
-  rdcstr ret = rdcstr(homedir) + "/.renderdoc/";
+  rdcstr ret;
+  if(xdg_config_home && xdg_config_home[0] == '/')
+  {
+    ret = rdcstr(xdg_config_home) + "/renderdoc/";
+  }
+  else
+  {
+    ret = rdcstr(homedir) + "/.config/renderdoc/";
+  }
+
+  mkdir(ret.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+
+  return ret + filename;
+}
+
+rdcstr GetCacheFolderFilename(const rdcstr &filename)
+{
+  const char *xdg_cache_home = getenv("XDG_CACHE_HOME");
+  passwd *pw = getpwuid(getuid());
+  const char *homedir = pw->pw_dir;
+
+  rdcstr ret;
+  if(xdg_cache_home && xdg_cache_home[0] == '/')
+  {
+    ret = rdcstr(xdg_cache_home) + "/renderdoc/";
+  }
+  else
+  {
+    ret = rdcstr(homedir) + "/.cache/renderdoc/";
+  }
 
   mkdir(ret.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 

--- a/renderdoc/os/posix/ggp/ggp_stringio.cpp
+++ b/renderdoc/os/posix/ggp/ggp_stringio.cpp
@@ -70,7 +70,28 @@ rdcstr GetTempRootPath()
   return "/tmp";
 }
 
-rdcstr GetAppFolderFilename(const rdcstr &filename)
+rdcstr GetConfigFolderFilename(const rdcstr &filename)
+{
+  const char *homedir = NULL;
+  if(getenv("HOME") != NULL)
+  {
+    homedir = getenv("HOME");
+    RDCLOG("$HOME value is %s", homedir);
+  }
+  else
+  {
+    RDCLOG("$HOME value is NULL");
+    homedir = getpwuid(getuid())->pw_dir;
+  }
+
+  rdcstr ret = rdcstr(homedir) + "/.renderdoc/";
+
+  mkdir(ret.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+
+  return ret + filename;
+}
+
+rdcstr GetCacheFolderFilename(const rdcstr &filename)
 {
   const char *homedir = NULL;
   if(getenv("HOME") != NULL)

--- a/renderdoc/os/posix/linux/linux_stringio.cpp
+++ b/renderdoc/os/posix/linux/linux_stringio.cpp
@@ -563,12 +563,42 @@ rdcstr GetTempRootPath()
   return "/tmp";
 }
 
-rdcstr GetAppFolderFilename(const rdcstr &filename)
+rdcstr GetConfigFolderFilename(const rdcstr &filename)
 {
+  const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
   passwd *pw = getpwuid(getuid());
   const char *homedir = pw->pw_dir;
 
-  rdcstr ret = rdcstr(homedir) + "/.renderdoc/";
+  rdcstr ret;
+  if(xdg_config_home && xdg_config_home[0] == '/')
+  {
+    ret = rdcstr(xdg_config_home) + "/renderdoc/";
+  }
+  else
+  {
+    ret = rdcstr(homedir) + "/.config/renderdoc/";
+  }
+
+  mkdir(ret.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+
+  return ret + filename;
+}
+
+rdcstr GetCacheFolderFilename(const rdcstr &filename)
+{
+  const char *xdg_cache_home = getenv("XDG_CACHE_HOME");
+  passwd *pw = getpwuid(getuid());
+  const char *homedir = pw->pw_dir;
+
+  rdcstr ret;
+  if(xdg_cache_home && xdg_cache_home[0] == '/')
+  {
+    ret = rdcstr(xdg_cache_home) + "/renderdoc/";
+  }
+  else
+  {
+    ret = rdcstr(homedir) + "/.cache/renderdoc/";
+  }
 
   mkdir(ret.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 

--- a/renderdoc/os/win32/win32_callstack.cpp
+++ b/renderdoc/os/win32/win32_callstack.cpp
@@ -723,7 +723,7 @@ rdcstr Win32CallstackResolver::pdbBrowse(rdcstr startingPoint)
 Win32CallstackResolver::Win32CallstackResolver(bool interactive, byte *moduleDB, size_t DBSize,
                                                RENDERDOC_ProgressCallback progress)
 {
-  rdcwstr configPath = StringFormat::UTF82Wide(FileIO::GetAppFolderFilename("config.ini"));
+  rdcwstr configPath = StringFormat::UTF82Wide(FileIO::GetConfigFolderFilename("config.ini"));
   {
     FILE *f = NULL;
     _wfopen_s(&f, configPath.c_str(), L"a");

--- a/renderdoc/os/win32/win32_stringio.cpp
+++ b/renderdoc/os/win32/win32_stringio.cpp
@@ -385,7 +385,28 @@ rdcstr GetHomeFolderFilename()
   return ret;
 }
 
-rdcstr GetAppFolderFilename(const rdcstr &filename)
+rdcstr GetConfigFolderFilename(const rdcstr &filename)
+{
+  PWSTR appDataPath = NULL;
+  HRESULT hr = SHGetKnownFolderPath(
+      FOLDERID_RoamingAppData, KF_FLAG_SIMPLE_IDLIST | KF_FLAG_DONT_UNEXPAND, NULL, &appDataPath);
+  if(appDataPath == NULL || FAILED(hr))
+    return "";
+
+  rdcstr ret = StringFormat::Wide2UTF8(appDataPath);
+  CoTaskMemFree(appDataPath);
+
+  while(ret.back() == '/' || ret.back() == '\\')
+    ret.pop_back();
+
+  ret += "\\renderdoc\\" + filename;
+
+  CreateParentDirectory(ret);
+
+  return ret;
+}
+
+rdcstr GetCacheFolderFilename(const rdcstr &filename)
 {
   PWSTR appDataPath = NULL;
   HRESULT hr = SHGetKnownFolderPath(


### PR DESCRIPTION
## Description

This applies to all platforms but Windows.

I was a bit unsure what the ggp platform even is, but it looked UNIX-
like enough so I moved it to XDG basedir too.

I didn’t attempt to do any migration since this is mostly cache, if this
is wanted please let me know, and I’ll update this PR.

I have also only tested on Linux, so more testing would be welcome.

See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html