### PR TITLE
Fix image ref state when loading old captures

### DIFF
--- a/renderdoc/driver/vulkan/vk_image_states.cpp
+++ b/renderdoc/driver/vulkan/vk_image_states.cpp
@@ -941,7 +941,7 @@ void ImageState::Merge(const ImageState &other, ImageTransitionInfo info)
 void ImageState::MergeCaptureBeginState(const ImageState &initialState)
 {
   oldQueueFamilyTransfers = initialState.oldQueueFamilyTransfers;
-  subresourceStates = initialState.subresourceStates;
+  subresourceStates.Merge(initialState.subresourceStates, ComposeFrameRefsFirstKnown);
   maxRefType = initialState.maxRefType;
 }
 


### PR DESCRIPTION
This fixes a performance regression when loading captures from <=v1.6 (before the new image state code went in). The code to import the old image state information was incorrectly discarding the frame ref information, forcing the images to be reinitialized on every replay.

In old captures `ImageRefs` chunk is processed, creating `ImageState` objects that only contain `refType`; then `BeginCaptureFrame` processes the `ImageLayouts` info, to construct a new `ImageState` object, containing the layout information. This `ImageState` was overwriting the
`ImageState` from the `ImageRefs` chunk, discarding the `refType` info. This change merges the `ImageState`s from `ImageRefs`, where each field of the merged image state comes from whichever `ImageState` had a non-undefined value for that field.

For new captures, this change should be safe, since the image state should be undefined when the `BeginCaptureFrame` chunk is processed, so the `MergCaptureBeginState` call will just take all the state fields from the `ImageState` stored in the `BeginCaptureFrame` chunk.

I verified this correctly loads captures from v1.6, and correctly sets the image refType. I also checked that captures from HEAD also load correctly.