### PR TITLE
Convert GPU Time counter correctly

### DIFF
--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -135,7 +135,7 @@ void VulkanReplay::convertKhrCounterResult(CounterResult &rdcResult,
   {
     RDCASSERT(type == CompType::Double);
 
-    if(khrStorage == VK_PERFORMANCE_COUNTER_STORAGE_FLOAT64_KHR)
+    if((khrStorage == VK_PERFORMANCE_COUNTER_STORAGE_FLOAT64_KHR) || (khrStorage == VK_PERFORMANCE_COUNTER_STORAGE_FLOAT32_KHR))
     {
       rdcResult.value.d = rdcResult.value.d / (1000.0 * 1000.0 * 1000.0);
     }

--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -134,7 +134,15 @@ void VulkanReplay::convertKhrCounterResult(CounterResult &rdcResult,
   if(khrUnit == VK_PERFORMANCE_COUNTER_UNIT_NANOSECONDS_KHR)
   {
     RDCASSERT(type == CompType::Double);
-    rdcResult.value.d /= 1000.0 * 1000.0 * 1000.0;
+
+    if(khrStorage == VK_PERFORMANCE_COUNTER_STORAGE_FLOAT64_KHR)
+    {
+      rdcResult.value.d = rdcResult.value.d / (1000.0 * 1000.0 * 1000.0);
+    }
+    else
+    {
+      rdcResult.value.d = (double)(rdcResult.value.u64) / (1000.0 * 1000.0 * 1000.0);
+    }
   }
 }
 


### PR DESCRIPTION
## Description

VK_PERFORMANCE_COUNTER_UNIT_NANOSECONDS_KHR performance counters will have integral storage types usually (assert for otherwise), its value should be converted to double correctly.

I tested this with a driver which exposes KHR performance counters (currently non-public!), counter result can be displayed as expected with the fix.