### PR TITLE
Add MSAA support to D3D12 debugging

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_debug.h
+++ b/renderdoc/driver/d3d12/d3d12_debug.h
@@ -60,6 +60,7 @@ enum CBVUAVSRVSlot
   PICK_RESULT_CLEAR_UAV,
 
   SHADER_DEBUG_UAV,
+  SHADER_DEBUG_MSAA_UAV,
 
   TMP_UAV,
 
@@ -222,7 +223,7 @@ void MoveRootSignatureElementsToRegisterSpace(D3D12RootSignature &sig, uint32_t 
                                               D3D12DescriptorType type,
                                               D3D12_SHADER_VISIBILITY visibility);
 
-void AddDebugDescriptorToRenderState(WrappedID3D12Device *pDevice, D3D12RenderState &rs,
-                                     const PortableHandle &handle,
-                                     D3D12_DESCRIPTOR_HEAP_TYPE heapType, uint32_t sigElem,
-                                     std::set<ResourceId> &copiedHeaps);
+void AddDebugDescriptorsToRenderState(WrappedID3D12Device *pDevice, D3D12RenderState &rs,
+                                      const rdcarray<PortableHandle> &handles,
+                                      D3D12_DESCRIPTOR_HEAP_TYPE heapType, uint32_t sigElem,
+                                      std::set<ResourceId> &copiedHeaps);

--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -145,8 +145,8 @@ struct D3D12QuadOverdrawCallback : public D3D12DrawcallCallback
     rs.pipe = GetResID(cache.pipe);
     rs.graphics.rootsig = GetResID(cache.sig);
 
-    AddDebugDescriptorToRenderState(m_pDevice, rs, m_UAV, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
-                                    cache.sigElem, m_CopiedHeaps);
+    AddDebugDescriptorsToRenderState(m_pDevice, rs, {m_UAV}, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
+                                     cache.sigElem, m_CopiedHeaps);
 
     // as we're changing the root signature, we need to reapply all elements,
     // so just apply all state

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
@@ -310,12 +310,18 @@ bool OperationFlushing(const DXBCBytecode::OpcodeType &op)
     case OPCODE_GATHER4_PO_C:
       return true;
 
-    // unclear if these flush and it's unlikely denorms will come up, so conservatively flush
-    case OPCODE_SAMPLE_INFO:
-    case OPCODE_SAMPLE_POS:
+    // don't flush eval ops as some inputs may be uint
     case OPCODE_EVAL_CENTROID:
     case OPCODE_EVAL_SAMPLE_INDEX:
     case OPCODE_EVAL_SNAPPED:
+      return false;
+
+    // don't flush samplepos since an operand is scalar
+    case OPCODE_SAMPLE_POS:
+      return false;
+
+    // unclear if these flush and it's unlikely denorms will come up, so conservatively flush
+    case OPCODE_SAMPLE_INFO:
     case OPCODE_LOD:
     case OPCODE_DERIV_RTX:
     case OPCODE_DERIV_RTX_COARSE:

--- a/util/test/tests/D3D11/D3D11_Shader_Debug_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_Shader_Debug_Zoo.py
@@ -17,6 +17,8 @@ class D3D11_Shader_Debug_Zoo(rdtest.TestCase):
         failed = False
 
         # Loop over every test
+        rdtest.log.print("Performing general tests:")
+        rdtest.log.indent()
         for test in range(draw.numInstances):
             # Debug the shader
             trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4 * test, 0, rd.ReplayController.NoPreference,
@@ -38,6 +40,40 @@ class D3D11_Shader_Debug_Zoo(rdtest.TestCase):
                 self.controller.FreeTrace(trace)
 
             rdtest.log.success("Test {} matched as expected".format(test))
+        rdtest.log.dedent()
+
+        rdtest.log.print("Performing MSAA tests:")
+        rdtest.log.indent()
+        draw = draw.next
+        self.controller.SetFrameEvent(draw.eventId, False)
+        pipe: rd.PipeState = self.controller.GetPipelineState()
+        for test in range(4):
+            # Debug the shader
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4, 4, test,
+                                                                    rd.ReplayController.NoPreference)
+
+            # Validate that the correct sample index was debugged
+            inputs: List[rd.ShaderVariable] = list(trace.inputs)
+            sampRegister = self.find_input_source_var(trace, rd.ShaderBuiltin.MSAASampleIndex)
+            sampInput = [var for var in inputs if var.name == sampRegister.variables[0].name][0]
+            if sampInput.value.uv[0] != test:
+                rdtest.log.error("Test {} did not pick the correct sample.".format(test))
+
+            cycles, variables = self.process_trace(trace)
+
+            output = self.find_output_source_var(trace, rd.ShaderBuiltin.ColorOutput, 0)
+
+            debugged = self.evalute_source_var(output, variables)
+
+            # Validate the debug output result
+            try:
+                self.check_pixel_sample_value(pipe.GetOutputTargets()[0].resourceId, 4, 4, test, debugged.value.fv[0:4], 0.0)
+            except rdtest.TestFailureException as ex:
+                failed = True
+                rdtest.log.error("Test {} did not match. {}".format(test, str(ex)))
+                continue
+
+        rdtest.log.dedent()
 
         if failed:
             raise rdtest.TestFailureException("Some tests were not as expected")


### PR DESCRIPTION
- Replicated the MSAA handling from the D3D11 code and got D3D12 to cooperate with it.
- Added tests to both D3D11 & D3D12 shader zoos to validate sample selection for debugging and eval operations.
- Fixed a bug with sample selection when debugging - the previous code would sometimes select a hit for the wrong sample.
- Changed eval instructions to not flush - the incoming attributes shouldn't be denorm and EvaluateAttributeSnapped/EvaluateAttributeAtSample have integer operands.