### PR TITLE
Fix image subresource order

### DIFF
--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -320,7 +320,11 @@ void VulkanResourceManager::SerialiseImageStates(SerialiserType &ser,
           }
 
           if(!subresourceStates.empty())
+          {
+            std::sort(subresourceStates.begin(), subresourceStates.end(),
+                      ImageSubresourceStateForRange::CompareRangeBegin);
             imageState.subresourceStates.FromArray(subresourceStates);
+          }
           imageState.maxRefType = eFrameRef_Unknown;
         }
       }

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1317,6 +1317,30 @@ struct ImageSubresourceStateForRange
 {
   ImageSubresourceRange range;
   ImageSubresourceState state;
+  inline static bool CompareRangeBegin(const ImageSubresourceStateForRange &x,
+                                       const ImageSubresourceStateForRange &y)
+  {
+    const ImageSubresourceRange &rx = x.range;
+    const ImageSubresourceRange &ry = y.range;
+
+    // Find the first (least significant) aspcet bit
+    VkImageAspectFlags ax = *ImageAspectFlagIter::begin(rx.aspectMask);
+    VkImageAspectFlags ay = *ImageAspectFlagIter::begin(ry.aspectMask);
+
+    if(ax == ay)
+    {
+      if(rx.baseMipLevel == ry.baseMipLevel)
+      {
+        if(rx.baseArrayLayer == ry.baseArrayLayer)
+        {
+          return rx.baseDepthSlice < ry.baseDepthSlice;
+        }
+        return rx.baseArrayLayer < ry.baseArrayLayer;
+      }
+      return rx.baseMipLevel < ry.baseMipLevel;
+    }
+    return ax < ay;
+  }
 };
 
 DECLARE_REFLECTION_STRUCT(ImageSubresourceStateForRange);


### PR DESCRIPTION
When importing captures from v1.6 and before, the order that image subresource states are listed in the capture differs from the order expected in `ImageState`. This change sorts the subresources into the correct order before importing.