### PR TITLE
Fix incorrect logical identifiers for constant buffers with D3D12

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_bytecode.cpp
@@ -350,9 +350,6 @@ DXBC::Reflection *Program::GuessReflection()
 
         cb.name = desc.name;
 
-        // In addition to the register, store the identifier that we'll use to lookup during
-        // debugging. For SM5.1, this is the logical identifier that correlates to the CB order in
-        // the bytecode. For SM5 and earlier, it's the CB register.
         cb.identifier = idx;
         cb.space = dcl.space;
         cb.reg = reg;

--- a/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
@@ -725,7 +725,7 @@ DXBCContainer::DXBCContainer(const void *ByteCode, size_t ByteCodeLength)
 
       struct CBufferBind
       {
-        uint32_t reg, space, bindCount;
+        uint32_t reg, space, bindCount, identifier;
       };
 
       std::map<rdcstr, CBufferBind> cbufferbinds;
@@ -776,6 +776,7 @@ DXBCContainer::DXBCContainer(const void *ByteCode, size_t ByteCodeLength)
           cb.space = desc.space;
           cb.reg = desc.reg;
           cb.bindCount = desc.bindCount;
+          cb.identifier = h->targetVersion >= 0x501 ? res->ID : desc.reg;
           cbufferbinds[cname] = cb;
         }
         else if(desc.IsSampler())
@@ -926,10 +927,7 @@ DXBCContainer::DXBCContainer(const void *ByteCode, size_t ByteCodeLength)
 
         cbuffernames.insert(cname);
 
-        // In addition to the register, store the identifier that we'll use to lookup during
-        // debugging. For SM5.1, this is the logical identifier that correlates to the CB order in
-        // the bytecode. For SM5 and earlier, it's the CB register.
-        cb.identifier = (h->targetVersion < 0x501) ? cbufferbinds[cname].reg : i;
+        cb.identifier = cbufferbinds[cname].identifier;
         cb.space = cbufferbinds[cname].space;
         cb.reg = cbufferbinds[cname].reg;
         cb.bindCount = cbufferbinds[cname].bindCount;

--- a/util/test/demos/d3d12/d3d12_cbuffer_zoo.cpp
+++ b/util/test/demos/d3d12/d3d12_cbuffer_zoo.cpp
@@ -49,7 +49,7 @@ struct nested_with_padding
                                         // [3]: {24, 25, 26}, <27>
 };
 
-cbuffer consts : register(b0)
+cbuffer consts : register(b7)
 {
   // dummy* entries are just to 'reset' packing to avoid pollution between tests
 
@@ -329,7 +329,7 @@ float4 main() : SV_Target0
     ID3D12ResourcePtr cb = MakeBuffer().Data(cbufferdata);
 
     ID3D12RootSignaturePtr sig = MakeSig({
-        cbvParam(D3D12_SHADER_VISIBILITY_PIXEL, 0, 0),
+        cbvParam(D3D12_SHADER_VISIBILITY_PIXEL, 0, 7),
         constParam(D3D12_SHADER_VISIBILITY_PIXEL, 0, 1, sizeof(rootData) / sizeof(uint32_t)),
         cbvParam(D3D12_SHADER_VISIBILITY_PIXEL, 999999999, 0),
     });

--- a/util/test/tests/D3D12/D3D12_CBuffer_Zoo.py
+++ b/util/test/tests/D3D12/D3D12_CBuffer_Zoo.py
@@ -1,7 +1,6 @@
 import rdtest
 import renderdoc as rd
 
-
 class D3D12_CBuffer_Zoo(rdtest.TestCase):
     demos_test_name = 'D3D12_CBuffer_Zoo'
 
@@ -19,9 +18,9 @@ class D3D12_CBuffer_Zoo(rdtest.TestCase):
         refl: rd.ShaderReflection = pipe.GetShaderReflection(stage)
         mapping: rd.ShaderBindpointMapping = pipe.GetBindpointMapping(stage)
 
-        # Make sure we have three constant buffers - b0 normal, b1 root constants, and space9999999:b0
+        # Make sure we have three constant buffers - b7 normal, b1 root constants, and space9999999:b0
         binds = [
-            (0, 0),
+            (0, 7),
             (0, 1),
             (999999999, 0),
         ]
@@ -104,6 +103,19 @@ class D3D12_CBuffer_Zoo(rdtest.TestCase):
             self.check_cbuffers(var_check, root_check, huge_check)
 
             rdtest.log.success("Debugged CBuffer variables are as expected")
+
+            cycles, variables = self.process_trace(trace)
+
+            output = self.find_output_source_var(trace, rd.ShaderBuiltin.ColorOutput, 0)
+
+            debugged = self.evaluate_source_var(output, variables)
+
+            if not rdtest.util.value_compare(debugged.value.fv[0:4], [512.1, 513.0, 514.0, 515.0]):
+                raise rdtest.TestFailureException(
+                    "Debugged output {} did not match expected {}".format(
+                        debugged.value.fv[0:4], [512.1, 513.0, 514.0, 515.0]))
+
+            rdtest.log.success("Debugged output matched as expected")
 
             self.controller.FreeTrace(trace)
 


### PR DESCRIPTION
The assignment of logical identifiers is not guaranteed to match the order of appearance in the shader bytecode - there is information in either the RDEF chunk or the declaration that provides it. Fixed selection of CB register indices when adding CBs for debugging to match. Adjusted D3D12_CBuffer_Zoo to exercise this for testing.