### PR TITLE
Prevent crash with OMSetRenderTargets in D3D12

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -1502,7 +1502,8 @@ void WrappedID3D12GraphicsCommandList::OMSetRenderTargets(
     m_ListRecord->AddChunk(scope.Get());
     if(RTsSingleHandleToDescriptorRange)
     {
-      D3D12Descriptor *desc = GetWrapped(pRenderTargetDescriptors[0]);
+      D3D12Descriptor *desc =
+          (NumRenderTargetDescriptors == 0) ? NULL : GetWrapped(pRenderTargetDescriptors[0]);
       for(UINT i = 0; i < NumRenderTargetDescriptors; i++)
       {
         m_ListRecord->MarkResourceFrameReferenced(desc->GetHeapResourceId(), eFrameRef_Read);

--- a/util/test/demos/d3d12/d3d12_rendertarget_binds.cpp
+++ b/util/test/demos/d3d12/d3d12_rendertarget_binds.cpp
@@ -123,6 +123,10 @@ void main(out float4 out1 : SV_Target0, out float4 out2 : SV_Target1)
 
       Reset(cmd);
 
+      // Set null render targets to ensure that these work properly when attached
+      cmd->OMSetRenderTargets(0, NULL, FALSE, NULL);
+      cmd->OMSetRenderTargets(0, NULL, TRUE, NULL);
+
       ID3D12ResourcePtr bb = StartUsingBackbuffer(cmd, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
       D3D12_CPU_DESCRIPTOR_HANDLE bbrtv =


### PR DESCRIPTION
OMSetRenderTargets(0, NULL, TRUE, NULL) is a valid API call, but was crashing when launched from RenderDoc.