### PR TITLE
Implement GetSampleInfo for D3D12 debugging

### DIFF
--- a/util/test/demos/d3d11/d3d11_shader_debug_zoo.cpp
+++ b/util/test/demos/d3d11/d3d11_shader_debug_zoo.cpp
@@ -101,6 +101,7 @@ Buffer<float> test : register(t0);
 ByteAddressBuffer byterotest : register(t1);
 StructuredBuffer<MyStruct> structrotest : register(t2);
 Texture2D<float> dimtex : register(t3);
+Texture2DMS<float> dimtexms : register(t4);
 RWByteAddressBuffer byterwtest : register(u1);
 RWStructuredBuffer<MyStruct> structrwtest : register(u2);
 
@@ -556,6 +557,33 @@ float4 main(v2f IN) : SV_Target0
     test.GetDimensions(width);
     return float4(max(1,width), 0.0f, 0.0f, 0.0f);
   }
+  if(IN.tri == 63)
+  {
+    uint width = 0, height = 0, numSamples = 0;
+    dimtexms.GetDimensions(width, height, numSamples);
+    return float4(width, height, numSamples, 0.0f);
+  }
+  if(IN.tri == 64)
+  {
+    uint width = 0, height = 0, numSamples = 0;
+    dimtexms.GetDimensions(width, height, numSamples);
+    float2 posLast = dimtexms.GetSamplePosition(numSamples - 1);
+    return float4(posLast, 0.0f, 0.0f);
+  }
+  if(IN.tri == 65)
+  {
+    uint width = 0, height = 0, numSamples = 0;
+    dimtexms.GetDimensions(width, height, numSamples);
+    float2 posInvalid = dimtexms.GetSamplePosition(numSamples + 1);
+    return float4(posInvalid, 0.0f, 0.0f);
+  }
+  if(IN.tri == 66)
+  {
+    // Test sampleinfo with a non-MSAA rasterizer
+    uint numSamples = GetRenderTargetSampleCount();
+    float2 pos = GetRenderTargetSamplePosition(0);
+    return float4(pos, numSamples, 0.0f);
+  }
 
   return float4(0.4f, 0.4f, 0.4f, 0.4f);
 }
@@ -582,7 +610,12 @@ float4 main(v2f IN, uint samp : SV_SampleIndex) : SV_Target0
   float y = (uvSamp0.x + uvSamp0.y) * 0.5f;
   float z = (uvSampThis.x + uvSampThis.y) * 0.5f;
   float w = (uvOffset.x + uvOffset.y) * 0.5f;
-  return float4(x, y, z, w);
+
+  // Test sampleinfo with a MSAA rasterizer
+  uint numSamples = GetRenderTargetSampleCount();
+  float2 pos = GetRenderTargetSamplePosition(samp);
+
+  return float4(x + pos.x, y + pos.y, z + (float)numSamples, w);
 }
 
 )EOSHADER";
@@ -660,6 +693,9 @@ float4 main(v2f IN, uint samp : SV_SampleIndex) : SV_Target0
     ID3D11Texture2DPtr testTex = MakeTexture(DXGI_FORMAT_R32G32B32A32_FLOAT, 16, 16).Mips(3).SRV();
     ID3D11ShaderResourceViewPtr testSRV = MakeSRV(testTex);
 
+    ID3D11Texture2DPtr msTex = MakeTexture(DXGI_FORMAT_R32_FLOAT, 16, 16).Multisampled(4).RTV().SRV();
+    ID3D11ShaderResourceViewPtr msSRV = MakeSRV(msTex);
+
     ID3D11BufferPtr rawBuf = MakeBuffer().SRV().ByteAddressed().Data(testdata);
     ID3D11ShaderResourceViewPtr rawsrv =
         MakeSRV(rawBuf).Format(DXGI_FORMAT_R32_TYPELESS).FirstElement(4).NumElements(12);
@@ -681,7 +717,7 @@ float4 main(v2f IN, uint samp : SV_SampleIndex) : SV_Target0
         MakeUAV(structBuf2).Format(DXGI_FORMAT_UNKNOWN).FirstElement(3).NumElements(5);
 
     ID3D11ShaderResourceView *srvs[] = {
-        srv, rawsrv, structsrv, testSRV,
+        srv, rawsrv, structsrv, testSRV, msSRV,
     };
 
     ctx->PSSetShaderResources(0, ARRAY_COUNT(srvs), srvs);


### PR DESCRIPTION
- Added GetSampleInfo impl for D3D12
- Added tests to D3D11/D3D12 shader debug zoos for sampleinfo/samplepos, for both SRVs and rasterizer resources
- Fixed some bugs with debugging these instructions uncovered with the new tests:
  - A temp register wouldn't work for samplepos - this would be necessary for looping over sample positions, for example.
  - samplepos index was using pre-resolved src operand which was missing register value
  - An invalid sample index for samplepos must return a zero vector
  - A binding slot isn't needed when getting sample info for a rasterizer resource