### PR TITLE
Use system libstb if found

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -255,15 +255,22 @@ set(sources
     3rdparty/zstd/zstd_opt.h
     3rdparty/zstd/zstdmt_compress.c
     3rdparty/zstd/zstdmt_compress.h
-    3rdparty/stb/stb_image.h
-    3rdparty/stb/stb_image_write.h
-    3rdparty/stb/stb_image_resize.h
-    3rdparty/stb/stb_impl.c
-    3rdparty/stb/stb_truetype.h
     3rdparty/tinyexr/tinyexr.cpp
     3rdparty/tinyexr/tinyexr.h
     3rdparty/tinyfiledialogs/tinyfiledialogs.c
     3rdparty/tinyfiledialogs/tinyfiledialogs.h)
+
+find_library(STB_LIBRARY stb)
+if ( NOT STB_LIBRARY )
+    list(APPEND sources
+        3rdparty/stb/stb_image.h
+        3rdparty/stb/stb_image_write.h
+        3rdparty/stb/stb_image_resize.h
+        3rdparty/stb/stb_impl.c
+        3rdparty/stb/stb_truetype.h)
+else()
+    list(APPEND RDOC_LIBRARIES PRIVATE ${STB_LIBRARY})
+endif()
 
 if(ANDROID)
     list(APPEND sources

--- a/renderdoc/driver/vulkan/vk_rendertext.cpp
+++ b/renderdoc/driver/vulkan/vk_rendertext.cpp
@@ -23,7 +23,7 @@
  ******************************************************************************/
 
 #include "vk_rendertext.h"
-#include "3rdparty/stb/stb_truetype.h"
+#include "stb/stb_truetype.h"
 #include "maths/matrix.h"
 #include "strings/string_utils.h"
 #include "vk_shader_cache.h"

--- a/renderdoc/os/win32/win32_shellext.cpp
+++ b/renderdoc/os/win32/win32_shellext.cpp
@@ -30,7 +30,7 @@
 #include <thumbcache.h>
 #include <windows.h>
 #include "3rdparty/lz4/lz4.h"
-#include "3rdparty/stb/stb_image_resize.h"
+#include "stb/stb_image_resize.h"
 #include "common/common.h"
 #include "core/core.h"
 #include "jpeg-compressor/jpgd.h"

--- a/renderdoc/serialise/rdcfile.cpp
+++ b/renderdoc/serialise/rdcfile.cpp
@@ -25,7 +25,7 @@
 #include "rdcfile.h"
 #include <errno.h>
 #include "3rdparty/jpeg-compressor/jpge.h"
-#include "3rdparty/stb/stb_image.h"
+#include "stb/stb_image.h"
 #include "api/replay/version.h"
 #include "common/dds_readwrite.h"
 #include "common/formatting.h"


### PR DESCRIPTION
If a system has support for libstb, then it is preferable to use that system
library rather than the vendored version. These patches make that possible.

If the library is not found, then the vendored version will still be used, so
hopefully this change should not disrupt users that don't have the library
available.

This has not been build tested on windows, so hopefully the changes in
the first patch will not break that. (Of course, CI will let me know soon. :)