### PR TITLE
Improve handling of resource arrays for D3D12

### DIFF
--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -2269,6 +2269,14 @@ void ShaderViewer::updateDebugState()
             VariableTag(DebugVariableReference(DebugVariableType::ReadOnlyResource, ro.name))));
         ui->constants->addTopLevelItem(node);
       }
+      else if(bind.arraySize == ~0U)
+      {
+        RDTreeWidgetItem *node = new RDTreeWidgetItem(
+            {m_ShaderDetails->readOnlyResources[i].name, ro.name, lit("[unbounded]"), QString()});
+        node->setTag(QVariant::fromValue(
+            VariableTag(DebugVariableReference(DebugVariableType::ReadOnlyResource, ro.name))));
+        ui->constants->addTopLevelItem(node);
+      }
       else
       {
         RDTreeWidgetItem *node =
@@ -2325,7 +2333,15 @@ void ShaderViewer::updateDebugState()
             new RDTreeWidgetItem({m_ShaderDetails->readWriteResources[i].name, rw.name,
                                   lit("Resource"), ToQStr(rwBind.resources[0].resourceId)});
         node->setTag(QVariant::fromValue(
-            VariableTag(DebugVariableReference(DebugVariableType::ReadOnlyResource, rw.name))));
+            VariableTag(DebugVariableReference(DebugVariableType::ReadWriteResource, rw.name))));
+        ui->constants->addTopLevelItem(node);
+      }
+      else if(bind.arraySize == ~0U)
+      {
+        RDTreeWidgetItem *node = new RDTreeWidgetItem(
+            {m_ShaderDetails->readWriteResources[i].name, rw.name, lit("[unbounded]"), QString()});
+        node->setTag(QVariant::fromValue(
+            VariableTag(DebugVariableReference(DebugVariableType::ReadWriteResource, rw.name))));
         ui->constants->addTopLevelItem(node);
       }
       else
@@ -2334,7 +2350,7 @@ void ShaderViewer::updateDebugState()
             new RDTreeWidgetItem({m_ShaderDetails->readWriteResources[i].name, rw.name,
                                   QFormatStr("[%1]").arg(bind.arraySize), QString()});
         node->setTag(QVariant::fromValue(
-            VariableTag(DebugVariableReference(DebugVariableType::ReadOnlyResource, rw.name))));
+            VariableTag(DebugVariableReference(DebugVariableType::ReadWriteResource, rw.name))));
 
         for(uint32_t a = 0; a < bind.arraySize; a++)
         {
@@ -2763,6 +2779,12 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
         if(bind.arraySize == 1)
         {
           value = ToQStr(res.resources[0].resourceId);
+        }
+        else if(bind.arraySize == ~0U)
+        {
+          regNames = QString();
+          typeName = lit("[unbounded]");
+          value = QString();
         }
         else
         {

--- a/util/test/demos/d3d12/d3d12_test.cpp
+++ b/util/test/demos/d3d12/d3d12_test.cpp
@@ -906,11 +906,11 @@ ID3DBlobPtr D3D12GraphicsTest::Compile(std::string src, std::string entry, std::
   ID3DBlobPtr blob = NULL;
   ID3DBlobPtr error = NULL;
 
-  HRESULT hr =
-      dyn_D3DCompile(src.c_str(), src.length(), "", NULL, NULL, entry.c_str(), profile.c_str(),
-                     D3DCOMPILE_WARNINGS_ARE_ERRORS | D3DCOMPILE_DEBUG |
-                         D3DCOMPILE_SKIP_OPTIMIZATION | D3DCOMPILE_OPTIMIZATION_LEVEL0,
-                     0, &blob, &error);
+  HRESULT hr = dyn_D3DCompile(
+      src.c_str(), src.length(), "", NULL, NULL, entry.c_str(), profile.c_str(),
+      D3DCOMPILE_WARNINGS_ARE_ERRORS | D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION |
+          D3DCOMPILE_OPTIMIZATION_LEVEL0 | D3DCOMPILE_ENABLE_UNBOUNDED_DESCRIPTOR_TABLES,
+      0, &blob, &error);
 
   if(FAILED(hr))
   {

--- a/util/test/tests/D3D12/D3D12_Resource_Mapping_Zoo.py
+++ b/util/test/tests/D3D12/D3D12_Resource_Mapping_Zoo.py
@@ -58,6 +58,17 @@ class D3D12_Resource_Mapping_Zoo(rdtest.TestCase):
 
         rdtest.log.end_section("Resource array tests")
 
+        rdtest.log.begin_section("Bindless tests")
+        test_marker: rd.DrawcallDescription = self.find_draw("Bindless")
+        draw = test_marker.next
+        self.controller.SetFrameEvent(draw.eventId, False)
+
+        for y in range(4):
+            for x in range(4):
+                failed = not self.test_debug_pixel(200 + x, 200 + y, "Bindless({},{})".format(x, y)) or failed
+
+        rdtest.log.end_section("Bindless tests")
+
         if failed:
             raise rdtest.TestFailureException("Some tests were not as expected")
 


### PR DESCRIPTION
- When getting read only resources from the pipe state, stitch back up according to the bindpoint mappings.
- When displaying resources in UI, don't traverse unbounded arrays and just display the size as [unbounded]
- Fix resource swizzle on load/sample/gather instructions, which happens on fetch result, not on the source operand. This was causing certain ways to index into resource arrays to use the wrong register.
- Added more tests for unbounded arrays and different ways to index into arrays.