### PR TITLE
Do not unmap memory is flush is in progress

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1090,6 +1090,7 @@ struct MemMapState
   bool mapCoherent;
   byte *mappedPtr;
   byte *refData;
+  Threading::CriticalSection mrLock;
 };
 
 struct AttachmentInfo

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -953,6 +953,8 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
         VkResourceRecord *record = *it;
         MemMapState &state = *record->memMapState;
 
+        SCOPED_LOCK(state.mrLock);
+
         // potential persistent map
         if(state.mapCoherent && state.mappedPtr && !state.mapFlushed)
         {


### PR DESCRIPTION
When capture is triggered, calls to vkQueueSubmit attempt to flush all
coherent mapped memory. This causes a problem in some cases if
application calls vkUnmapMemory on the memory that is being flushed.

The goal is to only allow vkUnmapMemory to proceed if that memory is not
currently being flushed, and is in one of the records in the copy that
vkQueueSubmit made of m_CoherentMaps.
