### PR TITLE
Disable crash reporting for unofficial renderdoccmd builds

### DIFF
--- a/renderdoccmd/renderdoccmd_win32.cpp
+++ b/renderdoccmd/renderdoccmd_win32.cpp
@@ -62,7 +62,7 @@ static std::wstring conv(const std::string &str)
 
 HINSTANCE hInstance = NULL;
 
-#if defined(RELEASE)
+#if defined(RELEASE) && RENDERDOC_OFFICIAL_BUILD
 #define CRASH_HANDLER 1
 #else
 #define CRASH_HANDLER 0


### PR DESCRIPTION
This follows the lead of crash_handler.h in renderdoc proper.

I guess this assumes `RENDERDOC_OFFICIAL_BUILD` is set for official builds of renderdoccmd but that seems reasonable to assume all of the projects are built with that set. You may want to double check prior to merging.