### PR TITLE
Show correct clear/CopyDst/CopySrc subresource in texture viewer

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -178,7 +178,7 @@ rdcarray<BoundResource> Following::GetOutputTargets(ICaptureContext &ctx)
 
   if(copy || clear)
   {
-    return {BoundResource(curDraw->copyDestination)};
+    return {BoundResource(curDraw->copyDestination, curDraw->copyDestinationSubresource)};
   }
   else if(compute)
   {
@@ -191,7 +191,7 @@ rdcarray<BoundResource> Following::GetOutputTargets(ICaptureContext &ctx)
     if(ret.isEmpty() && curDraw != NULL && (curDraw->flags & DrawFlags::Present))
     {
       if(curDraw->copyDestination != ResourceId())
-        return {BoundResource(curDraw->copyDestination)};
+        return {BoundResource(curDraw->copyDestination, curDraw->copyDestinationSubresource)};
 
       for(const TextureDescription &tex : ctx.GetTextures())
       {
@@ -255,7 +255,8 @@ rdcarray<BoundResourceArray> Following::GetReadOnlyResources(ICaptureContext &ct
 
     // only return copy source for one stage
     if(copy && stage == ShaderStage::Pixel)
-      ret.push_back(BoundResourceArray(Bindpoint(0, 0), {BoundResource(curDraw->copySource)}));
+      ret.push_back(BoundResourceArray(
+          Bindpoint(0, 0), {BoundResource(curDraw->copySource, curDraw->copySourceSubresource)}));
 
     return ret;
   }

--- a/renderdoc/api/replay/common_pipestate.h
+++ b/renderdoc/api/replay/common_pipestate.h
@@ -253,6 +253,15 @@ struct BoundResource
     firstSlice = -1;
     typeCast = CompType::Typeless;
   }
+
+  BoundResource(ResourceId id, Subresource subresource)
+  {
+    resourceId = id;
+    dynamicallyUsed = true;
+    firstMip = subresource.mip;
+    firstSlice = subresource.slice;
+    typeCast = CompType::Typeless;
+  }
   BoundResource(const BoundResource &) = default;
   BoundResource &operator=(const BoundResource &) = default;
 

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -1253,6 +1253,50 @@ struct EventUsage
 
 DECLARE_REFLECTION_STRUCT(EventUsage);
 
+DOCUMENT("Specifies a subresource within a texture.");
+struct Subresource
+{
+  DOCUMENT("");
+  Subresource(uint32_t mip = 0, uint32_t slice = 0, uint32_t sample = 0)
+      : mip(mip), slice(slice), sample(sample)
+  {
+  }
+  Subresource(const Subresource &) = default;
+  Subresource &operator=(const Subresource &) = default;
+
+  bool operator==(const Subresource &o) const
+  {
+    return mip == o.mip && slice == o.slice && sample == o.sample;
+  }
+  bool operator!=(const Subresource &o) const { return !(*this == o); }
+  bool operator<(const Subresource &o) const
+  {
+    if(!(mip == o.mip))
+      return mip < o.mip;
+    if(!(slice == o.slice))
+      return slice < o.slice;
+    if(!(sample == o.sample))
+      return sample < o.sample;
+    return false;
+  }
+
+  DOCUMENT("The mip level in the texture.");
+  uint32_t mip;
+  DOCUMENT(R"(The slice within the texture. For 3D textures this is a depth slice, for arrays it is
+an array slice.
+
+.. note::
+  Cubemaps are simply 2D array textures with a special meaning, so the faces of a cubemap are the 2D
+  array slices in the standard order: X+, X-, Y+, Y-, Z+, Z-. Cubemap arrays are 2D arrays with
+  ``6 * N`` faces, where each cubemap within the array takes up 6 slices in the above order.
+)");
+  uint32_t slice;
+  DOCUMENT("The sample in a multisampled texture.");
+  uint32_t sample;
+};
+
+DECLARE_REFLECTION_STRUCT(Subresource);
+
 DOCUMENT("Describes the properties of a drawcall, dispatch, debug marker, or similar event.");
 struct DrawcallDescription
 {
@@ -1360,10 +1404,15 @@ Valid values are 1 (depending on API), 2 or 4, or 0 if the drawcall is not an in
 operation.
 )");
   ResourceId copySource;
+  DOCUMENT(R"(The :class:`Subresource` specifying which part in :data:`copySource` is used.)");
+  Subresource copySourceSubresource;
+
   DOCUMENT(R"(The :class:`ResourceId` identifying the destination object in a copy, resolve or blit
 operation.
 )");
   ResourceId copyDestination;
+  DOCUMENT(R"(The :class:`Subresource` specifying which part in :data:`copyDestination` is used.)");
+  Subresource copyDestinationSubresource;
 
   DOCUMENT(R"(The parent of this drawcall, or ``None`` if there is no parent for this drawcall.
 )");
@@ -1644,50 +1693,6 @@ union PixelValue
 };
 
 DECLARE_REFLECTION_STRUCT(PixelValue);
-
-DOCUMENT("Specifies a subresource within a texture.");
-struct Subresource
-{
-  DOCUMENT("");
-  Subresource(uint32_t mip = 0, uint32_t slice = 0, uint32_t sample = 0)
-      : mip(mip), slice(slice), sample(sample)
-  {
-  }
-  Subresource(const Subresource &) = default;
-  Subresource &operator=(const Subresource &) = default;
-
-  bool operator==(const Subresource &o) const
-  {
-    return mip == o.mip && slice == o.slice && sample == o.sample;
-  }
-  bool operator!=(const Subresource &o) const { return !(*this == o); }
-  bool operator<(const Subresource &o) const
-  {
-    if(!(mip == o.mip))
-      return mip < o.mip;
-    if(!(slice == o.slice))
-      return slice < o.slice;
-    if(!(sample == o.sample))
-      return sample < o.sample;
-    return false;
-  }
-
-  DOCUMENT("The mip level in the texture.");
-  uint32_t mip;
-  DOCUMENT(R"(The slice within the texture. For 3D textures this is a depth slice, for arrays it is
-an array slice.
-
-.. note::
-  Cubemaps are simply 2D array textures with a special meaning, so the faces of a cubemap are the 2D
-  array slices in the standard order: X+, X-, Y+, Y-, Z+, Z-. Cubemap arrays are 2D arrays with
-  ``6 * N`` faces, where each cubemap within the array takes up 6 slices in the above order.
-)");
-  uint32_t slice;
-  DOCUMENT("The sample in a multisampled texture.");
-  uint32_t sample;
-};
-
-DECLARE_REFLECTION_STRUCT(Subresource);
 
 DOCUMENT("The value of pixel output at a particular event.");
 struct ModificationValue

--- a/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
@@ -5595,7 +5595,14 @@ bool WrappedID3D11DeviceContext::Serialise_CopySubresourceRegion(
       if(pDstResource && pSrcResource)
       {
         draw.copySource = srcOrigID;
+        draw.copySourceSubresource =
+            Subresource(GetMipForSubresource(pSrcResource, SrcSubresource),
+                        GetSliceForSubresource(pSrcResource, SrcSubresource));
+
         draw.copyDestination = dstOrigID;
+        draw.copyDestinationSubresource =
+            Subresource(GetMipForSubresource(pDstResource, DstSubresource),
+                        GetSliceForSubresource(pDstResource, DstSubresource));
 
         if(m_CurEventID)
         {
@@ -5743,7 +5750,9 @@ bool WrappedID3D11DeviceContext::Serialise_CopyResource(SerialiserType &ser,
       if(pDstResource && pSrcResource)
       {
         draw.copySource = srcOrigID;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = dstOrigID;
+        draw.copyDestinationSubresource = Subresource();
 
         if(m_CurEventID)
         {
@@ -6182,7 +6191,9 @@ bool WrappedID3D11DeviceContext::Serialise_CopyStructureCount(SerialiserType &se
       draw.name = "CopyStructureCount(" + ToStr(dstOrigID) + ", " + ToStr(srcOrigID) + ")";
       draw.flags |= DrawFlags::Copy;
       draw.copySource = srcOrigID;
+      draw.copySourceSubresource = Subresource();
       draw.copyDestination = dstOrigID;
+      draw.copyDestinationSubresource = Subresource();
 
       if(m_CurEventID)
       {
@@ -6295,7 +6306,13 @@ bool WrappedID3D11DeviceContext::Serialise_ResolveSubresource(SerialiserType &se
       if(pDstResource && pSrcResource)
       {
         draw.copySource = srcOrigID;
+        draw.copySourceSubresource =
+            Subresource(GetMipForSubresource(pSrcResource, SrcSubresource),
+                        GetSliceForSubresource(pSrcResource, SrcSubresource));
         draw.copyDestination = dstOrigID;
+        draw.copyDestinationSubresource =
+            Subresource(GetMipForSubresource(pDstResource, DstSubresource),
+                        GetSliceForSubresource(pDstResource, DstSubresource));
 
         if(m_CurEventID)
         {
@@ -6545,6 +6562,10 @@ bool WrappedID3D11DeviceContext::Serialise_ClearRenderTargetView(
             EventUsage(m_CurEventID, ResourceUsage::Clear, view->GetResourceID()));
         draw.copyDestination =
             m_pDevice->GetResourceManager()->GetOriginalID(view->GetResourceResID());
+        D3D11_RENDER_TARGET_VIEW_DESC viewDesc;
+        view->GetDesc(&viewDesc);
+        draw.copyDestinationSubresource =
+            Subresource(GetMipForRtv(viewDesc), GetSliceForRtv(viewDesc));
       }
 
       AddDrawcall(draw, true);
@@ -6626,6 +6647,7 @@ bool WrappedID3D11DeviceContext::Serialise_ClearUnorderedAccessViewUint(
             EventUsage(m_CurEventID, ResourceUsage::Clear, view->GetResourceID()));
         draw.copyDestination =
             m_pDevice->GetResourceManager()->GetOriginalID(view->GetResourceResID());
+        draw.copyDestinationSubresource = Subresource();
       }
 
       AddDrawcall(draw, true);
@@ -6706,6 +6728,7 @@ bool WrappedID3D11DeviceContext::Serialise_ClearUnorderedAccessViewFloat(
             EventUsage(m_CurEventID, ResourceUsage::Clear, view->GetResourceID()));
         draw.copyDestination =
             m_pDevice->GetResourceManager()->GetOriginalID(view->GetResourceResID());
+        draw.copyDestinationSubresource = Subresource();
       }
 
       AddDrawcall(draw, true);
@@ -6794,6 +6817,10 @@ bool WrappedID3D11DeviceContext::Serialise_ClearDepthStencilView(
             EventUsage(m_CurEventID, ResourceUsage::Clear, view->GetResourceID()));
         draw.copyDestination =
             m_pDevice->GetResourceManager()->GetOriginalID(view->GetResourceResID());
+        D3D11_DEPTH_STENCIL_VIEW_DESC viewDesc;
+        view->GetDesc(&viewDesc);
+        draw.copyDestinationSubresource =
+            Subresource(GetMipForDsv(viewDesc), GetSliceForDsv(viewDesc));
       }
 
       AddDrawcall(draw, true);

--- a/renderdoc/driver/d3d11/d3d11_resources.h
+++ b/renderdoc/driver/d3d11/d3d11_resources.h
@@ -41,6 +41,15 @@ UINT GetByteSize(ID3D11Texture2D *tex, int SubResource);
 UINT GetByteSize(ID3D11Texture3D *tex, int SubResource);
 
 UINT GetMipForSubresource(ID3D11Resource *res, int Subresource);
+UINT GetSliceForSubresource(ID3D11Resource *res, int Subresource);
+UINT GetMipForDsv(const D3D11_DEPTH_STENCIL_VIEW_DESC &dsv);
+UINT GetSliceForDsv(const D3D11_DEPTH_STENCIL_VIEW_DESC &dsv);
+UINT GetMipForRtv(const D3D11_RENDER_TARGET_VIEW_DESC &rtv);
+UINT GetSliceForRtv(const D3D11_RENDER_TARGET_VIEW_DESC &rtv);
+UINT GetMipForSrv(const D3D11_SHADER_RESOURCE_VIEW_DESC &srv);
+UINT GetSliceForSrv(const D3D11_SHADER_RESOURCE_VIEW_DESC &srv);
+UINT GetMipForUav(const D3D11_UNORDERED_ACCESS_VIEW_DESC &uav);
+UINT GetSliceForUav(const D3D11_UNORDERED_ACCESS_VIEW_DESC &uav);
 
 struct ResourcePitch
 {

--- a/renderdoc/driver/d3d12/d3d12_resources.cpp
+++ b/renderdoc/driver/d3d12/d3d12_resources.cpp
@@ -518,3 +518,79 @@ void WrappedID3D12PipelineState::ShaderEntry::BuildReflection()
   MakeShaderReflection(m_DXBCFile, &m_Details, &m_Mapping);
   m_Details.resourceId = GetResourceID();
 }
+
+UINT GetMipForSubresource(ID3D12Resource *res, int Subresource)
+{
+  D3D12_RESOURCE_DESC desc = res->GetDesc();
+
+  if(desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+    return Subresource;
+
+  int mipLevels = desc.MipLevels;
+
+  if(mipLevels == 0)
+    mipLevels = CalcNumMips((int)desc.Width, 1, 1);
+
+  return (Subresource % mipLevels);
+}
+
+UINT GetSliceForSubresource(ID3D12Resource *res, int Subresource)
+{
+  D3D12_RESOURCE_DESC desc = res->GetDesc();
+
+  if(desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+    return Subresource;
+
+  int mipLevels = desc.MipLevels;
+
+  if(mipLevels == 0)
+    mipLevels = CalcNumMips((int)desc.Width, 1, 1);
+
+  return (Subresource / mipLevels) % desc.DepthOrArraySize;
+}
+
+UINT GetMipForDsv(const D3D12_DEPTH_STENCIL_VIEW_DESC &view)
+{
+  switch(view.ViewDimension)
+  {
+    case D3D12_DSV_DIMENSION_TEXTURE1D: return view.Texture1D.MipSlice;
+    case D3D12_DSV_DIMENSION_TEXTURE1DARRAY: return view.Texture1DArray.MipSlice;
+    case D3D12_DSV_DIMENSION_TEXTURE2D: return view.Texture2D.MipSlice;
+    case D3D12_DSV_DIMENSION_TEXTURE2DARRAY: return view.Texture2DArray.MipSlice;
+    default: return 0;
+  }
+}
+
+UINT GetSliceForDsv(const D3D12_DEPTH_STENCIL_VIEW_DESC &view)
+{
+  switch(view.ViewDimension)
+  {
+    case D3D12_DSV_DIMENSION_TEXTURE1DARRAY: return view.Texture1DArray.FirstArraySlice;
+    case D3D12_DSV_DIMENSION_TEXTURE2DARRAY: return view.Texture2DArray.FirstArraySlice;
+    case D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY: return view.Texture2DMSArray.FirstArraySlice;
+    default: return 0;
+  }
+}
+
+UINT GetMipForRtv(const D3D12_RENDER_TARGET_VIEW_DESC &view)
+{
+  switch(view.ViewDimension)
+  {
+    case D3D12_RTV_DIMENSION_TEXTURE1D: return view.Texture1D.MipSlice;
+    case D3D12_RTV_DIMENSION_TEXTURE1DARRAY: return view.Texture1DArray.MipSlice;
+    case D3D12_RTV_DIMENSION_TEXTURE2D: return view.Texture2D.MipSlice;
+    case D3D12_RTV_DIMENSION_TEXTURE2DARRAY: return view.Texture2DArray.MipSlice;
+    case D3D12_RTV_DIMENSION_TEXTURE3D: return view.Texture3D.MipSlice;
+    default: return 0;
+  }
+}
+UINT GetSliceForRtv(const D3D12_RENDER_TARGET_VIEW_DESC &view)
+{
+  switch(view.ViewDimension)
+  {
+    case D3D12_RTV_DIMENSION_TEXTURE1DARRAY: return view.Texture1DArray.FirstArraySlice;
+    case D3D12_RTV_DIMENSION_TEXTURE2DARRAY: return view.Texture2DArray.FirstArraySlice;
+    case D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY: return view.Texture2DMSArray.FirstArraySlice;
+    default: return 0;
+  }
+}

--- a/renderdoc/driver/d3d12/d3d12_resources.h
+++ b/renderdoc/driver/d3d12/d3d12_resources.h
@@ -28,6 +28,13 @@
 #include "d3d12_device.h"
 #include "d3d12_manager.h"
 
+UINT GetMipForSubresource(ID3D12Resource *res, int Subresource);
+UINT GetSliceForSubresource(ID3D12Resource *res, int Subresource);
+UINT GetMipForDsv(const D3D12_DEPTH_STENCIL_VIEW_DESC &dsv);
+UINT GetSliceForDsv(const D3D12_DEPTH_STENCIL_VIEW_DESC &dsv);
+UINT GetMipForRtv(const D3D12_RENDER_TARGET_VIEW_DESC &rtv);
+UINT GetSliceForRtv(const D3D12_RENDER_TARGET_VIEW_DESC &rtv);
+
 class TrackedResource12
 {
 public:

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -1376,8 +1376,16 @@ bool WrappedVulkan::Serialise_vkCmdBlitImage(SerialiserType &ser, VkCommandBuffe
         draw.flags |= DrawFlags::Resolve;
 
         draw.copySource = srcid;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = dstid;
-
+        draw.copyDestinationSubresource = Subresource();
+        if(regionCount > 0)
+        {
+          draw.copySourceSubresource = Subresource(pRegions[0].srcSubresource.mipLevel,
+                                                   pRegions[0].srcSubresource.baseArrayLayer);
+          draw.copyDestinationSubresource = Subresource(pRegions[0].dstSubresource.mipLevel,
+                                                        pRegions[0].dstSubresource.baseArrayLayer);
+        }
         AddDrawcall(draw, true);
 
         VulkanDrawcallTreeNode &drawNode = GetDrawcallStack().back()->children.back();
@@ -1517,8 +1525,16 @@ bool WrappedVulkan::Serialise_vkCmdResolveImage(SerialiserType &ser, VkCommandBu
         draw.flags |= DrawFlags::Resolve;
 
         draw.copySource = srcid;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = dstid;
-
+        draw.copyDestinationSubresource = Subresource();
+        if(regionCount > 0)
+        {
+          draw.copySourceSubresource = Subresource(pRegions[0].srcSubresource.mipLevel,
+                                                   pRegions[0].srcSubresource.baseArrayLayer);
+          draw.copyDestinationSubresource = Subresource(pRegions[0].dstSubresource.mipLevel,
+                                                        pRegions[0].dstSubresource.baseArrayLayer);
+        }
         AddDrawcall(draw, true);
 
         VulkanDrawcallTreeNode &drawNode = GetDrawcallStack().back()->children.back();
@@ -1647,7 +1663,16 @@ bool WrappedVulkan::Serialise_vkCmdCopyImage(SerialiserType &ser, VkCommandBuffe
         draw.flags |= DrawFlags::Copy;
 
         draw.copySource = srcid;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = dstid;
+        draw.copyDestinationSubresource = Subresource();
+        if(regionCount > 0)
+        {
+          draw.copySourceSubresource = Subresource(pRegions[0].srcSubresource.mipLevel,
+                                                   pRegions[0].srcSubresource.baseArrayLayer);
+          draw.copyDestinationSubresource = Subresource(pRegions[0].dstSubresource.mipLevel,
+                                                        pRegions[0].dstSubresource.baseArrayLayer);
+        }
 
         AddDrawcall(draw, true);
 
@@ -1773,7 +1798,12 @@ bool WrappedVulkan::Serialise_vkCmdCopyBufferToImage(
         draw.flags |= DrawFlags::Copy;
 
         draw.copySource = bufid;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = imgid;
+        draw.copyDestinationSubresource = Subresource();
+        if(regionCount > 0)
+          draw.copyDestinationSubresource = Subresource(
+              pRegions[0].imageSubresource.mipLevel, pRegions[0].imageSubresource.baseArrayLayer);
 
         AddDrawcall(draw, true);
 
@@ -1881,7 +1911,12 @@ bool WrappedVulkan::Serialise_vkCmdCopyImageToBuffer(SerialiserType &ser,
         draw.flags |= DrawFlags::Copy;
 
         draw.copySource = imgid;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = bufid;
+        draw.copyDestinationSubresource = Subresource();
+        if(regionCount > 0)
+          draw.copySourceSubresource = Subresource(pRegions[0].imageSubresource.mipLevel,
+                                                   pRegions[0].imageSubresource.baseArrayLayer);
 
         AddDrawcall(draw, true);
 
@@ -1986,7 +2021,9 @@ bool WrappedVulkan::Serialise_vkCmdCopyBuffer(SerialiserType &ser, VkCommandBuff
         draw.flags |= DrawFlags::Copy;
 
         draw.copySource = srcid;
+        draw.copySourceSubresource = Subresource();
         draw.copyDestination = dstid;
+        draw.copyDestinationSubresource = Subresource();
 
         AddDrawcall(draw, true);
 
@@ -2095,6 +2132,7 @@ bool WrappedVulkan::Serialise_vkCmdFillBuffer(SerialiserType &ser, VkCommandBuff
         draw.name = StringFormat::Fmt("vkCmdFillBuffer(%s, %u)", ToStr(id).c_str(), data);
         draw.flags = DrawFlags::Clear;
         draw.copyDestination = id;
+        draw.copyDestinationSubresource = Subresource();
 
         AddDrawcall(draw, true);
 
@@ -2196,6 +2234,10 @@ bool WrappedVulkan::Serialise_vkCmdClearColorImage(SerialiserType &ser, VkComman
                                       Color.float32[1], Color.float32[2], Color.float32[3]);
         draw.flags |= DrawFlags::Clear | DrawFlags::ClearColor;
         draw.copyDestination = GetResourceManager()->GetOriginalID(GetResID(image));
+        draw.copyDestinationSubresource = Subresource();
+        if(rangeCount > 0)
+          draw.copyDestinationSubresource =
+              Subresource(pRanges[0].baseMipLevel, pRanges[0].baseArrayLayer);
 
         AddDrawcall(draw, true);
 
@@ -2306,6 +2348,10 @@ bool WrappedVulkan::Serialise_vkCmdClearDepthStencilImage(
                                       DepthStencil.stencil);
         draw.flags |= DrawFlags::Clear | DrawFlags::ClearDepthStencil;
         draw.copyDestination = GetResourceManager()->GetOriginalID(GetResID(image));
+        draw.copyDestinationSubresource = Subresource();
+        if(rangeCount > 0)
+          draw.copyDestinationSubresource =
+              Subresource(pRanges[0].baseMipLevel, pRanges[0].baseArrayLayer);
 
         AddDrawcall(draw, true);
 

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -559,7 +559,9 @@ void DoSerialise(SerialiserType &ser, DrawcallDescription &el)
   SERIALISE_MEMBER(topology);
 
   SERIALISE_MEMBER(copySource);
+  SERIALISE_MEMBER(copySourceSubresource);
   SERIALISE_MEMBER(copyDestination);
+  SERIALISE_MEMBER(copyDestinationSubresource);
 
   if(ser.IsReading())
     el.parent = el.previous = el.next = NULL;
@@ -570,7 +572,7 @@ void DoSerialise(SerialiserType &ser, DrawcallDescription &el)
   SERIALISE_MEMBER(events);
   SERIALISE_MEMBER(children);
 
-  SIZE_CHECK(288);
+  SIZE_CHECK(320);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
This is working on d3d12 for now. 
May as well get feedback before going too much further.