### PR TITLE
Fix missing byte to bit factor in normalization in decode_mesh example

### DIFF
--- a/docs/python_api/examples/renderdoc/decode_mesh.py
+++ b/docs/python_api/examples/renderdoc/decode_mesh.py
@@ -56,10 +56,10 @@ def unpackData(fmt, data):
 
 	# If the format needs post-processing such as normalisation, do that now
 	if fmt.compType == rd.CompType.UNorm:
-		divisor = float((1 << fmt.compByteWidth) - 1)
+		divisor = float((1 << (fmt.compByteWidth * 8)) - 1)
 		value = tuple(float(i) / divisor for i in value)
 	elif fmt.compType == rd.CompType.SNorm:
-		maxNeg = -(1 << (fmt.compByteWidth - 1))
+		maxNeg = -(1 << (fmt.compByteWidth * 8 - 1))
 		divisor = float(-(maxNeg-1))
 		value = tuple((float(i) if (i == maxNeg) else (float(i) / divisor)) for i in value)
 

--- a/docs/python_api/examples/renderdoc/decode_mesh.rst
+++ b/docs/python_api/examples/renderdoc/decode_mesh.rst
@@ -115,10 +115,10 @@ For normalised formats - :py:attr:`~renderdoc.CompType.UNorm` and :py:attr:`~ren
 
         # If the format needs post-processing such as normalisation, do that now
         if fmt.compType == rd.CompType.UNorm:
-            divisor = float((1 << fmt.compByteWidth) - 1)
+            divisor = float((1 << (fmt.compByteWidth * 8)) - 1)
             value = tuple(float(i) / divisor for i in value)
         elif fmt.compType == rd.CompType.SNorm:
-            maxNeg = -(1 << (fmt.compByteWidth - 1))
+            maxNeg = -(1 << (fmt.compByteWidth * 8 - 1))
             divisor = float(-(maxNeg-1))
             value = tuple((float(i) if (i == maxNeg) else (float(i) / divisor)) for i in value)
 


### PR DESCRIPTION
## Description

`fmt.compByteWidth` is in bytes, so must be multiplied by 8 when used as a **bit** offset: `1 << (fmt.compByteWidth * 8)`
