### PR TITLE
Disable tiled resources for d3d12 check feature

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -2789,6 +2789,25 @@ HRESULT WrappedID3D12Device::CheckFeatureSupport(D3D12_FEATURE Feature, void *pF
 
     return hr;
   }
+  if(Feature == D3D12_FEATURE_D3D12_OPTIONS)
+  {
+    HRESULT hr = m_pDevice->CheckFeatureSupport(Feature, pFeatureSupportData, FeatureSupportDataSize);
+
+    if(SUCCEEDED(hr))
+    {
+      D3D12_FEATURE_DATA_D3D12_OPTIONS *opts =
+          (D3D12_FEATURE_DATA_D3D12_OPTIONS *)pFeatureSupportData;
+      if(FeatureSupportDataSize != sizeof(D3D12_FEATURE_DATA_D3D12_OPTIONS))
+        return E_INVALIDARG;
+
+      // renderdoc doesn't support tiled resources (calls to CreateReservedResource will fail), so don't report it as supported
+      opts->TiledResourcesTier = D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
+
+      return S_OK;
+    }
+
+    return hr;
+  }
   return m_pDevice->CheckFeatureSupport(Feature, pFeatureSupportData, FeatureSupportDataSize);
 }
 


### PR DESCRIPTION
Renderdoc doesn't support TiledResource, as WrappedID3D12Device::CreateReservedResource returns E_NOINTERFACE. This commit reflects the lack of support in WrappedID3D12Device::CheckFeatureSupport.

This allows the application to behave as if the gpu doesn't support
tiled resources.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
