### PR TITLE
Installer: Add install path to registry key

### DIFF
--- a/util/installer/Installer32.wxs
+++ b/util/installer/Installer32.wxs
@@ -217,7 +217,7 @@
         <Directory Id="ProgramMenuDir" Name="RenderDoc">
           <Component Id="ProgramMenuDir" Guid="30CCCAB1-49D5-45B3-952C-53E3B581E691">
             <RemoveFolder Id='ProgramMenuDir' On='uninstall' />
-            <RegistryValue Root='HKCU' Key='Software\[Manufacturer]\[ProductName]' Type='string' Value='' KeyPath='yes' />
+            <RegistryValue Root='HKCU' Key='Software\[Manufacturer]\[ProductName]' Type='string' Value='INSTALLDIR' KeyPath='yes' />
           </Component>
         </Directory>
       </Directory>

--- a/util/installer/Installer64.wxs
+++ b/util/installer/Installer64.wxs
@@ -245,7 +245,7 @@
         <Directory Id="ProgramMenuDir" Name="RenderDoc">
           <Component Id="ProgramMenuDir" Guid="D0755B01-F8D5-4DFE-8D21-DA4ED84B555D">
             <RemoveFolder Id='ProgramMenuDir' On='uninstall' />
-            <RegistryValue Root='HKCU' Key='Software\[Manufacturer]\[ProductName]' Type='string' Value='' KeyPath='yes' />
+            <RegistryValue Root='HKCU' Key='Software\[Manufacturer]\[ProductName]' Type='string' Value='INSTALLDIR' KeyPath='yes' />
           </Component>
         </Directory>
       </Directory>


### PR DESCRIPTION
## Description

Because the installer doesn't store the install path in the registry any application that wants to explicitly load in `renderdoc.dll` has to figure out the path to it from either the keys in `HKEY_CLASSES_ROOT`, the Vulkan implicit layers or prompting the user for it explicitly.

This PR simply adds the install path as the value for an empty registry key that the installer was already creating.