### PR TITLE
Pixel history changes + config to enable

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -27,6 +27,7 @@
 #include "core/core.h"
 #include "vk_common.h"
 #include "vk_core.h"
+#include "vk_shader_cache.h"
 
 struct MeshDisplayPipelines
 {
@@ -76,6 +77,7 @@ public:
                                                  const MeshFormat &primary,
                                                  const MeshFormat &secondary);
 
+  void PatchOutputLocation(VkShaderModule &mod, BuiltinShader shaderType, uint32_t framebufferIndex);
   void PatchFixedColShader(VkShaderModule &mod, float col[4]);
   void PatchLineStripIndexBuffer(const DrawcallDescription *draw, GPUBuffer &indexBuffer,
                                  uint32_t &indexCount);

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -272,6 +272,55 @@ struct VulkanQuadOverdrawCallback : public VulkanDrawcallCallback
   VulkanRenderState m_PrevState;
 };
 
+void VulkanDebugManager::PatchOutputLocation(VkShaderModule &mod, BuiltinShader shaderType,
+                                             uint32_t framebufferIndex)
+{
+  union
+  {
+    uint32_t *spirv;
+    float *data;
+  } alias;
+
+  rdcarray<uint32_t> spv = *m_pDriver->GetShaderCache()->GetBuiltinBlob(shaderType);
+
+  alias.spirv = &spv[0];
+  size_t spirvLength = spv.size();
+
+  bool patched = false;
+
+  size_t it = 5;
+  while(it < spirvLength)
+  {
+    uint16_t WordCount = alias.spirv[it] >> rdcspv::WordCountShift;
+    rdcspv::Op opcode = rdcspv::Op(alias.spirv[it] & rdcspv::OpCodeMask);
+
+    if(opcode == rdcspv::Op::Decorate &&
+       (rdcspv::Decoration(alias.spirv[it + 2]) == rdcspv::Decoration::Location))
+    {
+      alias.spirv[it + 3] = framebufferIndex;
+
+      patched = true;
+      break;
+    }
+
+    it += WordCount;
+  }
+
+  if(!patched)
+    RDCERR("Didn't patch the output location");
+
+  VkShaderModuleCreateInfo modinfo = {
+      VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+      NULL,
+      0,
+      spv.size() * sizeof(uint32_t),
+      alias.spirv,
+  };
+
+  VkResult vkr = m_pDriver->vkCreateShaderModule(m_Device, &modinfo, NULL, &mod);
+  RDCASSERTEQUAL(vkr, VK_SUCCESS);
+}
+
 void VulkanDebugManager::PatchFixedColShader(VkShaderModule &mod, float col[4])
 {
   union

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -44,6 +44,7 @@
 
 RDOC_CONFIG(bool, Vulkan_ShaderDebugging, false,
             "BETA: Enable experimental shader debugging support.");
+RDOC_CONFIG(bool, Vulkan_PixelHistory, false, "BETA: Enable experimental pixel history support.");
 
 static const char *SPIRVDisassemblyTarget = "SPIR-V (RenderDoc)";
 static const char *AMDShaderInfoTarget = "AMD_shader_info";
@@ -191,6 +192,7 @@ APIProperties VulkanReplay::GetAPIProperties()
   ret.rgpCapture =
       m_DriverInfo.vendor == GPUVendor::AMD && m_RGP != NULL && m_RGP->DriverSupportsInterop();
   ret.shaderDebugging = Vulkan_ShaderDebugging;
+  ret.pixelHistory = Vulkan_PixelHistory;
 
   return ret;
 }


### PR DESCRIPTION
- Add config to enable pixel history
- Fix several validation errors
- Fix primitive ID reporting when depth test is OFF
- Patch primitive ID and fixed color shader to output to the correct
framebuffer location when there are multiple color attachments
