### PR TITLE
qrenderdoc: Drop building swig .py.c files

### DIFF
--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -258,14 +258,7 @@ foreach(in ${swig_interfaces})
             DEPENDS ${RDOC_REPLAY_FILES}
             DEPENDS ${QRD_INTERFACE_FILES})
 
-    add_custom_command(OUTPUT ${swig_file}.py.c
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin ${swig_file}.py ${swig_file}.py.c
-            DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
-            DEPENDS ${swig_file}_python.cxx)
-
     list(APPEND swig_output ${swig_file}_python.cxx)
-    list(APPEND swig_output ${swig_file}.py.c)
 endforeach()
 
 add_custom_target(swig-bindings ALL DEPENDS ${swig_output})

--- a/qrenderdoc/qrenderdoc.pro
+++ b/qrenderdoc/qrenderdoc.pro
@@ -128,9 +128,7 @@ win32 {
 
 	# Add the SWIG files that were generated in cmake
 	SOURCES += $$CMAKE_DIR/qrenderdoc/renderdoc_python.cxx
-	SOURCES += $$CMAKE_DIR/qrenderdoc/renderdoc.py.c
 	SOURCES += $$CMAKE_DIR/qrenderdoc/qrenderdoc_python.cxx
-	SOURCES += $$CMAKE_DIR/qrenderdoc/qrenderdoc.py.c
 
 	CONFIG += warn_off
 	CONFIG += c++14


### PR DESCRIPTION
This is an alternative to https://github.com/baldurk/renderdoc/pull/1768 suggested by baldurk.

I found that for some reason when cross compiling, the qrenderdoc CMakeLists.txt was failing to see the include-bin executable that renderdoc should have built.

Apparently the .py.c files were no longer required for qrenderdoc, so removing it also fixed the issue I was seeing.