### PR TITLE
Fixed the launch of adb when using the Android SDK path on Windows

### DIFF
--- a/renderdoc/os/win32/win32_process.cpp
+++ b/renderdoc/os/win32/win32_process.cpp
@@ -998,19 +998,27 @@ uint32_t Process::LaunchProcess(const char *app, const char *workingDir, const c
 {
   HANDLE hChildStdOutput_Rd = NULL, hChildStdError_Rd = NULL;
 
+  rdcstr appPath = app;
+  size_t len = appPath.length();
+  rdcstr ext;
+  if(len > 4)
+    ext = strlower(appPath.substr(len - 4));
+  if(ext != ".exe")
+    appPath += ".exe";
+
   PROCESS_INFORMATION pi =
-      RunProcess(app, workingDir, cmdLine, {}, internal, result ? &hChildStdOutput_Rd : NULL,
-                 result ? &hChildStdError_Rd : NULL);
+      RunProcess(appPath.c_str(), workingDir, cmdLine, {}, internal,
+                 result ? &hChildStdOutput_Rd : NULL, result ? &hChildStdError_Rd : NULL);
 
   if(pi.dwProcessId == 0)
   {
     if(!internal)
-      RDCWARN("Couldn't launch process '%s'", app);
+      RDCWARN("Couldn't launch process '%s'", appPath.c_str());
     return 0;
   }
 
   if(!internal)
-    RDCLOG("Launched process '%s' with '%s'", app, cmdLine);
+    RDCLOG("Launched process '%s' with '%s'", appPath.c_str(), cmdLine);
 
   ResumeThread(pi.hThread);
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

When an Android SDK path is configured in Settings, the function getToolInSDK in android_tools.cpp returns a path without an extension. Then toolExists validates that path by checking if either {path} or {path + ".exe"} exists. This is then passed to LaunchProcess, then RunProcess, then CreateProcess, which requires a fullpath and fails due to the missing extension.

It's not an issue when the android SDK path isn't configured, because the function FileIO::FindFileInPath is used and, on Windows, it adds ".exe" and ".bat" to the path before doing a file search, and path returned in that case is a fullpath with the .exe extension.

The suggested fix here is to add .exe when calling CreateProcess.

There were 2 other options that I could see:
- The test for the path existence could have been both for {path} and {path + ".exe"} separately and the first one found could have been returned. However this would potentially return the wrong path for people who have both linux or mac and Windows platforms-tools in the same folder, which is the case for me for example.
- A platform function could be called to update the path and adds ".exe" / ".bat", paired with checks, it doesn't feel as clean as just adding the .exe when needed.
