### PR TITLE
Added system packages as hidden folders in the Executable Path dialog

### DIFF
--- a/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/VirtualFileDialog.cpp
@@ -454,7 +454,6 @@ private:
 
     Renderer.ListFolder(makePath(node), true, [node](const rdcstr &path,
                                                      const rdcarray<PathEntry> &files) {
-
       if(files.count() == 1 && (files[0].flags & PathProperty::ErrorAccessDenied))
       {
         node->file.flags |= PathProperty::ErrorAccessDenied;
@@ -602,6 +601,9 @@ VirtualFileDialog::VirtualFileDialog(ICaptureContext &ctx, QString initialDirect
 
   if(!index.isValid())
     index = m_Model->homeFolder();
+
+  if(index.data(RemoteFileModel::FileIsHiddenRole).toBool())
+    ui->showHidden->setChecked(true);
 
   // switch to home folder and expand it
   changeCurrentDir(index);


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Added the system packages as hidden folders in the Executable Path selection on Android. This is useful for platform makers when debugging system packages.

The showHidden check box is automatically set if the previously selected package was a system package to make sure that it's visible when the dialog box is reopened. It's done after
```
m_DirProxy->showHidden = ui->showHidden->isChecked();
```

because ui->showHidden->setChecked triggers a callback which calls m_DirProxy->showHidden, so m_DirProxy needs to be created before calling ui->showHidden->setChecked can be called.

