### PR TITLE
Add resource tracking to DXBC shader debugging

### DIFF
--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -655,6 +655,10 @@ bool RichResourceTextMouseEvent(const QWidget *owner, const QVariant &var, QRect
   if(event->type() != QEvent::MouseButtonRelease && event->type() != QEvent::MouseMove)
     return false;
 
+  // only process left button clicks
+  if(event->type() == QEvent::MouseButtonRelease && event->button() != Qt::LeftButton)
+    return false;
+
   // special case handling for ResourceId/GPUAddress on its own
   if(var.userType() == qMetaTypeId<ResourceId>() || var.userType() == qMetaTypeId<GPUAddressPtr>())
   {

--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -357,7 +357,8 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
                                ResourceId pipeline, ShaderDebugTrace *trace,
                                const QString &debugContext)
 {
-  m_Mapping = bind;
+  if(bind)
+    m_Mapping = *bind;
   m_ShaderDetails = shader;
   m_Pipeline = pipeline;
   m_Trace = trace;
@@ -370,7 +371,7 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
   // no replacing allowed, stay in find mode
   m_FindReplace->allowUserModeChange(false);
 
-  if(!m_ShaderDetails || !m_Mapping)
+  if(!bind || !m_ShaderDetails)
     m_Trace = NULL;
 
   if(m_ShaderDetails)
@@ -2462,12 +2463,12 @@ void ShaderViewer::updateDebugState()
       if(varsMapped.contains(ro.name))
         continue;
 
-      int32_t idx = m_Mapping->readOnlyResources.indexOf(Bindpoint(ro.GetBinding()));
+      int32_t idx = m_Mapping.readOnlyResources.indexOf(Bindpoint(ro.GetBinding()));
 
       if(idx < 0)
         continue;
 
-      Bindpoint bind = m_Mapping->readOnlyResources[idx];
+      Bindpoint bind = m_Mapping.readOnlyResources[idx];
 
       if(!bind.used)
         continue;
@@ -2530,12 +2531,12 @@ void ShaderViewer::updateDebugState()
       if(varsMapped.contains(rw.name))
         continue;
 
-      int32_t idx = m_Mapping->readWriteResources.indexOf(Bindpoint(rw.GetBinding()));
+      int32_t idx = m_Mapping.readWriteResources.indexOf(Bindpoint(rw.GetBinding()));
 
       if(idx < 0)
         continue;
 
-      Bindpoint bind = m_Mapping->readWriteResources[idx];
+      Bindpoint bind = m_Mapping.readWriteResources[idx];
 
       if(!bind.used)
         continue;
@@ -2598,12 +2599,12 @@ void ShaderViewer::updateDebugState()
       if(varsMapped.contains(s.name))
         continue;
 
-      int32_t idx = m_Mapping->samplers.indexOf(Bindpoint(s.GetBinding()));
+      int32_t idx = m_Mapping.samplers.indexOf(Bindpoint(s.GetBinding()));
 
       if(idx < 0)
         continue;
 
-      Bindpoint bind = m_Mapping->samplers[idx];
+      Bindpoint bind = m_Mapping.samplers[idx];
 
       if(!bind.used)
         continue;
@@ -3070,12 +3071,12 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
 
         rdcarray<BoundResourceArray> samplers = m_Ctx.CurPipelineState().GetSamplers(m_Stage);
 
-        int32_t idx = m_Mapping->samplers.indexOf(Bindpoint(reg->GetBinding()));
+        int32_t idx = m_Mapping.samplers.indexOf(Bindpoint(reg->GetBinding()));
 
         if(idx < 0)
           continue;
 
-        Bindpoint bind = m_Mapping->samplers[idx];
+        Bindpoint bind = m_Mapping.samplers[idx];
 
         int32_t bindIdx = samplers.indexOf(bind);
 
@@ -3124,14 +3125,14 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
             isReadOnlyResource ? m_ReadOnlyResources : m_ReadWriteResources;
 
         int32_t idx =
-            (isReadOnlyResource ? m_Mapping->readOnlyResources : m_Mapping->readWriteResources)
+            (isReadOnlyResource ? m_Mapping.readOnlyResources : m_Mapping.readWriteResources)
                 .indexOf(Bindpoint(reg->GetBinding()));
 
         if(idx < 0)
           continue;
 
-        Bindpoint bind = isReadOnlyResource ? m_Mapping->readOnlyResources[idx]
-                                            : m_Mapping->readWriteResources[idx];
+        Bindpoint bind = isReadOnlyResource ? m_Mapping.readOnlyResources[idx]
+                                            : m_Mapping.readWriteResources[idx];
 
         int32_t bindIdx = resList.indexOf(bind);
 
@@ -3279,10 +3280,10 @@ RDTreeWidgetItem *ShaderViewer::makeAccessedResourceNode(const ShaderVariable &v
   if(v.type == VarType::ReadOnlyResource)
   {
     typeName = lit("Resource");
-    int32_t idx = m_Mapping->readOnlyResources.indexOf(Bindpoint(bp));
+    int32_t idx = m_Mapping.readOnlyResources.indexOf(Bindpoint(bp));
     if(idx >= 0)
     {
-      Bindpoint bind = m_Mapping->readOnlyResources[idx];
+      Bindpoint bind = m_Mapping.readOnlyResources[idx];
       if(bind.used)
       {
         int32_t bindIdx = m_ReadOnlyResources.indexOf(bind);
@@ -3298,10 +3299,10 @@ RDTreeWidgetItem *ShaderViewer::makeAccessedResourceNode(const ShaderVariable &v
   else if(v.type == VarType::ReadWriteResource)
   {
     typeName = lit("RW Resource");
-    int32_t idx = m_Mapping->readWriteResources.indexOf(Bindpoint(bp));
+    int32_t idx = m_Mapping.readWriteResources.indexOf(Bindpoint(bp));
     if(idx >= 0)
     {
-      Bindpoint bind = m_Mapping->readWriteResources[idx];
+      Bindpoint bind = m_Mapping.readWriteResources[idx];
       if(bind.used)
       {
         int32_t bindIdx = m_ReadWriteResources.indexOf(bind);

--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -57,9 +57,26 @@ struct VariableTag
 
   DebugVariableReference debugVar;
 };
+
+struct AccessedResourceTag
+{
+  AccessedResourceTag() : type(VarType::Unknown) { bind.bind = -1; }
+  AccessedResourceTag(BindpointIndex bp, VarType t) : bind(bp), type(t) {}
+  AccessedResourceTag(ShaderVariable var)
+  {
+    type = var.type;
+    if(var.type == VarType::ReadOnlyResource || var.type == VarType::ReadWriteResource)
+      bind = var.GetBinding();
+    else
+      bind.bind = -1;
+  }
+  BindpointIndex bind;
+  VarType type;
+};
 };
 
 Q_DECLARE_METATYPE(VariableTag);
+Q_DECLARE_METATYPE(AccessedResourceTag);
 
 ShaderViewer::ShaderViewer(ICaptureContext &ctx, QWidget *parent)
     : QFrame(parent), ui(new Ui::ShaderViewer), m_Ctx(ctx)
@@ -67,6 +84,7 @@ ShaderViewer::ShaderViewer(ICaptureContext &ctx, QWidget *parent)
   ui->setupUi(this);
 
   ui->constants->setFont(Formatter::PreferredFont());
+  ui->accessedResources->setFont(Formatter::PreferredFont());
   ui->debugVars->setFont(Formatter::PreferredFont());
   ui->sourceVars->setFont(Formatter::PreferredFont());
   ui->watch->setFont(Formatter::PreferredFont());
@@ -228,6 +246,7 @@ void ShaderViewer::editShader(ResourceId id, ShaderStage stage, const QString &e
   ui->watch->hide();
   ui->debugVars->hide();
   ui->constants->hide();
+  ui->resourcesPanel->hide();
   ui->callstack->hide();
   ui->sourceVars->hide();
 
@@ -326,6 +345,12 @@ void ShaderViewer::editShader(ResourceId id, ShaderStage stage, const QString &e
         ui->compilationGroup,
         ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow);
   }
+}
+
+void ShaderViewer::cacheResources()
+{
+  m_ReadOnlyResources = m_Ctx.CurPipelineState().GetReadOnlyResources(m_Stage);
+  m_ReadWriteResources = m_Ctx.CurPipelineState().GetReadWriteResources(m_Stage);
 }
 
 void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderReflection *shader,
@@ -497,43 +522,55 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
 
     ui->constants->header()->resizeSection(0, 80);
 
+    ui->accessedResources->setColumns({tr("Register(s)"), tr("Type"), tr("Resource")});
+    ui->accessedResources->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    ui->accessedResources->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    ui->accessedResources->header()->setSectionResizeMode(2, QHeaderView::Interactive);
+
+    ui->accessedResources->header()->resizeSection(0, 80);
+
     ui->debugVars->setTooltipElidedItems(false);
     ui->constants->setTooltipElidedItems(false);
+    ui->accessedResources->setTooltipElidedItems(false);
 
+    ToolWindowManager::ToolWindowProperty windowProps =
+        ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow;
     ui->watch->setWindowTitle(tr("Watch"));
     ui->docking->addToolWindow(
         ui->watch, ToolWindowManager::AreaReference(ToolWindowManager::BottomOf,
                                                     ui->docking->areaOf(m_DisassemblyFrame), 0.25f));
-    ui->docking->setToolWindowProperties(
-        ui->watch, ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow);
+    ui->docking->setToolWindowProperties(ui->watch, windowProps);
 
     ui->debugVars->setWindowTitle(tr("Variable Values"));
     ui->docking->addToolWindow(
         ui->debugVars,
         ToolWindowManager::AreaReference(ToolWindowManager::AddTo, ui->docking->areaOf(ui->watch)));
-    ui->docking->setToolWindowProperties(
-        ui->debugVars, ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow);
+    ui->docking->setToolWindowProperties(ui->debugVars, windowProps);
 
     ui->constants->setWindowTitle(tr("Constants && Resources"));
     ui->docking->addToolWindow(
         ui->constants, ToolWindowManager::AreaReference(ToolWindowManager::LeftOf,
                                                         ui->docking->areaOf(ui->debugVars), 0.5f));
-    ui->docking->setToolWindowProperties(
-        ui->constants, ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow);
+    ui->docking->setToolWindowProperties(ui->constants, windowProps);
+
+    ui->resourcesPanel->setWindowTitle(tr("Accessed Resources"));
+    ui->docking->addToolWindow(
+        ui->resourcesPanel, ToolWindowManager::AreaReference(ToolWindowManager::AddTo,
+                                                             ui->docking->areaOf(ui->constants)));
+    ui->docking->setToolWindowProperties(ui->resourcesPanel, windowProps);
+    ui->docking->raiseToolWindow(ui->constants);
 
     ui->callstack->setWindowTitle(tr("Callstack"));
     ui->docking->addToolWindow(
         ui->callstack, ToolWindowManager::AreaReference(ToolWindowManager::RightOf,
                                                         ui->docking->areaOf(ui->debugVars), 0.2f));
-    ui->docking->setToolWindowProperties(
-        ui->callstack, ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow);
+    ui->docking->setToolWindowProperties(ui->callstack, windowProps);
 
     ui->sourceVars->setWindowTitle(tr("High-level Variables"));
     ui->docking->addToolWindow(
         ui->sourceVars, ToolWindowManager::AreaReference(ToolWindowManager::AddTo,
                                                          ui->docking->areaOf(ui->debugVars)));
-    ui->docking->setToolWindowProperties(
-        ui->sourceVars, ToolWindowManager::HideCloseButton | ToolWindowManager::DisallowFloatWindow);
+    ui->docking->setToolWindowProperties(ui->sourceVars, windowProps);
 
     m_Line2Insts.resize(m_ShaderDetails->debugInfo.files.count());
 
@@ -609,8 +646,11 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
 
     // event filter to pick up tooltip events
     ui->constants->installEventFilter(this);
+    ui->accessedResources->installEventFilter(this);
     ui->debugVars->installEventFilter(this);
     ui->watch->installEventFilter(this);
+
+    cacheResources();
 
     m_Ctx.Replay().AsyncInvoke([this](IReplayController *r) {
       rdcarray<ShaderDebugState> states = r->ContinueDebug(m_Trace->debugger);
@@ -670,6 +710,9 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
     ui->sourceVars->setContextMenuPolicy(Qt::CustomContextMenu);
     QObject::connect(ui->sourceVars, &RDTreeWidget::customContextMenuRequested, this,
                      &ShaderViewer::variables_contextMenu);
+    ui->accessedResources->setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(ui->accessedResources, &RDTreeWidget::customContextMenuRequested, this,
+                     &ShaderViewer::accessedResources_contextMenu);
 
     ui->watch->insertRow(0);
 
@@ -691,6 +734,7 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
     ui->watch->hide();
     ui->debugVars->hide();
     ui->constants->hide();
+    ui->resourcesPanel->hide();
     ui->sourceVars->hide();
     ui->callstack->hide();
 
@@ -1154,6 +1198,33 @@ void ShaderViewer::variables_contextMenu(const QPoint &pos)
   RDDialog::show(&contextMenu, w->viewport()->mapToGlobal(pos));
 }
 
+void ShaderViewer::accessedResources_contextMenu(const QPoint &pos)
+{
+  QAbstractItemView *w = qobject_cast<QAbstractItemView *>(QObject::sender());
+  RDTreeWidget *tree = qobject_cast<RDTreeWidget *>(w);
+  if(tree->selectedItem() == NULL)
+    return;
+
+  QMenu contextMenu(this);
+
+  QAction prevAccess(tr("Run To Previous Access"), this);
+  QAction nextAccess(tr("Run To Next Access"), this);
+
+  contextMenu.addAction(&prevAccess);
+  contextMenu.addAction(&nextAccess);
+
+  QObject::connect(&prevAccess, &QAction::triggered, [this, tree] {
+    const AccessedResourceTag &tag = tree->selectedItem()->tag().value<AccessedResourceTag>();
+    runToResourceAccess(false, tag.type, tag.bind);
+  });
+  QObject::connect(&nextAccess, &QAction::triggered, [this, tree] {
+    const AccessedResourceTag &tag = tree->selectedItem()->tag().value<AccessedResourceTag>();
+    runToResourceAccess(true, tag.type, tag.bind);
+  });
+
+  RDDialog::show(&contextMenu, w->viewport()->mapToGlobal(pos));
+}
+
 void ShaderViewer::disassembly_buttonReleased(QMouseEvent *event)
 {
   if(event->button() == Qt::LeftButton)
@@ -1195,6 +1266,7 @@ void ShaderViewer::disassembly_buttonReleased(QMouseEvent *event)
 
         highlightMatchingVars(ui->debugVars->invisibleRootItem(), text, highlightColor);
         highlightMatchingVars(ui->constants->invisibleRootItem(), text, highlightColor);
+        highlightMatchingVars(ui->accessedResources->invisibleRootItem(), text, highlightColor);
         highlightMatchingVars(ui->sourceVars->invisibleRootItem(), text, highlightColor);
 
         m_DisassemblyView->setIndicatorCurrent(INDICATOR_REGHIGHLIGHT);
@@ -1570,6 +1642,50 @@ void ShaderViewer::runTo(QVector<size_t> runToInstruction, bool forward, ShaderE
   updateDebugState();
 }
 
+void ShaderViewer::runToResourceAccess(bool forward, VarType type, const BindpointIndex &resource)
+{
+  if(!m_Trace || m_States.empty())
+    return;
+
+  // this is effectively infinite as we break out before moving to next/previous state if that would
+  // be first/last
+  while((forward && !IsLastState()) || (!forward && !IsFirstState()))
+  {
+    if(forward)
+    {
+      if(IsLastState())
+        break;
+      applyForwardsChange();
+    }
+    else
+    {
+      if(IsFirstState())
+        break;
+      applyBackwardsChange();
+    }
+
+    // Break if the current state references the specific resource requested
+    bool foundResource = false;
+    for(const ShaderVariableChange &c : GetCurrentState().changes)
+    {
+      if(c.after.type == type && c.after.GetBinding() == resource)
+      {
+        foundResource = true;
+        break;
+      }
+    }
+
+    if(foundResource)
+      break;
+
+    // or breakpoint
+    if(m_Breakpoints.contains((int)GetCurrentState().nextInstruction))
+      break;
+  }
+
+  updateDebugState();
+}
+
 void ShaderViewer::applyBackwardsChange()
 {
   if(!IsFirstState())
@@ -1587,6 +1703,15 @@ void ShaderViewer::applyBackwardsChange()
           if(c.after.name == m_Variables[i].name)
           {
             m_Variables.erase(i);
+            break;
+          }
+        }
+
+        for(size_t i = 0; i < m_AccessedResources.size(); i++)
+        {
+          if(c.after.name == m_AccessedResources[i].name)
+          {
+            m_AccessedResources.erase(i);
             break;
           }
         }
@@ -1623,6 +1748,7 @@ void ShaderViewer::applyForwardsChange()
     m_CurrentStateIdx++;
 
     rdcarray<ShaderVariable> newVariables;
+    rdcarray<ShaderVariable> newAccessedResources;
 
     for(const ShaderVariableChange &c : GetCurrentState().changes)
     {
@@ -1655,10 +1781,27 @@ void ShaderViewer::applyForwardsChange()
           *v = c.after;
         else
           newVariables.push_back(c.after);
+
+        if(c.after.type == VarType::ReadOnlyResource || c.after.type == VarType::ReadWriteResource)
+        {
+          bool found = false;
+          for(size_t i = 0; i < m_AccessedResources.size(); i++)
+          {
+            if(c.after.name == m_AccessedResources[i].name)
+            {
+              found = true;
+              break;
+            }
+          }
+
+          if(!found)
+            newAccessedResources.push_back(c.after);
+        }
       }
     }
 
     m_Variables.insert(0, newVariables);
+    m_AccessedResources.insert(0, newAccessedResources);
   }
 }
 
@@ -1677,9 +1820,9 @@ QString ShaderViewer::stringRep(const ShaderVariable &var, uint32_t row)
     rdcarray<BoundResourceArray> resList;
 
     if(type == VarType::ReadOnlyResource)
-      resList = m_Ctx.CurPipelineState().GetReadOnlyResources(m_Stage);
+      resList = m_ReadOnlyResources;
     else if(type == VarType::ReadWriteResource)
-      resList = m_Ctx.CurPipelineState().GetReadWriteResources(m_Stage);
+      resList = m_ReadWriteResources;
     else if(type == VarType::Sampler)
       resList = m_Ctx.CurPipelineState().GetSamplers(m_Stage);
 
@@ -2310,7 +2453,7 @@ void ShaderViewer::updateDebugState()
       }
     }
 
-    rdcarray<BoundResourceArray> roBinds = m_Ctx.CurPipelineState().GetReadOnlyResources(m_Stage);
+    rdcarray<BoundResourceArray> &roBinds = m_ReadOnlyResources;
 
     for(int i = 0; i < m_Trace->readOnlyResources.count(); i++)
     {
@@ -2334,7 +2477,7 @@ void ShaderViewer::updateDebugState()
       if(bindIdx < 0)
         continue;
 
-      BoundResourceArray roBind = roBinds[bindIdx];
+      BoundResourceArray &roBind = roBinds[bindIdx];
 
       if(bind.arraySize == 1)
       {
@@ -2361,7 +2504,8 @@ void ShaderViewer::updateDebugState()
         node->setTag(QVariant::fromValue(
             VariableTag(DebugVariableReference(DebugVariableType::ReadOnlyResource, ro.name))));
 
-        for(uint32_t a = 0; a < bind.arraySize; a++)
+        uint32_t count = qMin(bind.arraySize, (uint32_t)roBind.resources.size());
+        for(uint32_t a = 0; a < count; a++)
         {
           QString childName = QFormatStr("%1[%2]").arg(ro.name).arg(a);
           RDTreeWidgetItem *child = new RDTreeWidgetItem({
@@ -2377,7 +2521,7 @@ void ShaderViewer::updateDebugState()
       }
     }
 
-    rdcarray<BoundResourceArray> rwBinds = m_Ctx.CurPipelineState().GetReadWriteResources(m_Stage);
+    rdcarray<BoundResourceArray> &rwBinds = m_ReadWriteResources;
 
     for(int i = 0; i < m_Trace->readWriteResources.count(); i++)
     {
@@ -2401,7 +2545,7 @@ void ShaderViewer::updateDebugState()
       if(bindIdx < 0)
         continue;
 
-      BoundResourceArray rwBind = rwBinds[bindIdx];
+      BoundResourceArray &rwBind = rwBinds[bindIdx];
 
       if(bind.arraySize == 1)
       {
@@ -2428,7 +2572,8 @@ void ShaderViewer::updateDebugState()
         node->setTag(QVariant::fromValue(
             VariableTag(DebugVariableReference(DebugVariableType::ReadWriteResource, rw.name))));
 
-        for(uint32_t a = 0; a < bind.arraySize; a++)
+        uint32_t count = qMin(bind.arraySize, (uint32_t)rwBind.resources.size());
+        for(uint32_t a = 0; a < count; a++)
         {
           QString childName = QFormatStr("%1[%2]").arg(rw.name).arg(a);
           RDTreeWidgetItem *child = new RDTreeWidgetItem({
@@ -2604,6 +2749,31 @@ void ShaderViewer::updateDebugState()
     ui->debugVars->endUpdate();
 
     ui->debugVars->applyExpansion(expansion, 0);
+  }
+
+  {
+    ui->accessedResources->beginUpdate();
+
+    ui->accessedResources->clear();
+
+    for(int i = 0; i < m_AccessedResources.count(); i++)
+    {
+      bool modified = false;
+
+      for(const ShaderVariableChange &c : GetCurrentState().changes)
+      {
+        if(c.before.name == m_AccessedResources[i].name || c.after.name == m_AccessedResources[i].name)
+        {
+          modified = true;
+          break;
+        }
+      }
+
+      ui->accessedResources->addTopLevelItem(
+          makeAccessedResourceNode(m_AccessedResources[i], modified));
+    }
+
+    ui->accessedResources->endUpdate();
   }
 
   updateWatchVariables();
@@ -2912,7 +3082,7 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
         if(bindIdx < 0)
           continue;
 
-        BoundResourceArray res = samplers[bindIdx];
+        BoundResourceArray &res = samplers[bindIdx];
 
         if(bind.arraySize == 1)
         {
@@ -2950,9 +3120,8 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
         regNames = r.name;
         typeName = isReadOnlyResource ? lit("Resource") : lit("RW Resource");
 
-        rdcarray<BoundResourceArray> resList =
-            isReadOnlyResource ? m_Ctx.CurPipelineState().GetReadOnlyResources(m_Stage)
-                               : m_Ctx.CurPipelineState().GetReadWriteResources(m_Stage);
+        rdcarray<BoundResourceArray> &resList =
+            isReadOnlyResource ? m_ReadOnlyResources : m_ReadWriteResources;
 
         int32_t idx =
             (isReadOnlyResource ? m_Mapping->readOnlyResources : m_Mapping->readWriteResources)
@@ -2969,8 +3138,7 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
         if(bindIdx < 0)
           continue;
 
-        BoundResourceArray res = resList[bindIdx];
-
+        BoundResourceArray &res = resList[bindIdx];
         if(bind.arraySize == 1)
         {
           value = ToQStr(res.resources[0].resourceId);
@@ -2983,11 +3151,14 @@ RDTreeWidgetItem *ShaderViewer::makeSourceVariableNode(const SourceVariableMappi
         }
         else
         {
-          for(uint32_t a = 0; a < bind.arraySize; a++)
+          uint32_t count = qMin(bind.arraySize, (uint32_t)res.resources.size());
+          for(uint32_t a = 0; a < count; a++)
+          {
             children.push_back(new RDTreeWidgetItem({
                 QFormatStr("%1[%2]").arg(localName).arg(a), QFormatStr("%1[%2]").arg(regNames).arg(a),
                 typeName, ToQStr(res.resources[a].resourceId),
             }));
+          }
 
           regNames = QString();
           typeName = QFormatStr("[%1]").arg(bind.arraySize);
@@ -3096,6 +3267,62 @@ RDTreeWidgetItem *ShaderViewer::makeDebugVariableNode(const ShaderVariable &v, r
 
   if(modified)
     node->setForegroundColor(QColor(Qt::red));
+
+  return node;
+}
+
+RDTreeWidgetItem *ShaderViewer::makeAccessedResourceNode(const ShaderVariable &v, bool modified)
+{
+  BindpointIndex bp = v.GetBinding();
+  ResourceId resId;
+  QString typeName;
+  if(v.type == VarType::ReadOnlyResource)
+  {
+    typeName = lit("Resource");
+    int32_t idx = m_Mapping->readOnlyResources.indexOf(Bindpoint(bp));
+    if(idx >= 0)
+    {
+      Bindpoint bind = m_Mapping->readOnlyResources[idx];
+      if(bind.used)
+      {
+        int32_t bindIdx = m_ReadOnlyResources.indexOf(bind);
+        if(bindIdx >= 0)
+        {
+          BoundResourceArray &roBind = m_ReadOnlyResources[bindIdx];
+          if(bp.arrayIndex < roBind.resources.size())
+            resId = roBind.resources[bp.arrayIndex].resourceId;
+        }
+      }
+    }
+  }
+  else if(v.type == VarType::ReadWriteResource)
+  {
+    typeName = lit("RW Resource");
+    int32_t idx = m_Mapping->readWriteResources.indexOf(Bindpoint(bp));
+    if(idx >= 0)
+    {
+      Bindpoint bind = m_Mapping->readWriteResources[idx];
+      if(bind.used)
+      {
+        int32_t bindIdx = m_ReadWriteResources.indexOf(bind);
+        if(bindIdx >= 0)
+        {
+          BoundResourceArray &rwBind = m_ReadWriteResources[bindIdx];
+          if(bp.arrayIndex < rwBind.resources.size())
+            resId = rwBind.resources[bp.arrayIndex].resourceId;
+        }
+      }
+    }
+  }
+
+  RDTreeWidgetItem *node = NULL;
+  if(resId != ResourceId())
+  {
+    node = new RDTreeWidgetItem({v.name, typeName, ToQStr(resId)});
+    node->setTag(QVariant::fromValue(AccessedResourceTag(bp, v.type)));
+    if(modified)
+      node->setForegroundColor(QColor(Qt::red));
+  }
 
   return node;
 }

--- a/qrenderdoc/Windows/ShaderViewer.h
+++ b/qrenderdoc/Windows/ShaderViewer.h
@@ -124,6 +124,7 @@ private slots:
   void editable_keyPressed(QKeyEvent *event);
   void debug_contextMenu(const QPoint &pos);
   void variables_contextMenu(const QPoint &pos);
+  void accessedResources_contextMenu(const QPoint &pos);
   void disassembly_buttonReleased(QMouseEvent *event);
   void disassemble_typeChanged(int index);
   void watch_keyPress(QKeyEvent *event);
@@ -175,6 +176,8 @@ private:
   void hideVariableTooltip();
 
   bool isSourceDebugging();
+
+  void cacheResources();
 
   ShaderEncoding currentEncoding();
 
@@ -235,6 +238,9 @@ private:
   rdcarray<ShaderDebugState> m_States;
   size_t m_CurrentStateIdx = 0;
   rdcarray<ShaderVariable> m_Variables;
+  rdcarray<ShaderVariable> m_AccessedResources;
+  rdcarray<BoundResourceArray> m_ReadOnlyResources;
+  rdcarray<BoundResourceArray> m_ReadWriteResources;
   QList<int> m_Breakpoints;
 
   static const int CURRENT_MARKER = 0;
@@ -276,6 +282,7 @@ private:
   RDTreeWidgetItem *makeSourceVariableNode(const SourceVariableMapping &l, int globalVarIdx,
                                            int localVarIdx);
   RDTreeWidgetItem *makeDebugVariableNode(const ShaderVariable &v, rdcstr prefix, bool modified);
+  RDTreeWidgetItem *makeAccessedResourceNode(const ShaderVariable &v, bool modified);
 
   const ShaderVariable *GetDebugVariable(const DebugVariableReference &r);
 
@@ -285,6 +292,8 @@ private:
 
   void runTo(QVector<size_t> runToInstructions, bool forward,
              ShaderEvents condition = ShaderEvents::NoEvent);
+
+  void runToResourceAccess(bool forward, VarType type, const BindpointIndex &resource);
 
   void applyBackwardsChange();
   void applyForwardsChange();

--- a/qrenderdoc/Windows/ShaderViewer.h
+++ b/qrenderdoc/Windows/ShaderViewer.h
@@ -188,7 +188,7 @@ private:
 
   Ui::ShaderViewer *ui;
   ICaptureContext &m_Ctx;
-  const ShaderBindpointMapping *m_Mapping = NULL;
+  ShaderBindpointMapping m_Mapping;
   const ShaderReflection *m_ShaderDetails = NULL;
   bool m_CustomShader = false;
   ShaderCompileFlags m_Flags;

--- a/qrenderdoc/Windows/ShaderViewer.ui
+++ b/qrenderdoc/Windows/ShaderViewer.ui
@@ -116,6 +116,57 @@
     <bool>true</bool>
    </property>
   </widget>
+  <widget class="QFrame" name="resourcesPanel">
+    <property name="geometry">
+      <rect>
+        <x>20</x>
+        <y>310</y>
+        <width>256</width>
+        <height>192</height>
+      </rect>
+    </property>
+    <property name="contextMenuPolicy">
+      <enum>Qt::PreventContextMenu</enum>
+    </property>
+    <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+        <number>2</number>
+      </property>
+      <property name="leftMargin">
+        <number>0</number>
+      </property>
+      <property name="topMargin">
+        <number>0</number>
+      </property>
+      <property name="rightMargin">
+        <number>0</number>
+      </property>
+      <property name="bottomMargin">
+        <number>0</number>
+      </property>
+      <item>
+        <widget class="RDTreeWidget" name="accessedResources">
+          <property name="geometry">
+            <rect>
+              <x>20</x>
+              <y>310</y>
+              <width>256</width>
+              <height>192</height>
+            </rect>
+          </property>
+          <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="allColumnsShowFocus">
+            <bool>true</bool>
+          </property>
+        </widget>
+      </item>
+    </layout>
+  </widget>
   <widget class="RDTreeWidget" name="debugVars">
    <property name="geometry">
     <rect>

--- a/renderdoc/driver/shaders/dxbc/dxbc_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_bytecode.cpp
@@ -58,9 +58,9 @@ void HandleResourceArrayIndices(const rdcarray<DXBCBytecode::RegIndex> &indices,
     // Start/end registers are inclusive, so one resource will have the same start/end register
     desc.bindCount = uint32_t(indices[2].index - indices[1].index + 1);
 
-    // If it's an unbounded resource array, mark the bind count as 0
+    // If it's an unbounded resource array, mark the bind count as ~0U
     if(indices[2].index == 0xffffffff)
-      desc.bindCount = 0;
+      desc.bindCount = ~0U;
   }
 }
 

--- a/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
@@ -755,6 +755,11 @@ DXBCContainer::DXBCContainer(const void *ByteCode, size_t ByteCodeLength)
         desc.dimension = (ShaderInputBind::Dimension)res->dimension;
         desc.numSamples = res->sampleCount;
 
+        // Bindless resources report a bind count of 0 from the shader bytecode, but many other
+        // places in this codebase assume ~0U means bindless. Patch it up now.
+        if(h->targetVersion >= 0x501 && desc.bindCount == 0)
+          desc.bindCount = ~0U;
+
         if(desc.numSamples == ~0 && desc.retType != RETURN_TYPE_MIXED &&
            desc.retType != RETURN_TYPE_UNKNOWN && desc.retType != RETURN_TYPE_CONTINUED)
         {

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.h
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.h
@@ -307,6 +307,9 @@ private:
   void SetDst(ShaderDebugState *state, const DXBCBytecode::Operand &dstoper,
               const DXBCBytecode::Operation &op, const ShaderVariable &val);
 
+  void MarkResourceAccess(ShaderDebugState *state, DXBCBytecode::OperandType type,
+                          const BindingSlot &slot);
+
   // retrieves the value of the operand, by looking up
   // in the register file and performing any swizzling and
   // negation/abs functions
@@ -320,6 +323,9 @@ private:
 
   const DXBC::Reflection *reflection;
   const DXBCBytecode::Program *program;
+
+  rdcarray<BindpointIndex> m_accessedSRVs;
+  rdcarray<BindpointIndex> m_accessedUAVs;
 };
 
 struct InterpretDebugger : public ShaderDebugger
@@ -342,6 +348,10 @@ struct InterpretDebugger : public ShaderDebugger
   void CalcActiveMask(rdcarray<bool> &activeMask);
   rdcarray<ShaderDebugState> ContinueDebug(DebugAPIWrapper *apiWrapper);
 };
+
+uint32_t GetLogicalIdentifierForBindingSlot(const DXBCBytecode::Program &program,
+                                            DXBCBytecode::OperandType declType,
+                                            const DXBCDebug::BindingSlot &slot);
 
 void ApplyAllDerivatives(GlobalState &global, rdcarray<ThreadState> &quad, int destIdx,
                          const rdcarray<PSInputElement> &initialValues, float *data);


### PR DESCRIPTION
When a resource is accessed, it is now tracked by the debug step. The shader viewer prunes resource arrays larger than 8 elements to only display accessed resources. I picked 8 as a limit arbitrarily, but it seemed like a good number where any more than that would add a decent amount of scrolling to the view.

I added another test to d3d12_resource_mapping_zoo to validate different resource access patterns.