### PR TITLE
Vulkan Pixel History: secondary command buffers

### DIFF
--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -400,6 +400,15 @@ struct VulkanAMDDrawCallback : public VulkanDrawcallCallback
   {
     m_AliasEvents.push_back(make_rdcpair(primary, alias));
   }
+  bool SplitSecondary() override { return false; }
+  void PreCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                     VkCommandBuffer cmd) override
+  {
+  }
+  void PostCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                      VkCommandBuffer cmd) override
+  {
+  }
 
   uint32_t *m_pSampleId;
   WrappedVulkan *m_pDriver;
@@ -555,6 +564,15 @@ struct VulkanKHRCallback : public VulkanDrawcallCallback
   void AliasEvent(uint32_t primary, uint32_t alias) override
   {
     m_AliasEvents.push_back(std::make_pair(primary, alias));
+  }
+  bool SplitSecondary() override { return false; }
+  void PreCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                     VkCommandBuffer cmd) override
+  {
+  }
+  void PostCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                      VkCommandBuffer cmd) override
+  {
   }
 
   void PreEndCommandBuffer(VkCommandBuffer cmd) override {}
@@ -757,6 +775,15 @@ struct VulkanGPUTimerCallback : public VulkanDrawcallCallback
   void AliasEvent(uint32_t primary, uint32_t alias) override
   {
     m_AliasEvents.push_back(make_rdcpair(primary, alias));
+  }
+  bool SplitSecondary() override { return false; }
+  void PreCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                     VkCommandBuffer cmd) override
+  {
+  }
+  void PostCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                      VkCommandBuffer cmd) override
+  {
   }
 
   void PreEndCommandBuffer(VkCommandBuffer cmd) override {}

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -255,6 +255,15 @@ struct VulkanQuadOverdrawCallback : public VulkanDrawcallCallback
   {
     // don't care
   }
+  bool SplitSecondary() { return false; }
+  void PreCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                     VkCommandBuffer cmd)
+  {
+  }
+  void PostCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                      VkCommandBuffer cmd)
+  {
+  }
 
   WrappedVulkan *m_pDriver;
   VkDescriptorSetLayout m_DescSetLayout;

--- a/renderdoc/driver/vulkan/vk_postvs.cpp
+++ b/renderdoc/driver/vulkan/vk_postvs.cpp
@@ -3300,6 +3300,15 @@ struct VulkanInitPostVSCallback : public VulkanDrawcallCallback
     if(m_Events.contains(primary))
       m_pDriver->GetReplay()->AliasPostVSBuffers(primary, alias);
   }
+  bool SplitSecondary() { return false; }
+  void PreCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                     VkCommandBuffer cmd)
+  {
+  }
+  void PostCmdExecute(uint32_t baseEid, uint32_t secondaryFirst, uint32_t secondaryLast,
+                      VkCommandBuffer cmd)
+  {
+  }
 
   WrappedVulkan *m_pDriver;
   const rdcarray<uint32_t> &m_Events;

--- a/renderdoc/driver/vulkan/vk_state.cpp
+++ b/renderdoc/driver/vulkan/vk_state.cpp
@@ -77,7 +77,7 @@ void VulkanRenderState::BeginRenderPassAndApplyState(WrappedVulkan *vk, VkComman
     imagelessAttachments.pAttachments = imagelessViews.data();
   }
 
-  ObjDisp(cmd)->CmdBeginRenderPass(Unwrap(cmd), &rpbegin, VK_SUBPASS_CONTENTS_INLINE);
+  ObjDisp(cmd)->CmdBeginRenderPass(Unwrap(cmd), &rpbegin, subpassContents);
 
   BindPipeline(vk, cmd, binding, true);
 

--- a/renderdoc/driver/vulkan/vk_state.h
+++ b/renderdoc/driver/vulkan/vk_state.h
@@ -109,6 +109,7 @@ struct VulkanRenderState
 
   ResourceId renderPass;
   uint32_t subpass = 0;
+  VkSubpassContents subpassContents;
 
   // framebuffer accessors - to allow for imageless framebuffers and prevent accidentally changing
   // only the framebuffer without updating the attachments


### PR DESCRIPTION
Also:
- support for choosing mip level and slice
- tests for secondary command buffers
- adds a callback around vkCmdExecuteCommands
- refactors pixel history occlusion callback into its own
callback. Allows processing fewer events later on, and getting colour
information separately.
- keep track of subpassContents for vkCmdBeginRenderPass (inline or
  secondary)
