### PR TITLE
Improve perf of opening captures & navigating texture viewer

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.h
+++ b/qrenderdoc/Windows/TextureViewer.h
@@ -65,6 +65,9 @@ struct Following
   bool operator!=(const Following &o);
   static void GetDrawContext(ICaptureContext &ctx, bool &copy, bool &clear, bool &compute);
 
+  void SetResources(const rdcarray<BoundResourceArray> &readOnly,
+                    const rdcarray<BoundResourceArray> &readWrite);
+
   int GetHighestMip(ICaptureContext &ctx);
   int GetFirstArraySlice(ICaptureContext &ctx);
   CompType GetTypeHint(ICaptureContext &ctx);
@@ -89,6 +92,10 @@ struct Following
 
   const ShaderBindpointMapping &GetMapping(ICaptureContext &ctx);
   static const ShaderBindpointMapping &GetMapping(ICaptureContext &ctx, ShaderStage stage);
+
+private:
+  const rdcarray<BoundResourceArray> *readOnlyResources;
+  const rdcarray<BoundResourceArray> *readWriteResources;
 };
 
 struct TexSettings
@@ -329,6 +336,9 @@ private:
   TextureDescription *m_CachedTexture;
   Following m_Following = Following::Default;
   QMap<ResourceId, TexSettings> m_TextureSettings;
+
+  rdcarray<BoundResourceArray> m_ReadOnlyResources[(uint32_t)ShaderStage::Count];
+  rdcarray<BoundResourceArray> m_ReadWriteResources[(uint32_t)ShaderStage::Count];
 
   QTime m_CustomShaderTimer;
   int m_CustomShaderWriteTime = 0;

--- a/renderdoc/driver/d3d12/d3d12_manager.cpp
+++ b/renderdoc/driver/d3d12/d3d12_manager.cpp
@@ -703,26 +703,24 @@ void D3D12ResourceManager::SerialiseResourceStates(SerialiserType &ser,
     {
       for(size_t m = 0; m < States.size(); m++)
       {
-        D3D12_RESOURCE_BARRIER b;
-        b.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        b.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-        b.Transition.pResource = (ID3D12Resource *)GetCurrentResource(liveid);
-        b.Transition.Subresource = (UINT)m;
-        b.Transition.StateBefore = states[liveid][m];
-        b.Transition.StateAfter = States[m];
+        if(states[liveid][m] != States[m])
+        {
+          D3D12_RESOURCE_BARRIER b;
+          b.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+          b.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+          b.Transition.pResource = (ID3D12Resource *)GetCurrentResource(liveid);
+          b.Transition.Subresource = (UINT)m;
+          b.Transition.StateBefore = states[liveid][m];
+          b.Transition.StateAfter = States[m];
 
-        barriers.push_back(b);
+          barriers.push_back(b);
+        }
       }
     }
 
     if(ser.IsWriting())
       srcit++;
   }
-
-  // erase any do-nothing barriers
-  barriers.removeIf([](const D3D12_RESOURCE_BARRIER &barrier) {
-    return barrier.Transition.StateBefore == barrier.Transition.StateAfter;
-  });
 
   ApplyBarriers(barriers, states);
 }


### PR DESCRIPTION
- `removeIf` after generating the list of barriers on capture load was costly. This change improved capture load times by about 20% in a few production captures that I tested.
- Cache resources in the texture viewer. Certain actions can cause resource fetches after the event has changed - clicking a thumbnail causes 4 fetches, for example. For pipeline states with many resources, especially bindless scenarios, this was a measurable cost.