### PR TITLE
Vk Pixel History: multi sampled colour

### DIFF
--- a/renderdoc/data/glsl/ms2array.comp
+++ b/renderdoc/data/glsl/ms2array.comp
@@ -70,9 +70,18 @@ uniform ivec4 mscopy;
 void main()
 {
   ivec3 id = ivec3(gl_GlobalInvocationID);
-
-  int slice = int(id.z / numMultiSamples);
-  int sampleIdx = int(id.z % numMultiSamples);
+  int slice;
+  int sampleIdx;
+  if(numMultiSamples == 0)
+  {
+    slice = currentSlice;
+    sampleIdx = currentSample;
+  }
+  else
+  {
+    slice = int(id.z / numMultiSamples);
+    sampleIdx = int(id.z % numMultiSamples);
+  }
 
   uvec4 data = texelFetch(srcMS, ivec3(int(id.x), int(id.y), slice), sampleIdx);
 

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -1714,6 +1714,10 @@ void VulkanReplay::CreateResources()
 
   m_PixelPick.Init(m_pDriver, m_General.DescriptorPool);
 
+  RenderDoc::Inst().SetProgress(LoadProgress::DebugManagerInit, 0.75f);
+
+  m_PixelHistory.Init(m_pDriver, m_General.DescriptorPool);
+
   RenderDoc::Inst().SetProgress(LoadProgress::DebugManagerInit, 0.8f);
 
   m_Histogram.Init(m_pDriver, m_General.DescriptorPool);
@@ -1765,6 +1769,7 @@ void VulkanReplay::DestroyResources()
   m_Overlay.Destroy(m_pDriver);
   m_VertexPick.Destroy(m_pDriver);
   m_PixelPick.Destroy(m_pDriver);
+  m_PixelHistory.Destroy(m_pDriver);
   m_Histogram.Destroy(m_pDriver);
   m_PostVS.Destroy(m_pDriver);
 
@@ -2592,6 +2597,23 @@ void VulkanReplay::PixelPicking::Destroy(WrappedVulkan *driver)
   ReadbackBuffer.Destroy();
   driver->vkDestroyFramebuffer(driver->GetDev(), FB, NULL);
   driver->vkDestroyRenderPass(driver->GetDev(), RP, NULL);
+}
+
+void VulkanReplay::PixelHistory::Init(WrappedVulkan *driver, VkDescriptorPool descriptorPool)
+{
+  CREATE_OBJECT(MSCopyDescSetLayout,
+                {
+                    {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, NULL},
+                    {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, NULL},
+                    {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, NULL},
+                });
+  CREATE_OBJECT(MSCopyDescSet, descriptorPool, MSCopyDescSetLayout);
+}
+
+void VulkanReplay::PixelHistory::Destroy(WrappedVulkan *driver)
+{
+  if(MSCopyDescSetLayout != VK_NULL_HANDLE)
+    driver->vkDestroyDescriptorSetLayout(driver->GetDev(), MSCopyDescSetLayout, NULL);
 }
 
 void VulkanReplay::HistogramMinMax::Init(WrappedVulkan *driver, VkDescriptorPool descriptorPool)

--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -68,6 +68,8 @@ public:
                           uint32_t samples, VkFormat fmt);
   void CopyArrayToTex2DMS(VkImage destMS, VkImage srcArray, VkExtent3D extent, uint32_t layers,
                           uint32_t samples, VkFormat fmt);
+  void CopyTex2DMSPixel(VkCommandBuffer cmd, VkDescriptorSet descSet, VkExtent3D extent,
+                        uint32_t sample, VkFormat fmt);
 
   VkPipelineCache GetPipelineCache() { return m_PipelineCache; }
   VkPipeline GetCustomPipeline() { return m_Custom.TexPipeline; }
@@ -86,8 +88,9 @@ public:
   void PatchLineStripIndexBuffer(const DrawcallDescription *draw, GPUBuffer &indexBuffer,
                                  uint32_t &indexCount);
 
-  bool PixelHistorySetupResources(PixelHistoryResources &resources, VkExtent3D extent,
-                                  VkFormat format, uint32_t numEvents);
+  bool PixelHistorySetupResources(PixelHistoryResources &resources, VkImage targetImage,
+                                  VkExtent3D extent, VkFormat format, VkSampleCountFlagBits samples,
+                                  const Subresource &sub, uint32_t numEvents);
   bool PixelHistoryDestroyResources(const PixelHistoryResources &resources);
 
   void PixelHistoryCopyPixel(VkCommandBuffer cmd, CopyPixelParams &p, size_t offset);
@@ -114,13 +117,11 @@ private:
 
   // CopyArrayToTex2DMS & CopyTex2DMSToArray
   VkDescriptorPool m_ArrayMSDescriptorPool;
-
   VkDescriptorSetLayout m_ArrayMSDescSetLayout = VK_NULL_HANDLE;
   VkPipelineLayout m_ArrayMSPipeLayout = VK_NULL_HANDLE;
   VkDescriptorSet m_ArrayMSDescSet = VK_NULL_HANDLE;
   VkPipeline m_Array2MSPipe = VK_NULL_HANDLE;
   VkPipeline m_MS2ArrayPipe = VK_NULL_HANDLE;
-
   VkSampler m_ArrayMSSampler = VK_NULL_HANDLE;
 
   // [0] = non-MSAA, [1] = MSAA

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -2795,6 +2795,13 @@ rdcarray<EventUsage> VulkanReplay::GetUsage(ResourceId id)
   return m_pDriver->GetUsage(id);
 }
 
+void VulkanReplay::CopyPixelForPixelHistory(VkCommandBuffer cmd, VkExtent3D extent, uint32_t sample,
+                                            VkFormat fmt)
+{
+  m_pDriver->GetDebugManager()->CopyTex2DMSPixel(cmd, m_PixelHistory.MSCopyDescSet, extent, sample,
+                                                 fmt);
+}
+
 void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
                                   const GetTextureDataParams &params, bytebuf &data)
 {

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -319,6 +319,7 @@ public:
                  float *maxval);
   bool GetHistogram(ResourceId texid, const Subresource &sub, CompType typeCast, float minval,
                     float maxval, bool channels[4], rdcarray<uint32_t> &histogram);
+  void UpdatePixelHistoryDescriptor(VkImageView sourceView, VkImageView destView);
 
   void InitPostVSBuffers(uint32_t eventId);
   void InitPostVSBuffers(uint32_t eventId, VulkanRenderState &state);
@@ -410,6 +411,9 @@ public:
   void SetDriverInformation(const VkPhysicalDeviceProperties &props);
 
   AMDCounters *GetAMDCounters() { return m_pAMDCounters; }
+  void CopyPixelForPixelHistory(VkCommandBuffer cmd, VkExtent3D extent, uint32_t sample,
+                                VkFormat fmt);
+
 private:
   void FetchShaderFeedback(uint32_t eventId);
   void ClearFeedbackCache();
@@ -652,6 +656,15 @@ private:
     VkFramebuffer FB = VK_NULL_HANDLE;
     VkRenderPass RP = VK_NULL_HANDLE;
   } m_PixelPick;
+
+  struct PixelHistory
+  {
+    void Init(WrappedVulkan *driver, VkDescriptorPool descriptorPool);
+    void Destroy(WrappedVulkan *driver);
+
+    VkDescriptorSetLayout MSCopyDescSetLayout = VK_NULL_HANDLE;
+    VkDescriptorSet MSCopyDescSet = VK_NULL_HANDLE;
+  } m_PixelHistory;
 
   struct HistogramMinMax
   {


### PR DESCRIPTION
Colour only, depth/stencil copy not supported.
This means that we only report pre-mod and post-mod colour values for
events. Since stencil copy is not supported, number of fragments is not
reported, and shader output is not queried.
