### PR TITLE
Add Option for disabling Unsaved capture Message Boxes

### DIFF
--- a/qrenderdoc/Code/Interface/PersistantConfig.h
+++ b/qrenderdoc/Code/Interface/PersistantConfig.h
@@ -304,6 +304,8 @@ DECLARE_REFLECTION_STRUCT(BugReport);
                                                                                            \
   CONFIG_SETTING_VAL(public, bool, bool, AlwaysReplayLocally, false)                       \
                                                                                            \
+  CONFIG_SETTING_VAL(public, bool, bool, NeverPromptSaveCapture, false)                    \
+                                                                                           \
   CONFIG_SETTING_VAL(public, int, int, LocalProxyAPI, -1)                                  \
                                                                                            \
   CONFIG_SETTING_VAL(public, bool, bool, BufferFormatter_ShowHelp, true)                   \

--- a/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
@@ -712,7 +712,7 @@ bool LiveCapture::checkAllowClose()
 
     QMessageBox::StandardButton res = QMessageBox::No;
 
-    if(!suppressRemoteWarning && !notoall)
+    if(!suppressRemoteWarning && !notoall && !m_Ctx.Config().NeverPromptSaveCapture)
     {
       QString frameName = tr("Frame #%1").arg(cap->frameNumber);
       if(cap->frameNumber == ~0U)

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
@@ -133,6 +133,7 @@ SettingsDialog::SettingsDialog(ICaptureContext &ctx, QWidget *parent)
   ui->TextureViewer_PerTexYFlip->setEnabled(ui->TextureViewer_PerTexSettings->isChecked());
 
   ui->AlwaysReplayLocally->setChecked(m_Ctx.Config().AlwaysReplayLocally);
+  ui->NeverPromptSaveCapture->setChecked(m_Ctx.Config().NeverPromptSaveCapture);
 
   {
     const SDObject *getPaths = RENDERDOC_GetConfigSetting("DXBC.Debug.SearchDirPaths");
@@ -415,6 +416,13 @@ void SettingsDialog::on_Font_PreferMonospaced_toggled(bool checked)
 void SettingsDialog::on_AlwaysReplayLocally_toggled(bool checked)
 {
   m_Ctx.Config().AlwaysReplayLocally = ui->AlwaysReplayLocally->isChecked();
+
+  m_Ctx.Config().Save();
+}
+
+void SettingsDialog::on_NeverPromptSaveCapture_toggled(bool checked)
+{
+  m_Ctx.Config().NeverPromptSaveCapture = ui->NeverPromptSaveCapture->isChecked();
 
   m_Ctx.Config().Save();
 }

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.h
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.h
@@ -66,6 +66,7 @@ private slots:
   void on_CheckUpdate_AllowChecks_toggled(bool checked);
   void on_Font_PreferMonospaced_toggled(bool checked);
   void on_AlwaysReplayLocally_toggled(bool checked);
+  void on_NeverPromptSaveCapture_toggled(bool checked);
   void on_analyticsAutoSubmit_toggled(bool checked);
   void on_analyticsManualCheck_toggled(bool checked);
   void on_analyticsOptOut_toggled(bool checked);

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -414,6 +414,26 @@ e.g. 1000 * 10 = 1e4</string>
             </property>
            </widget>
           </item>
+          <item row="15" column="0">
+           <widget class="QLabel" name="label_29">
+            <property name="toolTip">
+             <string>Never show "Unsaved capture" message boxes, but automatically close captures immediately.</string>
+            </property>
+            <property name="text">
+             <string>Never prompt before closing unsaved captures</string>
+            </property>
+           </widget>
+          </item>
+          <item row="15" column="1">
+           <widget class="QCheckBox" name="NeverPromptSaveCapture">
+            <property name="toolTip">
+             <string>Never show "Unsaved capture" message boxes, but automatically close captures immediately.</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -948,6 +948,8 @@ bool MainWindow::PromptCloseCapture()
   if(!m_Ctx.IsCaptureLoaded())
     return true;
 
+  bool neverPrompt = m_Ctx.Config().NeverPromptSaveCapture;
+
   QString deletepath;
   bool caplocal = false;
 
@@ -956,20 +958,23 @@ bool MainWindow::PromptCloseCapture()
     QString temppath = m_Ctx.GetCaptureFilename();
     caplocal = m_Ctx.IsCaptureLocal();
 
-    QMessageBox::StandardButton res =
-        RDDialog::question(this, tr("Unsaved capture"), tr("Save this capture?"),
-                           QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-
-    if(res == QMessageBox::Cancel)
-      return false;
-
-    if(res == QMessageBox::Yes)
+    QMessageBox::StandardButton res = QMessageBox::No;
+    if (!neverPrompt)
     {
-      bool success = PromptSaveCaptureAs();
+      res = RDDialog::question(this, tr("Unsaved capture"), tr("Save this capture?"),
+                               QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
 
-      if(!success)
-      {
+      if(res == QMessageBox::Cancel)
         return false;
+
+      if(res == QMessageBox::Yes)
+      {
+        bool success = PromptSaveCaptureAs();
+
+        if(!success)
+        {
+          return false;
+        }
       }
     }
 
@@ -977,7 +982,7 @@ bool MainWindow::PromptCloseCapture()
       deletepath = temppath;
     m_OwnTempCapture = false;
   }
-  else if(m_Ctx.GetCaptureModifications() != CaptureModifications::NoModifications)
+  else if(m_Ctx.GetCaptureModifications() != CaptureModifications::NoModifications && !neverPrompt)
   {
     QString text = tr("This capture has the following modifications:\n\n");
 


### PR DESCRIPTION
## Description

This adds the following option to the Settings Dialog:
![Screenshot from 2020-05-01 14-05-02](https://user-images.githubusercontent.com/1460997/80804252-dc9ef300-8bb4-11ea-899d-13ed73c6c6f8.png)

Which can be used to disable all of these message boxes:
![unsaved-captures](https://user-images.githubusercontent.com/1460997/80804260-e6285b00-8bb4-11ea-811f-4a65fdbf0aac.png)

I often quickly switch between captures and program runs so these message boxes can become quite annoying when I almost never want to save a capture.