### PR TITLE
Extend info in accessed resources panel in the shader viewer

### DIFF
--- a/qrenderdoc/Windows/ShaderViewer.h
+++ b/qrenderdoc/Windows/ShaderViewer.h
@@ -56,6 +56,18 @@ enum class VariableCategory
   ByString,
 };
 
+enum class AccessedResourceView
+{
+  SortByStep,
+  SortByResource,
+};
+
+struct AccessedResourceData
+{
+  ShaderVariable resource;
+  rdcarray<size_t> steps;
+};
+
 class ShaderViewer : public QFrame, public IShaderViewer, public ICaptureViewer
 {
   Q_OBJECT
@@ -116,6 +128,9 @@ private slots:
   void on_intView_clicked();
   void on_floatView_clicked();
   void on_debugToggle_clicked();
+
+  void on_resources_sortByStep_clicked();
+  void on_resources_sortByResource_clicked();
 
   void on_watch_itemChanged(QTableWidgetItem *item);
 
@@ -238,7 +253,10 @@ private:
   rdcarray<ShaderDebugState> m_States;
   size_t m_CurrentStateIdx = 0;
   rdcarray<ShaderVariable> m_Variables;
-  rdcarray<ShaderVariable> m_AccessedResources;
+
+  rdcarray<AccessedResourceData> m_AccessedResources;
+  AccessedResourceView m_AccessedResourceView = AccessedResourceView::SortByResource;
+
   rdcarray<BoundResourceArray> m_ReadOnlyResources;
   rdcarray<BoundResourceArray> m_ReadWriteResources;
   QList<int> m_Breakpoints;
@@ -278,6 +296,7 @@ private:
 
   void updateDebugState();
   void updateWatchVariables();
+  void updateAccessedResources();
 
   RDTreeWidgetItem *makeSourceVariableNode(const ShaderVariable &var, const rdcstr &sourcePath,
                                            const rdcstr &debugVarPath, bool modified);

--- a/qrenderdoc/Windows/ShaderViewer.ui
+++ b/qrenderdoc/Windows/ShaderViewer.ui
@@ -165,6 +165,87 @@
           </property>
         </widget>
       </item>
+      <item>
+        <widget class="QFrame" name="sortGroup">
+          <property name="contextMenuPolicy">
+            <enum>Qt::PreventContextMenu</enum>
+          </property>
+          <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+            </sizepolicy>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <property name="leftMargin">
+              <number>0</number>
+            </property>
+            <property name="topMargin">
+              <number>0</number>
+            </property>
+            <property name="rightMargin">
+              <number>0</number>
+            </property>
+            <property name="bottomMargin">
+              <number>0</number>
+            </property>
+            <item>
+              <widget class="QToolButton" name="resources_sortByResource">
+                <property name="text">
+                  <string>Sort By Resource</string>
+                </property>
+                <property name="checkable">
+                  <bool>true</bool>
+                </property>
+                <property name="checked">
+                  <bool>true</bool>
+                </property>
+                <property name="autoRaise">
+                  <bool>true</bool>
+                </property>
+                <property name="toolTip">
+                  <string>Sort accessed resource by shader binding</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QToolButton" name="resources_sortByStep">
+                <property name="text">
+                  <string>Sort By Instruction</string>
+                </property>
+                <property name="checkable">
+                  <bool>true</bool>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+                <property name="autoRaise">
+                  <bool>true</bool>
+                </property>
+                <property name="toolTip">
+                  <string>Sort accessed resource by instruction step</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <spacer name="resources_horizontalSpacer">
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>40</width>
+                    <height>20</height>
+                  </size>
+                </property>
+              </spacer>
+            </item>
+          </layout>
+        </widget>
+      </item>
     </layout>
   </widget>
   <widget class="RDTreeWidget" name="debugVars">


### PR DESCRIPTION
This change adds buttons to the accessed resources panel to allow sorting by either resource or by instruction. When sorted by resource, each accessed instruction is a child row. When sorted by instruction, the resource accessed is a child row. Right click context menus allow running to the selected instruction or the previous/next access of a given resource.