### PR TITLE
MacOS Catalina compilation fixes

### DIFF
--- a/qrenderdoc/Widgets/CustomPaintWidget.cpp
+++ b/qrenderdoc/Widgets/CustomPaintWidget.cpp
@@ -24,6 +24,7 @@
 
 #include "CustomPaintWidget.h"
 #include <math.h>
+#include <QEvent>
 #include <QPainter>
 #include "Code/Interface/QRDInterface.h"
 

--- a/renderdoc/driver/shaders/spirv/CMakeLists.txt
+++ b/renderdoc/driver/shaders/spirv/CMakeLists.txt
@@ -126,7 +126,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.9)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_property(SOURCE "${glslang_sources}"
+    set_property(SOURCE ${glslang_sources}
         APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-unknown-warning-option")
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.9)


### PR DESCRIPTION
Compilation fixes when compiling on macOS Catalina 

## Description

Compilation errors on Apple Catalina
- "no-deprecated-copy" is not recognised
- QPaintEvent internals being accessed