### PR TITLE
Fix broken D3D shader linkage test cases

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
@@ -4666,6 +4666,47 @@ void LookupSRVFormatFromShaderReflection(const DXBC::Reflection &reflection,
   }
 }
 
+DXBCBytecode::InterpolationMode GetInterpolationModeForInputParam(const SigParameter &sig,
+                                                                  const DXBC::Reflection &psDxbc,
+                                                                  const DXBCBytecode::Program *program)
+{
+  if(sig.varType == VarType::SInt || sig.varType == VarType::UInt)
+    return DXBCBytecode::InterpolationMode::INTERPOLATION_CONSTANT;
+
+  if(sig.varType == VarType::Float)
+  {
+    // if we're packed with ints on either side, we must be nointerpolation
+    size_t numInputs = psDxbc.InputSig.size();
+    for(size_t j = 0; j < numInputs; j++)
+    {
+      if(sig.regIndex == psDxbc.InputSig[j].regIndex && psDxbc.InputSig[j].varType != VarType::Float)
+        return DXBCBytecode::InterpolationMode::INTERPOLATION_CONSTANT;
+    }
+
+    DXBCBytecode::InterpolationMode interpolation = DXBCBytecode::INTERPOLATION_UNDEFINED;
+
+    if(program)
+    {
+      for(size_t d = 0; d < program->GetNumDeclarations(); d++)
+      {
+        const DXBCBytecode::Declaration &decl = program->GetDeclaration(d);
+
+        if(decl.declaration == DXBCBytecode::OPCODE_DCL_INPUT_PS &&
+           decl.operand.indices[0].absolute && decl.operand.indices[0].index == sig.regIndex)
+        {
+          interpolation = decl.interpolation;
+          break;
+        }
+      }
+    }
+
+    return interpolation;
+  }
+
+  RDCERR("Unexpected input signature type: %s", ToStr(sig.varType).c_str());
+  return DXBCBytecode::InterpolationMode::INTERPOLATION_UNDEFINED;
+}
+
 void GatherPSInputDataForInitialValues(const DXBC::DXBCContainer *dxbc,
                                        const DXBC::Reflection &prevStageDxbc,
                                        rdcarray<PSInputElement> &initialValues,
@@ -4793,50 +4834,11 @@ void GatherPSInputDataForInitialValues(const DXBC::DXBCContainer *dxbc,
 
     nextreg = sig.regIndex + 1;
 
-    if(sig.varType == VarType::Float)
-    {
-      // if we're packed with ints on either side, we must be nointerpolation
-      bool nointerp = false;
-      for(size_t j = 0; j < numInputs; j++)
-      {
-        if(sig.regIndex == psDxbc.InputSig[j].regIndex && psDxbc.InputSig[j].varType != VarType::Float)
-        {
-          nointerp = true;
-          break;
-        }
-      }
-
-      DXBCBytecode::InterpolationMode interpolation = DXBCBytecode::INTERPOLATION_UNDEFINED;
-
-      if(program)
-      {
-        for(size_t d = 0; d < program->GetNumDeclarations(); d++)
-        {
-          const DXBCBytecode::Declaration &decl = program->GetDeclaration(d);
-
-          if(decl.declaration == DXBCBytecode::OPCODE_DCL_INPUT_PS &&
-             decl.operand.indices[0].absolute && decl.operand.indices[0].index == sig.regIndex)
-          {
-            interpolation = decl.interpolation;
-            break;
-          }
-        }
-      }
-
-      if(nointerp)
-        psInputDefinition += "nointerpolation ";
-      else if(interpolation != DXBCBytecode::INTERPOLATION_UNDEFINED &&
-              interpolation != DXBCBytecode::INTERPOLATION_CONSTANT)
-        psInputDefinition += ToStr(interpolation) + " ";
-
-      psInputDefinition += "float";
-    }
-    else if(sig.varType == VarType::SInt)
-      psInputDefinition += "nointerpolation int";
-    else if(sig.varType == VarType::UInt)
-      psInputDefinition += "nointerpolation uint";
-    else
-      RDCERR("Unexpected input signature type: %s", ToStr(sig.varType).c_str());
+    DXBCBytecode::InterpolationMode interpolation =
+        GetInterpolationModeForInputParam(sig, psDxbc, program);
+    if(interpolation != DXBCBytecode::INTERPOLATION_UNDEFINED)
+      psInputDefinition += ToStr(interpolation) + " ";
+    psInputDefinition += ToStr(sig.varType);
 
     int numCols = (sig.regChannelMask & 0x1 ? 1 : 0) + (sig.regChannelMask & 0x2 ? 1 : 0) +
                   (sig.regChannelMask & 0x4 ? 1 : 0) + (sig.regChannelMask & 0x8 ? 1 : 0);
@@ -4869,17 +4871,22 @@ void GatherPSInputDataForInitialValues(const DXBC::DXBCContainer *dxbc,
 
       for(size_t j = i + 1; j < numInputs; j++)
       {
-        // if we've found the 'next' semantic
-        if(sig.semanticName == psDxbc.InputSig[j].semanticName &&
-           nextIdx == psDxbc.InputSig[j].semanticIndex)
-        {
-          int jNumCols = (psDxbc.InputSig[j].regChannelMask & 0x1 ? 1 : 0) +
-                         (psDxbc.InputSig[j].regChannelMask & 0x2 ? 1 : 0) +
-                         (psDxbc.InputSig[j].regChannelMask & 0x4 ? 1 : 0) +
-                         (psDxbc.InputSig[j].regChannelMask & 0x8 ? 1 : 0);
+        const SigParameter &jSig = psDxbc.InputSig[j];
 
-          // if it's the same size, and it's at the start of the next register
-          if(jNumCols == numCols && psDxbc.InputSig[j].regChannelMask <= 0x3)
+        // if we've found the 'next' semantic
+        if(sig.semanticName == jSig.semanticName && nextIdx == jSig.semanticIndex)
+        {
+          int jNumCols = (jSig.regChannelMask & 0x1 ? 1 : 0) + (jSig.regChannelMask & 0x2 ? 1 : 0) +
+                         (jSig.regChannelMask & 0x4 ? 1 : 0) + (jSig.regChannelMask & 0x8 ? 1 : 0);
+
+          DXBCBytecode::InterpolationMode jInterp =
+              GetInterpolationModeForInputParam(jSig, psDxbc, program);
+
+          // if it's the same size, type, and interpolation mode, then it could potentially be
+          // packed into an array. Check if it's using the first channel component to tell whether
+          // it's tightly packed with another semantic.
+          if(jNumCols == numCols && interpolation == jInterp && sig.varType == jSig.varType &&
+             jSig.regChannelMask & 0x1)
           {
             if(arrayLength == 0)
               arrayLength = 2;
@@ -4908,13 +4915,13 @@ void GatherPSInputDataForInitialValues(const DXBC::DXBCContainer *dxbc,
     // detected but it WILL be put in its own register (not packed together), so detect this
     // case too.
     // Note we have to search *backwards* because we need to know if this register should have
-    // been packed into the previous register, but wasn't. float/float2 can be packed after an
-    // array just fine.
-    if(included && i > 0 && arrayLength == 0 && numCols <= 2 && sig.regChannelMask <= 0x3)
+    // been packed into the previous register, but wasn't. float/float2/float3 can be packed after
+    // an array just fine, so long as the sum of their components doesn't exceed a register width
+    if(included && i > 0 && arrayLength == 0)
     {
       const SigParameter &prev = psDxbc.InputSig[i - 1];
 
-      if(prev.regIndex != sig.regIndex && prev.compCount <= 2 && prev.regChannelMask <= 0x3)
+      if(prev.regIndex != sig.regIndex && prev.compCount + sig.compCount <= 4)
         arrayLength = 1;
     }
 

--- a/util/test/demos/d3d11/d3d11_shader_linkage_zoo.cpp
+++ b/util/test/demos/d3d11/d3d11_shader_linkage_zoo.cpp
@@ -264,6 +264,11 @@ float4 main(v2f IN) : SV_Target0
                                    {false, VarType::Float, 3, 0, "TEXCOORD1", true},
                                    {false, VarType::Float, 2, 0, "TEXCOORD2", true}}));
 
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 1, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 1, "TEXCOORD1", true},
+                                   {false, VarType::Float, 3, 2, "TEXCOORD2", true},
+                                   {false, VarType::Float, 2, 0, "TEXCOORD4", true}}));
+
     // Semantics that don't pack together due to being arrays
     tests.push_back(BuildTestCase({{false, VarType::Float, 1, 2, "TEXCOORD0", true}}));
     tests.push_back(BuildTestCase({{false, VarType::Float, 2, 1, "TEXCOORD0", true},
@@ -276,26 +281,25 @@ float4 main(v2f IN) : SV_Target0
     // Tests focusing on different interpolation modes
     tests.push_back(BuildTestCase({{false, VarType::Float, 2, 0, "TEXCOORD0", true},
                                    {true, VarType::Float, 2, 0, "TEXCOORD1", true}}));
-    // The following test is currently broken: the semantics live in v1.x and v1.y, but during
-    // debugging our initial inputs shader places them in an array[2], resulting in v1.x and v2.x
+    // These semantics are placed in v1.x and v1.y since they share interpolation modes and types
+    // (all int semantics are nointerpolation). Test that they don't get placed in v1.x and v2.x
     tests.push_back(BuildTestCase({{false, VarType::UInt, 1, 0, "TEXCOORD0", true},
                                    {true, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
-    // The following test is currently broken: the semantics live in v1.x and v2.x, but during
-    // debugging our initial inputs shader places them in an array[2], resulting in the correct
-    // register placement, but incorrect interpolation modes since uints are always nointerpolation
+    // These semantics are placed in v1.x and v2.x since their interpolation modes differ. Test that
+    // they don't turn into an array[2] which would result in an erroneous interpolation mode for
+    // one semantic or the other
     tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true},
                                    {false, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
-    // The following test is currently broken: the semantics live in v1.x and v1.y, despite having
-    // different types since the interpolation mode is the same. During debugging our initial inputs
-    // shader places them in an array[2], resulting in the wrong register placement
+    // These semantics are placed in v1.x and v1.y despite having different types since the
+    // interpolation mode is the same. Test that they don't turn into an array[2] which would place
+    // them in the wrong registers
     tests.push_back(BuildTestCase({{true, VarType::Float, 1, 0, "TEXCOORD0", true},
                                    {false, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
 
     // Bespoke tests for broken scenarios discovered through bug reports:
 
-    // The following test is currently broken: the semantics live in v1.xy, v2.x, and v3.xyz due
-    // to each being an array. During debugging, out initial input shader defines the last semantic
-    // without an array size, so FXC packs it into v2.yzw
+    // These semantics live in v1.xy, v2.x, and v3.xyz due to each being an array. If any of them
+    // are not treated as an array[1], they will incorrectly pack together with a previous semantic
     tests.push_back(BuildTestCase({{false, VarType::Float, 2, 1, "TEXCOORD0", true},
                                    {false, VarType::Float, 1, 1, "TEXCOORD1", false},
                                    {false, VarType::Float, 3, 1, "TEXCOORD2", true}}));

--- a/util/test/demos/d3d11/d3d11_shader_linkage_zoo.cpp
+++ b/util/test/demos/d3d11/d3d11_shader_linkage_zoo.cpp
@@ -1,0 +1,334 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "d3d11_test.h"
+
+RD_TEST(D3D11_Shader_Linkage_Zoo, D3D11GraphicsTest)
+{
+  static constexpr const char *Description =
+      "Tests various shader linkage scenarios to ensure proper handling of data between shader "
+      "stages.";
+
+  enum class VarType : uint32_t
+  {
+    Float = 0,
+    UInt = 1,
+    Count = 2,
+  };
+  const std::string varTypeName[(uint32_t)VarType::Count] = {"float", "uint"};
+
+  struct ShaderLinkageEntry
+  {
+    bool nointerp;
+    VarType type;
+    uint32_t components;
+    uint32_t arraySize;
+    std::string semantic;
+    bool consumedByPS;
+  };
+
+  std::string BuildStruct(const std::vector<ShaderLinkageEntry> &outputs)
+  {
+    std::string structDef = R"EOSHADER(
+struct v2f
+{
+  float4 pos : SV_POSITION;
+)EOSHADER";
+
+    for(size_t i = 0; i < outputs.size(); ++i)
+    {
+      structDef += "  ";
+      if(outputs[i].nointerp)
+        structDef += "nointerpolation ";
+      structDef += varTypeName[(uint32_t)outputs[i].type];
+      structDef += std::to_string(outputs[i].components);
+      structDef += " ";
+      structDef += "element" + std::to_string(i);
+      if(outputs[i].arraySize != 0)
+        structDef += "[" + std::to_string(outputs[i].arraySize) + "]";
+      structDef += " : " + outputs[i].semantic + ";\n";
+    }
+
+    structDef += "};";
+    return structDef;
+  }
+
+  std::string BuildVS(const std::vector<ShaderLinkageEntry> &outputs)
+  {
+    std::string vs = R"EOSHADER(
+struct vertin
+{
+  float3 pos : POSITION;
+  float4 col : COLOR0;
+  float2 uv : TEXCOORD0;
+};
+)EOSHADER";
+
+    vs += BuildStruct(outputs);
+
+    vs += R"EOSHADER(
+
+v2f main(vertin IN, uint vid : SV_VertexID)
+{
+  v2f OUT = (v2f)0;
+  OUT.pos = float4(IN.pos, 1.0f);
+)EOSHADER";
+
+    float counterFloat = 0.0f;
+    uint32_t counterUInt = 0;
+    for(size_t i = 0; i < outputs.size(); ++i)
+    {
+      uint32_t count = std::max(1U, outputs[i].arraySize);
+      for(uint32_t j = 0; j < count; ++j)
+      {
+        vs += "  OUT.element" + std::to_string(i);
+        if(outputs[i].arraySize != 0)
+          vs += "[" + std::to_string(j) + "]";
+        vs += " = ";
+        vs += varTypeName[(uint32_t)outputs[i].type];
+        vs += std::to_string(outputs[i].components);
+        vs += "(";
+        for(uint32_t k = 0; k < outputs[i].components; ++k)
+        {
+          if(k != 0)
+            vs += ", ";
+          vs += std::to_string(outputs[i].type == VarType::Float ? counterFloat++ : counterUInt++);
+        }
+        vs += ");\n";
+      }
+    }
+
+    vs += "\n  return OUT;\n}\n";
+
+    return vs;
+  }
+
+  std::string BuildPS(const std::vector<ShaderLinkageEntry> &inputs)
+  {
+    std::string ps = BuildStruct(inputs);
+
+    ps += R"EOSHADER(
+
+float4 main(v2f IN) : SV_Target0
+{
+  float4 outF = float4(0.0f, 0.0f, 0.0f, 0.0f);
+  uint4 outU = uint4(0, 0, 0, 0);
+
+)EOSHADER";
+
+    const std::string varAccess[] = {"  outF", "  outU"};
+    const std::string componentAccess[] = {".x", ".xy", ".xyz", ".xyzw"};
+
+    for(size_t i = 0; i < inputs.size(); ++i)
+    {
+      if(inputs[i].consumedByPS)
+      {
+        if(inputs[i].arraySize == 0)
+        {
+          ps += varAccess[(uint32_t)inputs[i].type];
+          ps += componentAccess[inputs[i].components - 1];
+          ps += " += IN.element" + std::to_string(i) + ";\n";
+        }
+        else
+        {
+          // Access each element
+          for(uint32_t j = 0; j < inputs[i].arraySize; ++j)
+          {
+            ps += varAccess[(uint32_t)inputs[i].type];
+            ps += componentAccess[inputs[i].components - 1];
+            ps += " += IN.element" + std::to_string(i);
+            ps += "[" + std::to_string(j) + "];\n";
+          }
+        }
+      }
+    }
+
+    ps += "\n  return outF + (float4)outU;\n}\n";
+    return ps;
+  }
+
+  struct TestCase
+  {
+    ID3D11VertexShaderPtr vs;
+    ID3D11PixelShaderPtr ps;
+    ID3D11InputLayoutPtr inputLayout;
+  };
+
+  TestCase BuildTestCase(const std::vector<ShaderLinkageEntry> &elements)
+  {
+    ID3DBlobPtr vsblob = Compile(BuildVS(elements), "main", "vs_5_0");
+    ID3DBlobPtr psblob = Compile(BuildPS(elements), "main", "ps_5_0");
+    TestCase ret;
+    ret.vs = CreateVS(vsblob);
+    ret.ps = CreatePS(psblob);
+
+    D3D11_INPUT_ELEMENT_DESC layoutdesc[] = {
+        {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+        {"COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 28, D3D11_INPUT_PER_VERTEX_DATA, 0},
+    };
+
+    CHECK_HR(dev->CreateInputLayout(layoutdesc, ARRAY_COUNT(layoutdesc), vsblob->GetBufferPointer(),
+                                    vsblob->GetBufferSize(), &ret.inputLayout));
+
+    return ret;
+  }
+
+  int main()
+  {
+    // initialise, create window, create device, etc
+    if(!Init())
+      return 3;
+
+    ID3D11BufferPtr vb = MakeBuffer().Vertex().Data(DefaultTri);
+
+    ID3D11Texture2DPtr fltTex =
+        MakeTexture(DXGI_FORMAT_R32G32B32A32_FLOAT, screenWidth, screenHeight).RTV();
+    ID3D11RenderTargetViewPtr fltRT = MakeRTV(fltTex);
+
+    std::vector<TestCase> tests;
+
+    // No additional semantics
+    tests.push_back(BuildTestCase({}));
+
+    // A single semantic of various types, interpolation modes, and components
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{true, VarType::Float, 1, 0, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 4, 0, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 4, 0, "TEXCOORD0", false}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 1, 0, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 4, 0, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 4, 0, "TEXCOORD0", false}}));
+    tests.push_back(BuildTestCase({{true, VarType::UInt, 4, 0, "TEXCOORD0", true}}));
+
+    // A single semantic with various array sizes
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 1, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 2, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 5, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 1, 1, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 1, 2, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 1, 5, "TEXCOORD0", true}}));
+
+    // Multiple semantics that pack together
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 2, 0, "TEXCOORD0", true},
+                                   {false, VarType::UInt, 2, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{true, VarType::Float, 2, 0, "TEXCOORD0", true},
+                                   {true, VarType::Float, 2, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 3, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 1, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 3, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 0, "TEXCOORD1", true},
+                                   {false, VarType::Float, 1, 0, "TEXCOORD2", true}}));
+    // These pack into v1.x, v2.xy, and v1.y
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true},
+                                   {false, VarType::UInt, 2, 0, "TEXCOORD1", true},
+                                   {false, VarType::Float, 1, 0, "TEXCOORD2", true}}));
+
+    // Multiple semantics that don't pack together
+    tests.push_back(BuildTestCase({{false, VarType::Float, 3, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 3, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 4, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 1, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 4, 0, "TEXCOORD1", true}}));
+
+    // Multiple semantics that will pack together "out of order" thanks to FXC's rules
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 3, 0, "TEXCOORD1", true},
+                                   {false, VarType::Float, 2, 0, "TEXCOORD2", true}}));
+
+    // Semantics that don't pack together due to being arrays
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 2, "TEXCOORD0", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 1, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 1, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 1, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 0, "TEXCOORD1", true}}));
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 0, "TEXCOORD0", true},
+                                   {false, VarType::Float, 2, 1, "TEXCOORD1", true}}));
+
+    // Tests focusing on different interpolation modes
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 0, "TEXCOORD0", true},
+                                   {true, VarType::Float, 2, 0, "TEXCOORD1", true}}));
+    // The following test is currently broken: the semantics live in v1.x and v1.y, but during
+    // debugging our initial inputs shader places them in an array[2], resulting in v1.x and v2.x
+    tests.push_back(BuildTestCase({{false, VarType::UInt, 1, 0, "TEXCOORD0", true},
+                                   {true, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
+    // The following test is currently broken: the semantics live in v1.x and v2.x, but during
+    // debugging our initial inputs shader places them in an array[2], resulting in the correct
+    // register placement, but incorrect interpolation modes since uints are always nointerpolation
+    tests.push_back(BuildTestCase({{false, VarType::Float, 1, 0, "TEXCOORD0", true},
+                                   {false, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
+    // The following test is currently broken: the semantics live in v1.x and v1.y, despite having
+    // different types since the interpolation mode is the same. During debugging our initial inputs
+    // shader places them in an array[2], resulting in the wrong register placement
+    tests.push_back(BuildTestCase({{true, VarType::Float, 1, 0, "TEXCOORD0", true},
+                                   {false, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
+
+    // Bespoke tests for broken scenarios discovered through bug reports:
+
+    // The following test is currently broken: the semantics live in v1.xy, v2.x, and v3.xyz due
+    // to each being an array. During debugging, out initial input shader defines the last semantic
+    // without an array size, so FXC packs it into v2.yzw
+    tests.push_back(BuildTestCase({{false, VarType::Float, 2, 1, "TEXCOORD0", true},
+                                   {false, VarType::Float, 1, 1, "TEXCOORD1", false},
+                                   {false, VarType::Float, 3, 1, "TEXCOORD2", true}}));
+
+    while(Running())
+    {
+      ClearRenderTargetView(fltRT, {0.2f, 0.2f, 0.2f, 1.0f});
+      ClearRenderTargetView(bbRTV, {0.2f, 0.2f, 0.2f, 1.0f});
+
+      IASetVertexBuffer(vb, sizeof(DefaultA2V), 0);
+      ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+      RSSetViewport({0.0f, 0.0f, (float)screenWidth, (float)screenHeight, 0.0f, 1.0f});
+
+      ctx->OMSetRenderTargets(1, &fltRT.GetInterfacePtr(), NULL);
+
+      for(size_t i = 0; i < tests.size(); ++i)
+      {
+        setMarker("draw" + std::to_string(i));
+
+        ctx->IASetInputLayout(tests[i].inputLayout);
+
+        ctx->VSSetShader(tests[i].vs, NULL, 0);
+        ctx->PSSetShader(tests[i].ps, NULL, 0);
+
+        ctx->Draw(3, 0);
+      }
+
+      Present();
+    }
+
+    return 0;
+  }
+};
+
+REGISTER_TEST();

--- a/util/test/demos/d3d12/d3d12_shader_linkage_zoo.cpp
+++ b/util/test/demos/d3d12/d3d12_shader_linkage_zoo.cpp
@@ -250,6 +250,11 @@ float4 main(v2f IN) : SV_Target0
                                   {false, VarType::Float, 3, 0, "TEXCOORD1", true},
                                   {false, VarType::Float, 2, 0, "TEXCOORD2", true}}));
 
+    psos.push_back(BuildPSO(sig, {{false, VarType::Float, 2, 1, "TEXCOORD0", true},
+                                  {false, VarType::Float, 2, 1, "TEXCOORD1", true},
+                                  {false, VarType::Float, 3, 2, "TEXCOORD2", true},
+                                  {false, VarType::Float, 2, 0, "TEXCOORD4", true}}));
+
     // Semantics that don't pack together due to being arrays
     psos.push_back(BuildPSO(sig, {{false, VarType::Float, 1, 2, "TEXCOORD0", true}}));
     psos.push_back(BuildPSO(sig, {{false, VarType::Float, 2, 1, "TEXCOORD0", true},
@@ -262,26 +267,25 @@ float4 main(v2f IN) : SV_Target0
     // Tests focusing on different interpolation modes
     psos.push_back(BuildPSO(sig, {{false, VarType::Float, 2, 0, "TEXCOORD0", true},
                                   {true, VarType::Float, 2, 0, "TEXCOORD1", true}}));
-    // The following test is currently broken: the semantics live in v1.x and v1.y, but during
-    // debugging our initial inputs shader places them in an array[2], resulting in v1.x and v2.x
+    // These semantics are placed in v1.x and v1.y since they share interpolation modes and types
+    // (all int semantics are nointerpolation). Test that they don't get placed in v1.x and v2.x
     psos.push_back(BuildPSO(sig, {{false, VarType::UInt, 1, 0, "TEXCOORD0", true},
                                   {true, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
-    // The following test is currently broken: the semantics live in v1.x and v2.x, but during
-    // debugging our initial inputs shader places them in an array[2], resulting in the correct
-    // register placement, but incorrect interpolation modes since uints are always nointerpolation
+    // These semantics are placed in v1.x and v2.x since their interpolation modes differ. Test that
+    // they don't turn into an array[2] which would result in an erroneous interpolation mode for
+    // one semantic or the other
     psos.push_back(BuildPSO(sig, {{false, VarType::Float, 1, 0, "TEXCOORD0", true},
                                   {false, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
-    // The following test is currently broken: the semantics live in v1.x and v1.y, despite having
-    // different types since the interpolation mode is the same. During debugging our initial inputs
-    // shader places them in an array[2], resulting in the wrong register placement
+    // These semantics are placed in v1.x and v1.y despite having different types since the
+    // interpolation mode is the same. Test that they don't turn into an array[2] which would place
+    // them in the wrong registers
     psos.push_back(BuildPSO(sig, {{true, VarType::Float, 1, 0, "TEXCOORD0", true},
                                   {false, VarType::UInt, 1, 0, "TEXCOORD1", true}}));
 
     // Bespoke tests for broken scenarios discovered through bug reports:
 
-    // The following test is currently broken: the semantics live in v1.xy, v2.x, and v3.xyz due
-    // to each being an array. During debugging, out initial input shader defines the last semantic
-    // without an array size, so FXC packs it into v2.yzw
+    // These semantics live in v1.xy, v2.x, and v3.xyz due to each being an array. If any of them
+    // are not treated as an array[1], they will incorrectly pack together with a previous semantic
     psos.push_back(BuildPSO(sig, {{false, VarType::Float, 2, 1, "TEXCOORD0", true},
                                   {false, VarType::Float, 1, 1, "TEXCOORD1", false},
                                   {false, VarType::Float, 3, 1, "TEXCOORD2", true}}));

--- a/util/test/demos/demos.vcxproj
+++ b/util/test/demos/demos.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="d3d11\d3d11_saturate.cpp" />
     <ClCompile Include="d3d11\d3d11_shader_editing.cpp" />
     <ClCompile Include="d3d11\d3d11_shader_isa.cpp" />
+    <ClCompile Include="d3d11\d3d11_shader_linkage_zoo.cpp" />
     <ClCompile Include="d3d11\d3d11_simple_dispatch.cpp" />
     <ClCompile Include="d3d11\d3d11_simple_triangle.cpp" />
     <ClCompile Include="d3d11\d3d11_stream_out.cpp" />

--- a/util/test/demos/demos.vcxproj.filters
+++ b/util/test/demos/demos.vcxproj.filters
@@ -487,6 +487,9 @@
     <ClCompile Include="d3d12\d3d12_shader_linkage_zoo.cpp">
       <Filter>D3D12\demos</Filter>
     </ClCompile>
+    <ClCompile Include="d3d11\d3d11_shader_linkage_zoo.cpp">
+      <Filter>D3D11\demos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="D3D11">

--- a/util/test/tests/D3D11/D3D11_Shader_Linkage_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_Shader_Linkage_Zoo.py
@@ -1,0 +1,49 @@
+import renderdoc as rd
+from typing import List
+import rdtest
+
+
+class D3D11_Shader_Linkage_Zoo(rdtest.TestCase):
+    demos_test_name = 'D3D11_Shader_Linkage_Zoo'
+
+    def check_capture(self):
+        failed = False
+
+        test_marker: rd.DrawcallDescription = self.find_draw("draw")
+        while test_marker is not None:
+            drawcall = test_marker.next
+            event_name = test_marker.name
+            test_marker: rd.DrawcallDescription = self.find_draw("draw", drawcall.eventId)
+
+            self.controller.SetFrameEvent(drawcall.eventId, False)
+            pipe: rd.PipeState = self.controller.GetPipelineState()
+
+            # Debug the shader
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(200, 150, rd.ReplayController.NoPreference,
+                                                                    rd.ReplayController.NoPreference)
+            if trace.debugger is None:
+                failed = True
+                rdtest.log.error("Test {} could not be debugged.".format(event_name))
+                continue
+
+            cycles, variables = self.process_trace(trace)
+
+            output = self.find_output_source_var(trace, rd.ShaderBuiltin.ColorOutput, 0)
+
+            debugged = self.evaluate_source_var(output, variables)
+
+            try:
+                self.check_pixel_value(pipe.GetOutputTargets()[0].resourceId, 200, 150, debugged.value.fv[0:4])
+            except rdtest.TestFailureException as ex:
+                failed = True
+                rdtest.log.error("Test {} did not match. {}".format(event_name, str(ex)))
+                continue
+            finally:
+                self.controller.FreeTrace(trace)
+
+            rdtest.log.success("Test {} matched as expected".format(event_name))
+
+        if failed:
+            raise rdtest.TestFailureException("Some tests were not as expected")
+
+        rdtest.log.success("All tests matched")


### PR DESCRIPTION
- The rules for merging semantics into an array were not strict enough. If either the type, interpolation mode, or size is different, or if it is not using a register's x component, then we can't combine it.
- The rules for marking a semantic as array length 1 were too strict, resulting in some semantics packing into other registers incorrectly.
- Added a D3D11 test for shader linkage.
