### PR TITLE
Fix relative path directory of capture creation

### DIFF
--- a/renderdoc/os/posix/posix_stringio.cpp
+++ b/renderdoc/os/posix/posix_stringio.cpp
@@ -71,9 +71,6 @@ void CreateParentDirectory(const rdcstr &filename)
   // want trailing slash so that we create all directories
   fn.push_back('/');
 
-  if(fn[0] != '/')
-    return;
-
   int offs = fn.find('/', 1);
 
   while(offs >= 0)


### PR DESCRIPTION
From executable path, relative path directory of capture is not created (temp/<template name>) because CreateParentDirectory function admit only absolute path

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
I'm on Arch Linux, and I have trouble when I launch executable, the log message from app_api.cpp(67) tell me that the capture file template is temp/bgfx.
Also my executable path is /home/gauthier/tmp/build-bgfx.cmake-Desktop-Debug/example-00-helloworld.
When I capture frame, i have errno 2 error : can't open capture file 'temp/bgfx_frame244.rdc'.
This is because the temp/ directory hasn't been created before.
In CreateParentDirectory function you admit only absolute path, I don't understand why you do that, maybe there are a reason i don't know.
I create the temp directory manually in working executable path, and it's work good.
I have no idea if I have a wrong capture file template because of the working directory path name (*tmp*), I don't know if the capture file template is necessarily an absolute path, it's my first look of your software, I have no idea how this one usually work.
![screen](https://user-images.githubusercontent.com/25795773/81617294-72bcef80-93e5-11ea-85f0-4ce410f5b3d2.png)
