### PR TITLE
Vulkan: fix usage based on shaders

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -3798,7 +3798,20 @@ void WrappedVulkan::AddUsage(VulkanDrawcallTreeNode &drawNode, rdcarray<DebugMes
 
   static bool hugeRangeWarned = false;
 
-  for(int shad = 0; shad < 6; shad++)
+  int shaderStart = 0;
+  int shaderEnd = 0;
+  if(d.flags & DrawFlags::Dispatch)
+  {
+    shaderStart = 5;
+    shaderEnd = 6;
+  }
+  else if(d.flags & DrawFlags::Drawcall)
+  {
+    shaderStart = 0;
+    shaderEnd = 5;
+  }
+
+  for(int shad = shaderStart; shad < shaderEnd; shad++)
   {
     bool compute = (shad == 5);
     ResourceId pipe = (compute ? state.compute.pipeline : state.graphics.pipeline);


### PR DESCRIPTION
This was based on an example where there is:
eid 1: vkCmdDispatch (used image as ssbo)
eid 2: vkCmdDraw (used image in FBO)
eid 3: vkCmdDraw (used image in FBO)

Image usage added CS_RWResource to draws in eid 2 and eid 3,
since a compute pipeline with the compute shader from eid 1
was still bound.