### PR TITLE
Add link dependency on renderdoc_libentry

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -538,6 +538,7 @@ target_compile_definitions(renderdoc ${RDOC_DEFINITIONS})
 target_include_directories(renderdoc ${RDOC_INCLUDES})
 target_link_libraries(renderdoc ${RDOC_LIBRARIES})
 
+set_target_properties(renderdoc PROPERTIES LINK_DEPENDS $<TARGET_FILE:renderdoc_libentry>)
 add_dependencies(renderdoc renderdoc_libentry)
 
 if(UNIX AND NOT ANDROID AND NOT APPLE)


### PR DESCRIPTION
renderdoc will not be re-linked without the dependency on renderdoc_libentry which is modified.

touch ../renderdoc/os/posix/posix_libentry.cpp
make

librenderdoc_libentry.a will be re-compiled while renderdoc is not.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
