### PR TITLE
Fix link dependency on renderdoc_libentry

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -528,9 +528,9 @@ link_directories(${CMAKE_CURRENT_BINARY_DIR})
 # On apple we need to pass the force_load parameter here - if we set it with LINK_FLAGS below
 # it gets applied too early (even if the -lrenderdoc_libentry is later)
 if(APPLE)
-    list(APPEND RDOC_LIBRARIES PRIVATE "-Wl,-force_load,librenderdoc_libentry.a -lrenderdoc_libentry")
+    list(APPEND RDOC_LIBRARIES PRIVATE "-Wl,-force_load,librenderdoc_libentry.a" renderdoc_libentry)
 else()
-    list(APPEND RDOC_LIBRARIES PRIVATE -lrenderdoc_libentry)
+    list(APPEND RDOC_LIBRARIES PRIVATE renderdoc_libentry)
 endif()
 
 add_library(renderdoc SHARED ${renderdoc_objects})


### PR DESCRIPTION
renderdoc will not be re-linked without the dependency on renderdoc_libentry which is modified.

touch ../renderdoc/os/posix/posix_libentry.cpp
make

librenderdoc_libentry.a will be re-compiled while renderdoc is not.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
