### PR TITLE
vulkan low-memory-mode

### DIFF
--- a/renderdoc/common/wrapped_pool.h
+++ b/renderdoc/common/wrapped_pool.h
@@ -243,7 +243,7 @@ private:
   static PoolType m_Pool;                                     \
   void *operator new(size_t sz) { return m_Pool.Allocate(); } \
   void operator delete(void *p) { m_Pool.Deallocate(p); }     \
-  static bool IsAlloc(void *p) { return m_Pool.IsAlloc(p); }
+  static bool IsAlloc(const void *p) { return m_Pool.IsAlloc(p); }
 #if ENABLED(INCLUDE_TYPE_NAMES)
 #define DECL_TYPENAME(a)             \
   template <>                        \

--- a/renderdoc/core/resource_manager.h
+++ b/renderdoc/core/resource_manager.h
@@ -1200,6 +1200,7 @@ void ResourceManager<Configuration>::PrepareInitialContents()
 
   RDCDEBUG("Preparing up to %u potentially dirty resources", (uint32_t)m_DirtyResources.size());
   uint32_t prepared = 0;
+  uint32_t postponed = 0;
 
   float num = float(m_DirtyResources.size());
   float idx = 0.0f;
@@ -1229,6 +1230,7 @@ void ResourceManager<Configuration>::PrepareInitialContents()
       m_PostponedResourceIDs.insert(id);
       // Set empty contents here, it'll be prepared on serialization.
       SetInitialContents(id, InitialContentData());
+      postponed++;
       continue;
     }
 
@@ -1241,7 +1243,7 @@ void ResourceManager<Configuration>::PrepareInitialContents()
     Prepare_InitialState(res);
   }
 
-  RDCDEBUG("Prepared %u dirty resources", prepared);
+  RDCDEBUG("Prepared %u dirty resources, postponed %u", prepared, postponed);
 }
 
 template <typename Configuration>

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1536,6 +1536,8 @@ void WrappedVulkan::StartFrameCapture(void *dev, void *wnd)
 
   m_CaptureTimer.Restart();
 
+  GetResourceManager()->ResetCaptureStartTime();
+
   m_AppControlledCapture = true;
 
   m_SubmitCounter = 0;
@@ -2036,6 +2038,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
     m_CmdBufferRecords[i]->Delete(GetResourceManager());
 
   m_CmdBufferRecords.clear();
+
+  GetResourceManager()->ResetLastWriteTimes();
 
   GetResourceManager()->MarkUnwrittenResources();
 

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -946,3 +946,8 @@ bool VulkanResourceManager::ResourceTypeRelease(WrappedVkRes *res)
 {
   return m_Core->ReleaseResource(res);
 }
+
+bool VulkanResourceManager::IsResourceTrackedForPersistency(WrappedVkRes *const &res)
+{
+  return IsPostponableRes(res);
+}

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -453,6 +453,14 @@ public:
     }
   }
 
+  bool IsResourceTrackedForPersistency(WrappedVkRes *const &res);
+
+  void MarkDirtyWithWriteReference(ResourceId id)
+  {
+    MarkResourceFrameReferenced(id, eFrameRef_ReadBeforeWrite);
+    MarkDirtyResource(id);
+  }
+
 private:
   bool ResourceTypeRelease(WrappedVkRes *res);
 

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -67,6 +67,11 @@ bool IsDispatchableRes(WrappedVkRes *ptr)
           WrappedVkCommandBuffer::IsAlloc(ptr));
 }
 
+bool IsPostponableRes(const WrappedVkRes *ptr)
+{
+  return (WrappedVkDeviceMemory::IsAlloc(ptr) || WrappedVkImage::IsAlloc(ptr));
+}
+
 VkResourceType IdentifyTypeByPtr(WrappedVkRes *ptr)
 {
   if(WrappedVkPhysicalDevice::IsAlloc(ptr))

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -833,6 +833,7 @@ inline void SetTableIfDispatchable(bool writing, VkDevice parent, WrappedVulkan 
 }
 
 bool IsDispatchableRes(WrappedVkRes *ptr);
+bool IsPostponableRes(const WrappedVkRes *ptr);
 VkResourceType IdentifyTypeByPtr(WrappedVkRes *ptr);
 
 #define UNKNOWN_PREV_IMG_LAYOUT ((VkImageLayout)0xffffffff)

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -704,7 +704,7 @@ void WrappedVulkan::vkUnmapMemory(VkDevice device, VkDeviceMemory mem)
         capframe = IsActiveCapturing(m_State);
 
         if(!capframe)
-          GetResourceManager()->MarkDirtyResource(id);
+          GetResourceManager()->MarkDirtyWithWriteReference(id);
       }
 
       SCOPED_LOCK(state.mrLock);
@@ -885,7 +885,7 @@ VkResult WrappedVulkan::vkFlushMappedMemoryRanges(VkDevice device, uint32_t memR
       }
       else
       {
-        GetResourceManager()->MarkDirtyResource(memid);
+        GetResourceManager()->MarkDirtyWithWriteReference(memid);
       }
     }
   }
@@ -1009,7 +1009,7 @@ VkResult WrappedVulkan::vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkD
                                                       record->memSize, eFrameRef_ReadBeforeWrite);
 
       // the memory is immediately dirty because we have no way of tracking writes to it
-      GetResourceManager()->MarkDirtyResource(GetResID(memory));
+      GetResourceManager()->MarkDirtyWithWriteReference(GetResID(memory));
     }
   }
 
@@ -1314,7 +1314,7 @@ VkResult WrappedVulkan::vkCreateBuffer(VkDevice device, const VkBufferCreateInfo
         // buffers are always bound opaquely and in arbitrary divisions, sparse residency
         // only means not all the buffer needs to be bound, which is not that interesting for
         // our purposes. We just need to make sure sparse buffers are dirty.
-        GetResourceManager()->MarkDirtyResource(id);
+        GetResourceManager()->MarkDirtyWithWriteReference(id);
       }
 
       if(isSparse || isExternal)
@@ -1793,7 +1793,7 @@ VkResult WrappedVulkan::vkCreateImage(VkDevice device, const VkImageCreateInfo *
       // not be valid to map from/into if the image isn't in GENERAL layout).
       if(isSparse || isExternal || isLinear)
       {
-        GetResourceManager()->MarkDirtyResource(id);
+        GetResourceManager()->MarkDirtyWithWriteReference(id);
 
         // for external images, try creating a non-external version and take the worst case of
         // memory requirements, in case the non-external one (as we will replay it) needs more
@@ -2129,7 +2129,7 @@ VkResult WrappedVulkan::vkBindBufferMemory2(VkDevice device, uint32_t bindInfoCo
             eFrameRef_ReadBeforeWrite);
 
         // the memory is immediately dirty because we have no way of tracking writes to it
-        GetResourceManager()->MarkDirtyResource(GetResID(pBindInfos[i].memory));
+        GetResourceManager()->MarkDirtyWithWriteReference(GetResID(pBindInfos[i].memory));
       }
     }
   }


### PR DESCRIPTION
## Description
Port DmitrySoshnikov's low memory mode to Vulkan, postponing Images and Buffers initial state creation to after the frame, if the image/buffer hasn't been written to in the past 3 seconds. 

Tested on PC using Vulkan-Samples, scenes msaa and renderpasses, and on Oculus Quest using UE4.25. In both cases, I never saw the log
"Preparing resource %s after it has been postponed." of Prepare_ResourceIfActivePostponed, and a good amount of resources got postponed. 