### PR TITLE
Fix HWND resize timing issue

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -2221,6 +2221,11 @@ void TextureViewer::InitResourcePreview(ResourcePreview *prev, BoundResource res
 
     WindowingData winData = m_Ctx.CreateWindowingData(prev->thumbWidget());
 
+    prev->setProperty("f", QVariant::fromValue(follow));
+    prev->setSlotName(slotName);
+    prev->setActive(true);
+    prev->setSelected(m_Following == follow);
+
     if(m_Ctx.GetTexture(res.resourceId))
     {
       m_Ctx.Replay().AsyncInvoke([this, winData, res](IReplayController *) {
@@ -2238,11 +2243,6 @@ void TextureViewer::InitResourcePreview(ResourcePreview *prev, BoundResource res
         m_Output->AddThumbnail(winData, ResourceId(), {0, 0, ~0U}, CompType::Typeless);
       });
     }
-
-    prev->setProperty("f", QVariant::fromValue(follow));
-    prev->setSlotName(slotName);
-    prev->setActive(true);
-    prev->setSelected(m_Following == follow);
   }
   else if(m_Following == follow)
   {


### PR DESCRIPTION
* There was a race condition where the newly created HWND surface could
  be resized during swap chain creation. This causes a
  `VK_ERROR_DEVICE_LOST`, but is very timing dependent.
* The fix was to finish the resize, via `ResourcePreview::setActive()` /
  `QWidget::show()` before scheduling any async functions that could
  create a swapchain, namely `IReplayOutput::AddThumbnail()`.
