### PR TITLE
Fixed hlsl cbuffer variable gen bug

### DIFF
--- a/qrenderdoc/Windows/PipelineState/PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/PipelineStateViewer.cpp
@@ -613,7 +613,15 @@ void PipelineStateViewer::MakeShaderVariablesHLSL(bool cbufferContents,
       }
     }
 
-    struct_contents += lit("\t%1 %2").arg(v.type.descriptor.name).arg(v.name);
+    if(v.type.descriptor.elements > 1)
+    {
+      struct_contents +=
+          lit("\t%1 %2[%3]").arg(v.type.descriptor.name).arg(v.name).arg(v.type.descriptor.elements);
+    }
+    else
+    {
+      struct_contents += lit("\t%1 %2").arg(v.type.descriptor.name).arg(v.name);
+    }
 
     if((v.byteOffset % 4) != 0)
       qWarning() << "Variable " << QString(v.name) << " is not DWORD aligned";


### PR DESCRIPTION
the cbuffer variables with elements not equal to zero should generate as array