### PR TITLE
Include QPainterPath header as necessary

### DIFF
--- a/qrenderdoc/Windows/TimelineBar.cpp
+++ b/qrenderdoc/Windows/TimelineBar.cpp
@@ -25,6 +25,7 @@
 #include "TimelineBar.h"
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QScrollBar>
 #include <QWheelEvent>
 #include "Code/QRDUtils.h"


### PR DESCRIPTION
Fixes compiler errors when building against Qt 5.15, which recently landed in Arch Linux repositories. The errors in question are all about `QPainterPath` being an incomplete type due to the missing include.