### PR TITLE
Vulkan skip cleared attachments

### DIFF
--- a/renderdoc/core/resource_manager.cpp
+++ b/renderdoc/core/resource_manager.cpp
@@ -170,6 +170,11 @@ bool IsDirtyFrameRef(FrameRefType refType)
   return (refType != eFrameRef_None && refType != eFrameRef_Read);
 }
 
+bool IsCompleteWriteFrameRef(FrameRefType refType)
+{
+  return refType == eFrameRef_CompleteWrite;
+}
+
 void ResourceRecord::AddResourceReferences(ResourceRecordHandler *mgr)
 {
   for(auto it = m_FrameRefs.begin(); it != m_FrameRefs.end(); ++it)

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -2054,6 +2054,8 @@ bool WrappedVulkan::EndFrameCapture(void *dev, void *wnd)
 
   GetResourceManager()->ResetLastWriteTimes();
 
+  GetResourceManager()->ResetLastPartialUseTimes();
+
   GetResourceManager()->MarkUnwrittenResources();
 
   GetResourceManager()->ClearReferencedMemory();

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -853,6 +853,14 @@ void VulkanResourceManager::MarkMemoryFrameReferenced(ResourceId mem, VkDeviceSi
   SCOPED_LOCK(m_Lock);
 
   FrameRefType maxRef = MarkMemoryReferenced(m_MemFrameRefs, mem, offset, size, refType);
+  if(maxRef == eFrameRef_CompleteWrite)
+  {
+    // check and make sure this is really a CompleteWrite
+    VkResourceRecord *record = GetResourceRecord(mem);
+    // if we are not writing the entire memory, degrade it to a partial write
+    if(offset != 0 || size != record->Length)
+      maxRef = eFrameRef_PartialWrite;
+  }
   MarkResourceFrameReferenced(mem, maxRef, ComposeFrameRefsDisjoint);
 }
 

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -455,12 +455,6 @@ public:
 
   bool IsResourceTrackedForPersistency(WrappedVkRes *const &res);
 
-  void MarkDirtyWithWriteReference(ResourceId id)
-  {
-    MarkResourceFrameReferenced(id, eFrameRef_ReadBeforeWrite);
-    MarkDirtyResource(id);
-  }
-
 private:
   bool ResourceTypeRelease(WrappedVkRes *res);
 

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3523,7 +3523,9 @@ bool FramebufferInfo::AttachmentFullyReferenced(size_t attachmentIndex, const Re
   }
   // if view doesn't reference the entire image
   if(att->viewRange.baseArrayLayer != 0 ||
-     att->viewRange.layerCount() != (uint32_t)att->resInfo->imageInfo.layerCount)
+     att->viewRange.layerCount() != (uint32_t)att->resInfo->imageInfo.layerCount ||
+     att->viewRange.baseMipLevel != 0 ||
+     att->viewRange.levelCount() != (uint32_t)att->resInfo->imageInfo.levelCount)
   {
     return false;
   }

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1108,6 +1108,36 @@ struct AttachmentInfo
   VkImageMemoryBarrier barrier;
 };
 
+struct RenderPassInfo
+{
+  RenderPassInfo(const VkRenderPassCreateInfo &ci);
+  RenderPassInfo(const VkRenderPassCreateInfo2 &ci);
+
+  ~RenderPassInfo();
+
+  AttachmentInfo *imageAttachments;
+
+  // table of loadOps for each attachment
+  VkAttachmentLoadOp *loadOpTable;
+
+  // table of multiview viewMasks for each attachment
+  uint32_t *multiviewViewMaskTable;
+};
+
+struct FramebufferInfo
+{
+  FramebufferInfo(const VkFramebufferCreateInfo &ci);
+  ~FramebufferInfo();
+
+  bool AttachmentFullyReferenced(size_t attachmentIndex, const RenderPassInfo *rpi);
+
+  AttachmentInfo *imageAttachments;
+
+  uint32_t width;
+  uint32_t height;
+  uint32_t layers;
+};
+
 struct ImageRange
 {
   ImageRange() {}
@@ -2217,7 +2247,8 @@ public:
     SwapchainInfo *swapInfo;                 // only for swapchains
     MemMapState *memMapState;                // only for device memory
     CmdBufferRecordingInfo *cmdInfo;         // only for command buffers
-    AttachmentInfo *imageAttachments;        // only for framebuffers and render passes
+    FramebufferInfo *framebufferInfo;        // only for framebuffers
+    RenderPassInfo *renderPassInfo;          // only for render passes
     PipelineLayoutData *pipeLayoutInfo;      // only for pipeline layouts
     DescriptorSetData *descInfo;             // only for descriptor sets and descriptor set layouts
     DescUpdateTemplate *descTemplateInfo;    // only for descriptor update templates

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -1024,6 +1024,17 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
         GetResourceManager()->MarkResourceFrameReferenced(record->GetResourceID(),
                                                           eFrameRef_ReadBeforeWrite);
       }
+
+      // pull in frame refs while background capturing too
+      for(uint32_t s = 0; s < submitCount; s++)
+      {
+        for(uint32_t i = 0; i < pSubmits[s].commandBufferCount; i++)
+        {
+          VkResourceRecord *record = GetRecord(pSubmits[s].pCommandBuffers[i]);
+
+          record->bakedCommands->AddResourceReferences(GetResourceManager());
+        }
+      }
     }
 
     if(capframe)

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -910,7 +910,7 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
             it != record->bakedCommands->cmdInfo->dirtied.end(); ++it)
         {
           if(GetResourceManager()->HasCurrentResource(*it))
-            GetResourceManager()->MarkDirtyWithWriteReference(*it);
+            GetResourceManager()->MarkDirtyResource(*it);
         }
 
         // with EXT_descriptor_indexing a binding might have been updated after
@@ -931,7 +931,7 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
                refit->second.second == eFrameRef_ReadBeforeWrite)
             {
               if(GetResourceManager()->HasCurrentResource(refit->first))
-                GetResourceManager()->MarkDirtyWithWriteReference(refit->first);
+                GetResourceManager()->MarkDirtyResource(refit->first);
             }
           }
         }
@@ -1119,7 +1119,7 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
               state.mapFlushed = false;
             }
 
-            GetResourceManager()->MarkDirtyWithWriteReference(record->GetResourceID());
+            GetResourceManager()->MarkDirtyResource(record->GetResourceID());
           }
           else
           {


### PR DESCRIPTION
This change adds another layer to the existing Vulkan
low memory mode that skips the initial states of rendertargets
that get cleared in a renderpass.
