### PR TITLE
Add custom shaders directory to the Texture Viewer settings

### DIFF
--- a/qrenderdoc/Code/Interface/PersistantConfig.h
+++ b/qrenderdoc/Code/Interface/PersistantConfig.h
@@ -302,6 +302,8 @@ DECLARE_REFLECTION_STRUCT(BugReport);
                                                                                            \
   CONFIG_SETTING_VAL(public, bool, bool, TextureViewer_PerTexYFlip, false)                 \
                                                                                            \
+  CONFIG_SETTING_VAL(public, QString, rdcstr, TextureViewer_CustomShadersDirectory, "")    \
+                                                                                           \
   CONFIG_SETTING_VAL(public, bool, bool, AlwaysReplayLocally, false)                       \
                                                                                            \
   CONFIG_SETTING_VAL(public, int, int, LocalProxyAPI, -1)                                  \
@@ -522,6 +524,13 @@ For more information about some of these settings that are user-facing see
   Does nothing if per-texture settings are disabled in general.
 
   Defaults to ``False``.
+
+.. data:: TextureViewer_CustomShadersDirectory
+
+  Path to the directory containing custom shader files for Texture Viewer. If left empty, config
+  directory is used.
+
+  Defaults to ``""``
 
 .. data:: AlwaysReplayLocally
 

--- a/qrenderdoc/Code/Interface/PersistantConfig.h
+++ b/qrenderdoc/Code/Interface/PersistantConfig.h
@@ -302,7 +302,7 @@ DECLARE_REFLECTION_STRUCT(BugReport);
                                                                                            \
   CONFIG_SETTING_VAL(public, bool, bool, TextureViewer_PerTexYFlip, false)                 \
                                                                                            \
-  CONFIG_SETTING_VAL(public, QString, rdcstr, TextureViewer_CustomShadersDirectory, "")    \
+  CONFIG_SETTING(public, QVariantList, rdcarray<rdcstr>, TextureViewer_ShaderDirs)         \
                                                                                            \
   CONFIG_SETTING_VAL(public, bool, bool, AlwaysReplayLocally, false)                       \
                                                                                            \
@@ -525,12 +525,9 @@ For more information about some of these settings that are user-facing see
 
   Defaults to ``False``.
 
-.. data:: TextureViewer_CustomShadersDirectory
+.. data:: TextureViewer_ShadersDirs
 
-  Path to the directory containing custom shader files for Texture Viewer. If left empty, config
-  directory is used.
-
-  Defaults to ``""``
+  List of the directories containing custom shader files for the Texture Viewer.
 
 .. data:: AlwaysReplayLocally
 

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
@@ -127,6 +127,7 @@ SettingsDialog::SettingsDialog(ICaptureContext &ctx, QWidget *parent)
   ui->TextureViewer_ResetRange->setChecked(m_Ctx.Config().TextureViewer_ResetRange);
   ui->TextureViewer_PerTexSettings->setChecked(m_Ctx.Config().TextureViewer_PerTexSettings);
   ui->TextureViewer_PerTexYFlip->setChecked(m_Ctx.Config().TextureViewer_PerTexYFlip);
+  ui->TextureViewer_CustomShadersPath->setText(m_Ctx.Config().TextureViewer_CustomShadersDirectory);
   ui->CheckUpdate_AllowChecks->setChecked(m_Ctx.Config().CheckUpdate_AllowChecks);
   ui->Font_PreferMonospaced->setChecked(m_Ctx.Config().Font_PreferMonospaced);
 
@@ -560,6 +561,28 @@ void SettingsDialog::on_TextureViewer_PerTexSettings_toggled(bool checked)
 void SettingsDialog::on_TextureViewer_PerTexYFlip_toggled(bool checked)
 {
   m_Ctx.Config().TextureViewer_PerTexYFlip = ui->TextureViewer_PerTexYFlip->isChecked();
+
+  m_Ctx.Config().Save();
+}
+
+void SettingsDialog::on_browseCustomShadersPath_clicked()
+{
+  QString dir = RDDialog::getExistingDirectory(this, tr("Choose directory for custom shaders"),
+                                               m_Ctx.Config().TextureViewer_CustomShadersDirectory);
+
+  if(!dir.isEmpty())
+  {
+    m_Ctx.Config().TextureViewer_CustomShadersDirectory = dir;
+    ui->TextureViewer_CustomShadersPath->setText(dir);
+  }
+
+  m_Ctx.Config().Save();
+}
+
+void SettingsDialog::on_resetCustomShadersPath_clicked()
+{
+  m_Ctx.Config().TextureViewer_CustomShadersDirectory = "";
+  ui->TextureViewer_CustomShadersPath->setText(QString());
 
   m_Ctx.Config().Save();
 }

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.h
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.h
@@ -81,6 +81,8 @@ private slots:
   void on_TextureViewer_PerTexSettings_toggled(bool checked);
   void on_TextureViewer_ResetRange_toggled(bool checked);
   void on_TextureViewer_PerTexYFlip_toggled(bool checked);
+  void on_browseCustomShadersPath_clicked();
+  void on_resetCustomShadersPath_clicked();
 
   // shader viewer
   void on_ShaderViewer_FriendlyNaming_toggled(bool checked);

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.h
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.h
@@ -81,8 +81,7 @@ private slots:
   void on_TextureViewer_PerTexSettings_toggled(bool checked);
   void on_TextureViewer_ResetRange_toggled(bool checked);
   void on_TextureViewer_PerTexYFlip_toggled(bool checked);
-  void on_browseCustomShadersPath_clicked();
-  void on_resetCustomShadersPath_clicked();
+  void on_TextureViewer_ChooseShaderDirectories_clicked();
 
   // shader viewer
   void on_ShaderViewer_FriendlyNaming_toggled(bool checked);

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>561</width>
-    <height>519</height>
+    <width>564</width>
+    <height>530</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -410,7 +410,7 @@ e.g. 1000 * 10 = 1e4</string>
              <string>A global scale for all fonts in the program. This will only scale text, icons and other UI elements will be scaled according to DPI settings as normal.</string>
             </property>
             <property name="editable">
-              <bool>true</bool>
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -649,6 +649,16 @@ After interop is enabled you will need to reload any capture.</string>
           <string>Texture Viewer</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
+          <item row="4" column="1">
+           <widget class="QPushButton" name="browseCustomShadersPath">
+            <property name="toolTip">
+             <string>Browse for the directory with custom shaders for Texture Viewer</string>
+            </property>
+            <property name="text">
+             <string>Browse</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_12">
             <property name="sizePolicy">
@@ -662,22 +672,6 @@ After interop is enabled you will need to reload any capture.</string>
             </property>
             <property name="text">
              <string>Reset Range on changing selection</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="TextureViewer_ResetRange">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Reset visible range when changing event or texture</string>
-            </property>
-            <property name="text">
-             <string/>
             </property>
            </widget>
           </item>
@@ -697,6 +691,29 @@ After interop is enabled you will need to reload any capture.</string>
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_29">
+            <property name="toolTip">
+             <string>Path to the directory with custom shaders for Texture Viewer</string>
+            </property>
+            <property name="text">
+             <string>Custom shaders directory</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>378</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
           <item row="1" column="1">
            <widget class="QCheckBox" name="TextureViewer_PerTexSettings">
             <property name="minimumSize">
@@ -707,6 +724,22 @@ After interop is enabled you will need to reload any capture.</string>
             </property>
             <property name="toolTip">
              <string>Settings such as visible channels (RGBA) and selected mip/slice are remembered and restored per-texture.</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="TextureViewer_ResetRange">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Reset visible range when changing event or texture</string>
             </property>
             <property name="text">
              <string/>
@@ -745,18 +778,22 @@ After interop is enabled you will need to reload any capture.</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+          <item row="4" column="0">
+           <widget class="QLineEdit" name="TextureViewer_CustomShadersPath">
+            <property name="toolTip">
+             <string>Path to the directory with custom shaders for Texture Viewer</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>378</height>
-             </size>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QPushButton" name="resetCustomShadersPath">
+            <property name="toolTip">
+             <string>Reset custom shaders directory to default config path</string>
             </property>
-           </spacer>
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -649,29 +649,61 @@ After interop is enabled you will need to reload any capture.</string>
           <string>Texture Viewer</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="4" column="1">
-           <widget class="QPushButton" name="browseCustomShadersPath">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_29">
             <property name="toolTip">
-             <string>Browse for the directory with custom shaders for Texture Viewer</string>
+             <string>List of the directories with custom shaders</string>
             </property>
             <property name="text">
-             <string>Browse</string>
+             <string>Custom shader directories</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="TextureViewer_ResetRange">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
             </property>
             <property name="toolTip">
              <string>Reset visible range when changing event or texture</string>
             </property>
+            <property name="layoutDirection">
+             <enum>Qt::RightToLeft</enum>
+            </property>
             <property name="text">
-             <string>Reset Range on changing selection</string>
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="TextureViewer_PerTexSettings">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Settings such as visible channels (RGBA) and selected mip/slice are remembered and restored per-texture.</string>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::RightToLeft</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="TextureViewer_ChooseShaderDirectories">
+            <property name="toolTip">
+             <string>Choose custom shader search directories.</string>
+            </property>
+            <property name="text">
+             <string>Choose directories</string>
             </property>
            </widget>
           </item>
@@ -691,17 +723,42 @@ After interop is enabled you will need to reload any capture.</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_29">
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="TextureViewer_PerTexYFlip">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="toolTip">
-             <string>Path to the directory with custom shaders for Texture Viewer</string>
+             <string>Y-flipping state is remembered and restored per-texture, rather than treated as a global toggle.</string>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::RightToLeft</enum>
             </property>
             <property name="text">
-             <string>Custom shaders directory</string>
+             <string/>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Reset visible range when changing event or texture</string>
+            </property>
+            <property name="text">
+             <string>Reset Range on changing selection</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
            <spacer name="verticalSpacer_3">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -713,38 +770,6 @@ After interop is enabled you will need to reload any capture.</string>
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="TextureViewer_PerTexSettings">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Settings such as visible channels (RGBA) and selected mip/slice are remembered and restored per-texture.</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="TextureViewer_ResetRange">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Reset visible range when changing event or texture</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_26">
@@ -759,39 +784,6 @@ After interop is enabled you will need to reload any capture.</string>
             </property>
             <property name="text">
              <string>Y-flipping state saved per-texture</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="TextureViewer_PerTexYFlip">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Y-flipping state is remembered and restored per-texture, rather than treated as a global toggle.</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLineEdit" name="TextureViewer_CustomShadersPath">
-            <property name="toolTip">
-             <string>Path to the directory with custom shaders for Texture Viewer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QPushButton" name="resetCustomShadersPath">
-            <property name="toolTip">
-             <string>Reset custom shaders directory to default config path</string>
-            </property>
-            <property name="text">
-             <string>Reset</string>
             </property>
            </widget>
           </item>

--- a/qrenderdoc/Windows/TextureViewer.h
+++ b/qrenderdoc/Windows/TextureViewer.h
@@ -350,6 +350,7 @@ private:
 
   bool canCompileCustomShader(ShaderEncoding encoding);
   void reloadCustomShaders(const QString &filter);
+  QDir getCustomShadersDir() const;
 
   TextureDisplay m_TexDisplay;
 };

--- a/qrenderdoc/Windows/TextureViewer.h
+++ b/qrenderdoc/Windows/TextureViewer.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <QDir>
 #include <QFrame>
 #include <QMenu>
 #include <QMouseEvent>
@@ -350,7 +351,8 @@ private:
 
   bool canCompileCustomShader(ShaderEncoding encoding);
   void reloadCustomShaders(const QString &filter);
-  QDir getCustomShadersDir() const;
+  QList<QDir> getShaderDirectories() const;
+  QString getShaderPath(const QString &filename) const;
 
   TextureDisplay m_TexDisplay;
 };


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change.

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Resolves #1938

Commit adds a setting "Custom shaders directory" to the Texture Viewer section of the settings dialog. By default, path to the custom directory is empty - in this case current behavior is kept and config directory is used. If the setting contains a path, that directory is used.

In the ``TextureViewer`` class this change basically replaces direct ``configFilePath()`` call with a wrapped call that decides to use a custom directory or default one based on the ``PersistantConfig`` setting value. All the rest is UI work.

### Issues

I've encountered the following limitations while implementing functionality. I didn't want to blow up the code to get rid of these issues because I think they are really minor.
* "Reset" button was required to set empty path (reset to default config directory). Setting an empty path via Browse directory dialog is impossible. Other alternatives I could think of were not better than one additional button.
* Changing this setting requires application restart to function properly. I could not find any mechanism to notify PersistantConfig users about changes. Keeping track of the setting within ``TextureViewer`` class is not a good option I guess.

### Note

This is my very first PR. Please let me know what can be done better. I'm open for all your advices :)
