### PR TITLE
Enable KHR performance queries on render pass boundary commands

### DIFF
--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -154,7 +154,12 @@ rdcarray<GPUCounter> VulkanReplay::EnumerateCounters()
         Unwrap(physDev), 0, &khrCounters, &m_KHRCounters[0], &m_KHRCountersDescriptions[0]);
 
     for(uint32_t c = 0; c < khrCounters; c++)
-      ret.push_back(ToKHRCounter(c));
+    {
+      // Only report counters with command scope. We currently don't
+      // have use for renderpass ones.
+      if(m_KHRCounters[c].scope == VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_KHR)
+        ret.push_back(ToKHRCounter(c));
+    }
   }
 
   if(m_pAMDCounters)

--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -548,22 +548,13 @@ struct VulkanKHRCallback : public VulkanDrawcallCallback
   void PreDispatch(uint32_t eid, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
   bool PostDispatch(uint32_t eid, VkCommandBuffer cmd) override { return PostDraw(eid, cmd); }
   void PostRedispatch(uint32_t eid, VkCommandBuffer cmd) override { PostRedraw(eid, cmd); }
-  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
-  {
-    if(flags & DrawFlags::PassBoundary)
-      return;
-    PreDraw(eid, cmd);
-  }
+  void PreMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override { PreDraw(eid, cmd); }
   bool PostMisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
-    if(flags & DrawFlags::PassBoundary)
-      return false;
     return PostDraw(eid, cmd);
   }
   void PostRemisc(uint32_t eid, DrawFlags flags, VkCommandBuffer cmd) override
   {
-    if(flags & DrawFlags::PassBoundary)
-      return;
     PostRedraw(eid, cmd);
   }
   void AliasEvent(uint32_t primary, uint32_t alias) override


### PR DESCRIPTION
## Description

This change allows to spot implicit resolve operations at pass boundary commands.
