### PR TITLE
Fix Document Decoding Mesh Data script bug

### DIFF
--- a/docs/python_api/examples/renderdoc/decode_mesh.py
+++ b/docs/python_api/examples/renderdoc/decode_mesh.py
@@ -56,10 +56,10 @@ def unpackData(fmt, data):
 
 	# If the format needs post-processing such as normalisation, do that now
 	if fmt.compType == rd.CompType.UNorm:
-		divisor = float((1 << fmt.compByteWidth) - 1)
+		divisor = float((2 ** (fmt.compByteWidth * 8)) - 1)
 		value = tuple(float(i) / divisor for i in value)
 	elif fmt.compType == rd.CompType.SNorm:
-		maxNeg = -(1 << (fmt.compByteWidth - 1))
+		maxNeg = -float(2 ** (fmt.compByteWidth * 8)) / 2
 		divisor = float(-(maxNeg-1))
 		value = tuple((float(i) if (i == maxNeg) else (float(i) / divisor)) for i in value)
 

--- a/docs/python_api/examples/renderdoc/decode_mesh.rst
+++ b/docs/python_api/examples/renderdoc/decode_mesh.rst
@@ -118,7 +118,7 @@ For normalised formats - :py:attr:`~renderdoc.CompType.UNorm` and :py:attr:`~ren
             divisor = float((2 ** (fmt.compByteWidth * 8)) - 1)
             value = tuple(float(i) / divisor for i in value)
         elif fmt.compType == rd.CompType.SNorm:
-            maxNeg = -float((2 ** (fmt.compByteWidth * 8)) - 1) / 2
+            maxNeg = -float(2 ** (fmt.compByteWidth * 8)) / 2
             divisor = float(-(maxNeg-1))
             value = tuple((float(i) if (i == maxNeg) else (float(i) / divisor)) for i in value)
 

--- a/docs/python_api/examples/renderdoc/decode_mesh.rst
+++ b/docs/python_api/examples/renderdoc/decode_mesh.rst
@@ -115,10 +115,10 @@ For normalised formats - :py:attr:`~renderdoc.CompType.UNorm` and :py:attr:`~ren
 
         # If the format needs post-processing such as normalisation, do that now
         if fmt.compType == rd.CompType.UNorm:
-            divisor = float((1 << fmt.compByteWidth) - 1)
+            divisor = float((2 ** (fmt.compByteWidth * 8)) - 1)
             value = tuple(float(i) / divisor for i in value)
         elif fmt.compType == rd.CompType.SNorm:
-            maxNeg = -(1 << (fmt.compByteWidth - 1))
+            maxNeg = -float((2 ** (fmt.compByteWidth * 8)) - 1) / 2
             divisor = float(-(maxNeg-1))
             value = tuple((float(i) if (i == maxNeg) else (float(i) / divisor)) for i in value)
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

The unpackData function in document Decoding Mesh Data is not correct when handling UNorm & SNorm data types.
