### PR TITLE
Added Scoped Storage Support for Android

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -1218,6 +1218,8 @@ ExecuteResult AndroidRemoteServer::ExecuteAndInject(const char *a, const char *w
                               "shell setprop debug.vulkan.layers " RENDERDOC_VULKAN_LAYER_NAME);
     }
 
+    rdcstr folderName = Android::GetFolderName(m_deviceID);
+
     // if in VR mode, enable frame delimiter markers
     Android::adbExecCommand(m_deviceID, "shell setprop debug.vr.profiler 1");
 
@@ -1228,9 +1230,9 @@ ExecuteResult AndroidRemoteServer::ExecuteAndInject(const char *a, const char *w
     // Android/data/<package>
     // has the permissions set correctly, and we don't have a convenient way to get the package name
     // from native code.
-    Android::adbExecCommand(m_deviceID, "shell mkdir -p /sdcard/Android/data/" + processName);
-    Android::adbExecCommand(m_deviceID,
-                            "shell mkdir -p /sdcard/Android/data/" + processName + "/files");
+    Android::adbExecCommand(m_deviceID, "shell mkdir -p /sdcard/Android/" + folderName + processName);
+    Android::adbExecCommand(
+        m_deviceID, "shell mkdir -p /sdcard/Android/" + folderName + processName + "/files");
     // set our property with the capture options encoded, to be picked up by the library on the
     // device
     Android::adbExecCommand(m_deviceID,
@@ -1239,7 +1241,7 @@ ExecuteResult AndroidRemoteServer::ExecuteAndInject(const char *a, const char *w
 
     // try to push our settings file into the appdata folder
     Android::adbExecCommand(m_deviceID, "push \"" + FileIO::GetAppFolderFilename("renderdoc.conf") +
-                                            "\" /sdcard/Android/data/" + processName +
+                                            "\" /sdcard/Android/" + folderName + processName +
                                             "/files/renderdoc.conf");
 
     rdcstr installedPath = Android::GetPathForPackage(m_deviceID, packageName);

--- a/renderdoc/android/android_utils.cpp
+++ b/renderdoc/android/android_utils.cpp
@@ -188,6 +188,19 @@ bool IsSupported(rdcstr deviceID)
   return true;
 }
 
+rdcstr GetFolderName(const rdcstr &deviceID)
+{
+  rdcstr api =
+      Android::adbExecCommand(deviceID, "shell getprop ro.build.version.sdk").strStdout.trimmed();
+
+  int apiVersion = atoi(api.c_str());
+
+  if(apiVersion >= 30)
+    return "media/";
+
+  return "data/";
+}
+
 bool SupportsNativeLayers(const rdcstr &deviceID)
 {
   rdcstr api =

--- a/renderdoc/android/android_utils.h
+++ b/renderdoc/android/android_utils.h
@@ -70,6 +70,7 @@ rdcstr GetPlainABIName(ABI abi);
 rdcarray<ABI> GetSupportedABIs(const rdcstr &deviceID);
 rdcstr GetRenderDocPackageForABI(ABI abi);
 rdcstr GetPathForPackage(const rdcstr &deviceID, const rdcstr &packageName);
+rdcstr GetFolderName(const rdcstr &deviceID);
 
 bool PatchManifest(bytebuf &manifest);
 };

--- a/renderdoc/os/posix/android/android_stringio.cpp
+++ b/renderdoc/os/posix/android/android_stringio.cpp
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <dlfcn.h>
 #include <fcntl.h>
+#include <sys/system_properties.h>
 #include <unistd.h>
 #include "common/common.h"
 #include "common/formatting.h"
@@ -68,7 +69,15 @@ rdcstr GetTempRootPath()
   // This is the same as returned by getExternalFilesDir(). It might possibly change in the future.
   rdcstr package;
   GetExecutableFilename(package);
-  return "/sdcard/Android/data/" + package + "/files";
+
+  char platformVersionChar[PROP_VALUE_MAX];
+  __system_property_get("ro.build.version.sdk", platformVersionChar);
+  int platformVersion = atoi(platformVersionChar);
+
+  if(platformVersion < 30)
+    return "/sdcard/Android/data/" + package + "/files";
+  else
+    return "/sdcard/Android/media/" + package + "/files";
 }
 
 rdcstr GetAppFolderFilename(const rdcstr &filename)

--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
   <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="26"/>
 
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.INTERNET" />
 
   <!-- Use GL ES 3.2 version -->


### PR DESCRIPTION
## Description
Updated permissions for the renderdoccmd app based on which version of
android the app is running on
**WRITE_EXTERNAL_STORAGE for <R
**MANAGE_EXTERNAL_STORAGE for >=R

Updated the Java portion of renderdoccmd to check/request the correct
permission based on android version

Changed the file path for renderdoc files on Android from
/sdcard/Android/data/$PACKAGE_NAME to
/sdcard/Android/media/$PACKAGE_NAME to comply with new file access
controls under Android 11 Scoped Storage

Updated documentation to for Android dependencies to specify Android NDK
r21d and platform-30 being needed (in order to support Scoped Storage)

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
