### PR TITLE
Use actual size of Intel performance counters metadata.

### DIFF
--- a/renderdoc/driver/ihv/intel/intel_gl_counters.cpp
+++ b/renderdoc/driver/ihv/intel/intel_gl_counters.cpp
@@ -93,6 +93,9 @@ void IntelGlCounters::addCounter(const IntelGlQuery &query, GLuint counterId)
       (GLuint)counter.desc.description.size(), &counter.desc.description[0], &counter.offset,
       &counter.desc.resultByteWidth, &counter.type, &counter.dataType, NULL);
 
+  counter.desc.name.resize(strlen(&counter.desc.name[0]));
+  counter.desc.description.resize(strlen(&counter.desc.description[0]));
+
   if(m_CounterNames.find(counter.desc.name) != m_CounterNames.end())
     return;
 
@@ -124,6 +127,7 @@ void IntelGlCounters::addQuery(GLuint queryId)
   if(GL.glGetError() != eGL_NONE)
     return;
 
+  query.name.resize(strlen(&query.name[0]));
   if(metricSetBlacklist.contains(query.name))
     return;
 


### PR DESCRIPTION
Fixes exporting of performance counter values to CSV.
Without this patch, each column name in the CSV file has a lot of NUL bytes at the end.