### PR TITLE
Open the Resource Initialisation Parameters as fully expanded.

### DIFF
--- a/qrenderdoc/Widgets/Extended/RDTreeView.h
+++ b/qrenderdoc/Widgets/Extended/RDTreeView.h
@@ -132,6 +132,8 @@ public:
   using QTreeView::expandAll;
   using QTreeView::collapseAll;
 
+  bool getDidAutoExpand(ResourceId resourceId) { return m_AutoExpanded[resourceId]; }
+  void setDidAutoExpand(ResourceId resourceId) { m_AutoExpanded[resourceId] = true; }
 signals:
   void leave(QEvent *e);
   void keyPress(QKeyEvent *e);
@@ -162,6 +164,7 @@ private:
   bool m_customCopyPaste = false;
 
   QMap<uint, RDTreeViewExpansionState> m_Expansions;
+  QMap<ResourceId, bool> m_AutoExpanded;
 
   void saveExpansionFromRow(RDTreeViewExpansionState &state, QModelIndex idx, uint seed,
                             const ExpansionKeyGen &keygen);

--- a/qrenderdoc/Windows/ResourceInspector.cpp
+++ b/qrenderdoc/Windows/ResourceInspector.cpp
@@ -332,8 +332,16 @@ void ResourceInspector::Inspect(ResourceId id)
   ui->initChunks->setUpdatesEnabled(true);
 
   if(m_Resource != ResourceId())
-    ui->initChunks->applyExpansion(ui->initChunks->getInternalExpansion(qHash(ToQStr(m_Resource))),
-                                   0);
+  {
+    RDTreeViewExpansionState rdtves = ui->initChunks->getInternalExpansion(qHash(ToQStr(m_Resource)));
+    if(!rdtves.isEmpty())
+      ui->initChunks->applyExpansion(rdtves, 0);
+    else if(!ui->initChunks->getDidAutoExpand(m_Resource))    // empty and have not auto-expanded
+    {
+      ui->initChunks->expandAll();
+      ui->initChunks->setDidAutoExpand(m_Resource);
+    }
+  }
 }
 
 void ResourceInspector::OnCaptureLoaded()


### PR DESCRIPTION
## Description

When opening a resource in the Resource Inspector the Resource
Initialisation Parameter window is fully collapsed by default, but
RenderDoc will remember how you expanded or collapsed the tree
if you switch between resources.  This change keeps that behavior
but starts the Resource Initialisation Parameter tree as fully
expanded. This saves developers from having to 'drill down' to the
parameter they are interested in every time they open a resource.
