### PR TITLE
Don't hide counters belonging to multiple Intel queries.

### DIFF
--- a/renderdoc/driver/ihv/intel/intel_gl_counters.cpp
+++ b/renderdoc/driver/ihv/intel/intel_gl_counters.cpp
@@ -96,9 +96,6 @@ void IntelGlCounters::addCounter(const IntelGlQuery &query, GLuint counterId)
   counter.desc.name.resize(strlen(&counter.desc.name[0]));
   counter.desc.description.resize(strlen(&counter.desc.description[0]));
 
-  if(m_CounterNames.find(counter.desc.name) != m_CounterNames.end())
-    return;
-
   uint32_t query_hash = strhash(query.name.c_str());
   uint32_t name_hash = strhash(counter.desc.name.c_str());
   uint32_t desc_hash = strhash(counter.desc.description.c_str());
@@ -107,7 +104,6 @@ void IntelGlCounters::addCounter(const IntelGlQuery &query, GLuint counterId)
   counter.desc.unit = CounterUnit::Absolute;
 
   m_Counters.push_back(counter);
-  m_CounterNames[counter.desc.name] = counter;
 }
 
 void IntelGlCounters::addQuery(GLuint queryId)

--- a/renderdoc/driver/ihv/intel/intel_gl_counters.h
+++ b/renderdoc/driver/ihv/intel/intel_gl_counters.h
@@ -79,7 +79,6 @@ private:
     GLuint dataType = 0;
   };
   rdcarray<IntelGlCounter> m_Counters;
-  std::map<rdcstr, IntelGlCounter> m_CounterNames;
 
   struct IntelGlQuery
   {


### PR DESCRIPTION
Many counters are exposed in multiple queries. By hiding that fact,
we are making life harder for users, because they need to find
related counters all around the query tree. Don't do that.

As a side effect, this will decrease the number of needed passes if
all selected counters belong to the same query.
