### PR TITLE
Fix D3D12 debugging with a texture mapped as UAV

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
@@ -385,6 +385,9 @@ bool D3D12DebugAPIWrapper::FetchUAV(const DXBCDebug::BindingSlot &slot)
                   uavData.tex = true;
                   m_pDevice->GetReplay()->GetTextureData(uavId, Subresource(),
                                                          GetTextureDataParams(), uavData.data);
+
+                  D3D12_RESOURCE_DESC resDesc = pResource->GetDesc();
+                  uavData.rowPitch = GetByteSize((int)resDesc.Width, 1, 1, uavDesc.Format, 0);
                 }
 
                 return true;


### PR DESCRIPTION
The row pitch was not initialized, so any ld_uav_typed instructions would likely return the wrong data if coming from a texture resource.