### PR TITLE
Fix dry-run option in CreatePipelineLibrary in D3D12

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device_wrap1.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap1.cpp
@@ -29,6 +29,13 @@ HRESULT WrappedID3D12Device::CreatePipelineLibrary(_In_reads_(BlobLength) const 
                                                    SIZE_T BlobLength, REFIID riid,
                                                    _COM_Outptr_ void **ppPipelineLibrary)
 {
+  // CreatePipelineLibrary supports doing a dry run if ppPipelineLibrary receives
+  // nullptr. That feature is optional and not supported in every driver, since
+  // we are not supporting pipeline libraries anyway, returns the unsupported
+  // driver case.
+  if(ppPipelineLibrary == NULL)
+    return DXGI_ERROR_UNSUPPORTED;
+
 // we don't want to ever use pipeline libraries since then we can't get the
 // bytecode and pipeline config. So instead we always return that a blob is
 // non-matching and return a dummy interface that does nothing when stored.


### PR DESCRIPTION
## Description

This PR addresses an issue where the application is crashing when receiving nullptr in ppPipelineLibrary. As per the specifications, ppPipelineLibrary can optionally accept nullptr and perform a dry run.
Since pipeline libraries are not supported, we return the driver unsupported case.

https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device1-createpipelinelibrary