### PR TITLE
Allow Python 3.8 to be detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,7 +390,7 @@ add_subdirectory(renderdoc)
 # are handled in common
 if(ENABLE_QRENDERDOC OR ENABLE_PYRENDERDOC)
     # Make sure Python 3 is found
-    set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7)
+    set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7 3.8)
     find_package(PythonInterp 3 REQUIRED)
     find_package(PythonLibs 3 REQUIRED)
     # we also need python3-config for swig


### PR DESCRIPTION
Adds python 3.8 to the list of python 3 versions. 

Thank you so much for renderdoc!

## Description

Adds python 3.8 to the list of Python 3 versions so that it can be detected.