### PR TITLE
Added Android Hardware Buffer Extension Support

### DIFF
--- a/renderdoc/driver/vulkan/vk_android.cpp
+++ b/renderdoc/driver/vulkan/vk_android.cpp
@@ -50,6 +50,26 @@ VkResult WrappedVulkan::vkCreateAndroidSurfaceKHR(VkInstance instance,
   return ret;
 }
 
+// VK_ANDROID_external_memory_android_hardware_buffer
+VkResult WrappedVulkan::vkGetAndroidHardwareBufferPropertiesANDROID(
+    VkDevice device, const struct AHardwareBuffer *buffer,
+    VkAndroidHardwareBufferPropertiesANDROID *pProperties)
+{
+  return ObjDisp(device)->GetAndroidHardwareBufferPropertiesANDROID(Unwrap(device), buffer,
+                                                                    pProperties);
+}
+
+// VK_ANDROID_external_memory_android_hardware_buffer
+VkResult WrappedVulkan::vkGetMemoryAndroidHardwareBufferANDROID(
+    VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
+    struct AHardwareBuffer **pBuffer)
+{
+  VkMemoryGetAndroidHardwareBufferInfoANDROID unwrappedInfo = *pInfo;
+  unwrappedInfo.memory = Unwrap(unwrappedInfo.memory);
+  return ObjDisp(device)->GetMemoryAndroidHardwareBufferANDROID(Unwrap(device), &unwrappedInfo,
+                                                                pBuffer);
+}
+
 void VulkanReplay::OutputWindow::SetWindowHandle(WindowingData window)
 {
   RDCASSERT(window.system == WindowingSystem::Android, window.system);

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -1445,6 +1445,23 @@ DECLARE_DESERIALISE_TYPE(VkWin32KeyedMutexAcquireReleaseInfoKHR);
 DECLARE_DESERIALISE_TYPE(VkWin32KeyedMutexAcquireReleaseInfoNV);
 #endif
 
+// android only structs
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+DECLARE_REFLECTION_STRUCT(VkAndroidHardwareBufferUsageANDROID);
+DECLARE_REFLECTION_STRUCT(VkAndroidHardwareBufferPropertiesANDROID);
+DECLARE_REFLECTION_STRUCT(VkAndroidHardwareBufferFormatPropertiesANDROID);
+DECLARE_REFLECTION_STRUCT(VkImportAndroidHardwareBufferInfoANDROID);
+DECLARE_REFLECTION_STRUCT(VkMemoryGetAndroidHardwareBufferInfoANDROID);
+DECLARE_REFLECTION_STRUCT(VkExternalFormatANDROID);
+
+DECLARE_DESERIALISE_TYPE(VkAndroidHardwareBufferUsageANDROID);
+DECLARE_DESERIALISE_TYPE(VkAndroidHardwareBufferPropertiesANDROID);
+DECLARE_DESERIALISE_TYPE(VkAndroidHardwareBufferFormatPropertiesANDROID);
+DECLARE_DESERIALISE_TYPE(VkImportAndroidHardwareBufferInfoANDROID);
+DECLARE_DESERIALISE_TYPE(VkMemoryGetAndroidHardwareBufferInfoANDROID);
+DECLARE_DESERIALISE_TYPE(VkExternalFormatANDROID);
+#endif
+
 // enums
 
 DECLARE_REFLECTION_ENUM(VkAccessFlagBits);

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -748,6 +748,12 @@ static const VkExtensionProperties supportedExtensions[] = {
     {
         VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME, VK_AMD_TEXTURE_GATHER_BIAS_LOD_SPEC_VERSION,
     },
+#ifdef VK_ANDROID_external_memory_android_hardware_buffer
+    {
+        VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME,
+        VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_SPEC_VERSION,
+    },
+#endif
 #ifdef VK_EXT_acquire_xlib_display
     {
         VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME, VK_EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION,

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1775,6 +1775,16 @@ public:
   VkResult vkCreateAndroidSurfaceKHR(VkInstance instance,
                                      const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
                                      const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface);
+
+  // VK_ANDROID_external_memory_android_hardware_buffer
+  VkResult vkGetAndroidHardwareBufferPropertiesANDROID(
+      VkDevice device, const struct AHardwareBuffer *buffer,
+      VkAndroidHardwareBufferPropertiesANDROID *pProperties);
+
+  // VK_ANDROID_external_memory_android_hardware_buffer
+  VkResult vkGetMemoryAndroidHardwareBufferANDROID(
+      VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
+      struct AHardwareBuffer **pBuffer);
 #endif
 
 #if defined(VK_USE_PLATFORM_MACOS_MVK)

--- a/renderdoc/driver/vulkan/vk_hookset_defs.h
+++ b/renderdoc/driver/vulkan/vk_hookset_defs.h
@@ -144,20 +144,33 @@
 
 #define HookInitExtension_Instance_Android() \
   HookInitExtension(VK_KHR_android_surface, CreateAndroidSurfaceKHR);
-#define HookDefine_Android()                                                                     \
-  HookDefine4(VkResult, vkCreateAndroidSurfaceKHR, VkInstance, instance,                         \
-              const VkAndroidSurfaceCreateInfoKHR *, pCreateInfo, const VkAllocationCallbacks *, \
-              pAllocator, VkSurfaceKHR *, pSurface);
+
+#define HookInitExtension_Device_Android()                              \
+  HookInitExtension(VK_ANDROID_external_memory_android_hardware_buffer, \
+                    GetMemoryAndroidHardwareBufferANDROID);             \
+  HookInitExtension(VK_ANDROID_external_memory_android_hardware_buffer, \
+                    GetAndroidHardwareBufferPropertiesANDROID);
+
+#define HookDefine_Android()                                                                      \
+  HookDefine4(VkResult, vkCreateAndroidSurfaceKHR, VkInstance, instance,                          \
+              const VkAndroidSurfaceCreateInfoKHR *, pCreateInfo, const VkAllocationCallbacks *,  \
+              pAllocator, VkSurfaceKHR *, pSurface);                                              \
+  HookDefine3(VkResult, vkGetAndroidHardwareBufferPropertiesANDROID, VkDevice, device,            \
+              const struct AHardwareBuffer *, buffer, VkAndroidHardwareBufferPropertiesANDROID *, \
+              pProperties);                                                                       \
+  HookDefine3(VkResult, vkGetMemoryAndroidHardwareBufferANDROID, VkDevice, device,                \
+              const VkMemoryGetAndroidHardwareBufferInfoANDROID *, pInfo,                         \
+              struct AHardwareBuffer **, pBuffer);
 
 #else    // defined(VK_USE_PLATFORM_ANDROID_KHR)
 
 #define HookInitExtension_Instance_Android()
+#define HookInitExtension_Device_Android()
 #define HookDefine_Android()
 
 #endif    // defined(VK_USE_PLATFORM_ANDROID_KHR)
 
 #define HookInitExtension_PhysDev_Android()
-#define HookInitExtension_Device_Android()
 
 #if defined(VK_USE_PLATFORM_GGP)
 

--- a/renderdoc/driver/vulkan/vk_next_chains.cpp
+++ b/renderdoc/driver/vulkan/vk_next_chains.cpp
@@ -584,9 +584,6 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
   case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV:           \
   case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_VERSION_KHR:                           \
   case VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR:                              \
-  case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:            \
-  case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID:                   \
-  case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:                        \
   case VK_STRUCTURE_TYPE_BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_KHR:                  \
   case VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV:                                           \
   case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM:   \
@@ -600,7 +597,6 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
   case VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD:                  \
   case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT:                           \
   case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:                      \
-  case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:                                      \
   case VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV:                     \
   case VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV:                                   \
   case VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV:               \
@@ -616,12 +612,10 @@ static void AppendModifiedChainedStruct(byte *&tempMem, VkStruct *outputStruct,
   case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT:                     \
   case VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX:                            \
   case VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX:                                   \
-  case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:                  \
   case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:                          \
   case VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NV:                      \
   case VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_TOKEN_NV:                            \
   case VK_STRUCTURE_TYPE_INITIALIZE_PERFORMANCE_API_INFO_INTEL:                        \
-  case VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:              \
   case VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT:                           \
   case VK_STRUCTURE_TYPE_PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL:                 \
   case VK_STRUCTURE_TYPE_PERFORMANCE_MARKER_INFO_INTEL:                                \
@@ -857,6 +851,32 @@ size_t GetNextPatchSize(const void *pNext)
         }
         break;
       }
+
+// Android External Buffer Memory Extension
+#if ENABLED(RDOC_ANDROID)
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                                 VkImportAndroidHardwareBufferInfoANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID,
+                                 VkAndroidHardwareBufferUsageANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID, VkExternalFormatANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+                                 VkAndroidHardwareBufferFormatPropertiesANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+                                 VkAndroidHardwareBufferPropertiesANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                                 VkMemoryGetAndroidHardwareBufferInfoANDROID);
+#else
+      case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
+      case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
+      case VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID:
+      {
+        RDCERR("Support for android external memory buffer extension not compiled in");
+        break;
+      }
+#endif
 
 // NV win32 external memory extensions
 #if ENABLED(RDOC_WIN32)
@@ -1443,6 +1463,33 @@ void UnwrapNextChain(CaptureState state, const char *structName, byte *&tempMem,
         break;
       }
 
+// Android External Buffer Memory Extension
+#if ENABLED(RDOC_ANDROID)
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                                 VkImportAndroidHardwareBufferInfoANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID,
+                                 VkAndroidHardwareBufferUsageANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID, VkExternalFormatANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+                                 VkAndroidHardwareBufferFormatPropertiesANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+                                 VkAndroidHardwareBufferPropertiesANDROID);
+        UNWRAP_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                                   VkMemoryGetAndroidHardwareBufferInfoANDROID,
+                                   UnwrapInPlace(out->memory));
+#else
+      case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
+      case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
+      case VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID:
+      {
+        RDCERR("Support for android external memory buffer extension not compiled in");
+        break;
+      }
+#endif
+
 // NV win32 external memory extensions
 #if ENABLED(RDOC_WIN32)
         // Structs that can be copied into place
@@ -1655,6 +1702,33 @@ void CopyNextChainForPatching(const char *structName, byte *&tempMem, VkBaseInSt
       case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET:
         CopyNextChainedStruct(sizeof(VkWriteDescriptorSet), tempMem, nextInput, nextChainTail);
         break;
+
+// Android External Buffer Memory Extension
+#if ENABLED(RDOC_ANDROID)
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                                 VkImportAndroidHardwareBufferInfoANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID,
+                                 VkAndroidHardwareBufferUsageANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID, VkExternalFormatANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
+                                 VkAndroidHardwareBufferFormatPropertiesANDROID);
+        COPY_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+                                 VkAndroidHardwareBufferPropertiesANDROID);
+        UNWRAP_STRUCT_CAPTURE_ONLY(VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                                   VkMemoryGetAndroidHardwareBufferInfoANDROID,
+                                   UnwrapInPlace(out->memory));
+#else
+      case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
+      case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
+      case VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+      case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID:
+      {
+        RDCERR("Support for android external memory buffer extension not compiled in");
+        break;
+      }
+#endif
 
 // NV win32 external memory extensions
 #if ENABLED(RDOC_WIN32)

--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -275,7 +275,7 @@ SERIALISE_VK_HANDLES();
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 
-#define HANDLE_PNEXT_OS()                                                                             \
+#define HANDLE_PNEXT_OS_WIN32()                                                                       \
   /* VK_NV_external_memory_win32 */                                                                   \
   PNEXT_STRUCT(VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV, VkImportMemoryWin32HandleInfoNV) \
   PNEXT_STRUCT(VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV, VkExportMemoryWin32HandleInfoNV) \
@@ -321,7 +321,7 @@ SERIALISE_VK_HANDLES();
 
 #else
 
-#define HANDLE_PNEXT_OS()                                                             \
+#define HANDLE_PNEXT_OS_WIN32()                                                       \
   /* VK_NV_external_memory_win32 */                                                   \
   PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV)             \
   PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV)             \
@@ -356,10 +356,38 @@ SERIALISE_VK_HANDLES();
 
 #endif
 
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+
+#define HANDLE_PNEXT_OS_ANDROID()                                                   \
+  /* VK_ANDROID_external_memory_android_hardware_buffer */                          \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID,             \
+               VkAndroidHardwareBufferUsageANDROID)                                 \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,        \
+               VkAndroidHardwareBufferPropertiesANDROID)                            \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID, \
+               VkAndroidHardwareBufferFormatPropertiesANDROID)                      \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,       \
+               VkImportAndroidHardwareBufferInfoANDROID)                            \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,   \
+               VkMemoryGetAndroidHardwareBufferInfoANDROID)                         \
+  PNEXT_STRUCT(VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID, VkExternalFormatANDROID)
+#else
+
+#define HANDLE_PNEXT_OS_ANDROID()                                                        \
+  /* VK_ANDROID_external_memory_android_hardware_buffer */                               \
+  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID)             \
+  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID)        \
+  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID) \
+  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID)       \
+  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID)   \
+  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID)
+#endif
+
 // pNext structure type dispatch
 #define HANDLE_PNEXT()                                                                                 \
   /* OS-specific extensions */                                                                         \
-  HANDLE_PNEXT_OS()                                                                                    \
+  HANDLE_PNEXT_OS_WIN32()                                                                              \
+  HANDLE_PNEXT_OS_ANDROID()                                                                            \
                                                                                                        \
   /* Core 1.0 structs. Should never be serialised in a pNext chain */                                  \
   PNEXT_STRUCT(VK_STRUCTURE_TYPE_APPLICATION_INFO, VkApplicationInfo)                                  \
@@ -1057,14 +1085,6 @@ SERIALISE_VK_HANDLES();
                                                                                                        \
   /* VK_AMD_shader_core_properties2 */                                                                 \
   PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD)                    \
-                                                                                                       \
-  /* VK_ANDROID_external_memory_android_hardware_buffer */                                             \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID)                           \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID)                      \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID)               \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID)                     \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID)                 \
-  PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID)                                         \
                                                                                                        \
   /* VK_EXT_blend_operation_advanced */                                                                \
   PNEXT_UNSUPPORTED(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT)           \
@@ -9318,4 +9338,115 @@ INSTANTIATE_SERIALISE_TYPE(VkFenceGetWin32HandleInfoKHR);
 INSTANTIATE_SERIALISE_TYPE(VkSurfaceCapabilitiesFullScreenExclusiveEXT);
 INSTANTIATE_SERIALISE_TYPE(VkSurfaceFullScreenExclusiveInfoEXT);
 INSTANTIATE_SERIALISE_TYPE(VkSurfaceFullScreenExclusiveWin32InfoEXT);
+#endif
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAndroidHardwareBufferPropertiesANDROID &el)
+{
+  RDCASSERT(ser.IsReading() ||
+            el.sType == VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(allocationSize);
+  SERIALISE_MEMBER_TYPED(uint32_t, memoryTypeBits);
+}
+
+template <>
+void Deserialise(const VkAndroidHardwareBufferPropertiesANDROID &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkMemoryGetAndroidHardwareBufferInfoANDROID &el)
+{
+  RDCASSERT(ser.IsReading() ||
+            el.sType == VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(memory);
+}
+
+template <>
+void Deserialise(const VkMemoryGetAndroidHardwareBufferInfoANDROID &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAndroidHardwareBufferFormatPropertiesANDROID &el)
+{
+  RDCASSERT(ser.IsReading() ||
+            el.sType == VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(format);
+  SERIALISE_MEMBER(externalFormat);
+  SERIALISE_MEMBER_VKFLAGS(VkFormatFeatureFlags, formatFeatures);
+  SERIALISE_MEMBER(samplerYcbcrConversionComponents);
+  SERIALISE_MEMBER(suggestedYcbcrModel);
+  SERIALISE_MEMBER(suggestedYcbcrRange);
+  SERIALISE_MEMBER(suggestedXChromaOffset);
+  SERIALISE_MEMBER(suggestedYChromaOffset);
+}
+
+template <>
+void Deserialise(const VkAndroidHardwareBufferFormatPropertiesANDROID &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkExternalFormatANDROID &el)
+{
+  RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(externalFormat);
+}
+
+template <>
+void Deserialise(const VkExternalFormatANDROID &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAndroidHardwareBufferUsageANDROID &el)
+{
+  RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  SERIALISE_MEMBER(androidHardwareBufferUsage);
+}
+
+template <>
+void Deserialise(const VkAndroidHardwareBufferUsageANDROID &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkImportAndroidHardwareBufferInfoANDROID &el)
+{
+  RDCASSERT(ser.IsReading() ||
+            el.sType == VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID);
+  SerialiseNext(ser, el.sType, el.pNext);
+
+  // SERIALISE_MEMBER(buffer);
+}
+
+template <>
+void Deserialise(const VkImportAndroidHardwareBufferInfoANDROID &el)
+{
+  DeserialiseNext(el.pNext);
+}
+
+INSTANTIATE_SERIALISE_TYPE(VkAndroidHardwareBufferUsageANDROID);
+INSTANTIATE_SERIALISE_TYPE(VkAndroidHardwareBufferPropertiesANDROID);
+INSTANTIATE_SERIALISE_TYPE(VkAndroidHardwareBufferFormatPropertiesANDROID);
+INSTANTIATE_SERIALISE_TYPE(VkImportAndroidHardwareBufferInfoANDROID);
+INSTANTIATE_SERIALISE_TYPE(VkMemoryGetAndroidHardwareBufferInfoANDROID);
+INSTANTIATE_SERIALISE_TYPE(VkExternalFormatANDROID);
 #endif

--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -9349,7 +9349,7 @@ void DoSerialise(SerialiserType &ser, VkAndroidHardwareBufferPropertiesANDROID &
   SerialiseNext(ser, el.sType, el.pNext);
 
   SERIALISE_MEMBER(allocationSize);
-  SERIALISE_MEMBER_TYPED(uint32_t, memoryTypeBits);
+  SERIALISE_MEMBER(memoryTypeBits);
 }
 
 template <>
@@ -9434,7 +9434,14 @@ void DoSerialise(SerialiserType &ser, VkImportAndroidHardwareBufferInfoANDROID &
             el.sType == VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID);
   SerialiseNext(ser, el.sType, el.pNext);
 
-  // SERIALISE_MEMBER(buffer);
+  {
+    uint64_t buffer = (uint64_t)el.buffer;
+    ser.Serialise("buffer"_lit, buffer);
+
+    // won't be valid on read, though we won't try to replay this anyway
+    if(ser.IsReading())
+      el.buffer = NULL;
+  }
 }
 
 template <>

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -2010,7 +2010,8 @@ VkResult WrappedVulkan::vkCreateImage(VkDevice device, const VkImageCreateInfo *
       while(next)
       {
         if(next->sType == VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV ||
-           next->sType == VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO)
+           next->sType == VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO ||
+           next->sType == VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID)
         {
           isExternal = true;
           break;
@@ -2050,6 +2051,8 @@ VkResult WrappedVulkan::vkCreateImage(VkDevice device, const VkImageCreateInfo *
                                       VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV);
           removed |= RemoveNextStruct(&createInfo_adjusted,
                                       VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO);
+          removed |=
+              RemoveNextStruct(&createInfo_adjusted, VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID);
 
           RDCASSERTMSG("Couldn't find next struct indicating external memory", removed);
 


### PR DESCRIPTION
## Description

Added support for the VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER
device extension on Android

Created necessary hooks for vkGetAndroidHardwareBufferPropertiesANDROID
and vkGetMemoryAndroidHardwareBufferANDROID
