### PR TITLE
Update win32_callstack.cpp

### DIFF
--- a/renderdoc/os/win32/win32_callstack.cpp
+++ b/renderdoc/os/win32/win32_callstack.cpp
@@ -1044,8 +1044,6 @@ Callstack::AddressDetails Win32CallstackResolver::GetAddr(DWORD64 addr)
         // the module it came from, and an offset
         info.funcName = get_basename(info.fileName);
 
-        info.funcName = StringFormat::Fmt("%s+0x%08llx", info.funcName.c_str(), addr - base);
-
         int offs = info.funcName.find(".pdb");
 
         if(offs >= 0)
@@ -1057,6 +1055,8 @@ Callstack::AddressDetails Win32CallstackResolver::GetAddr(DWORD64 addr)
           else
             info.funcName += "dll";
         }
+
+        info.funcName = StringFormat::Fmt("%s+0x%08llx", info.funcName.c_str(), addr - base);
       }
 
       break;


### PR DESCRIPTION
Module offset mistakenly being erased together with .pdb extension

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

For modules without debug information, offsets were not appearing in the callstack list because the offset info was being erased together with the `.pdb` extension just after having been appended.