### PR TITLE
Fix missing handling of DXGI_SWAP_EFFECT_FLIP_DISCARD in DXGI

### DIFF
--- a/renderdoc/driver/dxgi/dxgi_wrapped.cpp
+++ b/renderdoc/driver/dxgi/dxgi_wrapped.cpp
@@ -367,6 +367,8 @@ void WrappedIDXGISwapChain4::WrapBuffersAfterResize()
 
   if(desc.SwapEffect == DXGI_SWAP_EFFECT_DISCARD)
     bufCount = 1;
+  else if(desc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD)
+    bufCount = 1;
 
   RDCASSERT(bufCount < MAX_NUM_BACKBUFFERS);
 


### PR DESCRIPTION
Fix that IDXGISwapChain::GetBuffer was called with indices greater than zero in the dxgi swapchain wrapper when the swapchain was created with DXGI_SWAP_EFFECT_FLIP_DISCARD.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
Fix for a crash described in https://github.com/baldurk/renderdoc/issues/2055

`IDXGISwapChain::GetBuffer` buffer parameter must be zero if the SwapEffect of the swapchain is a discard mode.
While MSDN does not describes this for DXGI_SWAP_EFFECT_FLIP_DISCARD it does for DXGI_SWAP_EFFECT_DISCARD.

MSDN: https://docs.microsoft.com/en-us/windows/win32/api/dxgi/nf-dxgi-idxgiswapchain-getbuffer
> If the swap chain's swap effect is DXGI_SWAP_EFFECT_DISCARD, this method can only access the first buffer; for this situation, set the index to zero.