### PR TITLE
Implement support for SPV_GOOGLE_user_type

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
@@ -250,6 +250,7 @@ void Reflector::CheckDebuggable(bool &debuggable, rdcstr &debugStatus) const
       "SPV_EXT_shader_atomic_float_add",
       "SPV_KHR_terminate_invocation",
       "SPV_EXT_shader_image_int64",
+      "SPV_GOOGLE_user_type",
   };
 
   // whitelist supported extensions


### PR DESCRIPTION
For debugging vulkan shaders generated by dxc

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
