### PR TITLE
Fix D3D12 depth targets using the wrong formats in TextureViewer

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -712,8 +712,7 @@ void D3D12Replay::FillResourceView(D3D12Pipe::View &view, const D3D12Descriptor 
     {
       const D3D12_DEPTH_STENCIL_VIEW_DESC &dsv = desc->GetDSV();
 
-      // we deliberately don't apply the DSV format
-      // fmt = dsv.Format;
+      fmt = dsv.Format;
 
       view.type = MakeTextureDim(dsv.ViewDimension);
 


### PR DESCRIPTION
This issue seemed to occur with depth targets that are viewed as depth, but the underlying resource is typeless. The checks in `D3D12DebugManager::PrepareTextureSampling` were referencing the underlying resource rather than the realized type for an SRV. Tested with `D16_UNORM` and `D32_FLOAT_S8X24_UINT`.