### PR TITLE
Update ADB Command to Install RenderDoc on Android

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -413,8 +413,20 @@ ReplayStatus InstallRenderDocServer(const rdcstr &deviceID)
           "%s missing - ensure you build all ABIs your device can support for full compatibility",
           apk.c_str());
 
-    Process::ProcessResult adbInstall =
-        adbExecCommand(deviceID, "install -r -g --force-queryable \"" + apk + "\"");
+    rdcstr api =
+        Android::adbExecCommand(deviceID, "shell getprop ro.build.version.sdk").strStdout.trimmed();
+
+    int apiVersion = atoi(api.c_str());
+
+    Process::ProcessResult adbInstall;
+    if(apiVersion >= 30)
+    {
+      adbInstall = adbExecCommand(deviceID, "install -r -g --force-queryable \"" + apk + "\"");
+    }
+    else
+    {
+      adbInstall = adbExecCommand(deviceID, "install -r -g \"" + apk + "\"");
+    }
 
     RDCLOG("Installed package '%s', checking for success...", apk.c_str());
 

--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -413,7 +413,8 @@ ReplayStatus InstallRenderDocServer(const rdcstr &deviceID)
           "%s missing - ensure you build all ABIs your device can support for full compatibility",
           apk.c_str());
 
-    Process::ProcessResult adbInstall = adbExecCommand(deviceID, "install -r -g \"" + apk + "\"");
+    Process::ProcessResult adbInstall =
+        adbExecCommand(deviceID, "install -r -g --force-queryable \"" + apk + "\"");
 
     RDCLOG("Installed package '%s', checking for success...", apk.c_str());
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Added the --force-queryable flag to the adb install command for
renderdoc Android on devices running Android R/11/SDK 30

A feature being introduced in Android R requires all explicit interactions between 
apps to be declared ahead of time (either via manifest or during adb install)

The --force-queryable flag during adb install does this, and is what allows for the
shared objects from renderdoc (in this case the layers) to be discoverable by 
other apps targeting SDK 30+