### PR TITLE
supporting full glCopyImageSubData

### DIFF
--- a/renderdoc/driver/gl/gl_resources.cpp
+++ b/renderdoc/driver/gl/gl_resources.cpp
@@ -278,6 +278,186 @@ size_t GetCompressedByteSize(GLsizei w, GLsizei h, GLsizei d, GLenum internalfor
   return GetByteSize(w, h, d, GetBaseFormat(internalformat), GetDataType(internalformat));
 }
 
+rdcpair<uint32_t, uint32_t> GetCompressedBlockSize(GLenum internalformat)
+{
+  if(!IsCompressedFormat(internalformat))
+  {
+    RDCERR("Not compressed format %s", ToStr(internalformat).c_str());
+    return make_rdcpair(1u, 1u);
+  }
+
+  uint32_t astc[2] = {0, 0};
+
+  switch(internalformat)
+  {
+    // BC1
+    case eGL_COMPRESSED_RGB_S3TC_DXT1_EXT:
+    case eGL_COMPRESSED_RGBA_S3TC_DXT1_EXT:
+    case eGL_COMPRESSED_SRGB_S3TC_DXT1_EXT:
+    case eGL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT:
+    // BC2
+    case eGL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
+    case eGL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT:
+    // BC3
+    case eGL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
+    case eGL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT:
+    // BC4
+    case eGL_COMPRESSED_RED_RGTC1:
+    case eGL_COMPRESSED_SIGNED_RED_RGTC1:
+    // BC5
+    case eGL_COMPRESSED_RG_RGTC2:
+    case eGL_COMPRESSED_SIGNED_RG_RGTC2:
+    // BC6
+    case eGL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB:
+    case eGL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB:
+    // BC7
+    case eGL_COMPRESSED_RGBA_BPTC_UNORM_ARB:
+    case eGL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB:
+    // ETC1
+    case eGL_ETC1_RGB8_OES:
+    // ETC2
+    case eGL_COMPRESSED_RGB8_ETC2:
+    case eGL_COMPRESSED_SRGB8_ETC2:
+    case eGL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+    case eGL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+    // EAC
+    case eGL_COMPRESSED_RGBA8_ETC2_EAC:
+    case eGL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC:
+    case eGL_COMPRESSED_R11_EAC:
+    case eGL_COMPRESSED_SIGNED_R11_EAC:
+    case eGL_COMPRESSED_RG11_EAC:
+    case eGL_COMPRESSED_SIGNED_RG11_EAC:
+      return make_rdcpair(4u, 4u);
+    // ASTC
+    case GL_COMPRESSED_RGBA_ASTC_4x4_KHR:
+      astc[0] = 4;
+      astc[1] = 4;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_5x4_KHR:
+      astc[0] = 5;
+      astc[1] = 4;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_5x5_KHR:
+      astc[0] = 5;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_6x5_KHR:
+      astc[0] = 6;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_6x6_KHR:
+      astc[0] = 6;
+      astc[1] = 6;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_8x5_KHR:
+      astc[0] = 8;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_8x6_KHR:
+      astc[0] = 8;
+      astc[1] = 6;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_8x8_KHR:
+      astc[0] = 8;
+      astc[1] = 8;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_10x5_KHR:
+      astc[0] = 10;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_10x6_KHR:
+      astc[0] = 10;
+      astc[1] = 6;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_10x8_KHR:
+      astc[0] = 10;
+      astc[1] = 8;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_10x10_KHR:
+      astc[0] = 10;
+      astc[1] = 10;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_12x10_KHR:
+      astc[0] = 12;
+      astc[1] = 10;
+      break;
+    case GL_COMPRESSED_RGBA_ASTC_12x12_KHR:
+      astc[0] = 12;
+      astc[1] = 12;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR:
+      astc[0] = 4;
+      astc[1] = 4;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR:
+      astc[0] = 5;
+      astc[1] = 4;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR:
+      astc[0] = 5;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR:
+      astc[0] = 6;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR:
+      astc[0] = 6;
+      astc[1] = 6;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR:
+      astc[0] = 8;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR:
+      astc[0] = 8;
+      astc[1] = 6;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR:
+      astc[0] = 8;
+      astc[1] = 8;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR:
+      astc[0] = 10;
+      astc[1] = 5;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR:
+      astc[0] = 10;
+      astc[1] = 6;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR:
+      astc[0] = 10;
+      astc[1] = 8;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR:
+      astc[0] = 10;
+      astc[1] = 10;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR:
+      astc[0] = 12;
+      astc[1] = 10;
+      break;
+    case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR:
+      astc[0] = 12;
+      astc[1] = 12;
+      break;
+    // PVRTC
+    case eGL_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT:
+    case eGL_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT:
+    case eGL_COMPRESSED_SRGB_PVRTC_4BPPV1_EXT:
+    case eGL_COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT: return make_rdcpair(4u, 4u);
+    default: break;
+  }
+
+  if(astc[0] > 0 && astc[1] > 0)
+  {
+    return make_rdcpair(astc[0], astc[1]);
+  }
+
+  RDCERR("Unrecognised compressed format %s", ToStr(internalformat).c_str());
+  return make_rdcpair(1u, 1u);
+}
+
 size_t GetByteSize(GLsizei w, GLsizei h, GLsizei d, GLenum format, GLenum type)
 {
   size_t elemSize = 1;

--- a/renderdoc/driver/gl/gl_resources.h
+++ b/renderdoc/driver/gl/gl_resources.h
@@ -29,6 +29,7 @@
 #include "gl_common.h"
 
 size_t GetCompressedByteSize(GLsizei w, GLsizei h, GLsizei d, GLenum internalformat);
+rdcpair<uint32_t, uint32_t> GetCompressedBlockSize(GLenum internalformat);
 size_t GetByteSize(GLsizei w, GLsizei h, GLsizei d, GLenum format, GLenum type);
 GLenum GetBaseFormat(GLenum internalFormat);
 GLenum GetDataType(GLenum internalFormat);


### PR DESCRIPTION
## Description

Current version's glCopyImageSubData only supports full texture copy (with the same size). Copy with region raises assertions like this.
![image](https://user-images.githubusercontent.com/1546130/103075049-ccd19480-4605-11eb-88f3-4183a8111e42.png)

I implemented a line by line version when sub region is provided, and fast copy path still works with full copy.

Here is a example frame with two continuous copies (512x512 texture  -> 1024x1024 texture)
![image](https://user-images.githubusercontent.com/1546130/103075161-07d3c800-4606-11eb-90dc-e6422911018e.png)
![image](https://user-images.githubusercontent.com/1546130/103075191-14582080-4606-11eb-9d09-98e8340eb804.png)

BTW `GetCompressedBlockSize` is a bit ugly compared with `GetCompressedByteSize`. Any suggestion?

