### PR TITLE
replay_controller: Allow the user to alpha convert when saving PNG

### DIFF
--- a/renderdoc/replay/replay_controller.cpp
+++ b/renderdoc/replay/replay_controller.cpp
@@ -1064,7 +1064,14 @@ bool ReplayController::SaveTexture(const TextureSave &saveData, const rdcstr &pa
   }
 
   // handle formats that don't support alpha
-  if(numComps == 4 && (sd.destType == FileType::BMP || sd.destType == FileType::JPG))
+  if((sd.destType == FileType::BMP || sd.destType == FileType::JPG) &&
+     sd.alpha == AlphaMapping::Preserve)
+  {
+    sd.alpha = AlphaMapping::BlendToColor;
+  }
+
+  // convert alpha if necessary
+  if(numComps == 4 && sd.alpha != AlphaMapping::Preserve)
   {
     byte *nonalpha = new byte[td.width * td.height * 3];
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

It seems like the `alpha` field isn't read by SaveTexture unless we're saving to a format that doesn't support an alpha channel, like BMP/JPG. Perhaps that is intentional, but that would make `AlphaMapping::Preserve` and `AlphaMapping::BlendToColor` the same behavior. I chose to support `AlphaMapping::Preserve` when saving PNG while also allowing the user to choose BlendToColor/BlendToCheckerboard/Discard. When exporting textures without alpha support, BlendToColor is chosen as the fallback, which matches current behavior.