### PR TITLE
Prevent GPU hang in postvs incremental draws with many instances

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_postvs.cpp
+++ b/renderdoc/driver/d3d12/d3d12_postvs.cpp
@@ -978,6 +978,20 @@ void D3D12Replay::InitPostVSBuffers(uint32_t eventId)
           list->DrawInstanced(drawcall->numIndices, inst, drawcall->vertexOffset,
                               drawcall->instanceOffset);
         }
+
+        // Instanced draws with a wild number of instances can hang the GPU, sync after every 1000
+        if((inst % 1000) == 0)
+        {
+          list->Close();
+
+          l = list;
+          m_pDevice->GetQueue()->ExecuteCommandLists(1, &l);
+          m_pDevice->GPUSync();
+
+          GetDebugManager()->ResetDebugAlloc();
+
+          list = GetDebugManager()->ResetDebugList();
+        }
       }
 
       list->Close();


### PR DESCRIPTION
A production capture had a draw with over 19000 instances. When selected, the postvs data gathering caused GPU hang/device removal and prevented analysis. Adding a flush every so often alleviated it.
