### PR TITLE
Fix compile errors when the '-mf16c' CFLAG is enabled.

### DIFF
--- a/renderdoc/3rdparty/half/half.hpp
+++ b/renderdoc/3rdparty/half/half.hpp
@@ -266,9 +266,6 @@
 #if HALF_ENABLE_CPP11_HASH
 	#include <functional>
 #endif
-#if HALF_ENABLE_F16C_INTRINSICS
-	#include <immintrin.h>
-#endif
 
 
 #ifndef HALF_ENABLE_F16C_INTRINSICS
@@ -279,6 +276,10 @@
 	///
 	/// Unless predefined it will be enabled automatically when the `__F16C__` symbol is defined, which some compilers do on supporting platforms.
 	#define HALF_ENABLE_F16C_INTRINSICS __F16C__
+#endif
+
+#if HALF_ENABLE_F16C_INTRINSICS
+	#include <immintrin.h>
 #endif
 
 #ifdef HALF_DOXYGEN_ONLY


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

If the compile flag `-mf16c` is enabled, which `-march=native` might enable, `half.hpp` will define `HALF_ENABLE_F16C_INTRINSICS` after the previous `HALF_ENABLE_F16C_INTRINSICS` check.

This causes a build failure, because the `immintrin.h` include statement was skipped.