### PR TITLE
Fix extra read-only resources being displayed in D3D12

### DIFF
--- a/renderdoc/api/replay/pipestate.inl
+++ b/renderdoc/api/replay/pipestate.inl
@@ -1189,7 +1189,7 @@ rdcarray<BoundResourceArray> PipeState::GetReadOnlyResources(ShaderStage stage, 
             for(size_t j = 0; j < element.views.size(); ++j)
             {
               const D3D12Pipe::View &view = element.views[j];
-              if(view.bind >= start && view.bind <= end)
+              if(view.bind >= start && view.bind < end)
               {
                 val.push_back(BoundResource());
                 BoundResource &b = val.back();


### PR DESCRIPTION
Fix extra read-only resources being displayed in D3D12

## Description

Fixes a bug that caused read-only bind points to be displayed with an extra resource in the Texture Viewer.