### PR TITLE
Fixed missing ARM_pc define on armhf target.

### DIFF
--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -24,6 +24,7 @@
 
 #include <elf.h>
 #include <sys/ptrace.h>
+#include <asm/ptrace.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/user.h>

--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -24,7 +24,6 @@
 
 #include <elf.h>
 #include <sys/ptrace.h>
-#include <asm/ptrace.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/user.h>
@@ -38,6 +37,8 @@
 #include "core/core.h"
 #include "core/settings.h"
 #include "os/os_specific.h"
+
+#include <asm/ptrace.h>
 
 RDOC_CONFIG(bool, Linux_PtraceChildProcesses, true,
             "Use ptrace(2) to trace child processes at startup to ensure connection is made as "


### PR DESCRIPTION
## Description

On platforms such as armhf/Linux, building [linux_process.cpp](renderdoc/os/posix/linux/linux_process.cpp) fails due to missing ptrace definitions such as the ARM_pc macro found in the "asm/ptrace.h" header.

This PR includes said header in order to allow Renderdoc to be compiled successfully.