### PR TITLE
Split large pending cmd batches to prevent device removal on load

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -3431,7 +3431,11 @@ void WrappedID3D12Device::ExecuteLists(WrappedID3D12CommandQueue *queue, bool In
   if(queue == NULL)
     queue = GetQueue();
 
-  queue->ExecuteCommandListsInternal((UINT)cmds.size(), &cmds[0], InFrameCaptureBoundary, false);
+  for(size_t i = 0; i < cmds.size(); i += executeListsMaxSize)
+  {
+    UINT cmdCount = RDCMIN(executeListsMaxSize, (UINT)(cmds.size() - i));
+    queue->ExecuteCommandListsInternal(cmdCount, &cmds[i], InFrameCaptureBoundary, false);
+  }
 
   m_InternalCmds.submittedcmds.append(m_InternalCmds.pendingcmds);
   m_InternalCmds.pendingcmds.clear();

--- a/renderdoc/driver/d3d12/d3d12_device.h
+++ b/renderdoc/driver/d3d12/d3d12_device.h
@@ -848,6 +848,10 @@ public:
   int initStateCurBatch;
   ID3D12GraphicsCommandListX *initStateCurList;
 
+  // ExecuteLists may issue this many command lists together. If more than this are
+  // pending at once then they will be split up and issued in multiple calls.
+  static const UINT executeListsMaxSize = 50;
+
   ID3D12GraphicsCommandListX *GetNewList();
   ID3D12GraphicsCommandListX *GetInitialStateList();
   void CloseInitialStateList();


### PR DESCRIPTION
With some production captures, loading them would cause device hung from submitting too much work in a single execute lists call.