### PR TITLE
UI tweaks

### DIFF
--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -1630,7 +1630,7 @@ void RDStyle::drawControl(ControlElement control, const QStyleOption *opt, QPain
     qreal lineWidth = qMax(1, frame->lineWidth);
 
     p->save();
-    p->setPen(QPen(opt->palette.brush(widget->foregroundRole()), lineWidth));
+    p->setPen(QPen(outlineBrush(opt->palette), lineWidth));
 
     qreal adjust = 0.5 * lineWidth;
 

--- a/qrenderdoc/Windows/TimelineBar.cpp
+++ b/qrenderdoc/Windows/TimelineBar.cpp
@@ -625,10 +625,10 @@ void TimelineBar::paintEvent(QPaintEvent *e)
     qreal realMiddle = currentRect.center().x();
 
     // clamp the position from the left or right side
-    if(currentRect.left() < eidAxisRect.left())
-      currentRect.moveLeft(eidAxisRect.left());
-    else if(currentRect.right() > eidAxisRect.right())
-      currentRect.moveRight(eidAxisRect.right());
+    if(currentRect.left() < m_eidAxisRect.left())
+      currentRect.moveLeft(m_eidAxisRect.left());
+    else if(currentRect.right() > m_eidAxisRect.right())
+      currentRect.moveRight(m_eidAxisRect.right());
 
     // re-add the top margin so the lines match up with the border around the EID axis
     QRectF currentBackRect = currentRect.marginsAdded(QMargins(0, margin, 0, 0));
@@ -647,7 +647,7 @@ void TimelineBar::paintEvent(QPaintEvent *e)
 
     // draw a line from the bottom of the shadow downwards
     QPointF currentTop = currentRect.center();
-    currentTop.setX(int(qBound(eidAxisRect.left(), realMiddle, eidAxisRect.right() - 2.0)) + 0.5);
+    currentTop.setX(int(qBound(m_eidAxisRect.left(), realMiddle, m_eidAxisRect.right() - 2.0)) + 0.5);
     currentTop.setY(currentRect.bottom());
 
     QPointF currentBottom = currentTop;

--- a/qrenderdoc/Windows/TimelineBar.h
+++ b/qrenderdoc/Windows/TimelineBar.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <QAbstractScrollArea>
+#include <QStylePainter>
 #include "Code/Interface/QRDInterface.h"
 
 class TimelineBar : public QAbstractScrollArea, public ITimelineBar, public ICaptureViewer
@@ -82,7 +83,7 @@ private:
   QString m_UsageTarget;
   QList<EventUsage> m_UsageEvents;
 
-  const qreal margin = 2.0;
+  const qreal margin = 3.0;
   const qreal borderWidth = 1.0;
   const QString eidAxisTitle = lit("EID:");
   const int dataBarHeight = 16;
@@ -110,6 +111,7 @@ private:
   qreal offsetOf(uint32_t eid);
   uint32_t processDraws(QVector<Marker> &markers, QVector<uint32_t> &draws,
                         const rdcarray<DrawcallDescription> &curDraws);
+  void drawLine(QStylePainter &p, QPointF start, QPointF end);
   void paintMarkers(QPainter &p, const QVector<Marker> &markers, const QVector<uint32_t> &draws,
                     QRectF markerRect);
   Marker *findMarker(QVector<Marker> &markers, QRectF markerRect, QPointF pos);


### PR DESCRIPTION
## Description

As discussed in https://github.com/baldurk/renderdoc/issues/2168, this tweaks the UI drawing to provide a more even look for the dark theme.  I've done my best to avoid causing visual changes in the other themes, however I haven't tried doing a Windows build to see how it looks there.

I also fixed the clamping of the current event to the left side of the timeline view area since that seemed to be broken.