### PR TITLE
Fixed user level registration of vulkan layers in renderdoccmd.

### DIFF
--- a/renderdoccmd/renderdoccmd.cpp
+++ b/renderdoccmd/renderdoccmd.cpp
@@ -1404,7 +1404,7 @@ public:
       return 0;
     }
 
-    if(m_Info.flags & VulkanLayerFlags::UserRegisterable)
+    if(!(m_Info.flags & VulkanLayerFlags::UserRegisterable))
     {
       if(user)
       {


### PR DESCRIPTION
The conditional that ensures that user level registration of the vulkan layers is possible got inverted. As a result this type of registration was not possible 