### PR TITLE
Fix renderdoccmd unit tests failing on Apple M1 Mac Book Air

### DIFF
--- a/renderdoc/os/posix/apple/apple_threading.cpp
+++ b/renderdoc/os/posix/apple/apple_threading.cpp
@@ -33,7 +33,7 @@ double Timing::GetTickFrequency()
 
   uint64_t numer = timeInfo.numer;
   uint64_t denom = timeInfo.denom;
-  return ((double)numer / (double)denom) * 1000000.0;
+  return ((double)denom / (double)numer) * 1000000.0;
 }
 
 uint64_t Timing::GetTick()


### PR DESCRIPTION

## Description

On Apple M1 Mac Book Air the renderdoccmd unit tests were failing in the Timing and streamio tests.

Debugging this discovered the Apple implementation for Timing::GetTickFrequency() had a small mistake the numerator and denominator were the wrong way around. On other Apple CPUs the numerator and denominator were probably the same value and it did not matter which way around they were used.

Locally tested this change on Apple Intel CPU and the unit tests pass after this change.
