### PR TITLE
Hook up EnumerateInstanceExtensionProps on Android

### DIFF
--- a/renderdoc/driver/vulkan/vk_layer_android.cpp
+++ b/renderdoc/driver/vulkan/vk_layer_android.cpp
@@ -42,13 +42,17 @@
 
 extern "C" {
 
-// these are in vk_tracelayer.cpp
+// these are in vk_layer.cpp
 VK_LAYER_EXPORT VkResult VKAPI_CALL VK_LAYER_RENDERDOC_CaptureEnumerateDeviceLayerProperties(
     VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount, VkLayerProperties *pProperties);
 
 VK_LAYER_EXPORT VkResult VKAPI_CALL VK_LAYER_RENDERDOC_CaptureEnumerateDeviceExtensionProperties(
     VkPhysicalDevice physicalDevice, const char *pLayerName, uint32_t *pPropertyCount,
     VkExtensionProperties *pProperties);
+
+VK_LAYER_EXPORT VkResult VKAPI_CALL VK_LAYER_RENDERDOC_CaptureEnumerateInstanceExtensionProperties(
+    const VkEnumerateInstanceExtensionPropertiesChain *pChain, const char *pLayerName,
+    uint32_t *pPropertyCount, VkExtensionProperties *pProperties);
 
 VK_LAYER_EXPORT VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                      uint32_t *pPropertyCount,
@@ -78,10 +82,7 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t 
 VK_LAYER_EXPORT VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(
     const char *pLayerName, uint32_t *pPropertyCount, VkExtensionProperties *pProperties)
 {
-  // we don't export any instance extensions
-  if(pPropertyCount)
-    *pPropertyCount = 0;
-
-  return VK_SUCCESS;
+  return VK_LAYER_RENDERDOC_CaptureEnumerateInstanceExtensionProperties(
+      VK_NULL_HANDLE, pLayerName, pPropertyCount, pProperties);
 }
 }

--- a/renderdoc/driver/vulkan/vk_layer_android.cpp
+++ b/renderdoc/driver/vulkan/vk_layer_android.cpp
@@ -83,6 +83,6 @@ VK_LAYER_EXPORT VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(
     const char *pLayerName, uint32_t *pPropertyCount, VkExtensionProperties *pProperties)
 {
   return VK_LAYER_RENDERDOC_CaptureEnumerateInstanceExtensionProperties(
-      VK_NULL_HANDLE, pLayerName, pPropertyCount, pProperties);
+      NULL, pLayerName, pPropertyCount, pProperties);
 }
 }


### PR DESCRIPTION
Capture function for vkEnumerateInstanceExtensionProperties wasn't being
called at all for the Android Layer

There is still the issue of filtering not working and and
VK_EXT_debug_utils isn't properly being exposed as an available
extension due to differences with the Android Vulkan Loader and the
common Vulkan Loader on desktop platforms still being investigated

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
