### PR TITLE
Do not access "view" in getMetalLayerSize

### DIFF
--- a/renderdoc/driver/vulkan/vk_apple.cpp
+++ b/renderdoc/driver/vulkan/vk_apple.cpp
@@ -29,7 +29,7 @@
 #include <dlfcn.h>
 
 // helpers defined in vk_apple.mm
-void getMetalLayerSize(void *viewHandle, void *layerHandle, int &width, int &height);
+void getMetalLayerSize(void *layerHandle, int &width, int &height);
 
 #if defined(VK_USE_PLATFORM_MACOS_MVK)
 
@@ -147,7 +147,7 @@ void VulkanReplay::GetOutputWindowDimensions(uint64_t id, int32_t &w, int32_t &h
     return;
   }
 
-  getMetalLayerSize(outw.cocoa.view, outw.cocoa.layer, w, h);
+  getMetalLayerSize(outw.cocoa.layer, w, h);
 }
 
 static const rdcstr VulkanLibraryName = "libvulkan.1.dylib"_lit;

--- a/renderdoc/driver/vulkan/vk_apple.mm
+++ b/renderdoc/driver/vulkan/vk_apple.mm
@@ -1,13 +1,11 @@
 #import <Cocoa/Cocoa.h>
 
-void getMetalLayerSize(void *viewHandle, void* layerHandle, int& width, int& height)
+void getMetalLayerSize(void* layerHandle, int& width, int& height)
 {
-  NSView *view = (NSView *)viewHandle;
-  assert([view isKindOfClass:[NSView class]]);
   CALayer *layer = (CALayer *)layerHandle;
   assert([layer isKindOfClass:[CALayer class]]);
 
-  CGSize viewScale = [view convertSizeToBacking:layer.bounds.size];
-  width = viewScale.width;
-  height = viewScale.height;
+  const CGFloat scaleFactor = layer.contentsScale;
+  width = layer.bounds.size.width * scaleFactor;
+  height = layer.bounds.size.height * scaleFactor;
 }

--- a/renderdoc/replay/replay_output.cpp
+++ b/renderdoc/replay/replay_output.cpp
@@ -77,7 +77,7 @@ static uint64_t GetHandle(WindowingData window)
 #elif ENABLED(RDOC_APPLE)
 
   RDCASSERT(window.system == WindowingSystem::MacOS);
-  return (uint64_t)window.macOS.layer;    // CALayer *
+  return (uint64_t)window.macOS.view;    // NSView *
 
 #else
   RDCFATAL("No windowing data defined for this platform! Must be implemented for replay outputs");


### PR DESCRIPTION
## Description

Fixes Main thread checker assert in getMetalLayerSize
Use the layer.contentsScale to adjust for high DPI instead of "view convertSizeToBacking"

On Apple use the view object as the window handle
The view is constant per window, the layer can change.
The layer is constant for Vulkan windows
The layer changes for GL windows

## Testing

Checking the hover colour and pixel context match the cursor position
Tested on a high DPI display
Tested on a normal DPI display
Tested by launching qrenderdoc on a high DPI display and moving the window to a norma, DPI display, and vice-versa.
The hover colour and pixel context matched the cursor position when moving the window to both DPI displays.

Enabled the Xcode main thread checker option before the code change the main thread checker assert fired on the Replay thread in getMetalLayerSize and after the code change, there are no main thread checker asserts.

Made some sample Vulkan captures from the Vulkan-Tools vkcube applications


