### PR TITLE
Apple support for capture keys F11, F12, PrtScrn

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -288,6 +288,7 @@ elseif(APPLE)
     list(APPEND sources
         data/embedded_files.h
         os/posix/apple/apple_stringio.cpp
+        os/posix/apple/apple_helpers.mm
         os/posix/apple/apple_callstack.cpp
         os/posix/apple/apple_process.cpp
         os/posix/apple/apple_threading.cpp

--- a/renderdoc/os/posix/apple/apple_helpers.mm
+++ b/renderdoc/os/posix/apple/apple_helpers.mm
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2021 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#import <Cocoa/Cocoa.h>
+
+#define MAX_COUNT_KEYS (65536)
+static bool s_keysPressed[MAX_COUNT_KEYS];
+static id s_eventMonitor;
+
+void apple_InitKeyboard()
+{
+    s_eventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:
+    (NSEventMaskKeyDown|NSEventMaskKeyUp)
+    handler:^(NSEvent *incomingEvent) {
+        NSEvent *result = incomingEvent;
+        //NSWindow *targetWindowForEvent = [incomingEvent window];
+        //if (targetWindowForEvent == _window) 
+        {
+            unsigned short keyCode = [incomingEvent keyCode];
+            if ([incomingEvent type] == NSEventTypeKeyDown) 
+            {
+                s_keysPressed[keyCode] = true;
+            }
+            if ([incomingEvent type] == NSEventTypeKeyUp) 
+            {
+                s_keysPressed[keyCode] = false;
+            }
+        }
+        return result;
+    }];
+}
+
+bool apple_IsKeyPressed(int appleKeyCode)
+{
+    return s_keysPressed[appleKeyCode];
+}

--- a/renderdoc/os/posix/apple/apple_stringio.cpp
+++ b/renderdoc/os/posix/apple/apple_stringio.cpp
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+// To get kVK_ entries
+#include <Carbon/Carbon.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <iconv.h>
@@ -31,19 +33,25 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <uuid/uuid.h>
+#include "api/app/renderdoc_app.h"
 #include "common/common.h"
 #include "common/threading.h"
 #include "os/os_specific.h"
+
+// helpers defined in apple_helpers.mm
+extern void apple_InitKeyboard();
+extern bool apple_IsKeyPressed(int appleKeyCode);
 
 namespace Keyboard
 {
 void Init()
 {
+  apple_InitKeyboard();
 }
 
 bool PlatformHasKeyInput()
 {
-  return false;
+  return true;
 }
 
 void AddInputWindow(WindowingSystem windowSystem, void *wnd)
@@ -56,7 +64,79 @@ void RemoveInputWindow(WindowingSystem windowSystem, void *wnd)
 
 bool GetKeyState(int key)
 {
-  return false;
+  unsigned short appleKeyCode;
+
+  switch(key)
+  {
+    case eRENDERDOC_Key_A: appleKeyCode = kVK_ANSI_A; break;
+    case eRENDERDOC_Key_B: appleKeyCode = kVK_ANSI_B; break;
+    case eRENDERDOC_Key_C: appleKeyCode = kVK_ANSI_C; break;
+    case eRENDERDOC_Key_D: appleKeyCode = kVK_ANSI_D; break;
+    case eRENDERDOC_Key_E: appleKeyCode = kVK_ANSI_E; break;
+    case eRENDERDOC_Key_F: appleKeyCode = kVK_ANSI_F; break;
+    case eRENDERDOC_Key_G: appleKeyCode = kVK_ANSI_G; break;
+    case eRENDERDOC_Key_H: appleKeyCode = kVK_ANSI_H; break;
+    case eRENDERDOC_Key_I: appleKeyCode = kVK_ANSI_I; break;
+    case eRENDERDOC_Key_J: appleKeyCode = kVK_ANSI_J; break;
+    case eRENDERDOC_Key_K: appleKeyCode = kVK_ANSI_K; break;
+    case eRENDERDOC_Key_L: appleKeyCode = kVK_ANSI_L; break;
+    case eRENDERDOC_Key_M: appleKeyCode = kVK_ANSI_M; break;
+    case eRENDERDOC_Key_N: appleKeyCode = kVK_ANSI_N; break;
+    case eRENDERDOC_Key_O: appleKeyCode = kVK_ANSI_O; break;
+    case eRENDERDOC_Key_P: appleKeyCode = kVK_ANSI_P; break;
+    case eRENDERDOC_Key_Q: appleKeyCode = kVK_ANSI_Q; break;
+    case eRENDERDOC_Key_R: appleKeyCode = kVK_ANSI_R; break;
+    case eRENDERDOC_Key_S: appleKeyCode = kVK_ANSI_S; break;
+    case eRENDERDOC_Key_T: appleKeyCode = kVK_ANSI_T; break;
+    case eRENDERDOC_Key_U: appleKeyCode = kVK_ANSI_U; break;
+    case eRENDERDOC_Key_V: appleKeyCode = kVK_ANSI_V; break;
+    case eRENDERDOC_Key_W: appleKeyCode = kVK_ANSI_W; break;
+    case eRENDERDOC_Key_X: appleKeyCode = kVK_ANSI_X; break;
+    case eRENDERDOC_Key_Y: appleKeyCode = kVK_ANSI_Y; break;
+    case eRENDERDOC_Key_Z: appleKeyCode = kVK_ANSI_Z; break;
+
+    case eRENDERDOC_Key_0: appleKeyCode = kVK_ANSI_0; break;
+    case eRENDERDOC_Key_1: appleKeyCode = kVK_ANSI_1; break;
+    case eRENDERDOC_Key_2: appleKeyCode = kVK_ANSI_2; break;
+    case eRENDERDOC_Key_3: appleKeyCode = kVK_ANSI_3; break;
+    case eRENDERDOC_Key_4: appleKeyCode = kVK_ANSI_4; break;
+    case eRENDERDOC_Key_5: appleKeyCode = kVK_ANSI_5; break;
+    case eRENDERDOC_Key_6: appleKeyCode = kVK_ANSI_6; break;
+    case eRENDERDOC_Key_7: appleKeyCode = kVK_ANSI_7; break;
+    case eRENDERDOC_Key_8: appleKeyCode = kVK_ANSI_8; break;
+    case eRENDERDOC_Key_9: appleKeyCode = kVK_ANSI_9; break;
+
+    case eRENDERDOC_Key_Divide: appleKeyCode = kVK_ANSI_KeypadDivide; break;
+    case eRENDERDOC_Key_Multiply: appleKeyCode = kVK_ANSI_KeypadMultiply; break;
+    case eRENDERDOC_Key_Subtract: appleKeyCode = kVK_ANSI_KeypadMinus; break;
+    case eRENDERDOC_Key_Plus: appleKeyCode = kVK_ANSI_KeypadPlus; break;
+
+    case eRENDERDOC_Key_F1: appleKeyCode = kVK_F1; break;
+    case eRENDERDOC_Key_F2: appleKeyCode = kVK_F2; break;
+    case eRENDERDOC_Key_F3: appleKeyCode = kVK_F3; break;
+    case eRENDERDOC_Key_F4: appleKeyCode = kVK_F4; break;
+    case eRENDERDOC_Key_F5: appleKeyCode = kVK_F5; break;
+    case eRENDERDOC_Key_F6: appleKeyCode = kVK_F6; break;
+    case eRENDERDOC_Key_F7: appleKeyCode = kVK_F7; break;
+    case eRENDERDOC_Key_F8: appleKeyCode = kVK_F8; break;
+    case eRENDERDOC_Key_F9: appleKeyCode = kVK_F9; break;
+    case eRENDERDOC_Key_F10: appleKeyCode = kVK_F10; break;
+    case eRENDERDOC_Key_F11: appleKeyCode = kVK_F11; break;
+    case eRENDERDOC_Key_F12: appleKeyCode = kVK_F12; break;
+
+    case eRENDERDOC_Key_Home: appleKeyCode = kVK_Home; break;
+    case eRENDERDOC_Key_End: appleKeyCode = kVK_End; break;
+    case eRENDERDOC_Key_Insert: appleKeyCode = kVK_Help; break;
+    case eRENDERDOC_Key_Delete: appleKeyCode = kVK_ForwardDelete; break;
+    case eRENDERDOC_Key_PageUp: appleKeyCode = kVK_PageUp; break;
+    case eRENDERDOC_Key_PageDn: appleKeyCode = kVK_PageDown; break;
+    case eRENDERDOC_Key_Backspace: appleKeyCode = kVK_Delete; break;
+    case eRENDERDOC_Key_Tab: appleKeyCode = kVK_Tab; break;
+    case eRENDERDOC_Key_PrtScrn: appleKeyCode = kVK_F13; break;
+    case eRENDERDOC_Key_Pause: appleKeyCode = kVK_F16; break;
+    default: return false;
+  }
+  return apple_IsKeyPressed(appleKeyCode);
 }
 }
 


### PR DESCRIPTION
## Description

Implemented bool GetKeyState(int key) for the Apple platform

Added apple_helpers.mm
apple_isKeyPressed() & apple_initKeyboard 
keyboard capturing is implemented using addLocalMonitorForEventsMatchingMask

Have not implemented support for AddInputWindow() or RemoveInputWindow() which could be done by tracking the window handle and testing it in the event callback ie.
NSWindow *targetWindowForEvent = [incomingEvent window];

## Testing

Locally on GL and Vulkan sample programs using F12 and PrintScreen (F13) to trigger captures.
Attached a debugger to check F11 was being detected for window cycling.
Verified the keyboard events are only captured when the window has focus.
