### PR TITLE
fix DllMain hang

### DIFF
--- a/renderdoc/os/win32/win32_libentry.cpp
+++ b/renderdoc/os/win32/win32_libentry.cpp
@@ -30,6 +30,7 @@
 #include "core/core.h"
 #include "hooks/hooks.h"
 #include "strings/string_utils.h"
+#include "os/os_specific.h"
 
 static BOOL add_hooks()
 {
@@ -74,9 +75,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 {
   if(ul_reason_for_call == DLL_PROCESS_ATTACH)
   {
-    BOOL ret = add_hooks();
+    Threading::CloseThread(Threading::CreateThread([]() { (void)add_hooks(); }));
     SetLastError(0);
-    return ret;
   }
 
   return TRUE;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
when Enabled RenderDoc Plugin in UE4Editor, sometimes, renderdoc.dll will hang when
startup, my fix is put all initialization work inside a thread, which is safe.
According to MSDN, DllMain cannot do heavy initialization work because LoadLibrary 
hold LdrLoaderLock

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
