### PR TITLE
[AMD][DX12] Fix a crash and a replay issue when agsDriverExtensionsDX12_CreateDevice() is called

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -1110,6 +1110,12 @@ HRESULT WrappedID3D12Device::QueryInterface(REFIID riid, void **ppvObject)
     *ppvObject = (INVAPID3DDevice *)&m_WrappedNVAPI;
     return S_OK;
   }
+  else if(riid == __uuidof(IAGSD3DDevice))
+  {
+    // don't addref, this is an internal interface so we just don't addref at all
+    *ppvObject = (IAGSD3DDevice *)&m_WrappedAGS;
+    return S_OK;
+  }
   else if(riid == __uuidof(ID3D12DebugDevice))
   {
     // we queryinterface for this at startup, so if it's present we can

--- a/renderdoc/driver/ihv/amd/ags_wrapper.cpp
+++ b/renderdoc/driver/ihv/amd/ags_wrapper.cpp
@@ -192,7 +192,7 @@ public:
     // this doesn't catch the case where some intrinsics are used on replay that are newer. We don't
     // store that fine-grained information about which intrinsics are used.
     if(device12)
-      return extensionsSupported11.intrinsics16;
+      return extensionsSupported12.intrinsics16;
     else if(device11)
       return extensionsSupported11.intrinsics16;
     else

--- a/renderdoc/driver/ihv/amd/amd_hooks.cpp
+++ b/renderdoc/driver/ihv/amd/amd_hooks.cpp
@@ -317,6 +317,9 @@ private:
           // de-refcount our device.
           returnedParams->pDevice->AddRef();
 
+          if(ppDevice)
+            *ppDevice = returnedParams->pDevice;
+
           return S_OK;
         },
         creationParams->pAdapter, creationParams->FeatureLevel, __uuidof(ID3D12Device),


### PR DESCRIPTION
# Issue

When an application calling `agsDriverExtensionsDX12_CreateDevice()` is launched, RenderDoc crashes in the hook function of `agsDriverExtensionsDX12_CreateDevice()`.

There are 3 issues leading to the crash as well as the replay failing to play

1 - missing QueryInterface() detection for AGS device for DX12
2 - device returned to the app being null even though successfully initializing internally, causing a crash on the application side
3 - incorrect intrinsics struct being accessed during playback for device eligibility, causing a mistaken replay error

