### PR TITLE
Fix typo in JDWP TypeTag enums and Update URL to JDWP spec

### DIFF
--- a/renderdoc/android/jdwp.h
+++ b/renderdoc/android/jdwp.h
@@ -30,7 +30,7 @@
 namespace JDWP
 {
 // enums and structs defined by the JDWP spec. These are defined in:
-// https://docs.oracle.com/javase/7/docs/platform/jpda/jdwp/jdwp-protocol.html#JDWP_Tag
+// https://docs.oracle.com/javase/7/docs/platform/jpda/jdwp/jdwp-protocol.html
 
 enum class CommandSet : byte
 {
@@ -58,7 +58,7 @@ enum class TypeTag : byte
 {
   Class = 1,
   Interface = 2,
-  Arrary = 3,
+  Array = 3,
 };
 
 enum class Tag : byte


### PR DESCRIPTION
TypeTag is not actually used tho.


