### PR TITLE
Implement Apple universal binary support for nightly builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+if(APPLE)
+  SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
+endif()
+
 # Configure some stuff that needs to be set really early
 if(BUILD_ANDROID)
     if(NOT DEFINED ENV{JAVA_HOME})

--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -334,6 +334,6 @@ install (CODE "MESSAGE(\"NB: Your paths may vary.\")")
 endif() # if(ENABLE_QRENDERDOC)
 
 # Build python modules - primarily used for constructing documentation
-if(ENABLE_PYRENDERDOC AND UNIX)
+if(ENABLE_PYRENDERDOC AND UNIX AND NOT APPLE)
     add_subdirectory(Code/pyrenderdoc)
 endif()


### PR DESCRIPTION
## Description

Implement universal binary (arm64 & x86_64) support for the nightly builds for `librenderdoc.dylib`.

This does not include universal binary support for `qrenderdoc` which requires understanding how to use `qmake` to cross-compile.

This will allow users who download the nightly build to capture x86_64 and arm64 applications on Apple Silicon machines.

There is an impact to the Mac CI where it has to compile and link for two archictectures.

## Testing

Results from RenderDoc.app nightly build downloaded from RenderDoc website (ie. before the change)

`lipo -archs ~/Desktop/RenderDoc.app/Contents/lib/librenderdoc.dylib`

> x86_64

`lipo -archs ~/Desktop/RenderDoc.app/Contents/bin/renderdoccmd `

> x86_64

Results from local branch after the change (on arm64 Mac)

`lipo -archs ./build/lib/librenderdoc.dylib`

> x86_64 arm64

`lipo -archs ./build/bin/renderdoccmd`

> x86_64 arm64

Could repeat the test locally on an Intel Mac?
The full test will be to download a nightly build after the change.

Is there a way to download the compiled binaries from the CI (when it runs on this PR)?
