### PR TITLE
Apple : get the executable path from the app bundle using NSBundle

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -2065,11 +2065,6 @@ WindowingData CaptureContext::CreateWindowingData(QWidget *window)
 
   return CreateMacOSWindowingData(view, layer);
 
-#elif defined(RENDERDOC_PLATFORM_APPLE)
-
-  WindowingData ret = {WindowingSystem::Unknown};
-  return ret;
-
 #elif defined(RENDERDOC_PLATFORM_GGP)
 
   WindowingData ret = {WindowingSystem::GGP};

--- a/renderdoc/os/posix/apple/apple_helpers.mm
+++ b/renderdoc/os/posix/apple/apple_helpers.mm
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include "api/replay/rdcstr.h"
+
 #import <Cocoa/Cocoa.h>
 
 #define MAX_COUNT_KEYS (65536)
@@ -55,4 +57,14 @@ void apple_InitKeyboard()
 bool apple_IsKeyPressed(int appleKeyCode)
 {
   return s_keysPressed[appleKeyCode];
+}
+
+rdcstr apple_GetExecutablePathFromAppBundle(const char *appBundlePath)
+{
+  NSString *path = [NSString stringWithCString:appBundlePath encoding:NSUTF8StringEncoding];
+  NSBundle *nsBundle = [NSBundle bundleWithPath:path];
+  NSString *executablePath = nsBundle.executablePath;
+
+  rdcstr result([executablePath cStringUsingEncoding:NSUTF8StringEncoding]);
+  return result;
 }

--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -41,6 +41,9 @@
 #include "os/os_specific.h"
 #include "strings/string_utils.h"
 
+// defined in apple_helpers.mm
+extern rdcstr apple_GetExecutablePathFromAppBundle(const char *appBundlePath);
+
 // defined in foo/foo_process.cpp
 char **GetCurrentEnvironment();
 int GetIdentPort(pid_t childPid);
@@ -536,8 +539,7 @@ static pid_t RunProcess(rdcstr appName, rdcstr workDir, const rdcstr &cmdLine, c
 #if ENABLED(RDOC_APPLE)
   if(appName.size() > 5 && appName.endsWith(".app"))
   {
-    rdcstr realAppName = appName + "/Contents/MacOS/" + get_basename(appName);
-    realAppName.erase(realAppName.size() - 4, ~0U);
+    rdcstr realAppName = apple_GetExecutablePathFromAppBundle(appName.c_str());
 
     if(FileIO::exists(realAppName))
     {


### PR DESCRIPTION
## Description

Get the executable path from the app bundle using NSBundle.
Previously the executable path was being assumed to be the same as the app bundle name which is common but not guaranteed.

Using an app bundle where the executable name does not match the app bundle name ie. 
`kart-x64.app/Contents/MacOS/Kart`

Before the change:

```
> ./build/bin/renderdoccmd capture ~/Workspace/UnityProjects/kart-x64.app
Launching '/Users/jake/Workspace/UnityProjects/kart-x64.app'
exec failed
Failed to create & inject: RenderDoc injection failed
```

After the change:
```
> ./build/bin/renderdoccmd capture ~/Workspace/UnityProjects/kart-x64.app
Launching '/Users/jake/Workspace/UnityProjects/kart-x64.app'
Launched as ID 38920
```