### PR TITLE
Fix row count calculation when writing block-compressed DDS data

### DIFF
--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -924,7 +924,7 @@ bool write_dds_to_file(FILE *f, const write_dds_data &data)
           // pitch/rows are in blocks, not pixels, for block formats.
           if(blockFormat)
           {
-            numRows = RDCMAX(1U, numRows / 4);
+            numRows = RDCMAX(1U, (numRows + 3) / 4);
 
             uint32_t blockSize = (data.format.type == ResourceFormatType::BC1 ||
                                   data.format.type == ResourceFormatType::BC4)


### PR DESCRIPTION
## Description

Block-compressed textures with dimensions that are not evenly divisible by the block size are typically padded internally to align with the block size. `load_dds_from_file()` was previously corrected to account for this alignment when calculating the number of rows of blocks to read from a DDS file, but the fix was not applied to `write_dds_to_file()`, resulting in missing rows of texels or loading failures when attempting to open a DDS file generated by RenderDoc from a texture whose dimensions are not a multiple of four.