### PR TITLE
Fix incorrect backcolorPick button state after cancellation

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -3704,7 +3704,10 @@ void TextureViewer::on_backcolorPick_clicked()
   QColor col = QColorDialog::getColor(Qt::black, this, tr("Choose background colour"));
 
   if(!col.isValid())
+  {
+    ui->backcolorPick->setChecked(!ui->checkerBack->isChecked());
     return;
+  }
 
   col = col.toRgb();
   m_TexDisplay.backgroundColor = FloatVector(col.redF(), col.greenF(), col.blueF(), 1.0f);


### PR DESCRIPTION
## Description

When trying to switch alpha display mode from "checker" to "background color", by clicking on "backcolorPick" button in Texture Viewer, and then cancelling the operation in the pop-up window, the button becomes checked incorrectly:
![backcolorPick bug](https://user-images.githubusercontent.com/7783839/117645446-302b2000-b1bd-11eb-93cf-2abb20d3d672.png)
This PR fixes the bug.