### PR TITLE
Make glClear always a drawcall

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -4538,21 +4538,21 @@ bool WrappedOpenGL::Serialise_glClear(SerialiserType &ser, GLbitfield mask)
             dstId = res_id;
           }
         }
-
-        draw.copyDestination = GetResourceManager()->GetOriginalID(dstId);
-
-        if(m_Textures[dstId].curType != eGL_RENDERBUFFER)
-        {
-          GLuint curDrawFBO = 0;
-          GL.glGetIntegerv(eGL_DRAW_FRAMEBUFFER_BINDING, (GLint *)&curDrawFBO);
-          GLint mip = 0, slice = 0;
-          GetFramebufferMipAndLayer(curDrawFBO, eGL_COLOR_ATTACHMENT0, &mip, &slice);
-          draw.copyDestinationSubresource.mip = mip;
-          draw.copyDestinationSubresource.slice = slice;
-
-          AddDrawcall(draw, true);
-        }
       }
+
+      draw.copyDestination = GetResourceManager()->GetOriginalID(dstId);
+
+      if(m_Textures[dstId].curType != eGL_RENDERBUFFER)
+      {
+        GLuint curDrawFBO = 0;
+        GL.glGetIntegerv(eGL_DRAW_FRAMEBUFFER_BINDING, (GLint *)&curDrawFBO);
+        GLint mip = 0, slice = 0;
+        GetFramebufferMipAndLayer(curDrawFBO, eGL_COLOR_ATTACHMENT0, &mip, &slice);
+        draw.copyDestinationSubresource.mip = mip;
+        draw.copyDestinationSubresource.slice = slice;
+      }
+
+      AddDrawcall(draw, true);
     }
   }
   return true;

--- a/util/test/demos/gl/gl_draw_zoo.cpp
+++ b/util/test/demos/gl/gl_draw_zoo.cpp
@@ -306,12 +306,24 @@ void main()
     glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA32F, screenWidth, screenHeight);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colattach, 0);
 
+    // Depth texture
+    GLuint depthattach = MakeTexture();
+
+    glBindTexture(GL_TEXTURE_2D, depthattach);
+    glTexStorage2D(GL_TEXTURE_2D, 1, GL_DEPTH24_STENCIL8, screenWidth, screenHeight);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthattach,
+                           0);
+    glClearDepth(0.0f);
+
     while(Running())
     {
       glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
       float col[] = {0.2f, 0.2f, 0.2f, 1.0f};
       glClearBufferfv(GL_COLOR, 0, col);
+
+      setMarker("GL_ClearDepth");
+      glClear(GL_DEPTH_BUFFER_BIT);
 
       glBindFramebuffer(GL_FRAMEBUFFER, fbo);
       glBindVertexBuffer(0, vb, 0, sizeof(DefaultA2V));

--- a/util/test/tests/GL/GL_Draw_Zoo.py
+++ b/util/test/tests/GL/GL_Draw_Zoo.py
@@ -39,3 +39,11 @@ class GL_Draw_Zoo(rdtest.Draw_Zoo):
 
         self.check(pipe.IsStripRestartEnabled())
         self.check((pipe.GetStripRestartIndex() & ((1 << (ib.byteStride*8)) - 1)) == 0xffff)
+        
+        draw = self.find_draw("GL_ClearDepth")
+        self.check(draw is not None)
+        
+        draw = draw.next
+        
+        self.check(draw.flags & (rd.DrawFlags.Clear|rd.DrawFlags.ClearDepthStencil) == (rd.DrawFlags.Clear|rd.DrawFlags.ClearDepthStencil))
+        


### PR DESCRIPTION
Hi Baldur!

I have encountered a bug in our fork of RenderDoc because glClear is only considered as a drawcall if it clears the color buffer. Is there any reason this is the case? If this is not intentional, I have added a simple test and the corresponding fix.

Thanks!
Jimmy
