### PR TITLE
Couple of small fixes for the Tests project

### DIFF
--- a/util/test/demos/test_common.h
+++ b/util/test/demos/test_common.h
@@ -104,7 +104,7 @@ public:
     return Vec3f(y * o.z - z * o.y, z * o.x - x * o.z, x * o.y - y * o.x);
   }
 
-  inline float Length() const { return sqrt(Dot(*this)); }
+  inline float Length() const { return sqrtf(Dot(*this)); }
   inline void Normalise()
   {
     float l = Length();

--- a/util/test/demos/vk/vk_descriptor_reuse.cpp
+++ b/util/test/demos/vk/vk_descriptor_reuse.cpp
@@ -364,8 +364,8 @@ void main()
         vkh::cmdBindVertexBuffers(cmd, 0, {vb.buffer}, {0});
 
         VkRect2D s = {{0, 0},
-                      {uint32_t(screenWidth / (int)sqrt(descriptorCount)),
-                       uint32_t(screenHeight / (int)sqrt(descriptorCount))}};
+                      {uint32_t(screenWidth / (int)sqrtf((float)descriptorCount)),
+                       uint32_t(screenHeight / (int)sqrtf((float)descriptorCount))}};
         VkViewport v = {0, 0, (float)s.extent.width, (float)s.extent.height, 0, 1};
 
         size_t randSeed = curFrame * threadIndex + threadIndex;

--- a/util/test/demos/vk/vk_overlay_test.cpp
+++ b/util/test/demos/vk/vk_overlay_test.cpp
@@ -552,8 +552,8 @@ void main()
       v = mainWindow->viewport;
       v.width /= 8.0f;
       v.height /= 8.0f;
-      v.width = floor(v.width);
-      v.height = floor(v.height);
+      v.width = floorf(v.width);
+      v.height = floorf(v.height);
       v.x += 2.0f;
       v.y += 2.0f;
       v.width -= 4.0f;

--- a/util/test/demos/vk/vk_parameter_zoo.cpp
+++ b/util/test/demos/vk/vk_parameter_zoo.cpp
@@ -1528,7 +1528,10 @@ void main()
     vkDestroyImageView(device, view3, NULL);
 
     if(KHR_descriptor_update_template && KHR_push_descriptor)
+    {
       vkDestroyDescriptorUpdateTemplateKHR(device, pushtempl, NULL);
+      vkDestroyDescriptorUpdateTemplateKHR(device, refpushtempl, NULL);
+    }
 
     if(KHR_descriptor_update_template)
       vkDestroyDescriptorUpdateTemplateKHR(device, reftempl, NULL);


### PR DESCRIPTION
## Description

Proposed fixes for compile warnings when compiling the Tests project with VS2019 compiler (float vs double warnings which are now errors by default).

A fix for Vulkan validation error when running the `vk_parameter_zoo` test with `--debug` option. The `refpushtempl` descriptor was not destroyed on shutdown.