### PR TITLE
Change glGetInternalformativ bufSize usage to count of items instead of count of bytes

### DIFF
--- a/renderdoc/driver/gl/gl_common.cpp
+++ b/renderdoc/driver/gl/gl_common.cpp
@@ -2106,9 +2106,9 @@ ResourceFormat MakeResourceFormat(GLenum target, GLenum fmt)
   GLenum *edata = (GLenum *)data;
 
   GLint iscol = 0, isdepth = 0, isstencil = 0;
-  GL.glGetInternalformativ(target, fmt, eGL_COLOR_COMPONENTS, sizeof(GLint), &iscol);
-  GL.glGetInternalformativ(target, fmt, eGL_DEPTH_COMPONENTS, sizeof(GLint), &isdepth);
-  GL.glGetInternalformativ(target, fmt, eGL_STENCIL_COMPONENTS, sizeof(GLint), &isstencil);
+  GL.glGetInternalformativ(target, fmt, eGL_COLOR_COMPONENTS, 1, &iscol);
+  GL.glGetInternalformativ(target, fmt, eGL_DEPTH_COMPONENTS, 1, &isdepth);
+  GL.glGetInternalformativ(target, fmt, eGL_STENCIL_COMPONENTS, 1, &isstencil);
 
   if(iscol == GL_TRUE)
   {
@@ -2117,10 +2117,10 @@ ResourceFormat MakeResourceFormat(GLenum target, GLenum fmt)
 
     // colour format
 
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_RED_SIZE, sizeof(GLint), &data[0]);
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_GREEN_SIZE, sizeof(GLint), &data[1]);
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_BLUE_SIZE, sizeof(GLint), &data[2]);
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_ALPHA_SIZE, sizeof(GLint), &data[3]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_RED_SIZE, 1, &data[0]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_GREEN_SIZE, 1, &data[1]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_BLUE_SIZE, 1, &data[2]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_ALPHA_SIZE, 1, &data[3]);
 
     ret.compCount = 0;
     for(int i = 0; i < 4; i++)
@@ -2147,10 +2147,10 @@ ResourceFormat MakeResourceFormat(GLenum target, GLenum fmt)
       RDCERR("Unexpected/unhandled non-uniform format: '%s'", ToStr(fmt).c_str());
     }
 
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_RED_TYPE, sizeof(GLint), &data[0]);
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_GREEN_TYPE, sizeof(GLint), &data[1]);
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_BLUE_TYPE, sizeof(GLint), &data[2]);
-    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_ALPHA_TYPE, sizeof(GLint), &data[3]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_RED_TYPE, 1, &data[0]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_GREEN_TYPE, 1, &data[1]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_BLUE_TYPE, 1, &data[2]);
+    GL.glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_ALPHA_TYPE, 1, &data[3]);
 
     for(int i = ret.compCount; i < 4; i++)
       data[i] = data[0];
@@ -2174,7 +2174,7 @@ ResourceFormat MakeResourceFormat(GLenum target, GLenum fmt)
       RDCERR("Unexpected/unhandled non-uniform format: '%s'", ToStr(fmt).c_str());
     }
 
-    GL.glGetInternalformativ(target, fmt, eGL_COLOR_ENCODING, sizeof(GLint), &data[0]);
+    GL.glGetInternalformativ(target, fmt, eGL_COLOR_ENCODING, 1, &data[0]);
     if(edata[0] == eGL_SRGB || fmt == eGL_SR8_EXT || fmt == eGL_SRG8_EXT)
       ret.compType = CompType::UNormSRGB;
   }

--- a/renderdoc/driver/gl/gl_msaa_array_conv.cpp
+++ b/renderdoc/driver/gl/gl_msaa_array_conv.cpp
@@ -190,8 +190,8 @@ void WrappedOpenGL::CopyTex2DMSToArray(GLuint &destArray, GLuint srcMS, GLint wi
   rs.FetchState(this);
 
   GLenum viewClass;
-  GL.glGetInternalformativ(eGL_TEXTURE_2D_ARRAY, intFormat, eGL_VIEW_COMPATIBILITY_CLASS,
-                           sizeof(GLenum), (GLint *)&viewClass);
+  GL.glGetInternalformativ(eGL_TEXTURE_2D_ARRAY, intFormat, eGL_VIEW_COMPATIBILITY_CLASS, 1,
+                           (GLint *)&viewClass);
 
   GLenum fmt = eGL_R32UI;
   if(viewClass == eGL_VIEW_CLASS_8_BITS)
@@ -396,8 +396,8 @@ void WrappedOpenGL::CopyArrayToTex2DMS(GLuint destMS, GLuint srcArray, GLint wid
   rs.FetchState(this);
 
   GLenum viewClass;
-  drv.glGetInternalformativ(eGL_TEXTURE_2D_ARRAY, intFormat, eGL_VIEW_COMPATIBILITY_CLASS,
-                            sizeof(GLenum), (GLint *)&viewClass);
+  drv.glGetInternalformativ(eGL_TEXTURE_2D_ARRAY, intFormat, eGL_VIEW_COMPATIBILITY_CLASS, 1,
+                            (GLint *)&viewClass);
 
   GLenum fmt = eGL_R32UI;
   if(viewClass == eGL_VIEW_CLASS_8_BITS)

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -3626,8 +3626,8 @@ bool GLReplay::IsTextureSupported(const TextureDescription &tex)
   }
 
   GLint supported = 0, fragment = 0;
-  m_pDriver->glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_SUPPORTED, 4, &supported);
-  m_pDriver->glGetInternalformativ(target, fmt, eGL_FRAGMENT_TEXTURE, 4, &fragment);
+  m_pDriver->glGetInternalformativ(target, fmt, eGL_INTERNALFORMAT_SUPPORTED, 1, &supported);
+  m_pDriver->glGetInternalformativ(target, fmt, eGL_FRAGMENT_TEXTURE, 1, &fragment);
 
   // check the texture is supported
   if(supported == 0 || fragment == 0)
@@ -3638,8 +3638,8 @@ bool GLReplay::IsTextureSupported(const TextureDescription &tex)
   if(tex.msSamp > 1 && !IsDepthStencilFormat(fmt))
   {
     GLenum viewClass = eGL_NONE;
-    m_pDriver->glGetInternalformativ(eGL_TEXTURE_2D_ARRAY, fmt, eGL_VIEW_COMPATIBILITY_CLASS,
-                                     sizeof(GLenum), (GLint *)&viewClass);
+    m_pDriver->glGetInternalformativ(eGL_TEXTURE_2D_ARRAY, fmt, eGL_VIEW_COMPATIBILITY_CLASS, 1,
+                                     (GLint *)&viewClass);
 
     if(viewClass == eGL_NONE)
       return false;

--- a/util/test/demos/gl/gl_texture_zoo.cpp
+++ b/util/test/demos/gl/gl_texture_zoo.cpp
@@ -362,7 +362,7 @@ void main()
   bool QueryFormatBool(GLenum target, GLenum format, GLenum pname)
   {
     GLint param = 0;
-    glGetInternalformativ(target, format, pname, sizeof(param), &param);
+    glGetInternalformativ(target, format, pname, 1, &param);
     return param != 0;
   }
 
@@ -373,11 +373,10 @@ void main()
     test.canStencil = QueryFormatBool(test.target, test.fmt.internalFormat, GL_STENCIL_RENDERABLE);
 
     GLint numSamples = 0;
-    glGetInternalformativ(test.target, test.fmt.internalFormat, GL_NUM_SAMPLE_COUNTS,
-                          sizeof(numSamples), &numSamples);
+    glGetInternalformativ(test.target, test.fmt.internalFormat, GL_NUM_SAMPLE_COUNTS, 1, &numSamples);
 
     GLint samples[8];
-    glGetInternalformativ(test.target, test.fmt.internalFormat, GL_SAMPLES, sizeof(samples), samples);
+    glGetInternalformativ(test.target, test.fmt.internalFormat, GL_SAMPLES, 1, samples);
 
     Vec4i dimensions(texWidth, texHeight, texDepth);
 


### PR DESCRIPTION
## Description

Do not have to land this PR. It is something I noticed when debugging Android Vulkan replay on Mac RenderDoc. I suspect the GL API will not use this value. From what I can tell the current API and parameter values are all single values.

Specify the maximum count of parameters instead of number of bytes
i.e.

GLint iscol;

GL.glGetInternalformativ(target, fmt, eGL_DEPTH_COMPONENTS, sizeof(GLint), &isdepth);
becomes
GL.glGetInternalformativ(target, fmt, eGL_DEPTH_COMPONENTS, 1, &isdepth);

From GL references pages: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetInternalformat.xhtml

bufSize

Specifies the maximum number of integers of the specified width that may be written to params by the function.

## Testing

Ran GL automated tests on Windows