### PR TITLE
Fix null pointer crash trying to capture an invalid app name

### DIFF
--- a/renderdoc/os/posix/apple/apple_helpers.mm
+++ b/renderdoc/os/posix/apple/apple_helpers.mm
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include "api/replay/rdcstr.h"
+#include "common/common.h"
 
 #import <Cocoa/Cocoa.h>
 
@@ -62,8 +63,20 @@ bool apple_IsKeyPressed(int appleKeyCode)
 rdcstr apple_GetExecutablePathFromAppBundle(const char *appBundlePath)
 {
   NSString *path = [NSString stringWithCString:appBundlePath encoding:NSUTF8StringEncoding];
+
   NSBundle *nsBundle = [NSBundle bundleWithPath:path];
+  if(!nsBundle)
+  {
+    RDCERR("Failed to open application '%s' as an NSBundle", appBundlePath);
+    return rdcstr();
+  }
+
   NSString *executablePath = nsBundle.executablePath;
+  if(!executablePath)
+  {
+    RDCERR("Failed to get executable path from application '%s'", appBundlePath);
+    return rdcstr();
+  }
 
   rdcstr result([executablePath cStringUsingEncoding:NSUTF8StringEncoding]);
   return result;

--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -540,6 +540,11 @@ static pid_t RunProcess(rdcstr appName, rdcstr workDir, const rdcstr &cmdLine, c
   if(appName.size() > 5 && appName.endsWith(".app"))
   {
     rdcstr realAppName = apple_GetExecutablePathFromAppBundle(appName.c_str());
+    if(realAppName.empty())
+    {
+      RDCERR("Invalid application path '%s'", appName.c_str());
+      return (pid_t)0;
+    }
 
     if(FileIO::exists(realAppName))
     {


### PR DESCRIPTION
## Description

Before the code change this command

`renderdoccmd capture ~/dsdsds.app
`
would trigger a segmentation fault accessing a null pointer

## Testing

Running:
`renderdoccmd capture ~/dsdsds.app
`
Before code change:
```
Launching '/Users/jake/dsdsds.app'
zsh: segmentation fault  ./build-xcode-Debug/bin/renderdoccmd capture ~/dsdsds.app

```
After code change:
```
Launching '/Users/jake/dsdsds.app'
Failed to create & inject: RenderDoc injection failed

```