### PR TITLE
Fixed unused variable warnings when compiling with VS 2022 compiler

### DIFF
--- a/renderdoc/common/wrapped_pool.h
+++ b/renderdoc/common/wrapped_pool.h
@@ -172,8 +172,6 @@ private:
     }
     void *Allocate()
     {
-      const size_t itemSize = sizeof(WrapType);
-
       if(freeStackHead == 0)
       {
         return NULL;
@@ -182,6 +180,7 @@ private:
       void *ret = items + freeStack[freeStackHead];
 
 #if ENABLED(RDOC_DEVEL)
+      const size_t itemSize = sizeof(WrapType);
       memset(ret, 0xb0, itemSize);
 #endif
 
@@ -190,14 +189,13 @@ private:
 
     void Deallocate(void *p)
     {
-      const size_t itemSize = sizeof(WrapType);
-
       int idx = (int)((WrapType *)p - &items[0]);
 
       freeStack[freeStackHead] = idx;
       ++freeStackHead;
 
 #if ENABLED(RDOC_DEVEL)
+      const size_t itemSize = sizeof(WrapType);
       if(DebugClear)
         memset(p, 0xfe, itemSize);
 #endif

--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -2747,7 +2747,6 @@ bool ReplayProxy::Tick(int type)
   if(m_Writer.IsErrored() || m_Reader.IsErrored() || m_IsErrored)
     return false;
 
-  const ReplayProxyPacket expectedPacket = (ReplayProxyPacket)type;
   ReplayProxyPacket packet = (ReplayProxyPacket)type;
 
   PROXY_DEBUG("Received %s", ToStr(packet).c_str());

--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -3540,7 +3540,6 @@ void WrappedID3D12GraphicsCommandList::PatchExecuteIndirect(BakedCmdListInfo &in
 
   const bool multiaction = (count > 1 || comSig->sig.numActions > 1);
   const uint32_t sigSize = (uint32_t)comSig->sig.arguments.size();
-  const bool gfx = comSig->sig.graphics;
 
   // + 1 is because baseEvent refers to the marker before the commands
   exec.lastEvent = exec.baseEvent + 1 + sigSize * count;

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -1359,7 +1359,8 @@ void WrappedID3D12Device::AddCaptureSubmission()
     // 15 is quite a lot of submissions.
     const int expectedMaxSubmissions = 15;
 
-    RenderDoc::Inst().SetProgress(CaptureProgress::FrameCapture, FakeProgress(m_SubmitCounter, 15));
+    RenderDoc::Inst().SetProgress(CaptureProgress::FrameCapture,
+                                  FakeProgress(m_SubmitCounter, expectedMaxSubmissions));
     m_SubmitCounter++;
   }
 }

--- a/renderdoc/driver/d3d12/d3d12_msaa_array_conv.cpp
+++ b/renderdoc/driver/d3d12/d3d12_msaa_array_conv.cpp
@@ -163,7 +163,6 @@ void D3D12DebugManager::CopyTex2DMSToArray(ID3D12GraphicsCommandList *list,
   const bool isDepth = IsDepthFormat(rtvDesc.Format) ||
                        (descMS.Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL) != 0 ||
                        (descArr.Flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL) != 0;
-  const bool intFormat = IsUIntFormat(rtvDesc.Format) || IsIntFormat(rtvDesc.Format);
 
   const bool stencil = IsDepthAndStencilFormat(rtvDesc.Format);
   DXGI_FORMAT stencilFormat = DXGI_FORMAT_UNKNOWN;

--- a/renderdoc/driver/d3d8/d3d8_device.cpp
+++ b/renderdoc/driver/d3d8/d3d8_device.cpp
@@ -43,12 +43,6 @@ WrappedD3DDevice8::WrappedD3DDevice8(IDirect3DDevice8 *device, HWND wnd,
   m_InternalRefcount = 0;
   m_Alive = true;
 
-#if ENABLED(RDOC_RELEASE)
-  const bool debugSerialiser = false;
-#else
-  const bool debugSerialiser = true;
-#endif
-
   if(!RenderDoc::Inst().IsReplayApp())
   {
     m_State = CaptureState::BackgroundCapturing;

--- a/renderdoc/driver/shaders/dxbc/dxbc_bytecode_ops.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_bytecode_ops.cpp
@@ -2540,8 +2540,6 @@ void Program::EncodeOperation(rdcarray<uint32_t> &tokenStream, const Operation &
 
   uint32_t OpcodeToken0 = 0;
 
-  const bool sm51 = (m_Major == 0x5 && m_Minor == 0x1);
-
   Opcode::Type.Set(OpcodeToken0, op.operation);
 
   Opcode::TestNonZero.Set(OpcodeToken0, op.nonzero());

--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
@@ -1765,7 +1765,6 @@ void FlattenSingleVariable(const rdcstr &cbufferName, uint32_t byteOffset, const
   else
   {
     const uint32_t numRegisters = v.rowMajor ? v.rows : v.columns;
-    const uint32_t registerSize = v.rowMajor ? v.columns : v.rows;
     for(uint32_t reg = 0; reg < numRegisters; reg++)
     {
       outvars[outIdx + reg].rows = 1;

--- a/renderdoc/driver/shaders/dxil/dxil_reflect.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_reflect.cpp
@@ -571,8 +571,6 @@ static void AddResourceBind(DXBC::Reflection *refl, const TypeInfo &typeInfo, co
 {
   using namespace DXBC;
 
-  const bool uav = !srv;
-
   ShaderInputBind bind;
   bind.name = r->children[(size_t)ResField::Name]->str;
   bind.type = ShaderInputBind::TYPE_TEXTURE;

--- a/renderdoc/driver/vulkan/vk_postvs.cpp
+++ b/renderdoc/driver/vulkan/vk_postvs.cpp
@@ -72,8 +72,6 @@ static void ConvertToMeshOutputCompute(const ShaderReflection &refl,
 
   editor.Prepare();
 
-  const bool useBDA = (storageMode != Binding);
-
   uint32_t numInputs = (uint32_t)refl.inputSignature.size();
 
   uint32_t numOutputs = (uint32_t)refl.outputSignature.size();

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -1259,7 +1259,8 @@ VkResult WrappedVulkan::vkQueueSubmit(VkQueue queue, uint32_t submitCount,
     // 15 is quite a lot of submissions.
     const int expectedMaxSubmissions = 15;
 
-    RenderDoc::Inst().SetProgress(CaptureProgress::FrameCapture, FakeProgress(m_SubmitCounter, 15));
+    RenderDoc::Inst().SetProgress(CaptureProgress::FrameCapture,
+                                  FakeProgress(m_SubmitCounter, expectedMaxSubmissions));
     m_SubmitCounter++;
   }
 
@@ -1425,7 +1426,8 @@ VkResult WrappedVulkan::vkQueueSubmit2KHR(VkQueue queue, uint32_t submitCount,
     // 15 is quite a lot of submissions.
     const int expectedMaxSubmissions = 15;
 
-    RenderDoc::Inst().SetProgress(CaptureProgress::FrameCapture, FakeProgress(m_SubmitCounter, 15));
+    RenderDoc::Inst().SetProgress(CaptureProgress::FrameCapture,
+                                  FakeProgress(m_SubmitCounter, expectedMaxSubmissions));
     m_SubmitCounter++;
   }
 

--- a/util/test/demos/3rdparty/VulkanMemoryAllocator/vk_mem_alloc.h
+++ b/util/test/demos/3rdparty/VulkanMemoryAllocator/vk_mem_alloc.h
@@ -11888,8 +11888,6 @@ VkResult VmaAllocator_T::CreatePool(const VmaPoolCreateInfo* pCreateInfo, VmaPoo
 {
     VMA_DEBUG_LOG("  CreatePool: MemoryTypeIndex=%u, flags=%u", pCreateInfo->memoryTypeIndex, pCreateInfo->flags);
 
-    const bool isLinearAlgorithm = (pCreateInfo->flags & VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT) != 0;
-
     VmaPoolCreateInfo newCreateInfo = *pCreateInfo;
 
     if(newCreateInfo.maxBlockCount == 0)

--- a/util/test/demos/vk/vk_discard_zoo.cpp
+++ b/util/test/demos/vk/vk_discard_zoo.cpp
@@ -219,7 +219,6 @@ RD_TEST(VK_Discard_Zoo, VulkanGraphicsTest)
       delete[] empty;
     }
 
-    const VkImageUsageFlags usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     const VmaAllocationCreateInfo gpu = VmaAllocationCreateInfo({0, VMA_MEMORY_USAGE_GPU_ONLY});
 
     AllocatedImage ignoreimg(


### PR DESCRIPTION
## Description

Compiling Release & Debug configuration of RenderDoc.sln and Demos.sln with Visual Studio 2022 compiler identified some unused local variables which are warnings and thus errors in the Visual Studio 2022 compiler.

## Testing

Compiled RenderDoc.sln locally in Visual Studio 2022 with and without upgrading the solution to use the Visual Studio 2022 toolchain.