### PR TITLE
Fix broken capture when app uses dedicated allocation weirdly

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -315,9 +315,18 @@ bool WrappedVulkan::Serialise_vkAllocateMemory(SerialiserType &ser, VkDevice dev
 
       VkMemoryDedicatedAllocateInfo *dedicated = (VkMemoryDedicatedAllocateInfo *)FindNextStruct(
           &AllocateInfo, VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO);
+      if(dedicated && dedicated->buffer == VK_NULL_HANDLE && dedicated->image == VK_NULL_HANDLE)
+      {
+        dedicated = NULL;
+      }
+
       VkDedicatedAllocationMemoryAllocateInfoNV *dedicatedNV =
           (VkDedicatedAllocationMemoryAllocateInfoNV *)FindNextStruct(
               &AllocateInfo, VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV);
+      if(dedicatedNV && dedicatedNV->buffer == VK_NULL_HANDLE && dedicatedNV->image == VK_NULL_HANDLE)
+      {
+        dedicatedNV = NULL;
+      }
 
       if(dedicated)
       {
@@ -480,9 +489,18 @@ VkResult WrappedVulkan::vkAllocateMemory(VkDevice device, const VkMemoryAllocate
 
     VkMemoryDedicatedAllocateInfo *dedicated = (VkMemoryDedicatedAllocateInfo *)FindNextStruct(
         pAllocateInfo, VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO);
+    if(dedicated && dedicated->buffer == VK_NULL_HANDLE && dedicated->image == VK_NULL_HANDLE)
+    {
+      dedicated = NULL;
+    }
+
     VkDedicatedAllocationMemoryAllocateInfoNV *dedicatedNV =
         (VkDedicatedAllocationMemoryAllocateInfoNV *)FindNextStruct(
             pAllocateInfo, VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV);
+    if(dedicatedNV && dedicatedNV->buffer == VK_NULL_HANDLE && dedicatedNV->image == VK_NULL_HANDLE)
+    {
+      dedicatedNV = NULL;
+    }
 
     // create a buffer with the whole memory range bound, for copying to and from
     // conveniently (for initial state data)


### PR DESCRIPTION
## Description

Both image and buffer handles in VkMemoryDedicatedAllocateInfo can be VK_NULL_HANDLE, specification doesn't explicitly disallow this. It should be safe to just ignore dedicated struct in this case.