### PR TITLE
Fix crash when app tries to bind deleted framebuffer

### DIFF
--- a/renderdoc/driver/gl/gl_manager.cpp
+++ b/renderdoc/driver/gl/gl_manager.cpp
@@ -67,7 +67,14 @@ void GLResourceManager::MarkFBOReferenced(GLResource res, FrameRefType ref)
   if(res.name == 0)
     return;
 
-  rdcpair<ResourceId, GLResourceRecord *> &it = m_CurrentResources[res];
+  auto iter = m_CurrentResources.find(res);
+  if(iter == m_CurrentResources.end())
+  {
+    RDCERR("Non-existing FBO %u referenced!", res.name);
+    return;
+  }
+
+  rdcpair<ResourceId, GLResourceRecord *> &it = iter->second;
 
   MarkResourceFrameReferenced(it.first, ref);
 


### PR DESCRIPTION
## Description

This crash happens when application tries to `glBindFramebuffer` with an already deleted name.