### PR TITLE
Fix missing D3D12 counter

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_commands.cpp
+++ b/renderdoc/driver/d3d12/d3d12_commands.cpp
@@ -1494,7 +1494,7 @@ void D3D12CommandData::GetIndirectBuffer(size_t size, ID3D12Resource **buf, uint
   m_IndirectOffset = AlignUp16(m_IndirectOffset + size);
 }
 
-uint32_t D3D12CommandData::HandlePreCallback(ID3D12GraphicsCommandListX *list, bool dispatch,
+uint32_t D3D12CommandData::HandlePreCallback(ID3D12GraphicsCommandListX *list, ActionFlags type,
                                              uint32_t multiDrawOffset)
 {
   if(!m_ActionCallback)
@@ -1529,10 +1529,24 @@ uint32_t D3D12CommandData::HandlePreCallback(ID3D12GraphicsCommandListX *list, b
 
   eventId += multiDrawOffset;
 
-  if(dispatch)
-    m_ActionCallback->PreDispatch(eventId, list);
-  else
-    m_ActionCallback->PreDraw(eventId, list);
+  switch(type)
+  {
+    case ActionFlags::Drawcall:
+    {
+      m_ActionCallback->PreDraw(eventId, list);
+      break;
+    }
+    case ActionFlags::Dispatch:
+    {
+      m_ActionCallback->PreDispatch(eventId, list);
+      break;
+    }
+    default:
+    {
+      m_ActionCallback->PreMisc(eventId, type, list);
+      break;
+    }
+  }
 
   return eventId;
 }

--- a/renderdoc/driver/d3d12/d3d12_commands.h
+++ b/renderdoc/driver/d3d12/d3d12_commands.h
@@ -127,6 +127,11 @@ struct D3D12ActionCallback
   virtual bool PostDispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) = 0;
   virtual void PostRedispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) = 0;
 
+  // finally, these are for copy/blit/resolve/clear/etc
+  virtual void PreMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) = 0;
+  virtual bool PostMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) = 0;
+  virtual void PostRemisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) = 0;
+
   // called immediately before a command list is closed
   virtual void PreCloseCommandList(ID3D12GraphicsCommandListX *cmd) = 0;
   // if a command list is recorded once and submitted N > 1 times, then the same
@@ -367,8 +372,8 @@ struct D3D12CommandData
 
   // util function to handle fetching the right eventId, calling any
   // aliases then calling PreDraw/PreDispatch.
-  uint32_t HandlePreCallback(ID3D12GraphicsCommandListX *list, bool dispatch = false,
-                             uint32_t multiDrawOffset = 0);
+  uint32_t HandlePreCallback(ID3D12GraphicsCommandListX *list,
+                             ActionFlags type = ActionFlags::Drawcall, uint32_t multiDrawOffset = 0);
 
   bool InRerecordRange(ResourceId cmdid);
   bool HasRerecordCmdList(ResourceId cmdid);

--- a/renderdoc/driver/d3d12/d3d12_counters.cpp
+++ b/renderdoc/driver/d3d12/d3d12_counters.cpp
@@ -252,6 +252,24 @@ struct D3D12AMDActionCallback : public D3D12ActionCallback
   {
     PostRedraw(eid, cmd);
   }
+  void PreMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) override
+  {
+    if(flags & ActionFlags::PassBoundary)
+      return;
+    PreDraw(eid, cmd);
+  }
+  bool PostMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) override
+  {
+    if(flags & ActionFlags::PassBoundary)
+      return false;
+    return PostDraw(eid, cmd);
+  }
+  void PostRemisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) override
+  {
+    if(flags & ActionFlags::PassBoundary)
+      return;
+    PostRedraw(eid, cmd);
+  }
 
   void AliasEvent(uint32_t primary, uint32_t alias) override
   {
@@ -416,6 +434,25 @@ struct D3D12GPUTimerCallback : public D3D12ActionCallback
   {
     PostRedraw(eid, cmd);
   }
+  void PreMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) override
+  {
+    if(flags & ActionFlags::PassBoundary)
+      return;
+    PreDraw(eid, cmd);
+  }
+  bool PostMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) override
+  {
+    if(flags & ActionFlags::PassBoundary)
+      return false;
+    return PostDraw(eid, cmd);
+  }
+  void PostRemisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) override
+  {
+    if(flags & ActionFlags::PassBoundary)
+      return;
+    PostRedraw(eid, cmd);
+  }
+
   void PreCloseCommandList(ID3D12GraphicsCommandListX *cmd) override{};
   void AliasEvent(uint32_t primary, uint32_t alias) override
   {

--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -241,6 +241,10 @@ struct D3D12QuadOverdrawCallback : public D3D12ActionCallback
   void PreDispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) {}
   bool PostDispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) { return false; }
   void PostRedispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) {}
+  // Ditto copy/etc
+  void PreMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) {}
+  bool PostMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) { return false; }
+  void PostRemisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) {}
   void PreCloseCommandList(ID3D12GraphicsCommandListX *cmd) {}
   void AliasEvent(uint32_t primary, uint32_t alias)
   {

--- a/renderdoc/driver/d3d12/d3d12_postvs.cpp
+++ b/renderdoc/driver/d3d12/d3d12_postvs.cpp
@@ -1325,6 +1325,10 @@ struct D3D12InitPostVSCallback : public D3D12ActionCallback
   void PreDispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) override {}
   bool PostDispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) override { return false; }
   void PostRedispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd) override {}
+  // Ditto copy/etc
+  void PreMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) {}
+  bool PostMisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) { return false; }
+  void PostRemisc(uint32_t eid, ActionFlags flags, ID3D12GraphicsCommandListX *cmd) {}
   void PreCloseCommandList(ID3D12GraphicsCommandListX *cmd) override {}
   void AliasEvent(uint32_t primary, uint32_t alias) override
   {


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
The following D3D12 api are missing counters:
- ExecuteIndirect
- CopyBufferRegion
- CopyTextureRegion
- CopyResource
- CopyTiles
- ClearDepthStencilView
- ClearRenderTargetView
- ClearUnorderedAccessViewUint
- ClearUnorderedAccessViewFloat

**Before fix:**
![fix_missing_d3d12_counters_0](https://user-images.githubusercontent.com/52390838/128845825-a6117cac-980e-430b-8012-90ed8a9bc55f.png)


**After fix:**
![fix_missing_d3d12_counters_1](https://user-images.githubusercontent.com/52390838/128846295-15e62f38-8531-47aa-acee-f02266dfdf36.png)


This PR fixes the bug.


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
