### PR TITLE
Add a few missing header files to CMakeLists.txt

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -97,10 +97,12 @@ set(sources
     api/replay/apidefs.h
     api/replay/capture_options.h
     api/replay/common_pipestate.h
+    api/replay/pipestate.h
     api/replay/control_types.h
     api/replay/data_types.h
     api/replay/rdcarray.h
     api/replay/rdcdatetime.h
+    api/replay/rdcflatmap.h
     api/replay/rdcpair.h
     api/replay/rdcstr.h
     api/replay/replay_enums.h
@@ -118,6 +120,7 @@ set(sources
     common/custom_assert.h
     common/dds_readwrite.cpp
     common/dds_readwrite.h
+    common/formatting.h
     common/globalconfig.h
     common/shader_cache.h
     common/threading.h

--- a/renderdoc/driver/gl/CMakeLists.txt
+++ b/renderdoc/driver/gl/CMakeLists.txt
@@ -53,6 +53,7 @@ list(APPEND sources gl_hooks.cpp)
 
 if(APPLE)
     list(APPEND sources
+        apple_gl_hook_defs.h
         cgl_dispatch_table.h
         cgl_platform_helpers.mm
         cgl_platform.cpp

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(sources renderdoccmd.cpp)
+set(sources 
+    renderdoccmd.cpp
+    renderdoccmd.h
+    3rdparty/cmdline/cmdline.h
+    )
 set(includes PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty ${CMAKE_SOURCE_DIR}/renderdoc/api)
 set(libraries PRIVATE renderdoc)
 


### PR DESCRIPTION
## Description

Found `api/replay/pipestate.h` was missing by accident when debugging RenderDoc Metal side project
Ran "`ls -1`" on various renderdoc folders to find lists of header files and compared them against the header files in the CMakeLists.txt files to find the missing header files.

Useful to have all the header files in CMakeLists.txt for IDE projects which are generated from CMakeLists.txt ie. Xcode project on Apple

## Testing

Generated Xcode project and checked the headers were in the project file lists and "Goto File..." would find the newly added header files.
