### PR TITLE
renderdoccmd: Use Android `d8` instead of `dx` dexer

### DIFF
--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(sources 
+set(sources
     renderdoccmd.cpp
     renderdoccmd.h
     3rdparty/cmdline/cmdline.h
@@ -27,7 +27,7 @@ elseif(ANDROID)
     include_directories(${ANDROID_NDK_ROOT_PATH}/sources/android/native_app_glue)
     list(APPEND libraries PRIVATE -llog -landroid)
     set(LINKER_FLAGS "-Wl,--no-as-needed")
-    
+
     if(ENABLE_ASAN)
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=address")
     endif()
@@ -221,14 +221,14 @@ if(ANDROID)
         else()
             message(WARNING "Unknown ABI ${ANDROID_ABI}, libasan tag unknown")
         endif()
-        
+
         file(GLOB ASAN_LIBRARIES "${ANDROID_TOOLCHAIN_ROOT}/lib64/clang/*/lib/linux/libclang_rt.asan-${ASAN_ABI_TAG}-android.so")
         list(SORT ASAN_LIBRARIES)
 
         list(GET ASAN_LIBRARIES -1 ASAN_LIBRARY)
 
         set(WRAP_SCRIPT "${ANDROID_NDK_ROOT_PATH}/wrap.sh/asan.sh")
-        
+
         string(REPLACE "\\" "/" WRAP_SCRIPT "${WRAP_SCRIPT}")
         string(REPLACE "\\" "/" ASAN_LIBRARY "${ASAN_LIBRARY}")
 
@@ -245,11 +245,18 @@ if(ANDROID)
                 )
         endif()
     endif()
-    
+
+    set(D8_SCRIPT "${BUILD_TOOLS}/d8${TOOL_SCRIPT_EXTENSION}")
+    if(NOT EXISTS ${D8_SCRIPT})
+        set(DEX_COMMAND ${BUILD_TOOLS}/dx${TOOL_SCRIPT_EXTENSION} --dex --output=bin/classes.dex ./obj)
+    else()
+        set(DEX_COMMAND ${D8_SCRIPT} --output ./bin/ ./obj/org/renderdoc/renderdoccmd/*/*.class)
+    endif()
+
     add_custom_command(OUTPUT ${APK_FILE} APPEND
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
                        COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/org/renderdoc/renderdoccmd/*.java
-                       COMMAND ${BUILD_TOOLS}/dx${TOOL_SCRIPT_EXTENSION} --dex --output=bin/classes.dex ./obj
+                       COMMAND ${DEX_COMMAND}
                        COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml --version-code ${APK_VERSION_CODE} --version-name ${APK_VERSION_NAME} -S res -I ${ANDROID_JAR} -F RenderDocCmd-unaligned.apk bin libs
                        COMMAND ${BUILD_TOOLS}/zipalign -f 4 RenderDocCmd-unaligned.apk RenderDocCmd.apk
                        COMMAND ${BUILD_TOOLS}/apksigner${TOOL_SCRIPT_EXTENSION} sign --ks ${KEYSTORE} --ks-pass pass:android --key-pass pass:android --ks-key-alias rdocandroidkey RenderDocCmd.apk


### PR DESCRIPTION
build-tools 31.0.0 doesn't ship with `dx` anymore, and [Android Studio switched to `d8` back in April 2018][1].

[1]: https://android-developers.googleblog.com/2018/04/android-studio-switching-to-d8-dexer.html

Keeping this a draft because:
- Trailing whitespace is trimmed. Given the formatting requirements for cpp this might be desired, but it's unrelated noise in this PR nevertheless;
- Not sure what the backwards-compatibility requirements for Android are. If build tools from somewhere in 2018 are the oldest RenderDoc wants to support this should be fine, otherwise a fallback to `dx` might be needed;
- Windows: Validate whether `d8` is a batch file (with `.bat` extension) or a regular executable.