### PR TITLE
Add api/replay/pipestate.inl to sources list

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -98,6 +98,7 @@ set(sources
     api/replay/capture_options.h
     api/replay/common_pipestate.h
     api/replay/pipestate.h
+    api/replay/pipestate.inl
     api/replay/control_types.h
     api/replay/data_types.h
     api/replay/rdcarray.h


### PR DESCRIPTION
## Description

Xcode project generation is driven by the sources list.
Before this commit `pipestate.inl` was not present in the Xcode project.
After this commit it is present in the project and source browsing is able to find definitions inside the .inl file.

