### PR TITLE
Make Oculus' on device Vulkan Validation Layer avaiable for load

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -1043,6 +1043,14 @@ struct AndroidController : public IDeviceProtocolHandler
       Android::adbForwardPorts(dev.portbase, deviceID, 0, 0, false);
       Android::ResetCaptureSettings(deviceID);
 
+      // make Oculus' on device vulkan validation layer available for load
+      Android::adbExecCommand(
+          deviceID,
+          "shell setprop debug.oculus.usepackagedvvl." RENDERDOC_ANDROID_PACKAGE_BASE ".arm32 1");
+      Android::adbExecCommand(
+          deviceID,
+          "shell setprop debug.oculus.usepackagedvvl." RENDERDOC_ANDROID_PACKAGE_BASE ".arm64 1");
+
       rdcstr package = GetRenderDocPackageForABI(abis.back());
 
       rdcstr folderName = Android::GetFolderName(deviceID);


### PR DESCRIPTION
Hi Baldur!

We have vulkan validation layer shipped with the Oculus OS for a while now. This change simply sets a sysprop which will allow RenderDoc to load the layer. If RenderDoc is not set to API validation and therefore not load the layer, the layer won't be loaded.

Thanks,
Jimmy
