### PR TITLE
add explicit folder name to d8 commandline

### DIFF
--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -180,16 +180,18 @@ if(ANDROID)
 
     # Set the package name based on the ABI
     if(ANDROID_ABI STREQUAL "armeabi-v7a")
-        set(RENDERDOC_ANDROID_PACKAGE_NAME "org.renderdoc.renderdoccmd.arm32")
+        set(ABI_EXTENSION_NAME "arm32")
     elseif(ANDROID_ABI STREQUAL "arm64-v8a")
-        set(RENDERDOC_ANDROID_PACKAGE_NAME "org.renderdoc.renderdoccmd.arm64")
+        set(ABI_EXTENSION_NAME "arm64")
     elseif(ANDROID_ABI STREQUAL "x86")
-        set(RENDERDOC_ANDROID_PACKAGE_NAME "org.renderdoc.renderdoccmd.x86")
+        set(ABI_EXTENSION_NAME "x86")
     elseif(ANDROID_ABI STREQUAL "x86_64")
-        set(RENDERDOC_ANDROID_PACKAGE_NAME "org.renderdoc.renderdoccmd.x64")
+        set(ABI_EXTENSION_NAME "x64")
     else()
         message(FATAL_ERROR "ABI ${ANDROID_ABI} is not supported.")
     endif()
+
+    set(RENDERDOC_ANDROID_PACKAGE_NAME "org.renderdoc.renderdoccmd.${ABI_EXTENSION_NAME}")
 
     set(APK_FILE ${CMAKE_BINARY_DIR}/bin/${RENDERDOC_ANDROID_PACKAGE_NAME}.apk)
     add_custom_target(apk ALL
@@ -250,7 +252,7 @@ if(ANDROID)
     if(NOT EXISTS ${D8_SCRIPT})
         set(DEX_COMMAND ${BUILD_TOOLS}/dx${TOOL_SCRIPT_EXTENSION} --dex --output=bin/classes.dex ./obj)
     else()
-        set(DEX_COMMAND ${D8_SCRIPT} --output ./bin/ ./obj/org/renderdoc/renderdoccmd/*/*.class)
+        set(DEX_COMMAND ${D8_SCRIPT} --output ./bin/ ./obj/org/renderdoc/renderdoccmd/${ABI_EXTENSION_NAME}/*.class)
     endif()
 
     add_custom_command(OUTPUT ${APK_FILE} APPEND


### PR DESCRIPTION
d8 on cmd/powershell doesn't handle asterisks properly for folders, so replacing it by current ABI folder name