### PR TITLE
Parse the min- and max-range values to custom shaders

### DIFF
--- a/docs/how/how_custom_visualisation.rst
+++ b/docs/how/how_custom_visualisation.rst
@@ -79,6 +79,8 @@ There are several constant parameters available, each detailed below with the va
 		int SelectedSample;
 		uvec4 YUVDownsampleRate;
 		uvec4 YUVAChannels;
+		float SelectedRangeMin;
+		float SelectedRangeMax;
 	} RENDERDOC;
 
 In this way you can access the properties as ``RENDERDOC.TexDim`` instead of ``RENDERDOC_TexDim``.
@@ -155,6 +157,23 @@ Selected Multisample sample
 This variable will be filled out with the selected multisample sample index as chosen in the UI. If the UI has 'average value' selected, this variable will be negative and with an absolute value equal to the number of samples.
 
 So for example in a 4x MSAA texture, the valid values are ``0``, ``1``, ``2``, ``3`` to select a sample, or ``-4`` for 'average value'.
+
+
+Selected RangeMin, RangeMax
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. highlight:: c++
+.. code:: c++
+
+	float RENDERDOC_SelectedRangeMin; // hlsl
+	float RENDERDOC_SelectedRangeMax; // hlsl
+
+	uniform int RENDERDOC_SelectedRangeMin; // glsl
+	uniform int RENDERDOC_SelectedRangeMax; // glsl
+
+
+These variables will be filled out with the current Minimum and Maximum values for the Range-selector in the Texture Viewer.
+
 
 Current texture type
 ~~~~~~~~~~~~~~~~~~~~

--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -185,6 +185,7 @@ ShaderViewer::ShaderViewer(ICaptureContext &ctx, QWidget *parent)
     QAction *mip = new QAction(tr("Selected Mip Global"), this);
     QAction *slice = new QAction(tr("Selected Array Slice / Cubemap Face Global"), this);
     QAction *sample = new QAction(tr("Selected Sample Global"), this);
+    QAction *range = new QAction(tr("Selected TextureViewer Range Global"), this);
     QAction *type = new QAction(tr("Texture Type Global"), this);
     QAction *samplers = new QAction(tr("Point && Linear Samplers"), this);
     QAction *resources = new QAction(tr("Texture Resources"), this);
@@ -193,6 +194,7 @@ ShaderViewer::ShaderViewer(ICaptureContext &ctx, QWidget *parent)
     snippetsMenu->addAction(mip);
     snippetsMenu->addAction(slice);
     snippetsMenu->addAction(sample);
+    snippetsMenu->addAction(range);
     snippetsMenu->addAction(type);
     snippetsMenu->addSeparator();
     snippetsMenu->addAction(samplers);
@@ -202,8 +204,10 @@ ShaderViewer::ShaderViewer(ICaptureContext &ctx, QWidget *parent)
     QObject::connect(mip, &QAction::triggered, this, &ShaderViewer::snippet_selectedMip);
     QObject::connect(slice, &QAction::triggered, this, &ShaderViewer::snippet_selectedSlice);
     QObject::connect(sample, &QAction::triggered, this, &ShaderViewer::snippet_selectedSample);
+    QObject::connect(range, &QAction::triggered, this, &ShaderViewer::snippet_selectedRange);
     QObject::connect(type, &QAction::triggered, this, &ShaderViewer::snippet_selectedType);
     QObject::connect(samplers, &QAction::triggered, this, &ShaderViewer::snippet_samplers);
+    QObject::connect(resources, &QAction::triggered, this, &ShaderViewer::snippet_resources);
     QObject::connect(resources, &QAction::triggered, this, &ShaderViewer::snippet_resources);
 
     ui->snippets->setMenu(snippetsMenu);
@@ -4336,6 +4340,8 @@ layout(binding = 0, std140) uniform RENDERDOC_Uniforms
     int SelectedSample;
     uvec4 YUVDownsampleRate;
     uvec4 YUVAChannels;
+    float SelectedRangeMin;
+    float SelectedRangeMax;
 } RENDERDOC;
 
 #define RENDERDOC_TexDim RENDERDOC.TexDim
@@ -4345,6 +4351,8 @@ layout(binding = 0, std140) uniform RENDERDOC_Uniforms
 #define RENDERDOC_SelectedSample RENDERDOC.SelectedSample
 #define RENDERDOC_YUVDownsampleRate RENDERDOC.YUVDownsampleRate
 #define RENDERDOC_YUVAChannels RENDERDOC.YUVAChannels
+#define RENDERDOC_SelectedRangeMin RENDERDOC.SelectedRangeMin
+#define RENDERDOC_SelectedRangeMax RENDERDOC.SelectedRangeMax
 
 )");
   }
@@ -4360,6 +4368,8 @@ cbuffer RENDERDOC_Constants : register(b0)
     int RENDERDOC_SelectedSample;
     uint4 RENDERDOC_YUVDownsampleRate;
     uint4 RENDERDOC_YUVAChannels;
+    float RENDERDOC_SelectedRangeMin;
+    float RENDERDOC_SelectedRangeMax;
 };
 
 )");
@@ -4503,6 +4513,43 @@ int RENDERDOC_SelectedSample;
     text = lit(R"(
 // selected MSAA sample or -numSamples for resolve. See docs
 uniform int RENDERDOC_SelectedSample;
+
+)");
+  }
+  else if(encoding == ShaderEncoding::SPIRVAsm)
+  {
+    text = lit("; Can't insert snippets for SPIR-V ASM");
+  }
+
+  insertSnippet(text);
+}
+
+void ShaderViewer::snippet_selectedRange()
+{
+  ShaderEncoding encoding = currentEncoding();
+  GraphicsAPI api = m_Ctx.APIProps().localRenderer;
+
+  QString text;
+
+  if(api == GraphicsAPI::Vulkan)
+  {
+    text = vulkanUBO();
+  }
+  else if(encoding == ShaderEncoding::HLSL)
+  {
+    text = lit(R"(
+// selected range min/max in UI
+float RENDERDOC_SelectedRangeMin;
+float RENDERDOC_SelectedRangeMax;
+
+)");
+  }
+  else if(encoding == ShaderEncoding::GLSL)
+  {
+    text = lit(R"(
+// selected range minmax in UI
+float RENDERDOC_SelectedRangeMin;
+float RENDERDOC_SelectedRangeMax;
 
 )");
   }

--- a/qrenderdoc/Windows/ShaderViewer.h
+++ b/qrenderdoc/Windows/ShaderViewer.h
@@ -168,6 +168,7 @@ private slots:
   void snippet_selectedMip();
   void snippet_selectedSlice();
   void snippet_selectedSample();
+  void snippet_selectedRange();
   void snippet_selectedType();
   void snippet_samplers();
   void snippet_resources();

--- a/renderdoc/driver/d3d11/d3d11_rendertexture.cpp
+++ b/renderdoc/driver/d3d11/d3d11_rendertexture.cpp
@@ -702,6 +702,16 @@ bool D3D11Replay::RenderTextureInternal(TextureDisplay cfg, TexDisplayFlags flag
                           var.name.c_str());
                 }
               }
+              else if(var.name == "RENDERDOC_SelectedRangeMin")
+              {
+                float *d = (float *)(byteData + var.offset);
+                d[0] = cfg.rangeMin;
+              }
+              else if(var.name == "RENDERDOC_SelectedRangeMax")
+              {
+                float *d = (float *)(byteData + var.offset);
+                d[0] = cfg.rangeMax;
+              }
               else
               {
                 RDCWARN("Custom shader: Variable not recognised: %s", var.name.c_str());

--- a/renderdoc/driver/d3d11/d3d11_replay.cpp
+++ b/renderdoc/driver/d3d11/d3d11_replay.cpp
@@ -3515,8 +3515,8 @@ ResourceId D3D11Replay::ApplyCustomShader(TextureDisplay &display)
   disp.linearDisplayAsGamma = false;
   disp.subresource = display.subresource;
   disp.overlay = DebugOverlay::NoOverlay;
-  disp.rangeMin = 0.0f;
-  disp.rangeMax = 1.0f;
+  disp.rangeMin = display.rangeMin;
+  disp.rangeMax = display.rangeMax;
   disp.rawOutput = false;
   disp.scale = 1.0f;
 

--- a/renderdoc/driver/d3d12/d3d12_rendertexture.cpp
+++ b/renderdoc/driver/d3d12/d3d12_rendertexture.cpp
@@ -648,6 +648,16 @@ bool D3D12Replay::RenderTextureInternal(D3D12_CPU_DESCRIPTOR_HANDLE rtv, Texture
 
               d[0] = resType;
             }
+            else if(var.name == "RENDERDOC_SelectedRangeMin")
+            {
+              float *d = (float *)(byteData + var.offset);
+              d[0] = cfg.rangeMin;
+            }
+            else if(var.name == "RENDERDOC_SelectedRangeMax")
+            {
+              float *d = (float *)(byteData + var.offset);
+              d[0] = cfg.rangeMax;
+            }
             else
             {
               RDCWARN("Custom shader: Variable recognised but type wrong, expected uint: %s",

--- a/renderdoc/driver/gl/gl_rendertexture.cpp
+++ b/renderdoc/driver/gl/gl_rendertexture.cpp
@@ -424,6 +424,14 @@ bool GLReplay::RenderTextureInternal(TextureDisplay cfg, TexDisplayFlags flags)
       loc = drv.glGetUniformLocation(customProgram, "RENDERDOC_TextureType");
       if(loc >= 0)
         drv.glProgramUniform1ui(customProgram, loc, resType);
+
+      loc = drv.glGetUniformLocation(customProgram, "RENDERDOC_SelectedRangeMin");
+      if(loc >= 0)
+        drv.glProgramUniform1f(customProgram, loc, cfg.rangeMin);
+
+      loc = drv.glGetUniformLocation(customProgram, "RENDERDOC_SelectedRangeMax");
+      if(loc >= 0)
+        drv.glProgramUniform1f(customProgram, loc, cfg.rangeMax);
     }
   }
 

--- a/renderdoc/driver/vulkan/vk_rendertexture.cpp
+++ b/renderdoc/driver/vulkan/vk_rendertexture.cpp
@@ -374,6 +374,8 @@ bool VulkanReplay::RenderTextureInternal(TextureDisplay cfg, const ImageState &i
       int32_t selectedSample;
       Vec4u YUVDownsampleRate;
       Vec4u YUVAChannels;
+      float selectedRangeMin;
+      float selectedRangeMax;
     };
 
     CustomTexDisplayUBOData *customData = (CustomTexDisplayUBOData *)data;
@@ -388,6 +390,8 @@ bool VulkanReplay::RenderTextureInternal(TextureDisplay cfg, const ImageState &i
     customData->texType = (uint32_t)textype;
     customData->YUVDownsampleRate = YUVDownsampleRate;
     customData->YUVAChannels = YUVAChannels;
+    customData->selectedRangeMin = cfg.rangeMin;
+    customData->selectedRangeMax = cfg.rangeMax;
   }
 
   m_TexRender.UBO.Unmap();

--- a/renderdoc/replay/replay_output.cpp
+++ b/renderdoc/replay/replay_output.cpp
@@ -755,7 +755,7 @@ void ReplayOutput::DisplayTex()
 
   if(m_RenderData.texDisplay.customShaderId != ResourceId())
   {
-    m_CustomShaderResourceId = m_pDevice->ApplyCustomShader(m_RenderData.texDisplay);
+    m_CustomShaderResourceId = m_pDevice->ApplyCustomShader(texDisplay);
     m_pController->FatalErrorCheck();
 
     texDisplay.resourceId = m_pDevice->GetLiveID(m_CustomShaderResourceId);


### PR DESCRIPTION
## Description

This parses along the min- and max-range values to custom shaders.

This in turn allows custom shaders to do effects that depend on the currently displayed range, importantly dither the image to remove banding, according to the displayed value-range.

A Snippet is also provided to insert the new parameters in a custom shader, and the documentation has been updated.
