### PR TITLE
When starting a chunk assert that it starts from 0

### DIFF
--- a/renderdoc/serialise/serialiser.cpp
+++ b/renderdoc/serialise/serialiser.cpp
@@ -341,6 +341,9 @@ void Serialiser<SerialiserMode::Writing>::SetChunkMetadataRecording(uint32_t fla
 template <>
 uint32_t Serialiser<SerialiserMode::Writing>::BeginChunk(uint32_t chunkID, uint64_t byteLength)
 {
+  // cannot start a chunk inside a chunk
+  RDCASSERTMSG("Beginning a chunk inside another chunk", m_Write->GetOffset() == 0,
+               m_Write->GetOffset());
   {
     // chunk index needs to be valid
     RDCASSERT(chunkID > 0);


### PR DESCRIPTION

## Description

Help to catch the programmer's mistake of starting a chunk inside an active chunk ie. calling SCOPED_SERIALISE_CHUNK inside an existing SCOPED_SERIALISE_CHUNK.