### PR TITLE
Fix signedness mismatches

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
@@ -48,7 +48,7 @@ void FillSpecConstantVariables(ResourceId shader, const SPIRVPatchData &patchDat
     for(size_t v = 0; v < invars.size() && v < outvars.size(); v++)
     {
       int32_t idx = patchData.specIDs.indexOf(specInfo[i].specID);
-      if(idx == ~0U)
+      if(idx == -1)
         continue;
 
       if(idx * sizeof(uint64_t) == invars[v].byteOffset)

--- a/renderdoc/driver/vulkan/vk_pixelhistory.cpp
+++ b/renderdoc/driver/vulkan/vk_pixelhistory.cpp
@@ -979,7 +979,7 @@ protected:
     }
 
     // Either modify the existing depth stencil attachment, or add one.
-    if(sub.depthstencilAttachment != -1 && sub.depthstencilAttachment < atts.size())
+    if(sub.depthstencilAttachment != -1 && (size_t)sub.depthstencilAttachment < atts.size())
       atts[sub.depthstencilAttachment] = m_CallbackInfo.dsImageView;
     else
       atts.push_back(m_CallbackInfo.dsImageView);

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -1146,7 +1146,7 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
       {
         int32_t idx = p.shaders[i].patchData->specIDs.indexOf(s.specID);
 
-        if(idx == ~0U)
+        if(idx == -1)
         {
           RDCERR("Couldn't find offset for spec ID %u", s.specID);
           continue;
@@ -1264,7 +1264,7 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
       {
         int32_t idx = p.shaders[i].patchData->specIDs.indexOf(s.specID);
 
-        if(idx == ~0U)
+        if(idx == -1)
         {
           RDCERR("Couldn't find offset for spec ID %u", s.specID);
           continue;


### PR DESCRIPTION
My compiler (g++ 10.3) complained about these after the recent commits.  They seemed trivial enough to fix.