### PR TITLE
Minor tweak for building on Apple and ENABLE_PYRENDERDOC cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,10 @@ if(APPLE)
 
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/lib")
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin")
+
+    # By default disable the python modules (brew python does not provide universal libraries)
+    message(STATUS "Disabling renderdoc python modules for Apple build")
+    set(ENABLE_PYRENDERDOC OFF CACHE BOOL "" FORCE)
 endif()
 
 if(ENABLE_GL)

--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -357,6 +357,6 @@ install (CODE "MESSAGE(\"NB: Your paths may vary.\")")
 endif() # if(ENABLE_QRENDERDOC)
 
 # Build python modules - primarily used for constructing documentation
-if(ENABLE_PYRENDERDOC AND UNIX AND NOT APPLE)
+if(ENABLE_PYRENDERDOC AND UNIX)
     add_subdirectory(Code/pyrenderdoc)
 endif()


### PR DESCRIPTION
## Description

By default disable ENABLE_PYRENDERDOC for Apple.
Rely on ENABLE_PYRENDERDOC rather than a platform exception.

Note: cmake variable UNIX is true when building for Apple platform
