### PR TITLE
(Windows) Add command line information to process listing when injecting

### DIFF
--- a/qrenderdoc/Code/qprocessinfo.cpp
+++ b/qrenderdoc/Code/qprocessinfo.cpp
@@ -111,7 +111,7 @@ static void getProcessCommandLine(QProcessInfo *info, callbackContext *ctx)
           {
             info->setCommandLine(QString::fromWCharArray(cmd_line, process_params.CommandLine.Length));
           }
-          delete cmd_line;
+          delete[] cmd_line;
         }
       }
     }

--- a/qrenderdoc/Code/qprocessinfo.cpp
+++ b/qrenderdoc/Code/qprocessinfo.cpp
@@ -105,17 +105,17 @@ static void getProcessCommandLine(QProcessInfo *info, callbackContext *ctx)
       {
         if(process_params.CommandLine.Length > 0)
         {
-          cmd_line = new wchar_t[process_params.CommandLine.Length];
-          if(!ReadProcessMemory(handle, process_params.CommandLine.Buffer, cmd_line,
+          cmd_line = new wchar_t[process_params.CommandLine.Length]();
+          if(ReadProcessMemory(handle, process_params.CommandLine.Buffer, cmd_line,
                                 process_params.CommandLine.Length, &bytes_read))
           {
+            info->setCommandLine(QString::fromWCharArray(cmd_line, process_params.CommandLine.Length));
           }
+          delete cmd_line;
         }
       }
     }
   }
-  if(cmd_line != NULL)
-    info->setCommandLine(QString::fromStdWString(std::wstring(cmd_line)));
 }
 
 QProcessList QProcessInfo::enumerate(bool includeWindowTitles)

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -173,11 +173,12 @@ CaptureDialog::CaptureDialog(ICaptureContext &ctx, OnCaptureMethod captureCallba
 
   ui->envVar->setEnabled(false);
 
-  m_ProcessModel = new QStandardItemModel(0, 3, this);
+  m_ProcessModel = new QStandardItemModel(0, 4, this);
 
   m_ProcessModel->setHeaderData(0, Qt::Horizontal, tr("Name"));
   m_ProcessModel->setHeaderData(1, Qt::Horizontal, tr("PID"));
   m_ProcessModel->setHeaderData(2, Qt::Horizontal, tr("Window Title"));
+  m_ProcessModel->setHeaderData(3, Qt::Horizontal, tr("Command Line"));
 
   QSortFilterProxyModel *proxy = new QSortFilterProxyModel(this);
 
@@ -1090,6 +1091,7 @@ void CaptureDialog::fillProcessList()
     m_ProcessModel->setData(m_ProcessModel->index(n, 0), process.name());
     m_ProcessModel->setData(m_ProcessModel->index(n, 1), process.pid());
     m_ProcessModel->setData(m_ProcessModel->index(n, 2), process.windowTitle());
+    m_ProcessModel->setData(m_ProcessModel->index(n, 3), process.commandLine());
     n++;
   }
 }


### PR DESCRIPTION
## Description

I found it difficult to try and differentiate things like Java or Python programs in the process table when I was injecting, so I added command line information to the process table so it would be easier to identify which process you actually want to inject into.
