### PR TITLE
Fix rdcstr c_str() and size() for fixed allocations

### DIFF
--- a/renderdoc/api/replay/rdcstr.h
+++ b/renderdoc/api/replay/rdcstr.h
@@ -548,15 +548,19 @@ public:
   }
   size_t size() const
   {
-    if(is_alloc() || is_fixed())
+    if(is_alloc())
+      return d.alloc.size;
+    if(is_fixed())
       return d.fixed.size;
     return d.arr.get_size();
   }
   size_t length() const { return size(); }
   const char *c_str() const
   {
-    if(is_alloc() || is_fixed())
+    if(is_alloc())
       return d.alloc.str;
+    if(is_fixed())
+      return d.fixed.str;
     return d.arr.str;
   }
 


### PR DESCRIPTION
Fixes #2166

## Description

It's just a blind attempt to fix the issue gcc finds. Looks like gcc is confused by the use of unions for rdcstr, and this use may actually be incorrect, based on what I had to change.

With this fix, gcc is happy.
