### PR TITLE
renderdoc_replay: Expose ShutdownOutput to Python API

### DIFF
--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -434,6 +434,12 @@ struct IReplayController
 )");
   virtual IReplayOutput *CreateOutput(WindowingData window, ReplayOutputType type) = 0;
 
+  DOCUMENT(R"(Shuts down and destroys a previously created replay output
+
+:param ReplayOutput output: The :class:`ReplayOutput` to destroy.
+)");
+  virtual void ShutdownOutput(IReplayOutput *output) = 0;
+
   DOCUMENT("Shutdown and destroy the current interface and all outputs that have been created.");
   virtual void Shutdown() = 0;
 


### PR DESCRIPTION
Only one ReplayOutput is allowed for an underlying WindowingData, but the Python
API doesn't provide any means to shut down an existing one. Fix this, allowing
the user to create and destroy as many ReplayOutputs per window as they wish.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Hopefully should be obvious, but I'm doing some fairly ugly Python API shenanigans, it's possible I missed a better way to do this.