### PR TITLE
remove modified resources from m_LiveIDs

### DIFF
--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -1453,6 +1453,9 @@ void ReplayProxy::Proxied_ReplaceResource(ParamSerialiser &paramser, ReturnSeria
       m_Remote->ReplaceResource(from, to);
   }
 
+  if(paramser.IsWriting())
+    m_LiveIDs.erase(from);
+
   SERIALISE_RETURN_VOID();
 }
 
@@ -1479,6 +1482,9 @@ void ReplayProxy::Proxied_RemoveReplacement(ParamSerialiser &paramser, ReturnSer
     if(paramser.IsReading() && !paramser.IsErrored() && !m_IsErrored)
       m_Remote->RemoveReplacement(id);
   }
+
+  if(paramser.IsWriting())
+    m_LiveIDs.erase(id);
 
   SERIALISE_RETURN_VOID();
 }


### PR DESCRIPTION
when a resource is replaced, its liveID needs to be replaced as well instead of keeping the old resource cached in m_LiveID. 

This fixes pipeline state viewing of edited shaders on mobile/Vulkan