### PR TITLE
add serialization for shader messages in VKPipe

### DIFF
--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -1068,7 +1068,7 @@ void DoSerialise(SerialiserType &ser, ShaderMessage &el)
   SERIALISE_MEMBER(location);
   SERIALISE_MEMBER(message);
 
-  SIZE_CHECK(52);
+  SIZE_CHECK(56);
 }
 
 #pragma endregion
@@ -2325,6 +2325,8 @@ void DoSerialise(SerialiserType &ser, VKPipe::State &el)
 
   SERIALISE_MEMBER(images);
 
+  SERIALISE_MEMBER(shaderMessages);
+
   SERIALISE_MEMBER(conditionalRendering);
 
   SIZE_CHECK(2008);
@@ -2345,6 +2347,7 @@ INSTANTIATE_SERIALISE_TYPE(ShaderConstantType)
 INSTANTIATE_SERIALISE_TYPE(ShaderConstant)
 INSTANTIATE_SERIALISE_TYPE(ConstantBlock)
 INSTANTIATE_SERIALISE_TYPE(ShaderSampler)
+INSTANTIATE_SERIALISE_TYPE(ShaderMessage);
 INSTANTIATE_SERIALISE_TYPE(ShaderResource)
 INSTANTIATE_SERIALISE_TYPE(ShaderEntryPoint)
 INSTANTIATE_SERIALISE_TYPE(ShaderCompileFlags)


### PR DESCRIPTION
shaderMessages needs to be serialized for debug printf to work on remote replay. Tested on Quest2 with VS and PS. 