### PR TITLE
Don't treat VK_PIPELINE_COMPILE_REQUIRED_EXT as error

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_shader_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_shader_funcs.cpp
@@ -437,7 +437,7 @@ bool WrappedVulkan::Serialise_vkCreateGraphicsPipelines(
     VkResult ret = ObjDisp(device)->CreateGraphicsPipelines(Unwrap(device), Unwrap(pipelineCache),
                                                             1, unwrapped, NULL, &pipe);
 
-    if(ret != VK_SUCCESS)
+    if(ret != VK_SUCCESS && ret != VK_PIPELINE_COMPILE_REQUIRED_EXT)
     {
       RDCERR("Failed on resource serialise-creation, VkResult: %s", ToStr(ret).c_str());
       return false;


### PR DESCRIPTION
Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Discovered this while trying to debug the horrible FPS in DOTA2 main menu. `VK_SUCCESS` isn't the only success code returned by this function.
