### PR TITLE
add gl_ViewIndex to PS-debugprintf

### DIFF
--- a/qrenderdoc/Windows/ShaderMessageViewer.cpp
+++ b/qrenderdoc/Windows/ShaderMessageViewer.cpp
@@ -397,6 +397,7 @@ ShaderMessageViewer::ShaderMessageViewer(ICaptureContext &ctx, ShaderStageMask s
         m_Ctx.ShowTextureViewer();
         Subresource sub = m_Ctx.GetTextureViewer()->GetSelectedSubresource();
         sub.sample = msg.location.pixel.sample;
+        sub.slice = msg.location.pixel.view;
         m_Ctx.GetTextureViewer()->SetSelectedSubresource(sub);
 
         // select an actual output. Prefer the first colour output, but if there's no colour output
@@ -486,6 +487,8 @@ ShaderMessageViewer::ShaderMessageViewer(ICaptureContext &ctx, ShaderStageMask s
               return aloc.y < bloc.y;
             if(aloc.primitive != bloc.primitive)
               return aloc.primitive < bloc.primitive;
+            if(aloc.view != bloc.view)
+              return aloc.view < bloc.view;
             return aloc.sample < bloc.sample;
           }
           else if(am.stage == ShaderStage::Compute)
@@ -778,12 +781,15 @@ void ShaderMessageViewer::refreshMessages()
       else
         location += lit(", Prim %1").arg(msg.location.pixel.primitive);
 
-      if(m_Multisampled)
+      // only show the view if the draw has multiview enabled
+      if(m_Multiview)
       {
-        if(msg.location.pixel.sample == ~0U)
-          location += lit(", Samp ?");
-        else
-          location += lit(", Samp %1").arg(msg.location.pixel.sample);
+        location += lit(", View %1").arg(msg.location.pixel.view);
+      }
+
+      if(m_Multisampled && msg.location.pixel.sample != ~0U)
+      {
+        location += lit(", Samp %1").arg(msg.location.pixel.sample);
       }
     }
     else if(msg.stage == ShaderStage::Compute)

--- a/renderdoc/api/replay/common_pipestate.h
+++ b/renderdoc/api/replay/common_pipestate.h
@@ -590,6 +590,12 @@ struct ShaderPixelMessageLocation
 )");
   uint32_t primitive;
 
+  DOCUMENT(R"(The multiview view for this fragment, or ``0`` if multiview is disabled.
+
+:type: int
+)");
+  uint32_t view;
+
   static const uint32_t NoLocation = ~0U;
 };
 

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -1049,8 +1049,9 @@ void DoSerialise(SerialiserType &ser, ShaderPixelMessageLocation &el)
   SERIALISE_MEMBER(y);
   SERIALISE_MEMBER(sample);
   SERIALISE_MEMBER(primitive);
+  SERIALISE_MEMBER(view);
 
-  SIZE_CHECK(16);
+  SIZE_CHECK(20);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
adds gl_ViewIndex to the pixel shader as well (as gl_ViewIndex can be read as a builtin attribute by both). in the PS we OR it to the sampleID to avoid adding more words to the SSBO system. This is the SPIRV-Cross'd generated code. 

`
    _41 = uvec3((_52.x << 16u) | _52.y, (4294967295u << 16u) | gl_ViewIndex, uint(gl_PrimitiveID));
`

This also adds the multiview capability to both VS and PS : the application's shaders don't have to use the multiview extension in the shader to execute under a multiview pass, and renderdoc should still show the view that the instance is executing regardless. 

Tested on UE4.27-Vulkan on Quest2 with multiview 

![view-export](https://user-images.githubusercontent.com/644891/150926906-8994b41e-02f6-4a7a-838b-9add36d6e784.PNG)

and on UE4.27-vulkan on PC without multiview. 