### PR TITLE
Fixes 2 valid issues

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -2052,12 +2052,17 @@ void VulkanDebugManager::FillWithDiscardPattern(VkCommandBuffer cmd, DiscardType
 
     uint32_t pass = 0;
 
+    VkImageSubresourceRange barrierDiscardRange = discardRange;
+    barrierDiscardRange.aspectMask = imAspects;
+
     VkImageMemoryBarrier dstimBarrier = {
         VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, NULL,
-        VK_ACCESS_ALL_READ_BITS | VK_ACCESS_ALL_WRITE_BITS, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        VK_ACCESS_ALL_READ_BITS | VK_ACCESS_ALL_WRITE_BITS,
+        depth ? (VkAccessFlags)VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+              : (VkAccessFlags)VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
         curLayout, depth ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
                          : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-        VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, Unwrap(image), discardRange,
+        VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, Unwrap(image), barrierDiscardRange,
     };
 
     DoPipelineBarrier(cmd, 1, &dstimBarrier);

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1723,8 +1723,10 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass(SerialiserType &ser, VkComman
             if(clearAspects != 0)
             {
               VulkanCreationInfo::ImageView viewinfo = m_CreationInfo.m_ImageView[fbattachments[att]];
+              bool isMultiview = rpinfo.subpasses[0].multiviews.size() > 1;
 
-              VkClearRect rect = {unwrappedInfo.renderArea, 0, viewinfo.range.layerCount};
+              VkClearRect rect = {unwrappedInfo.renderArea, 0,
+                                  isMultiview ? 1 : viewinfo.range.layerCount};
               VkClearAttachment clear = {};
               clear.aspectMask = FormatImageAspects(rpinfo.attachments[att].format) & clearAspects;
               clear.colorAttachment = c;
@@ -2343,8 +2345,10 @@ bool WrappedVulkan::Serialise_vkCmdBeginRenderPass2(SerialiserType &ser,
             if(clearAspects != 0)
             {
               VulkanCreationInfo::ImageView viewinfo = m_CreationInfo.m_ImageView[fbattachments[att]];
+              bool isMultiview = rpinfo.subpasses[0].multiviews.size() > 1;
 
-              VkClearRect rect = {unwrappedInfo.renderArea, 0, viewinfo.range.layerCount};
+              VkClearRect rect = {unwrappedInfo.renderArea, 0,
+                                  isMultiview ? 1 : viewinfo.range.layerCount};
               VkClearAttachment clear = {};
               clear.aspectMask = FormatImageAspects(rpinfo.attachments[att].format) & clearAspects;
               clear.colorAttachment = c;


### PR DESCRIPTION
1) In the case of a depth/stencil image, we have to provide for the image memory barrier both the stencil and depth mask (even if we only intend to fill the stencil for the RPLoadDiscardPattern function afterwards), from VUID-VkImageMemoryBarrier-image-03320

2) If we're using multiview, vkCmdClearAttachments needs a layerCount of 1, not numLayers. VUID-vkCmdClearAttachments-baseArrayLayer-00018

This fixes GPU crash problems when clicking on the vkCmdBeginRenderPass EID of apps with D24S8 buffers, with depth cleared and stencil invalidated. 