### PR TITLE
Support VK_KHR_depth_stencil_resolve in Pipeline View

### DIFF
--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -2589,7 +2589,8 @@ void VulkanPipelineStateViewer::setState()
       bool filledSlot = (p.imageResourceId != ResourceId());
       bool usedSlot =
           (colIdx >= 0 || resIdx >= 0 || state.currentPass.renderpass.depthstencilAttachment == i ||
-           state.currentPass.renderpass.fragmentDensityAttachment == i);
+           state.currentPass.renderpass.fragmentDensityAttachment == i ||
+           state.currentPass.renderpass.depthstencilResolveAttachment == i);
 
       if(showNode(usedSlot, filledSlot))
       {
@@ -2639,6 +2640,10 @@ void VulkanPipelineStateViewer::setState()
         else if(resIdx >= 0)
         {
           slotname = QFormatStr("Resolve %1").arg(resIdx);
+        }
+        else if(state.currentPass.renderpass.depthstencilResolveAttachment == i)
+        {
+          slotname = lit("Depth/Stencil Resolve");
         }
         else if(state.currentPass.renderpass.fragmentDensityAttachment == i)
         {
@@ -4039,6 +4044,14 @@ void VulkanPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const VKPipe::
       xml.writeStartElement(lit("p"));
       xml.writeCharacters(
           tr("Depth-stencil Attachment: %1").arg(pass.renderpass.depthstencilAttachment));
+      xml.writeEndElement();
+    }
+
+    if(pass.renderpass.depthstencilResolveAttachment >= 0)
+    {
+      xml.writeStartElement(lit("p"));
+      xml.writeCharacters(tr("Depth-stencil Resolve Attachment: %1")
+                              .arg(pass.renderpass.depthstencilResolveAttachment));
       xml.writeEndElement();
     }
 

--- a/renderdoc/api/replay/vk_pipestate.h
+++ b/renderdoc/api/replay/vk_pipestate.h
@@ -979,6 +979,11 @@ attachments.
 If there is no depth-stencil attachment, this index is ``-1``.
 )");
   int32_t depthstencilAttachment = -1;
+  DOCUMENT(R"(An index into the framebuffer attachments for the depth-stencil resolve attachment.
+
+If there is no depth-stencil resolve attachment, this index is ``-1``.
+)");
+  int32_t depthstencilResolveAttachment = -1;
 
   DOCUMENT(R"(An index into the framebuffer attachments for the fragment density attachment.
 

--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -1037,6 +1037,17 @@ void VulkanCreationInfo::RenderPass::Init(VulkanResourceManager *resourceMan,
     if(separateStencil)
       dst.stencilLayout = separateStencil->stencilLayout;
 
+    // VK_KHR_depth_stencil_resolve
+    const VkSubpassDescriptionDepthStencilResolve *depthstencilResolve =
+        (const VkSubpassDescriptionDepthStencilResolve *)FindNextStruct(
+            &src, VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE);
+
+    dst.depthstencilResolveAttachment =
+        (depthstencilResolve &&
+                 depthstencilResolve->pDepthStencilResolveAttachment->attachment != VK_ATTACHMENT_UNUSED
+             ? depthstencilResolve->pDepthStencilResolveAttachment->attachment
+             : -1);
+
     dst.fragmentDensityAttachment =
         (fragmentDensity &&
                  fragmentDensity->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED

--- a/renderdoc/driver/vulkan/vk_info.h
+++ b/renderdoc/driver/vulkan/vk_info.h
@@ -449,6 +449,7 @@ struct VulkanCreationInfo
       rdcarray<uint32_t> colorAttachments;
       rdcarray<uint32_t> resolveAttachments;
       int32_t depthstencilAttachment;
+      int32_t depthstencilResolveAttachment;
       int32_t fragmentDensityAttachment;
 
       rdcarray<VkImageLayout> inputLayouts;

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -1687,6 +1687,8 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
         c.m_RenderPass[state.GetRenderPass()].subpasses[state.subpass].resolveAttachments;
     ret.currentPass.renderpass.depthstencilAttachment =
         c.m_RenderPass[state.GetRenderPass()].subpasses[state.subpass].depthstencilAttachment;
+    ret.currentPass.renderpass.depthstencilResolveAttachment =
+        c.m_RenderPass[state.GetRenderPass()].subpasses[state.subpass].depthstencilResolveAttachment;
     ret.currentPass.renderpass.fragmentDensityAttachment =
         c.m_RenderPass[state.GetRenderPass()].subpasses[state.subpass].fragmentDensityAttachment;
 
@@ -1759,6 +1761,7 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
     ret.currentPass.renderpass.colorAttachments.clear();
     ret.currentPass.renderpass.resolveAttachments.clear();
     ret.currentPass.renderpass.depthstencilAttachment = -1;
+    ret.currentPass.renderpass.depthstencilResolveAttachment = -1;
     ret.currentPass.renderpass.fragmentDensityAttachment = -1;
 
     ret.currentPass.framebuffer.resourceId = ResourceId();

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -2208,10 +2208,11 @@ void DoSerialise(SerialiserType &ser, VKPipe::RenderPass &el)
   SERIALISE_MEMBER(colorAttachments);
   SERIALISE_MEMBER(resolveAttachments);
   SERIALISE_MEMBER(depthstencilAttachment);
+  SERIALISE_MEMBER(depthstencilResolveAttachment);
   SERIALISE_MEMBER(fragmentDensityAttachment);
   SERIALISE_MEMBER(multiviews);
 
-  SIZE_CHECK(120);
+  SIZE_CHECK(128);
 }
 
 template <typename SerialiserType>
@@ -2261,7 +2262,7 @@ void DoSerialise(SerialiserType &ser, VKPipe::CurrentPass &el)
   SERIALISE_MEMBER(framebuffer);
   SERIALISE_MEMBER(renderArea);
 
-  SIZE_CHECK(184);
+  SIZE_CHECK(192);
 }
 
 template <typename SerialiserType>
@@ -2329,7 +2330,7 @@ void DoSerialise(SerialiserType &ser, VKPipe::State &el)
 
   SERIALISE_MEMBER(conditionalRendering);
 
-  SIZE_CHECK(2008);
+  SIZE_CHECK(2016);
 }
 
 #pragma endregion Vulkan pipeline state


### PR DESCRIPTION
## Description

Depth stencil resolve attachments were not being serialized and exposed in the pipeline state view. This change serializes the attachment id for the depth-stencil resolve attachment so that it can show up in the pipeline state view.

![272204477_3081439328779001_4310888299915384476_n](https://user-images.githubusercontent.com/91488186/151640079-6c1f4320-b1dc-441a-8b8f-38cc0e4f649a.png)

