### PR TITLE
erase all liveIDs when replacing resources

### DIFF
--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -1454,7 +1454,7 @@ void ReplayProxy::Proxied_ReplaceResource(ParamSerialiser &paramser, ReturnSeria
   }
 
   if(paramser.IsWriting())
-    m_LiveIDs.erase(from);
+    m_LiveIDs.clear();
 
   SERIALISE_RETURN_VOID();
 }
@@ -1484,7 +1484,7 @@ void ReplayProxy::Proxied_RemoveReplacement(ParamSerialiser &paramser, ReturnSer
   }
 
   if(paramser.IsWriting())
-    m_LiveIDs.erase(id);
+    m_LiveIDs.clear();
 
   SERIALISE_RETURN_VOID();
 }


### PR DESCRIPTION
all liveIDs should be erased when a resource is replaced to also erase derived resources like pipeline IDs. 

Confirmed that after shader editing, KHR_pipeline_executable_properties are refreshed on Quest2.