### PR TITLE
Fix incorrect link for `include-bin` credit.

### DIFF
--- a/docs/credits_acknowledgements.rst
+++ b/docs/credits_acknowledgements.rst
@@ -52,7 +52,7 @@ The following libraries and components are incorporated into RenderDoc, listed h
 
   Used for parsing command line arguments to renderdoccmd.
 
-* `include-bin <https://github.com/tanakh/cmdline>`_ - Copyright 2016 Hubert Jarosz, distributed under the zlib license.
+* `include-bin <https://github.com/Marqin/include-bin>`_ - Copyright 2016 Hubert Jarosz, distributed under the zlib license.
 
   Used to compile in data files embedded into the source on non-Windows platforms.
 


### PR DESCRIPTION
[PR created as draft to enable @Marqin to provide updated URL and/or copyright text if she wishes.]

## Description

The current link appears to be an accidental duplication of the URL from the project listed immediately above.

This commit appears to be the origin of the duplicated URL: https://github.com/baldurk/renderdoc/commit/b5c7944038572eebffde32e1279c45c4f6d84153#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1dL98

Note: This "corrected" link is to the original repository URL which appears to no longer exist.

For reference:

 * Original commit with the inclusion of `include-bin`: https://github.com/baldurk/renderdoc/commit/864fdbe179b6c1f20cae7c753fb018bec74b5738

 * Original issue which lead to the inclusion: https://github.com/baldurk/renderdoc/issues/314#issuecomment-238204556

[P.S. I'm not always the best at following up on drive-by PRs, so feel free to update & merge this PR as required.]