### PR TITLE
Implement Shadermodel 6.6 bindless feedback and display it to the pipeline state view

### DIFF
--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
@@ -91,15 +91,19 @@ struct D3D12ViewTag
     OMDepth,
   };
 
-  D3D12ViewTag() : type(SRV), space(0), rootSignatureIndex(0), immediate(false) {}
+  D3D12ViewTag()
+      : type(SRV), space(0), rootSignatureIndex(0), immediate(false), directHeapAccess(false)
+  {
+  }
   D3D12ViewTag(ResType t, int s, int el, bool imm, const D3D12Pipe::View &rs)
-      : type(t), space(s), rootSignatureIndex(el), immediate(imm), res(rs)
+      : type(t), space(s), rootSignatureIndex(el), immediate(imm), directHeapAccess(false), res(rs)
   {
   }
 
   ResType type;
   int space, rootSignatureIndex;
   bool immediate;
+  bool directHeapAccess;
   D3D12Pipe::View res;
 };
 
@@ -731,9 +735,10 @@ void D3D12PipelineStateViewer::addResourceRow(const D3D12ViewTag &view, const Bi
 {
   const D3D12Pipe::View &r = view.res;
   bool uav = view.type == D3D12ViewTag::UAV;
+  bool directHeapAccess = view.directHeapAccess;
 
   bool filledSlot = (r.resourceId != ResourceId());
-  bool usedSlot = (bind && bind->used && r.dynamicallyUsed);
+  bool usedSlot = (bind && bind->used && r.dynamicallyUsed) || directHeapAccess;
 
   // if a target is set to RTVs or DSV, it is implicitly used
   if(filledSlot)
@@ -751,6 +756,9 @@ void D3D12PipelineStateViewer::addResourceRow(const D3D12ViewTag &view, const Bi
 
     if(view.type == D3D12ViewTag::OMDepth)
       regname = tr("Depth");
+
+    if(directHeapAccess)
+      regname = tr("");
 
     uint32_t w = 1, h = 1, d = 1;
     uint32_t a = 1;
@@ -847,12 +855,20 @@ void D3D12PipelineStateViewer::addResourceRow(const D3D12ViewTag &view, const Bi
     }
     else
     {
-      QString rootel = view.immediate
-                           ? tr("#%1 Direct").arg(view.rootSignatureIndex)
-                           : tr("#%1 Table[%2]").arg(view.rootSignatureIndex).arg(r.tableIndex);
+      QString spaceStr;
+      if(!directHeapAccess)
+        spaceStr = QString::number(view.space);
+
+      QString rootel;
+      if(directHeapAccess)
+        rootel = tr("ResourceDescriptorHeap[%1]").arg(r.tableIndex);
+      else if(view.immediate)
+        rootel = tr("#%1 Direct").arg(view.rootSignatureIndex);
+      else
+        rootel = tr("#%1 Table[%2]").arg(view.rootSignatureIndex).arg(r.tableIndex);
 
       node = new RDTreeWidgetItem(
-          {rootel, view.space, regname, r.resourceId, typeName, w, h, d, a, format, QString()});
+          {rootel, spaceStr, regname, r.resourceId, typeName, w, h, d, a, format, QString()});
     }
 
     node->setTag(QVariant::fromValue(view));
@@ -1076,6 +1092,8 @@ void D3D12PipelineStateViewer::setShaderState(
     tag.rootSignatureIndex = rootElements[i].rootSignatureIndex;
     tag.immediate = rootElements[i].immediate;
 
+    bool directHeapAccess = rootElements[i].registerSpace == ~0U;
+
     switch(rootElements[i].type)
     {
       case BindType::ReadOnlyResource:
@@ -1092,6 +1110,19 @@ void D3D12PipelineStateViewer::setShaderState(
         tag.type = srv ? D3D12ViewTag::SRV : D3D12ViewTag::UAV;
 
         const rdcarray<D3D12Pipe::View> &views = rootElements[i].views;
+
+        // add direct heap access resources
+        if(directHeapAccess)
+        {
+          for(size_t view = 0; view < views.size(); ++view)
+          {
+            tag.space = -1;
+            tag.res = views[view];
+            tag.directHeapAccess = directHeapAccess;
+            addResourceRow(tag, NULL, NULL, tree);
+          }
+          continue;
+        }
 
         size_t firstView = rootElements[i].firstUsedIndex;
         size_t lastView = qMin(views.size() - 1, size_t(rootElements[i].lastUsedIndex));
@@ -1219,7 +1250,7 @@ void D3D12PipelineStateViewer::setShaderState(
           const Bindpoint *bind = NULL;
           const ShaderSampler *shaderInput = NULL;
 
-          if(stage.reflection)
+          if(stage.reflection && !directHeapAccess)
           {
             for(int k = 0; k < stage.bindpointMapping.samplers.count(); ++k)
             {
@@ -1241,19 +1272,30 @@ void D3D12PipelineStateViewer::setShaderState(
               }
             }
           }
-
-          QString rootel =
-              rootElements[i].immediate
-                  ? tr("#%1 Static").arg(rootElements[i].rootSignatureIndex)
-                  : tr("#%1 Table[%2]").arg(rootElements[i].rootSignatureIndex).arg(s.tableIndex);
+          QString spaceStr = QString::number(rootElements[i].registerSpace);
+          QString rootel;
+          if(directHeapAccess)
+          {
+            rootel = tr("SamplerDescriptorHeap[%1]").arg(s.tableIndex);
+            spaceStr = tr("");
+          }
+          else if(rootElements[i].immediate)
+          {
+            rootel = tr("#%1 Static").arg(rootElements[i].rootSignatureIndex);
+          }
+          else
+          {
+            rootel = tr("#%1 Table[%2]").arg(rootElements[i].rootSignatureIndex).arg(s.tableIndex);
+          }
 
           bool filledSlot = s.filter.minify != FilterMode::NoFilter;
-          bool usedSlot = (bind && bind->used);
+          bool usedSlot = (bind && bind->used) || directHeapAccess;
 
           if(showNode(usedSlot, filledSlot))
           {
-            QString regname = QString::number(s.bind);
-
+            QString regname;
+            if(!directHeapAccess)
+              regname = QString::number(s.bind);
             if(shaderInput && !shaderInput->name.empty())
               regname += lit(": ") + shaderInput->name;
 
@@ -1307,7 +1349,7 @@ void D3D12PipelineStateViewer::setShaderState(
               filter += QFormatStr(" (%1)").arg(ToQStr(s.filter.filter));
 
             RDTreeWidgetItem *node = new RDTreeWidgetItem(
-                {rootel, rootElements[i].registerSpace, regname, addressing, filter,
+                {rootel, spaceStr, regname, addressing, filter,
                  QFormatStr("%1 - %2")
                      .arg(s.minLOD == -FLT_MAX ? lit("0") : QString::number(s.minLOD))
                      .arg(s.maxLOD == FLT_MAX ? lit("FLT_MAX") : QString::number(s.maxLOD)),
@@ -1335,7 +1377,7 @@ void D3D12PipelineStateViewer::setShaderState(
           const Bindpoint *bind = NULL;
           const ConstantBlock *shaderCBuf = NULL;
 
-          if(stage.reflection)
+          if(stage.reflection && !directHeapAccess)
           {
             for(int k = 0; k < stage.bindpointMapping.constantBlocks.count(); ++k)
             {
@@ -1360,14 +1402,19 @@ void D3D12PipelineStateViewer::setShaderState(
               }
             }
           }
-
+          if(directHeapAccess)
+            cbuftag = QVariant::fromValue(D3D12CBufTag(0, (uint32_t)j, (uint32_t)i));
           if(!cbuftag.isValid())
             cbuftag =
                 QVariant::fromValue(D3D12CBufTag(rootElements[i].registerSpace, b.bind, (uint32_t)i));
 
           QString rootel;
 
-          if(rootElements[i].immediate)
+          if(directHeapAccess)
+          {
+            rootel = tr("ResourceDescriptorHeap[%1]").arg(b.tableIndex);
+          }
+          else if(rootElements[i].immediate)
           {
             if(!b.rootValues.empty())
               rootel = tr("#%1 Consts").arg(rootElements[i].rootSignatureIndex);
@@ -1383,7 +1430,7 @@ void D3D12PipelineStateViewer::setShaderState(
           if(rootElements[i].immediate && !b.rootValues.empty())
             filledSlot = true;
 
-          bool usedSlot = (bind && bind->used);
+          bool usedSlot = (bind && bind->used) || directHeapAccess;
 
           if(showNode(usedSlot, filledSlot))
           {
@@ -1397,12 +1444,18 @@ void D3D12PipelineStateViewer::setShaderState(
 
             QString regname = QString::number(b.bind);
 
-            if(shaderCBuf && !shaderCBuf->name.empty())
-              regname += lit(": ") + shaderCBuf->name;
+            if(directHeapAccess)
+            {
+              regname = tr("");
+            }
+            else
+            {
+              if(shaderCBuf && !shaderCBuf->name.empty())
+                regname += lit(": ") + shaderCBuf->name;
 
-            if(bind != NULL && bind->arraySize > 1)
-              regname += tr("[%1]").arg(b.bind - bind->bind);
-
+              if(bind != NULL && bind->arraySize > 1)
+                regname += tr("[%1]").arg(b.bind - bind->bind);
+            }
             QString sizestr;
             if(bytesize == (uint32_t)length)
               sizestr = tr("%1 Variables, %2 bytes").arg(numvars).arg(length);
@@ -1413,8 +1466,11 @@ void D3D12PipelineStateViewer::setShaderState(
             if(length < bytesize)
               filledSlot = false;
 
+            QString spaceStr = QString::number(rootElements[i].registerSpace);
+            if(directHeapAccess)
+              spaceStr = tr("");
             RDTreeWidgetItem *node = new RDTreeWidgetItem(
-                {rootel, (qulonglong)rootElements[i].registerSpace, regname, b.resourceId,
+                {rootel, spaceStr, regname, b.resourceId,
                  QFormatStr("%1 - %2").arg(offset).arg(offset + bytesize), sizestr, QString()});
 
             node->setTag(cbuftag);
@@ -2703,6 +2759,10 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
   {
     if((els[i].visibility & MaskForStage(sh.stage)) == ShaderStageMask::Unknown)
       continue;
+    bool directHeapAccess = els[i].registerSpace == ~0U;
+    QString spaceStr;
+    if(!directHeapAccess)
+      spaceStr = QString::number(els[i].registerSpace);
 
     switch(els[i].type)
     {
@@ -2713,7 +2773,7 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
           const D3D12Pipe::View &v = els[i].views[j];
           const ShaderResource *shaderInput = NULL;
 
-          if(sh.reflection)
+          if(sh.reflection && !directHeapAccess)
           {
             for(int32_t k = 0; k < sh.bindpointMapping.readOnlyResources.count(); ++k)
             {
@@ -2737,13 +2797,17 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
             }
           }
 
-          QString rootel = els[i].immediate
-                               ? tr("#%1 Direct").arg(els[i].rootSignatureIndex)
-                               : tr("#%1 Table[%2]").arg(els[i].rootSignatureIndex).arg(v.tableIndex);
+          QString rootel;
+          if(directHeapAccess)
+            rootel = tr("ResourceDescriptorHeap[%1]").arg(v.tableIndex);
+          else if(els[i].immediate)
+            rootel = tr("#%1 Direct").arg(els[i].rootSignatureIndex);
+          else
+            rootel = tr("#%1 Table[%2]").arg(els[i].rootSignatureIndex).arg(v.tableIndex);
 
           QVariantList row = exportViewHTML(v, false, shaderInput, QString());
 
-          row.push_front(els[i].registerSpace);
+          row.push_front(spaceStr);
           row.push_front(rootel);
 
           rowsRO.push_back(row);
@@ -2757,7 +2821,7 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
           const D3D12Pipe::View &v = els[i].views[j];
           const ShaderResource *shaderInput = NULL;
 
-          if(sh.reflection)
+          if(sh.reflection && !directHeapAccess)
           {
             for(int32_t k = 0; k < sh.bindpointMapping.readWriteResources.count(); ++k)
             {
@@ -2780,14 +2844,16 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
               }
             }
           }
-
-          QString rootel = els[i].immediate
-                               ? tr("#%1 Direct").arg(els[i].rootSignatureIndex)
-                               : tr("#%1 Table[%2]").arg(els[i].rootSignatureIndex).arg(v.tableIndex);
-
+          QString rootel;
+          if(directHeapAccess)
+            rootel = tr("ResourceDescriptorHeap[%1]").arg(v.tableIndex);
+          else if(els[i].immediate)
+            rootel = tr("#%1 Direct").arg(els[i].rootSignatureIndex);
+          else
+            rootel = tr("#%1 Table[%2]").arg(els[i].rootSignatureIndex).arg(v.tableIndex);
           QVariantList row = exportViewHTML(v, true, shaderInput, QString());
 
-          row.push_front(els[i].registerSpace);
+          row.push_front(spaceStr);
           row.push_front(rootel);
 
           rowsRW.push_back(row);
@@ -2801,7 +2867,7 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
           const D3D12Pipe::Sampler &s = els[i].samplers[j];
           const ShaderSampler *shaderInput = NULL;
 
-          if(sh.reflection)
+          if(sh.reflection && !directHeapAccess)
           {
             for(int32_t k = 0; k < sh.bindpointMapping.samplers.count(); ++k)
             {
@@ -2824,14 +2890,18 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
               }
             }
           }
-
-          QString rootel = els[i].immediate
-                               ? tr("#%1 Static").arg(els[i].rootSignatureIndex)
-                               : tr("#%1 Table[%2]").arg(els[i].rootSignatureIndex).arg(s.tableIndex);
+          QString rootel;
+          if(directHeapAccess)
+            rootel = tr("SamplerDescriptorHeap[%1]").arg(s.tableIndex);
+          else if(els[i].immediate)
+            rootel = tr("#%1 Static").arg(els[i].rootSignatureIndex);
+          else
+            rootel = tr("#%1 Table[%2]").arg(els[i].rootSignatureIndex).arg(s.tableIndex);
 
           {
-            QString regname = QString::number(s.bind);
-
+            QString regname;
+            if(!directHeapAccess)
+              regname = QString::number(s.bind);
             if(shaderInput && !shaderInput->name.empty())
               regname += lit(": ") + shaderInput->name;
 
@@ -2885,7 +2955,7 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
               filter += QFormatStr(" (%1)").arg(ToQStr(s.filter.filter));
 
             rowsSampler.push_back(
-                {rootel, els[i].registerSpace, regname, addressing, filter,
+                {rootel, spaceStr, regname, addressing, filter,
                  QFormatStr("%1 - %2")
                      .arg(s.minLOD == -FLT_MAX ? lit("0") : QString::number(s.minLOD))
                      .arg(s.maxLOD == FLT_MAX ? lit("FLT_MAX") : QString::number(s.maxLOD)),
@@ -2901,7 +2971,7 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
           const D3D12Pipe::ConstantBuffer &b = els[i].constantBuffers[j];
           const ConstantBlock *shaderCBuf = NULL;
 
-          if(sh.reflection)
+          if(sh.reflection && !directHeapAccess)
           {
             for(int32_t k = 0; k < sh.bindpointMapping.constantBlocks.count(); ++k)
             {
@@ -2927,8 +2997,11 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
           }
 
           QString rootel;
-
-          if(els[i].immediate)
+          if(directHeapAccess)
+          {
+            rootel = tr("ResourceDescriptorHeap[%1]").arg(b.tableIndex);
+          }
+          else if(els[i].immediate)
           {
             if(!b.rootValues.empty())
               rootel = tr("#%1 Consts").arg(els[i].rootSignatureIndex);
@@ -2955,15 +3028,16 @@ void D3D12PipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const D3D12Pipe
             else
               name = tr("Empty");
 
-            QString regname = QString::number(b.bind);
-
+            QString regname;
+            if(!directHeapAccess)
+              regname = QString::number(b.bind);
             if(shaderCBuf && !shaderCBuf->name.empty())
               regname += lit(": ") + shaderCBuf->name;
 
             length = qMin(length, (uint64_t)bytesize);
 
-            rowsCB.push_back({rootel, els[i].registerSpace, regname, name, (qulonglong)offset,
-                              (qulonglong)length, numvars});
+            rowsCB.push_back(
+                {rootel, spaceStr, regname, name, (qulonglong)offset, (qulonglong)length, numvars});
           }
         }
         break;

--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -55,19 +55,35 @@ struct D3D12FeedbackBindIdentifier
   size_t rootEl;
   size_t rangeIndex;
   UINT descIndex;
+  ShaderStage shaderStage;    // Only used for direct access views
+  BindType bindType;          // Only used for direct access views
+  bool directAccess;
 
   bool operator<(const D3D12FeedbackBindIdentifier &o) const
   {
-    if(rootEl != o.rootEl)
-      return rootEl < o.rootEl;
-    if(rangeIndex != o.rangeIndex)
-      return rangeIndex < o.rangeIndex;
+    if(directAccess != o.directAccess)
+      return directAccess < o.directAccess;
+    if(!directAccess)
+    {
+      if(rootEl != o.rootEl)
+        return rootEl < o.rootEl;
+      if(rangeIndex != o.rangeIndex)
+        return rangeIndex < o.rangeIndex;
+    }
+    else
+    {
+      if(shaderStage != o.shaderStage)
+        return shaderStage < o.shaderStage;
+      if(bindType != o.bindType)
+        return bindType < o.bindType;
+    }
     return descIndex < o.descIndex;
   }
 
   bool operator==(const D3D12FeedbackBindIdentifier &o) const
   {
-    return rootEl == o.rootEl && rangeIndex == o.rangeIndex && descIndex == o.descIndex;
+    return rootEl == o.rootEl && rangeIndex == o.rangeIndex && descIndex == o.descIndex &&
+           directAccess == o.directAccess && shaderStage == o.shaderStage && bindType == o.bindType;
   }
 };
 
@@ -245,6 +261,7 @@ private:
                         const ShaderBindpointMapping *mappings[(uint32_t)ShaderStage::Count],
                         rdcarray<D3D12Pipe::RootSignatureRange> &rootElements);
   void FillResourceView(D3D12Pipe::View &view, const D3D12Descriptor *desc);
+  void FillSampler(D3D12Pipe::Sampler &view, const D3D12_SAMPLER_DESC &desc);
 
   bool CreateSOBuffers();
   void ClearPostVSCache();

--- a/renderdoc/driver/d3d12/d3d12_shader_feedback.cpp
+++ b/renderdoc/driver/d3d12/d3d12_shader_feedback.cpp
@@ -1184,7 +1184,7 @@ void D3D12Replay::FetchShaderFeedback(uint32_t eventId)
 
                   // if the next bind is definitely outside this range, early out now instead of
                   // iterating fruitlessly
-                  if((uint32_t)bind.bind > range.BaseShaderRegister + num)
+                  if(((uint32_t)bind.bind - range.BaseShaderRegister) > num)
                     break;
 
                   int32_t lastBind =

--- a/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
@@ -1307,6 +1307,8 @@ Program::Program(const byte *bytes, size_t length)
 
               if(!inst.type->isVoid())
                 m_Values.push_back(Value(&f.instructions.back()));
+              if(inst.funcCall->name == "dx.op.createHandleFromHeap")
+                m_directHeapAccessCount++;
             }
             else if(op.type == FunctionRecord::INST_CAST)
             {

--- a/renderdoc/driver/shaders/dxil/dxil_bytecode.h
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode.h
@@ -673,6 +673,7 @@ public:
 
   const Metadata *GetMetadataByName(const rdcstr &name) const;
   size_t GetMetadataCount() const { return m_Metadata.size() + m_NamedMeta.size(); }
+  uint32_t GetDirectHeapAcessCount() const { return m_directHeapAccessCount; }
 protected:
   void MakeDisassemblyString();
 
@@ -703,6 +704,7 @@ protected:
   rdcarray<Alias> m_Aliases;
   rdcarray<Value> m_Values;
   rdcarray<rdcstr> m_Sections;
+  uint32_t m_directHeapAccessCount = 0;
 
   rdcarray<rdcstr> m_Kinds;
 

--- a/renderdoc/driver/shaders/dxil/dxil_bytecode_editor.h
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode_editor.h
@@ -76,6 +76,7 @@ public:
 
   const rdcarray<AttributeSet> &GetAttributeSets() { return m_AttributeSets; }
   // find existing type or metadata by name, returns NULL if not found
+  const rdcarray<Type> &GetTypes() const { return m_Types; }
   const Type *GetTypeByName(const rdcstr &name);
   Function *GetFunctionByName(const rdcstr &name);
   Metadata *GetMetadataByName(const rdcstr &name);
@@ -85,6 +86,7 @@ public:
   const Type *AddType(const Type &t);
   const Function *DeclareFunction(const Function &f);
   Metadata *AddMetadata(const Metadata &m);
+  NamedMetadata *AddNamedMetadata(const NamedMetadata &m);
 
   // I think constants have to be unique, so this will return an existing constant (for simple cases
   // like integers or NULL) if it exists

--- a/util/test/demos/d3d12/d3d12_descriptor_indexing.cpp
+++ b/util/test/demos/d3d12/d3d12_descriptor_indexing.cpp
@@ -255,9 +255,10 @@ float4 main(v2f IN) : SV_Target0
 
     ID3D12ResourcePtr structBuf = MakeBuffer().UAV().Size(8192);
     D3D12_GPU_DESCRIPTOR_HANDLE structGPU =
-        MakeUAV(structBuf).Format(DXGI_FORMAT_R32_UINT).CreateGPU(15);
+        MakeUAV(structBuf).Format(DXGI_FORMAT_R32_UINT).CreateGPU(16);
     D3D12_CPU_DESCRIPTOR_HANDLE structCPU =
-        MakeUAV(structBuf).Format(DXGI_FORMAT_R32_UINT).CreateClearCPU(15);
+        MakeUAV(structBuf).Format(DXGI_FORMAT_R32_UINT).CreateClearCPU(16);
+    MakeUAV(structBuf).StructureStride(2 * sizeof(uint32_t)).CreateGPU(15);
     MakeSRV(structBuf).StructureStride(2 * sizeof(uint32_t)).CreateGPU(8);
 
     MakeSRV(smiley).CreateGPU(12);
@@ -291,10 +292,10 @@ float4 main(v2f IN) : SV_Target0
 
         setMarker(cmd, markers[i]);
 
+        cmd->SetDescriptorHeaps(1, &m_CBVUAVSRV.GetInterfacePtr());
+
         UINT zero[4] = {};
         cmd->ClearUnorderedAccessViewUint(structGPU, structCPU, structBuf, zero, 0, NULL);
-
-        cmd->SetDescriptorHeaps(1, &m_CBVUAVSRV.GetInterfacePtr());
 
         cmd->SetPipelineState(computepso[i]);
         cmd->SetComputeRootSignature(computesig);

--- a/util/test/demos/d3d12/d3d12_test.cpp
+++ b/util/test/demos/d3d12/d3d12_test.cpp
@@ -184,6 +184,14 @@ void D3D12GraphicsTest::Prepare(int argc, char **argv)
       tmpdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS5, &opts5, sizeof(opts5));
       tmpdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS6, &opts6, sizeof(opts6));
       tmpdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS7, &opts7, sizeof(opts7));
+      D3D12_FEATURE_DATA_SHADER_MODEL oShaderModel = {};
+      oShaderModel.HighestShaderModel = D3D_SHADER_MODEL_6_6;
+      HRESULT hr = tmpdev->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &oShaderModel,
+                                               sizeof(oShaderModel));
+      if(SUCCEEDED(hr))
+      {
+        m_HighestShaderModel = oShaderModel.HighestShaderModel;
+      }
     }
   }
 }

--- a/util/test/demos/d3d12/d3d12_test.h
+++ b/util/test/demos/d3d12/d3d12_test.h
@@ -236,6 +236,7 @@ struct D3D12GraphicsTest : public GraphicsTest
   D3D12_FEATURE_DATA_D3D12_OPTIONS5 opts5 = {};
   D3D12_FEATURE_DATA_D3D12_OPTIONS6 opts6 = {};
   D3D12_FEATURE_DATA_D3D12_OPTIONS7 opts7 = {};
+  D3D_SHADER_MODEL m_HighestShaderModel = D3D_SHADER_MODEL_5_1;
 
   ID3D12FencePtr m_GPUSyncFence;
   HANDLE m_GPUSyncHandle = NULL;

--- a/util/test/demos/dx/official/d3d12.h
+++ b/util/test/demos/dx/official/d3d12.h
@@ -1,6 +1,7 @@
 /*-------------------------------------------------------------------------------------
  *
  * Copyright (c) Microsoft Corporation
+ * Licensed under the MIT license
  *
  *-------------------------------------------------------------------------------------*/
 
@@ -8,7 +9,7 @@
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 
 
- /* File created by MIDL compiler version 8.01.0622 */
+ /* File created by MIDL compiler version 8.01.0625 */
 
 
 
@@ -39,6 +40,14 @@
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1020)
 #pragma once
+#endif
+
+#ifndef DECLSPEC_XFGVIRT
+#if _CONTROL_FLOW_GUARD_XFG
+#define DECLSPEC_XFGVIRT(base, func) __declspec(xfg_virtual(base, func))
+#else
+#define DECLSPEC_XFGVIRT(base, func)
+#endif
 #endif
 
 /* Forward Declarations */ 
@@ -316,6 +325,13 @@ typedef interface ID3D12DeviceRemovedExtendedData1 ID3D12DeviceRemovedExtendedDa
 #endif 	/* __ID3D12DeviceRemovedExtendedData1_FWD_DEFINED__ */
 
 
+#ifndef __ID3D12DeviceRemovedExtendedData2_FWD_DEFINED__
+#define __ID3D12DeviceRemovedExtendedData2_FWD_DEFINED__
+typedef interface ID3D12DeviceRemovedExtendedData2 ID3D12DeviceRemovedExtendedData2;
+
+#endif 	/* __ID3D12DeviceRemovedExtendedData2_FWD_DEFINED__ */
+
+
 #ifndef __ID3D12Device6_FWD_DEFINED__
 #define __ID3D12Device6_FWD_DEFINED__
 typedef interface ID3D12Device6 ID3D12Device6;
@@ -386,11 +402,32 @@ typedef interface ID3D12GraphicsCommandList4 ID3D12GraphicsCommandList4;
 #endif 	/* __ID3D12GraphicsCommandList4_FWD_DEFINED__ */
 
 
+#ifndef __ID3D12ShaderCacheSession_FWD_DEFINED__
+#define __ID3D12ShaderCacheSession_FWD_DEFINED__
+typedef interface ID3D12ShaderCacheSession ID3D12ShaderCacheSession;
+
+#endif 	/* __ID3D12ShaderCacheSession_FWD_DEFINED__ */
+
+
+#ifndef __ID3D12Device9_FWD_DEFINED__
+#define __ID3D12Device9_FWD_DEFINED__
+typedef interface ID3D12Device9 ID3D12Device9;
+
+#endif 	/* __ID3D12Device9_FWD_DEFINED__ */
+
+
 #ifndef __ID3D12Tools_FWD_DEFINED__
 #define __ID3D12Tools_FWD_DEFINED__
 typedef interface ID3D12Tools ID3D12Tools;
 
 #endif 	/* __ID3D12Tools_FWD_DEFINED__ */
+
+
+#ifndef __ID3D12SDKConfiguration_FWD_DEFINED__
+#define __ID3D12SDKConfiguration_FWD_DEFINED__
+typedef interface ID3D12SDKConfiguration ID3D12SDKConfiguration;
+
+#endif 	/* __ID3D12SDKConfiguration_FWD_DEFINED__ */
 
 
 #ifndef __ID3D12GraphicsCommandList5_FWD_DEFINED__
@@ -408,8 +445,8 @@ typedef interface ID3D12GraphicsCommandList6 ID3D12GraphicsCommandList6;
 
 
 /* header files for imported files */
-#include "oaidl.h"
-#include "ocidl.h"
+#include "OAIdl.h"
+#include "OCIdl.h"
 #include "dxgicommon.h"
 #include "dxgiformat.h"
 #include "d3dcommon.h"
@@ -422,7 +459,7 @@ extern "C"{
 /* interface __MIDL_itf_d3d12_0000_0000 */
 /* [local] */ 
 
-#include "winapifamily.h"
+#include <winapifamily.h>
 #pragma region App Family
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_GAMES)
 #ifndef _D3D12_CONSTANTS
@@ -1070,6 +1107,8 @@ extern "C"{
 
 #define	D3D12_RS_SET_SHADING_RATE_COMBINER_COUNT	( 2 )
 
+#define	D3D12_SDK_VERSION	( 4 )
+
 #define	D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES	( 32 )
 
 #define	D3D12_SHADER_MAJOR_VERSION	( 5 )
@@ -1559,34 +1598,41 @@ EXTERN_C const IID IID_ID3D12Object;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Object * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Object * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Object * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Object * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Object * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Object * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Object * This,
             _In_z_  LPCWSTR Name);
@@ -1665,38 +1711,46 @@ EXTERN_C const IID IID_ID3D12DeviceChild;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DeviceChild * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DeviceChild * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DeviceChild * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12DeviceChild * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12DeviceChild * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12DeviceChild * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12DeviceChild * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12DeviceChild * This,
             REFIID riid,
@@ -1776,38 +1830,46 @@ EXTERN_C const IID IID_ID3D12RootSignature;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12RootSignature * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12RootSignature * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12RootSignature * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12RootSignature * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12RootSignature * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12RootSignature * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12RootSignature * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12RootSignature * This,
             REFIID riid,
@@ -2010,11 +2072,16 @@ enum D3D12_FEATURE
         D3D12_FEATURE_SERIALIZATION	= 24,
         D3D12_FEATURE_CROSS_NODE	= 25,
         D3D12_FEATURE_D3D12_OPTIONS5	= 27,
+        D3D12_FEATURE_DISPLAYABLE	= 28,
         D3D12_FEATURE_D3D12_OPTIONS6	= 30,
         D3D12_FEATURE_QUERY_META_COMMAND	= 31,
         D3D12_FEATURE_D3D12_OPTIONS7	= 32,
         D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPE_COUNT	= 33,
-        D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPES	= 34
+        D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPES	= 34,
+        D3D12_FEATURE_D3D12_OPTIONS8	= 36,
+        D3D12_FEATURE_D3D12_OPTIONS9	= 37,
+        D3D12_FEATURE_D3D12_OPTIONS10	= 39,
+        D3D12_FEATURE_D3D12_OPTIONS11	= 40
     } 	D3D12_FEATURE;
 
 typedef 
@@ -2232,7 +2299,8 @@ enum D3D_SHADER_MODEL
         D3D_SHADER_MODEL_6_3	= 0x63,
         D3D_SHADER_MODEL_6_4	= 0x64,
         D3D_SHADER_MODEL_6_5	= 0x65,
-        D3D_SHADER_MODEL_6_6	= 0x66
+        D3D_SHADER_MODEL_6_6	= 0x66,
+        D3D_SHADER_MODEL_6_7	= 0x67
     } 	D3D_SHADER_MODEL;
 
 typedef struct D3D12_FEATURE_DATA_SHADER_MODEL
@@ -2274,7 +2342,10 @@ enum D3D12_SHADER_CACHE_SUPPORT_FLAGS
         D3D12_SHADER_CACHE_SUPPORT_SINGLE_PSO	= 0x1,
         D3D12_SHADER_CACHE_SUPPORT_LIBRARY	= 0x2,
         D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_INPROC_CACHE	= 0x4,
-        D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_DISK_CACHE	= 0x8
+        D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_DISK_CACHE	= 0x8,
+        D3D12_SHADER_CACHE_SUPPORT_DRIVER_MANAGED_CACHE	= 0x10,
+        D3D12_SHADER_CACHE_SUPPORT_SHADER_CONTROL_CLEAR	= 0x20,
+        D3D12_SHADER_CACHE_SUPPORT_SHADER_SESSION_DELETE	= 0x40
     } 	D3D12_SHADER_CACHE_SUPPORT_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS( D3D12_SHADER_CACHE_SUPPORT_FLAGS );
@@ -2323,8 +2394,15 @@ enum D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER
     {
         D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_0	= 0,
         D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_1	= ( D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_0 + 1 ) ,
-        D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2	= ( D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_1 + 1 ) 
+        D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2	= ( D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_1 + 1 ) ,
+        D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3	= ( D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2 + 1 ) 
     } 	D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER;
+
+typedef struct D3D12_FEATURE_DATA_DISPLAYABLE
+    {
+    _Out_  BOOL DisplayableTexture;
+    _Out_  D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER SharedResourceCompatibilityTier;
+    } 	D3D12_FEATURE_DATA_DISPLAYABLE;
 
 typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS4
     {
@@ -2422,6 +2500,39 @@ typedef struct D3D12_FEATURE_DATA_QUERY_META_COMMAND
     _Field_size_bytes_full_( QueryOutputDataSizeInBytes )  void *pQueryOutputData;
     _In_  SIZE_T QueryOutputDataSizeInBytes;
     } 	D3D12_FEATURE_DATA_QUERY_META_COMMAND;
+
+typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS8
+    {
+    _Out_  BOOL UnalignedBlockTexturesSupported;
+    } 	D3D12_FEATURE_DATA_D3D12_OPTIONS8;
+
+typedef 
+enum D3D12_WAVE_MMA_TIER
+    {
+        D3D12_WAVE_MMA_TIER_NOT_SUPPORTED	= 0,
+        D3D12_WAVE_MMA_TIER_1_0	= 10
+    } 	D3D12_WAVE_MMA_TIER;
+
+typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS9
+    {
+    _Out_  BOOL MeshShaderPipelineStatsSupported;
+    _Out_  BOOL MeshShaderSupportsFullRangeRenderTargetArrayIndex;
+    _Out_  BOOL AtomicInt64OnTypedResourceSupported;
+    _Out_  BOOL AtomicInt64OnGroupSharedSupported;
+    _Out_  BOOL DerivativesInMeshAndAmplificationShadersSupported;
+    _Out_  D3D12_WAVE_MMA_TIER WaveMMATier;
+    } 	D3D12_FEATURE_DATA_D3D12_OPTIONS9;
+
+typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS10
+    {
+    _Out_  BOOL VariableRateShadingSumCombinerSupported;
+    _Out_  BOOL MeshShaderPerPrimitiveShadingRateSupported;
+    } 	D3D12_FEATURE_DATA_D3D12_OPTIONS10;
+
+typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS11
+    {
+    _Out_  BOOL AtomicInt64OnDescriptorHeapResourceSupported;
+    } 	D3D12_FEATURE_DATA_D3D12_OPTIONS11;
 
 typedef struct D3D12_RESOURCE_ALLOCATION_INFO
     {
@@ -2530,7 +2641,8 @@ enum D3D12_RESOURCE_FLAGS
         D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE	= 0x8,
         D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER	= 0x10,
         D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS	= 0x20,
-        D3D12_RESOURCE_FLAG_VIDEO_DECODE_REFERENCE_ONLY	= 0x40
+        D3D12_RESOURCE_FLAG_VIDEO_DECODE_REFERENCE_ONLY	= 0x40,
+        D3D12_RESOURCE_FLAG_VIDEO_ENCODE_REFERENCE_ONLY	= 0x80
     } 	D3D12_RESOURCE_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS( D3D12_RESOURCE_FLAGS );
@@ -2699,6 +2811,7 @@ enum D3D12_RESOURCE_STATES
         D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE	= 0x400000,
         D3D12_RESOURCE_STATE_SHADING_RATE_SOURCE	= 0x1000000,
         D3D12_RESOURCE_STATE_GENERIC_READ	= ( ( ( ( ( 0x1 | 0x2 )  | 0x40 )  | 0x80 )  | 0x200 )  | 0x800 ) ,
+        D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE	= ( 0x40 | 0x80 ) ,
         D3D12_RESOURCE_STATE_PRESENT	= 0,
         D3D12_RESOURCE_STATE_PREDICATION	= 0x200,
         D3D12_RESOURCE_STATE_VIDEO_DECODE_READ	= 0x10000,
@@ -3470,7 +3583,9 @@ enum D3D12_ROOT_SIGNATURE_FLAGS
         D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT	= 0x40,
         D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE	= 0x80,
         D3D12_ROOT_SIGNATURE_FLAG_DENY_AMPLIFICATION_SHADER_ROOT_ACCESS	= 0x100,
-        D3D12_ROOT_SIGNATURE_FLAG_DENY_MESH_SHADER_ROOT_ACCESS	= 0x200
+        D3D12_ROOT_SIGNATURE_FLAG_DENY_MESH_SHADER_ROOT_ACCESS	= 0x200,
+        D3D12_ROOT_SIGNATURE_FLAG_CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED	= 0x400,
+        D3D12_ROOT_SIGNATURE_FLAG_SAMPLER_HEAP_DIRECTLY_INDEXED	= 0x800
     } 	D3D12_ROOT_SIGNATURE_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS( D3D12_ROOT_SIGNATURE_FLAGS );
@@ -3615,17 +3730,21 @@ EXTERN_C const IID IID_ID3D12RootSignatureDeserializer;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12RootSignatureDeserializer * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12RootSignatureDeserializer * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12RootSignatureDeserializer * This);
         
+        DECLSPEC_XFGVIRT(ID3D12RootSignatureDeserializer, GetRootSignatureDesc)
         const D3D12_ROOT_SIGNATURE_DESC *( STDMETHODCALLTYPE *GetRootSignatureDesc )( 
             ID3D12RootSignatureDeserializer * This);
         
@@ -3696,22 +3815,27 @@ EXTERN_C const IID IID_ID3D12VersionedRootSignatureDeserializer;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12VersionedRootSignatureDeserializer * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12VersionedRootSignatureDeserializer * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12VersionedRootSignatureDeserializer * This);
         
+        DECLSPEC_XFGVIRT(ID3D12VersionedRootSignatureDeserializer, GetRootSignatureDescAtVersion)
         HRESULT ( STDMETHODCALLTYPE *GetRootSignatureDescAtVersion )( 
             ID3D12VersionedRootSignatureDeserializer * This,
             D3D_ROOT_SIGNATURE_VERSION convertToVersion,
             _Out_  const D3D12_VERSIONED_ROOT_SIGNATURE_DESC **ppDesc);
         
+        DECLSPEC_XFGVIRT(ID3D12VersionedRootSignatureDeserializer, GetUnconvertedRootSignatureDesc)
         const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *( STDMETHODCALLTYPE *GetUnconvertedRootSignatureDesc )( 
             ID3D12VersionedRootSignatureDeserializer * This);
         
@@ -3832,7 +3956,8 @@ enum D3D12_QUERY_HEAP_TYPE
         D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS	= 2,
         D3D12_QUERY_HEAP_TYPE_SO_STATISTICS	= 3,
         D3D12_QUERY_HEAP_TYPE_VIDEO_DECODE_STATISTICS	= 4,
-        D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP	= 5
+        D3D12_QUERY_HEAP_TYPE_COPY_QUEUE_TIMESTAMP	= 5,
+        D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS1	= 7
     } 	D3D12_QUERY_HEAP_TYPE;
 
 typedef struct D3D12_QUERY_HEAP_DESC
@@ -3853,7 +3978,8 @@ enum D3D12_QUERY_TYPE
         D3D12_QUERY_TYPE_SO_STATISTICS_STREAM1	= 5,
         D3D12_QUERY_TYPE_SO_STATISTICS_STREAM2	= 6,
         D3D12_QUERY_TYPE_SO_STATISTICS_STREAM3	= 7,
-        D3D12_QUERY_TYPE_VIDEO_DECODE_STATISTICS	= 8
+        D3D12_QUERY_TYPE_VIDEO_DECODE_STATISTICS	= 8,
+        D3D12_QUERY_TYPE_PIPELINE_STATISTICS1	= 10
     } 	D3D12_QUERY_TYPE;
 
 typedef 
@@ -3877,6 +4003,24 @@ typedef struct D3D12_QUERY_DATA_PIPELINE_STATISTICS
     UINT64 DSInvocations;
     UINT64 CSInvocations;
     } 	D3D12_QUERY_DATA_PIPELINE_STATISTICS;
+
+typedef struct D3D12_QUERY_DATA_PIPELINE_STATISTICS1
+    {
+    UINT64 IAVertices;
+    UINT64 IAPrimitives;
+    UINT64 VSInvocations;
+    UINT64 GSInvocations;
+    UINT64 GSPrimitives;
+    UINT64 CInvocations;
+    UINT64 CPrimitives;
+    UINT64 PSInvocations;
+    UINT64 HSInvocations;
+    UINT64 DSInvocations;
+    UINT64 CSInvocations;
+    UINT64 ASInvocations;
+    UINT64 MSInvocations;
+    UINT64 MSPrimitives;
+    } 	D3D12_QUERY_DATA_PIPELINE_STATISTICS1;
 
 typedef struct D3D12_QUERY_DATA_SO_STATISTICS
     {
@@ -4013,38 +4157,46 @@ EXTERN_C const IID IID_ID3D12Pageable;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Pageable * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Pageable * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Pageable * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Pageable * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Pageable * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Pageable * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Pageable * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Pageable * This,
             REFIID riid,
@@ -4127,45 +4279,55 @@ EXTERN_C const IID IID_ID3D12Heap;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Heap * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Heap * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Heap * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Heap * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Heap * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Heap * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Heap * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Heap * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
-        D3D12_HEAP_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12Heap * This);
+        DECLSPEC_XFGVIRT(ID3D12Heap, GetDesc)
+        D3D12_HEAP_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12Heap * This,
+            D3D12_HEAP_DESC * RetVal);
         
         END_INTERFACE
     } ID3D12HeapVtbl;
@@ -4208,17 +4370,13 @@ EXTERN_C const IID IID_ID3D12Heap;
 
 
 
-#define ID3D12Heap_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12Heap_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -4281,60 +4439,74 @@ EXTERN_C const IID IID_ID3D12Resource;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Resource * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Resource * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Resource * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Resource * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Resource * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Resource * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Resource * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Resource * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, Map)
         HRESULT ( STDMETHODCALLTYPE *Map )( 
             ID3D12Resource * This,
             UINT Subresource,
             _In_opt_  const D3D12_RANGE *pReadRange,
             _Outptr_opt_result_bytebuffer_(_Inexpressible_("Dependent on resource"))  void **ppData);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, Unmap)
         void ( STDMETHODCALLTYPE *Unmap )( 
             ID3D12Resource * This,
             UINT Subresource,
             _In_opt_  const D3D12_RANGE *pWrittenRange);
         
-        D3D12_RESOURCE_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12Resource * This);
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetDesc)
+        D3D12_RESOURCE_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12Resource * This,
+            D3D12_RESOURCE_DESC * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetGPUVirtualAddress)
         D3D12_GPU_VIRTUAL_ADDRESS ( STDMETHODCALLTYPE *GetGPUVirtualAddress )( 
             ID3D12Resource * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, WriteToSubresource)
         HRESULT ( STDMETHODCALLTYPE *WriteToSubresource )( 
             ID3D12Resource * This,
             UINT DstSubresource,
@@ -4343,6 +4515,7 @@ EXTERN_C const IID IID_ID3D12Resource;
             UINT SrcRowPitch,
             UINT SrcDepthPitch);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, ReadFromSubresource)
         HRESULT ( STDMETHODCALLTYPE *ReadFromSubresource )( 
             ID3D12Resource * This,
             _Out_  void *pDstData,
@@ -4351,6 +4524,7 @@ EXTERN_C const IID IID_ID3D12Resource;
             UINT SrcSubresource,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetHeapProperties)
         HRESULT ( STDMETHODCALLTYPE *GetHeapProperties )( 
             ID3D12Resource * This,
             _Out_opt_  D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -4403,8 +4577,8 @@ EXTERN_C const IID IID_ID3D12Resource;
 #define ID3D12Resource_Unmap(This,Subresource,pWrittenRange)	\
     ( (This)->lpVtbl -> Unmap(This,Subresource,pWrittenRange) ) 
 
-#define ID3D12Resource_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12Resource_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 #define ID3D12Resource_GetGPUVirtualAddress(This)	\
     ( (This)->lpVtbl -> GetGPUVirtualAddress(This) ) 
@@ -4422,10 +4596,6 @@ EXTERN_C const IID IID_ID3D12Resource;
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -4459,43 +4629,52 @@ EXTERN_C const IID IID_ID3D12CommandAllocator;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12CommandAllocator * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12CommandAllocator * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12CommandAllocator * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12CommandAllocator * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12CommandAllocator * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12CommandAllocator * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12CommandAllocator * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12CommandAllocator * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandAllocator, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12CommandAllocator * This);
         
@@ -4587,51 +4766,62 @@ EXTERN_C const IID IID_ID3D12Fence;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Fence * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Fence * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Fence * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Fence * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Fence * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Fence * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Fence * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Fence * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence, GetCompletedValue)
         UINT64 ( STDMETHODCALLTYPE *GetCompletedValue )( 
             ID3D12Fence * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence, SetEventOnCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnCompletion )( 
             ID3D12Fence * This,
             UINT64 Value,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence, Signal)
         HRESULT ( STDMETHODCALLTYPE *Signal )( 
             ID3D12Fence * This,
             UINT64 Value);
@@ -4723,55 +4913,67 @@ EXTERN_C const IID IID_ID3D12Fence1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Fence1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Fence1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Fence1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Fence1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Fence1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Fence1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Fence1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Fence1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence, GetCompletedValue)
         UINT64 ( STDMETHODCALLTYPE *GetCompletedValue )( 
             ID3D12Fence1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence, SetEventOnCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnCompletion )( 
             ID3D12Fence1 * This,
             UINT64 Value,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence, Signal)
         HRESULT ( STDMETHODCALLTYPE *Signal )( 
             ID3D12Fence1 * This,
             UINT64 Value);
         
+        DECLSPEC_XFGVIRT(ID3D12Fence1, GetCreationFlags)
         D3D12_FENCE_FLAGS ( STDMETHODCALLTYPE *GetCreationFlags )( 
             ID3D12Fence1 * This);
         
@@ -4867,43 +5069,52 @@ EXTERN_C const IID IID_ID3D12PipelineState;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12PipelineState * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12PipelineState * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12PipelineState * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12PipelineState * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12PipelineState * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12PipelineState * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12PipelineState * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12PipelineState * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineState, GetCachedBlob)
         HRESULT ( STDMETHODCALLTYPE *GetCachedBlob )( 
             ID3D12PipelineState * This,
             _COM_Outptr_  ID3DBlob **ppBlob);
@@ -4993,51 +5204,65 @@ EXTERN_C const IID IID_ID3D12DescriptorHeap;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DescriptorHeap * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DescriptorHeap * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DescriptorHeap * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12DescriptorHeap * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12DescriptorHeap * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12DescriptorHeap * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12DescriptorHeap * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12DescriptorHeap * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
-        D3D12_DESCRIPTOR_HEAP_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12DescriptorHeap * This);
+        DECLSPEC_XFGVIRT(ID3D12DescriptorHeap, GetDesc)
+        D3D12_DESCRIPTOR_HEAP_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12DescriptorHeap * This,
+            D3D12_DESCRIPTOR_HEAP_DESC * RetVal);
         
-        D3D12_CPU_DESCRIPTOR_HANDLE ( STDMETHODCALLTYPE *GetCPUDescriptorHandleForHeapStart )( 
-            ID3D12DescriptorHeap * This);
+        DECLSPEC_XFGVIRT(ID3D12DescriptorHeap, GetCPUDescriptorHandleForHeapStart)
+        D3D12_CPU_DESCRIPTOR_HANDLE *( STDMETHODCALLTYPE *GetCPUDescriptorHandleForHeapStart )( 
+            ID3D12DescriptorHeap * This,
+            D3D12_CPU_DESCRIPTOR_HANDLE * RetVal);
         
-        D3D12_GPU_DESCRIPTOR_HANDLE ( STDMETHODCALLTYPE *GetGPUDescriptorHandleForHeapStart )( 
-            ID3D12DescriptorHeap * This);
+        DECLSPEC_XFGVIRT(ID3D12DescriptorHeap, GetGPUDescriptorHandleForHeapStart)
+        D3D12_GPU_DESCRIPTOR_HANDLE *( STDMETHODCALLTYPE *GetGPUDescriptorHandleForHeapStart )( 
+            ID3D12DescriptorHeap * This,
+            D3D12_GPU_DESCRIPTOR_HANDLE * RetVal);
         
         END_INTERFACE
     } ID3D12DescriptorHeapVtbl;
@@ -5080,31 +5305,19 @@ EXTERN_C const IID IID_ID3D12DescriptorHeap;
 
 
 
-#define ID3D12DescriptorHeap_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12DescriptorHeap_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
-#define ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(This)	\
-    ( (This)->lpVtbl -> GetCPUDescriptorHandleForHeapStart(This) ) 
+#define ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(This,RetVal)	\
+    ( (This)->lpVtbl -> GetCPUDescriptorHandleForHeapStart(This,RetVal) ) 
 
-#define ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart(This)	\
-    ( (This)->lpVtbl -> GetGPUDescriptorHandleForHeapStart(This) ) 
+#define ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart(This,RetVal)	\
+    ( (This)->lpVtbl -> GetGPUDescriptorHandleForHeapStart(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -5136,38 +5349,46 @@ EXTERN_C const IID IID_ID3D12QueryHeap;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12QueryHeap * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12QueryHeap * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12QueryHeap * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12QueryHeap * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12QueryHeap * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12QueryHeap * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12QueryHeap * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12QueryHeap * This,
             REFIID riid,
@@ -5249,38 +5470,46 @@ EXTERN_C const IID IID_ID3D12CommandSignature;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12CommandSignature * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12CommandSignature * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12CommandSignature * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12CommandSignature * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12CommandSignature * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12CommandSignature * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12CommandSignature * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12CommandSignature * This,
             REFIID riid,
@@ -5364,43 +5593,52 @@ EXTERN_C const IID IID_ID3D12CommandList;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12CommandList * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12CommandList * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12CommandList * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12CommandList * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12CommandList * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12CommandList * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12CommandList * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12CommandList * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12CommandList * This);
         
@@ -5730,58 +5968,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT VertexCountPerInstance,
@@ -5789,6 +6040,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT IndexCountPerInstance,
@@ -5797,12 +6049,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -5811,6 +6065,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -5820,11 +6075,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -5834,6 +6091,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12Resource *pDstResource,
@@ -5842,76 +6100,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
@@ -5919,6 +6193,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
@@ -5926,52 +6201,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -5979,6 +6264,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -5988,6 +6274,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -5995,6 +6282,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -6004,6 +6292,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -6013,23 +6302,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -6039,27 +6332,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -6342,58 +6640,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList1 * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT VertexCountPerInstance,
@@ -6401,6 +6712,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT IndexCountPerInstance,
@@ -6409,12 +6721,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -6423,6 +6737,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -6432,11 +6747,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -6446,6 +6763,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -6454,76 +6772,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList1 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList1 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList1 * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList1 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList1 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
@@ -6531,6 +6865,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
@@ -6538,52 +6873,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList1 * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -6591,6 +6936,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -6600,6 +6946,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -6607,6 +6954,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -6616,6 +6964,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -6625,23 +6974,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -6651,27 +7004,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList1 * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList1 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList1 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -6681,6 +7039,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_opt_  ID3D12Resource *pCountBuffer,
             _In_  UINT64 CountBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -6691,6 +7050,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT64)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT64 )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -6701,17 +7061,20 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, OMSetDepthBounds)
         void ( STDMETHODCALLTYPE *OMSetDepthBounds )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  FLOAT Min,
             _In_  FLOAT Max);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetSamplePositions)
         void ( STDMETHODCALLTYPE *SetSamplePositions )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT NumSamplesPerPixel,
             _In_  UINT NumPixels,
             _In_reads_(NumSamplesPerPixel*NumPixels)  D3D12_SAMPLE_POSITION *pSamplePositions);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, ResolveSubresourceRegion)
         void ( STDMETHODCALLTYPE *ResolveSubresourceRegion )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -6724,6 +7087,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList1;
             _In_  DXGI_FORMAT Format,
             _In_  D3D12_RESOLVE_MODE ResolveMode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetViewInstanceMask)
         void ( STDMETHODCALLTYPE *SetViewInstanceMask )( 
             ID3D12GraphicsCommandList1 * This,
             _In_  UINT Mask);
@@ -7006,58 +7370,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList2 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList2 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList2 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList2 * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT VertexCountPerInstance,
@@ -7065,6 +7442,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT IndexCountPerInstance,
@@ -7073,12 +7451,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -7087,6 +7467,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -7096,11 +7477,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -7110,6 +7493,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -7118,76 +7502,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList2 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList2 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList2 * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList2 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList2 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
@@ -7195,6 +7595,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
@@ -7202,52 +7603,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList2 * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -7255,6 +7666,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -7264,6 +7676,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -7271,6 +7684,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -7280,6 +7694,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -7289,23 +7704,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -7315,27 +7734,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList2 * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList2 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList2 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -7345,6 +7769,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_opt_  ID3D12Resource *pCountBuffer,
             _In_  UINT64 CountBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -7355,6 +7780,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT64)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT64 )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -7365,17 +7791,20 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, OMSetDepthBounds)
         void ( STDMETHODCALLTYPE *OMSetDepthBounds )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  FLOAT Min,
             _In_  FLOAT Max);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetSamplePositions)
         void ( STDMETHODCALLTYPE *SetSamplePositions )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT NumSamplesPerPixel,
             _In_  UINT NumPixels,
             _In_reads_(NumSamplesPerPixel*NumPixels)  D3D12_SAMPLE_POSITION *pSamplePositions);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, ResolveSubresourceRegion)
         void ( STDMETHODCALLTYPE *ResolveSubresourceRegion )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -7388,10 +7817,12 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList2;
             _In_  DXGI_FORMAT Format,
             _In_  D3D12_RESOLVE_MODE ResolveMode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetViewInstanceMask)
         void ( STDMETHODCALLTYPE *SetViewInstanceMask )( 
             ID3D12GraphicsCommandList2 * This,
             _In_  UINT Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList2, WriteBufferImmediate)
         void ( STDMETHODCALLTYPE *WriteBufferImmediate )( 
             ID3D12GraphicsCommandList2 * This,
             UINT Count,
@@ -7706,43 +8137,52 @@ EXTERN_C const IID IID_ID3D12CommandQueue;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12CommandQueue * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12CommandQueue * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12CommandQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12CommandQueue * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12CommandQueue * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12CommandQueue * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12CommandQueue * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12CommandQueue * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, UpdateTileMappings)
         void ( STDMETHODCALLTYPE *UpdateTileMappings )( 
             ID3D12CommandQueue * This,
             _In_  ID3D12Resource *pResource,
@@ -7756,6 +8196,7 @@ EXTERN_C const IID IID_ID3D12CommandQueue;
             _In_reads_opt_(NumRanges)  const UINT *pRangeTileCounts,
             D3D12_TILE_MAPPING_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, CopyTileMappings)
         void ( STDMETHODCALLTYPE *CopyTileMappings )( 
             ID3D12CommandQueue * This,
             _In_  ID3D12Resource *pDstResource,
@@ -7765,47 +8206,57 @@ EXTERN_C const IID IID_ID3D12CommandQueue;
             _In_  const D3D12_TILE_REGION_SIZE *pRegionSize,
             D3D12_TILE_MAPPING_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, ExecuteCommandLists)
         void ( STDMETHODCALLTYPE *ExecuteCommandLists )( 
             ID3D12CommandQueue * This,
             _In_  UINT NumCommandLists,
             _In_reads_(NumCommandLists)  ID3D12CommandList *const *ppCommandLists);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12CommandQueue * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12CommandQueue * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12CommandQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, Signal)
         HRESULT ( STDMETHODCALLTYPE *Signal )( 
             ID3D12CommandQueue * This,
             ID3D12Fence *pFence,
             UINT64 Value);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, Wait)
         HRESULT ( STDMETHODCALLTYPE *Wait )( 
             ID3D12CommandQueue * This,
             ID3D12Fence *pFence,
             UINT64 Value);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, GetTimestampFrequency)
         HRESULT ( STDMETHODCALLTYPE *GetTimestampFrequency )( 
             ID3D12CommandQueue * This,
             _Out_  UINT64 *pFrequency);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, GetClockCalibration)
         HRESULT ( STDMETHODCALLTYPE *GetClockCalibration )( 
             ID3D12CommandQueue * This,
             _Out_  UINT64 *pGpuTimestamp,
             _Out_  UINT64 *pCpuTimestamp);
         
-        D3D12_COMMAND_QUEUE_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12CommandQueue * This);
+        DECLSPEC_XFGVIRT(ID3D12CommandQueue, GetDesc)
+        D3D12_COMMAND_QUEUE_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12CommandQueue * This,
+            D3D12_COMMAND_QUEUE_DESC * RetVal);
         
         END_INTERFACE
     } ID3D12CommandQueueVtbl;
@@ -7878,17 +8329,13 @@ EXTERN_C const IID IID_ID3D12CommandQueue;
 #define ID3D12CommandQueue_GetClockCalibration(This,pGpuTimestamp,pCpuTimestamp)	\
     ( (This)->lpVtbl -> GetClockCalibration(This,pGpuTimestamp,pCpuTimestamp) ) 
 
-#define ID3D12CommandQueue_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12CommandQueue_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -8143,65 +8590,78 @@ EXTERN_C const IID IID_ID3D12Device;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device * This,
             _In_  UINT nodeMask,
@@ -8211,22 +8671,26 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device * This,
             _In_  UINT nodeMask,
@@ -8235,17 +8699,20 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -8253,23 +8720,27 @@ EXTERN_C const IID IID_ID3D12Device;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -8280,6 +8751,7 @@ EXTERN_C const IID IID_ID3D12Device;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device * This,
             _In_  UINT NumDescriptors,
@@ -8287,17 +8759,22 @@ EXTERN_C const IID IID_ID3D12Device;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -8308,12 +8785,14 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device * This,
             _In_  ID3D12Heap *pHeap,
@@ -8324,6 +8803,7 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -8332,6 +8812,7 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -8340,12 +8821,14 @@ EXTERN_C const IID IID_ID3D12Device;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device * This,
             _In_  LPCWSTR Name,
@@ -8353,16 +8836,19 @@ EXTERN_C const IID IID_ID3D12Device;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device * This,
             UINT64 InitialValue,
@@ -8370,9 +8856,11 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -8384,16 +8872,19 @@ EXTERN_C const IID IID_ID3D12Device;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -8401,6 +8892,7 @@ EXTERN_C const IID IID_ID3D12Device;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -8411,8 +8903,10 @@ EXTERN_C const IID IID_ID3D12Device;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device * This,
+            LUID * RetVal);
         
         END_INTERFACE
     } ID3D12DeviceVtbl;
@@ -8504,11 +8998,11 @@ EXTERN_C const IID IID_ID3D12Device;
 #define ID3D12Device_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -8558,25 +9052,13 @@ EXTERN_C const IID IID_ID3D12Device;
 #define ID3D12Device_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -8630,48 +9112,58 @@ EXTERN_C const IID IID_ID3D12PipelineLibrary;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12PipelineLibrary * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12PipelineLibrary * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12PipelineLibrary * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12PipelineLibrary * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12PipelineLibrary * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12PipelineLibrary * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12PipelineLibrary * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12PipelineLibrary * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, StorePipeline)
         HRESULT ( STDMETHODCALLTYPE *StorePipeline )( 
             ID3D12PipelineLibrary * This,
             _In_opt_  LPCWSTR pName,
             _In_  ID3D12PipelineState *pPipeline);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, LoadGraphicsPipeline)
         HRESULT ( STDMETHODCALLTYPE *LoadGraphicsPipeline )( 
             ID3D12PipelineLibrary * This,
             _In_  LPCWSTR pName,
@@ -8679,6 +9171,7 @@ EXTERN_C const IID IID_ID3D12PipelineLibrary;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, LoadComputePipeline)
         HRESULT ( STDMETHODCALLTYPE *LoadComputePipeline )( 
             ID3D12PipelineLibrary * This,
             _In_  LPCWSTR pName,
@@ -8686,9 +9179,11 @@ EXTERN_C const IID IID_ID3D12PipelineLibrary;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, GetSerializedSize)
         SIZE_T ( STDMETHODCALLTYPE *GetSerializedSize )( 
             ID3D12PipelineLibrary * This);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, Serialize)
         HRESULT ( STDMETHODCALLTYPE *Serialize )( 
             ID3D12PipelineLibrary * This,
             _Out_writes_(DataSizeInBytes)  void *pData,
@@ -8790,48 +9285,58 @@ EXTERN_C const IID IID_ID3D12PipelineLibrary1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12PipelineLibrary1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12PipelineLibrary1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12PipelineLibrary1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12PipelineLibrary1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12PipelineLibrary1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12PipelineLibrary1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12PipelineLibrary1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12PipelineLibrary1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, StorePipeline)
         HRESULT ( STDMETHODCALLTYPE *StorePipeline )( 
             ID3D12PipelineLibrary1 * This,
             _In_opt_  LPCWSTR pName,
             _In_  ID3D12PipelineState *pPipeline);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, LoadGraphicsPipeline)
         HRESULT ( STDMETHODCALLTYPE *LoadGraphicsPipeline )( 
             ID3D12PipelineLibrary1 * This,
             _In_  LPCWSTR pName,
@@ -8839,6 +9344,7 @@ EXTERN_C const IID IID_ID3D12PipelineLibrary1;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, LoadComputePipeline)
         HRESULT ( STDMETHODCALLTYPE *LoadComputePipeline )( 
             ID3D12PipelineLibrary1 * This,
             _In_  LPCWSTR pName,
@@ -8846,14 +9352,17 @@ EXTERN_C const IID IID_ID3D12PipelineLibrary1;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, GetSerializedSize)
         SIZE_T ( STDMETHODCALLTYPE *GetSerializedSize )( 
             ID3D12PipelineLibrary1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary, Serialize)
         HRESULT ( STDMETHODCALLTYPE *Serialize )( 
             ID3D12PipelineLibrary1 * This,
             _Out_writes_(DataSizeInBytes)  void *pData,
             SIZE_T DataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12PipelineLibrary1, LoadPipeline)
         HRESULT ( STDMETHODCALLTYPE *LoadPipeline )( 
             ID3D12PipelineLibrary1 * This,
             _In_  LPCWSTR pName,
@@ -9000,65 +9509,78 @@ EXTERN_C const IID IID_ID3D12Device1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device1 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device1 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device1 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device1 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device1 * This,
             _In_  UINT nodeMask,
@@ -9068,22 +9590,26 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device1 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device1 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device1 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device1 * This,
             _In_  UINT nodeMask,
@@ -9092,17 +9618,20 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device1 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device1 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device1 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -9110,23 +9639,27 @@ EXTERN_C const IID IID_ID3D12Device1;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device1 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device1 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device1 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device1 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -9137,6 +9670,7 @@ EXTERN_C const IID IID_ID3D12Device1;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device1 * This,
             _In_  UINT NumDescriptors,
@@ -9144,17 +9678,22 @@ EXTERN_C const IID IID_ID3D12Device1;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device1 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device1 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device1 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -9165,12 +9704,14 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device1 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device1 * This,
             _In_  ID3D12Heap *pHeap,
@@ -9181,6 +9722,7 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device1 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -9189,6 +9731,7 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device1 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -9197,12 +9740,14 @@ EXTERN_C const IID IID_ID3D12Device1;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device1 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device1 * This,
             _In_  LPCWSTR Name,
@@ -9210,16 +9755,19 @@ EXTERN_C const IID IID_ID3D12Device1;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device1 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device1 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device1 * This,
             UINT64 InitialValue,
@@ -9227,9 +9775,11 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device1 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -9241,16 +9791,19 @@ EXTERN_C const IID IID_ID3D12Device1;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device1 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device1 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device1 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -9258,6 +9811,7 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device1 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -9268,9 +9822,12 @@ EXTERN_C const IID IID_ID3D12Device1;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device1 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device1 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device1 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -9278,6 +9835,7 @@ EXTERN_C const IID IID_ID3D12Device1;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device1 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -9286,6 +9844,7 @@ EXTERN_C const IID IID_ID3D12Device1;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device1 * This,
             UINT NumObjects,
@@ -9382,11 +9941,11 @@ EXTERN_C const IID IID_ID3D12Device1;
 #define ID3D12Device1_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device1_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device1_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device1_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device1_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device1_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -9436,8 +9995,8 @@ EXTERN_C const IID IID_ID3D12Device1;
 #define ID3D12Device1_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device1_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device1_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device1_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -9489,65 +10048,78 @@ EXTERN_C const IID IID_ID3D12Device2;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device2 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device2 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device2 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device2 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device2 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device2 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device2 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device2 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device2 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device2 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device2 * This,
             _In_  UINT nodeMask,
@@ -9557,22 +10129,26 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device2 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device2 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device2 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device2 * This,
             _In_  UINT nodeMask,
@@ -9581,17 +10157,20 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device2 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device2 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device2 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -9599,23 +10178,27 @@ EXTERN_C const IID IID_ID3D12Device2;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device2 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device2 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device2 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device2 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -9626,6 +10209,7 @@ EXTERN_C const IID IID_ID3D12Device2;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device2 * This,
             _In_  UINT NumDescriptors,
@@ -9633,17 +10217,22 @@ EXTERN_C const IID IID_ID3D12Device2;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device2 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device2 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device2 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -9654,12 +10243,14 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device2 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device2 * This,
             _In_  ID3D12Heap *pHeap,
@@ -9670,6 +10261,7 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device2 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -9678,6 +10270,7 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device2 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -9686,12 +10279,14 @@ EXTERN_C const IID IID_ID3D12Device2;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device2 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device2 * This,
             _In_  LPCWSTR Name,
@@ -9699,16 +10294,19 @@ EXTERN_C const IID IID_ID3D12Device2;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device2 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device2 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device2 * This,
             UINT64 InitialValue,
@@ -9716,9 +10314,11 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device2 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -9730,16 +10330,19 @@ EXTERN_C const IID IID_ID3D12Device2;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device2 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device2 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device2 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -9747,6 +10350,7 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device2 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -9757,9 +10361,12 @@ EXTERN_C const IID IID_ID3D12Device2;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device2 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device2 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device2 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -9767,6 +10374,7 @@ EXTERN_C const IID IID_ID3D12Device2;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device2 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -9775,12 +10383,14 @@ EXTERN_C const IID IID_ID3D12Device2;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device2 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device2 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
@@ -9877,11 +10487,11 @@ EXTERN_C const IID IID_ID3D12Device2;
 #define ID3D12Device2_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device2_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device2_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device2_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device2_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device2_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -9931,8 +10541,8 @@ EXTERN_C const IID IID_ID3D12Device2;
 #define ID3D12Device2_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device2_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device2_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device2_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -10016,65 +10626,78 @@ EXTERN_C const IID IID_ID3D12Device3;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device3 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device3 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device3 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device3 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device3 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device3 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device3 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device3 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device3 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device3 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device3 * This,
             _In_  UINT nodeMask,
@@ -10084,22 +10707,26 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device3 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device3 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device3 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device3 * This,
             _In_  UINT nodeMask,
@@ -10108,17 +10735,20 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device3 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device3 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device3 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -10126,23 +10756,27 @@ EXTERN_C const IID IID_ID3D12Device3;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device3 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device3 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device3 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device3 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -10153,6 +10787,7 @@ EXTERN_C const IID IID_ID3D12Device3;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device3 * This,
             _In_  UINT NumDescriptors,
@@ -10160,17 +10795,22 @@ EXTERN_C const IID IID_ID3D12Device3;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device3 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device3 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device3 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -10181,12 +10821,14 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device3 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device3 * This,
             _In_  ID3D12Heap *pHeap,
@@ -10197,6 +10839,7 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device3 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -10205,6 +10848,7 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device3 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -10213,12 +10857,14 @@ EXTERN_C const IID IID_ID3D12Device3;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device3 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device3 * This,
             _In_  LPCWSTR Name,
@@ -10226,16 +10872,19 @@ EXTERN_C const IID IID_ID3D12Device3;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device3 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device3 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device3 * This,
             UINT64 InitialValue,
@@ -10243,9 +10892,11 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device3 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -10257,16 +10908,19 @@ EXTERN_C const IID IID_ID3D12Device3;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device3 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device3 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device3 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -10274,6 +10928,7 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device3 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -10284,9 +10939,12 @@ EXTERN_C const IID IID_ID3D12Device3;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device3 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device3 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device3 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -10294,6 +10952,7 @@ EXTERN_C const IID IID_ID3D12Device3;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device3 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -10302,30 +10961,35 @@ EXTERN_C const IID IID_ID3D12Device3;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device3 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device3 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
             ID3D12Device3 * This,
             _In_  const void *pAddress,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
             ID3D12Device3 * This,
             _In_  HANDLE hFileMapping,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
         HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
             ID3D12Device3 * This,
             D3D12_RESIDENCY_FLAGS Flags,
@@ -10424,11 +11088,11 @@ EXTERN_C const IID IID_ID3D12Device3;
 #define ID3D12Device3_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device3_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device3_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device3_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device3_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device3_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -10478,8 +11142,8 @@ EXTERN_C const IID IID_ID3D12Device3;
 #define ID3D12Device3_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device3_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device3_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device3_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -10582,48 +11246,58 @@ EXTERN_C const IID IID_ID3D12ProtectedSession;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12ProtectedSession * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12ProtectedSession * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12ProtectedSession * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12ProtectedSession * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12ProtectedSession * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12ProtectedSession * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12ProtectedSession * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12ProtectedSession * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12ProtectedSession, GetStatusFence)
         HRESULT ( STDMETHODCALLTYPE *GetStatusFence )( 
             ID3D12ProtectedSession * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12ProtectedSession, GetSessionStatus)
         D3D12_PROTECTED_SESSION_STATUS ( STDMETHODCALLTYPE *GetSessionStatus )( 
             ID3D12ProtectedSession * This);
         
@@ -10745,53 +11419,65 @@ EXTERN_C const IID IID_ID3D12ProtectedResourceSession;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12ProtectedResourceSession * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12ProtectedResourceSession * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12ProtectedResourceSession * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12ProtectedResourceSession * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12ProtectedResourceSession * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12ProtectedResourceSession * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12ProtectedResourceSession * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12ProtectedResourceSession * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12ProtectedSession, GetStatusFence)
         HRESULT ( STDMETHODCALLTYPE *GetStatusFence )( 
             ID3D12ProtectedResourceSession * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12ProtectedSession, GetSessionStatus)
         D3D12_PROTECTED_SESSION_STATUS ( STDMETHODCALLTYPE *GetSessionStatus )( 
             ID3D12ProtectedResourceSession * This);
         
-        D3D12_PROTECTED_RESOURCE_SESSION_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12ProtectedResourceSession * This);
+        DECLSPEC_XFGVIRT(ID3D12ProtectedResourceSession, GetDesc)
+        D3D12_PROTECTED_RESOURCE_SESSION_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12ProtectedResourceSession * This,
+            D3D12_PROTECTED_RESOURCE_SESSION_DESC * RetVal);
         
         END_INTERFACE
     } ID3D12ProtectedResourceSessionVtbl;
@@ -10840,17 +11526,13 @@ EXTERN_C const IID IID_ID3D12ProtectedResourceSession;
     ( (This)->lpVtbl -> GetSessionStatus(This) ) 
 
 
-#define ID3D12ProtectedResourceSession_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12ProtectedResourceSession_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -10924,65 +11606,78 @@ EXTERN_C const IID IID_ID3D12Device4;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device4 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device4 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device4 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device4 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device4 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device4 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device4 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device4 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device4 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device4 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device4 * This,
             _In_  UINT nodeMask,
@@ -10992,22 +11687,26 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device4 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device4 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device4 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device4 * This,
             _In_  UINT nodeMask,
@@ -11016,17 +11715,20 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device4 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device4 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device4 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -11034,23 +11736,27 @@ EXTERN_C const IID IID_ID3D12Device4;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device4 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device4 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device4 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device4 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -11061,6 +11767,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device4 * This,
             _In_  UINT NumDescriptors,
@@ -11068,17 +11775,22 @@ EXTERN_C const IID IID_ID3D12Device4;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device4 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device4 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device4 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -11089,12 +11801,14 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device4 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device4 * This,
             _In_  ID3D12Heap *pHeap,
@@ -11105,6 +11819,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device4 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -11113,6 +11828,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device4 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -11121,12 +11837,14 @@ EXTERN_C const IID IID_ID3D12Device4;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device4 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device4 * This,
             _In_  LPCWSTR Name,
@@ -11134,16 +11852,19 @@ EXTERN_C const IID IID_ID3D12Device4;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device4 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device4 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device4 * This,
             UINT64 InitialValue,
@@ -11151,9 +11872,11 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device4 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -11165,16 +11888,19 @@ EXTERN_C const IID IID_ID3D12Device4;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device4 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device4 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device4 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -11182,6 +11908,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device4 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -11192,9 +11919,12 @@ EXTERN_C const IID IID_ID3D12Device4;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device4 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device4 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device4 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -11202,6 +11932,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device4 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -11210,30 +11941,35 @@ EXTERN_C const IID IID_ID3D12Device4;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device4 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device4 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
             ID3D12Device4 * This,
             _In_  const void *pAddress,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
             ID3D12Device4 * This,
             _In_  HANDLE hFileMapping,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
         HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
             ID3D12Device4 * This,
             D3D12_RESIDENCY_FLAGS Flags,
@@ -11242,6 +11978,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             _In_  ID3D12Fence *pFenceToSignal,
             UINT64 FenceValueToSignal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommandList1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList1 )( 
             ID3D12Device4 * This,
             _In_  UINT nodeMask,
@@ -11250,12 +11987,14 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession )( 
             ID3D12Device4 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC *pDesc,
             _In_  REFIID riid,
             _COM_Outptr_  void **ppSession);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommittedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource1 )( 
             ID3D12Device4 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -11267,6 +12006,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateHeap1)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap1 )( 
             ID3D12Device4 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
@@ -11274,6 +12014,7 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateReservedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource1 )( 
             ID3D12Device4 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -11283,8 +12024,10 @@ EXTERN_C const IID IID_ID3D12Device4;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
+        DECLSPEC_XFGVIRT(ID3D12Device4, GetResourceAllocationInfo1)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
             ID3D12Device4 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             UINT visibleMask,
             UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs,
@@ -11380,11 +12123,11 @@ EXTERN_C const IID IID_ID3D12Device4;
 #define ID3D12Device4_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device4_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device4_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device4_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device4_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device4_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -11434,8 +12177,8 @@ EXTERN_C const IID IID_ID3D12Device4;
 #define ID3D12Device4_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device4_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device4_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device4_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -11477,17 +12220,13 @@ EXTERN_C const IID IID_ID3D12Device4;
 #define ID3D12Device4_CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource)	\
     ( (This)->lpVtbl -> CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource) ) 
 
-#define ID3D12Device4_GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+#define ID3D12Device4_GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -11538,17 +12277,21 @@ EXTERN_C const IID IID_ID3D12LifetimeOwner;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12LifetimeOwner * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12LifetimeOwner * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12LifetimeOwner * This);
         
+        DECLSPEC_XFGVIRT(ID3D12LifetimeOwner, LifetimeStateUpdated)
         void ( STDMETHODCALLTYPE *LifetimeStateUpdated )( 
             ID3D12LifetimeOwner * This,
             D3D12_LIFETIME_STATE NewState);
@@ -11628,25 +12371,32 @@ EXTERN_C const IID IID_ID3D12SwapChainAssistant;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12SwapChainAssistant * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12SwapChainAssistant * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12SwapChainAssistant * This);
         
-        LUID ( STDMETHODCALLTYPE *GetLUID )( 
-            ID3D12SwapChainAssistant * This);
+        DECLSPEC_XFGVIRT(ID3D12SwapChainAssistant, GetLUID)
+        LUID *( STDMETHODCALLTYPE *GetLUID )( 
+            ID3D12SwapChainAssistant * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12SwapChainAssistant, GetSwapChainObject)
         HRESULT ( STDMETHODCALLTYPE *GetSwapChainObject )( 
             ID3D12SwapChainAssistant * This,
             REFIID riid,
             _COM_Outptr_  void **ppv);
         
+        DECLSPEC_XFGVIRT(ID3D12SwapChainAssistant, GetCurrentResourceAndCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *GetCurrentResourceAndCommandQueue )( 
             ID3D12SwapChainAssistant * This,
             REFIID riidResource,
@@ -11654,6 +12404,7 @@ EXTERN_C const IID IID_ID3D12SwapChainAssistant;
             REFIID riidQueue,
             _COM_Outptr_  void **ppvQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12SwapChainAssistant, InsertImplicitSync)
         HRESULT ( STDMETHODCALLTYPE *InsertImplicitSync )( 
             ID3D12SwapChainAssistant * This);
         
@@ -11680,8 +12431,8 @@ EXTERN_C const IID IID_ID3D12SwapChainAssistant;
     ( (This)->lpVtbl -> Release(This) ) 
 
 
-#define ID3D12SwapChainAssistant_GetLUID(This)	\
-    ( (This)->lpVtbl -> GetLUID(This) ) 
+#define ID3D12SwapChainAssistant_GetLUID(This,RetVal)	\
+    ( (This)->lpVtbl -> GetLUID(This,RetVal) ) 
 
 #define ID3D12SwapChainAssistant_GetSwapChainObject(This,riid,ppv)	\
     ( (This)->lpVtbl -> GetSwapChainObject(This,riid,ppv) ) 
@@ -11696,10 +12447,6 @@ EXTERN_C const IID IID_ID3D12SwapChainAssistant;
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -11734,43 +12481,52 @@ EXTERN_C const IID IID_ID3D12LifetimeTracker;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12LifetimeTracker * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12LifetimeTracker * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12LifetimeTracker * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12LifetimeTracker * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12LifetimeTracker * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12LifetimeTracker * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12LifetimeTracker * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12LifetimeTracker * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12LifetimeTracker, DestroyOwnedObject)
         HRESULT ( STDMETHODCALLTYPE *DestroyOwnedObject )( 
             ID3D12LifetimeTracker * This,
             _In_  ID3D12DeviceChild *pObject);
@@ -11928,38 +12684,46 @@ EXTERN_C const IID IID_ID3D12StateObject;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12StateObject * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12StateObject * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12StateObject * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12StateObject * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12StateObject * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12StateObject * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12StateObject * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12StateObject * This,
             REFIID riid,
@@ -12052,28 +12816,35 @@ EXTERN_C const IID IID_ID3D12StateObjectProperties;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12StateObjectProperties * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12StateObjectProperties * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12StateObjectProperties * This);
         
+        DECLSPEC_XFGVIRT(ID3D12StateObjectProperties, GetShaderIdentifier)
         void *( STDMETHODCALLTYPE *GetShaderIdentifier )( 
             ID3D12StateObjectProperties * This,
             _In_  LPCWSTR pExportName);
         
+        DECLSPEC_XFGVIRT(ID3D12StateObjectProperties, GetShaderStackSize)
         UINT64 ( STDMETHODCALLTYPE *GetShaderStackSize )( 
             ID3D12StateObjectProperties * This,
             _In_  LPCWSTR pExportName);
         
+        DECLSPEC_XFGVIRT(ID3D12StateObjectProperties, GetPipelineStackSize)
         UINT64 ( STDMETHODCALLTYPE *GetPipelineStackSize )( 
             ID3D12StateObjectProperties * This);
         
+        DECLSPEC_XFGVIRT(ID3D12StateObjectProperties, SetPipelineStackSize)
         void ( STDMETHODCALLTYPE *SetPipelineStackSize )( 
             ID3D12StateObjectProperties * This,
             UINT64 PipelineStackSizeInBytes);
@@ -12609,65 +13380,78 @@ EXTERN_C const IID IID_ID3D12Device5;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device5 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device5 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device5 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device5 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device5 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device5 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device5 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device5 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device5 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device5 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device5 * This,
             _In_  UINT nodeMask,
@@ -12677,22 +13461,26 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device5 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device5 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device5 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device5 * This,
             _In_  UINT nodeMask,
@@ -12701,17 +13489,20 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device5 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device5 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device5 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -12719,23 +13510,27 @@ EXTERN_C const IID IID_ID3D12Device5;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device5 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device5 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device5 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device5 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -12746,6 +13541,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device5 * This,
             _In_  UINT NumDescriptors,
@@ -12753,17 +13549,22 @@ EXTERN_C const IID IID_ID3D12Device5;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device5 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device5 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device5 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -12774,12 +13575,14 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device5 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device5 * This,
             _In_  ID3D12Heap *pHeap,
@@ -12790,6 +13593,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device5 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -12798,6 +13602,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device5 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -12806,12 +13611,14 @@ EXTERN_C const IID IID_ID3D12Device5;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device5 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device5 * This,
             _In_  LPCWSTR Name,
@@ -12819,16 +13626,19 @@ EXTERN_C const IID IID_ID3D12Device5;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device5 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device5 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device5 * This,
             UINT64 InitialValue,
@@ -12836,9 +13646,11 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device5 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -12850,16 +13662,19 @@ EXTERN_C const IID IID_ID3D12Device5;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device5 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device5 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device5 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -12867,6 +13682,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device5 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -12877,9 +13693,12 @@ EXTERN_C const IID IID_ID3D12Device5;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device5 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device5 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device5 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -12887,6 +13706,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device5 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -12895,30 +13715,35 @@ EXTERN_C const IID IID_ID3D12Device5;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device5 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device5 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
             ID3D12Device5 * This,
             _In_  const void *pAddress,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
             ID3D12Device5 * This,
             _In_  HANDLE hFileMapping,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
         HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
             ID3D12Device5 * This,
             D3D12_RESIDENCY_FLAGS Flags,
@@ -12927,6 +13752,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             _In_  ID3D12Fence *pFenceToSignal,
             UINT64 FenceValueToSignal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommandList1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList1 )( 
             ID3D12Device5 * This,
             _In_  UINT nodeMask,
@@ -12935,12 +13761,14 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession )( 
             ID3D12Device5 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC *pDesc,
             _In_  REFIID riid,
             _COM_Outptr_  void **ppSession);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommittedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource1 )( 
             ID3D12Device5 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -12952,6 +13780,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateHeap1)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap1 )( 
             ID3D12Device5 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
@@ -12959,6 +13788,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateReservedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource1 )( 
             ID3D12Device5 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -12968,27 +13798,33 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
+        DECLSPEC_XFGVIRT(ID3D12Device4, GetResourceAllocationInfo1)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
             ID3D12Device5 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             UINT visibleMask,
             UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs,
             _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateLifetimeTracker)
         HRESULT ( STDMETHODCALLTYPE *CreateLifetimeTracker )( 
             ID3D12Device5 * This,
             _In_  ID3D12LifetimeOwner *pOwner,
             REFIID riid,
             _COM_Outptr_  void **ppvTracker);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, RemoveDevice)
         void ( STDMETHODCALLTYPE *RemoveDevice )( 
             ID3D12Device5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommands)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommands )( 
             ID3D12Device5 * This,
             _Inout_  UINT *pNumMetaCommands,
             _Out_writes_opt_(*pNumMetaCommands)  D3D12_META_COMMAND_DESC *pDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommandParameters)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommandParameters )( 
             ID3D12Device5 * This,
             _In_  REFGUID CommandId,
@@ -12997,6 +13833,7 @@ EXTERN_C const IID IID_ID3D12Device5;
             _Inout_  UINT *pParameterCount,
             _Out_writes_opt_(*pParameterCount)  D3D12_META_COMMAND_PARAMETER_DESC *pParameterDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateMetaCommand)
         HRESULT ( STDMETHODCALLTYPE *CreateMetaCommand )( 
             ID3D12Device5 * This,
             _In_  REFGUID CommandId,
@@ -13006,17 +13843,20 @@ EXTERN_C const IID IID_ID3D12Device5;
             REFIID riid,
             _COM_Outptr_  void **ppMetaCommand);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateStateObject)
         HRESULT ( STDMETHODCALLTYPE *CreateStateObject )( 
             ID3D12Device5 * This,
             const D3D12_STATE_OBJECT_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, GetRaytracingAccelerationStructurePrebuildInfo)
         void ( STDMETHODCALLTYPE *GetRaytracingAccelerationStructurePrebuildInfo )( 
             ID3D12Device5 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *pDesc,
             _Out_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO *pInfo);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CheckDriverMatchingIdentifier)
         D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS ( STDMETHODCALLTYPE *CheckDriverMatchingIdentifier )( 
             ID3D12Device5 * This,
             _In_  D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
@@ -13112,11 +13952,11 @@ EXTERN_C const IID IID_ID3D12Device5;
 #define ID3D12Device5_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device5_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device5_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device5_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device5_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device5_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -13166,8 +14006,8 @@ EXTERN_C const IID IID_ID3D12Device5;
 #define ID3D12Device5_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device5_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device5_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device5_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -13209,8 +14049,8 @@ EXTERN_C const IID IID_ID3D12Device5;
 #define ID3D12Device5_CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource)	\
     ( (This)->lpVtbl -> CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource) ) 
 
-#define ID3D12Device5_GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+#define ID3D12Device5_GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
 
 
 #define ID3D12Device5_CreateLifetimeTracker(This,pOwner,riid,ppvTracker)	\
@@ -13296,7 +14136,9 @@ enum D3D12_AUTO_BREADCRUMB_OP
         D3D12_AUTO_BREADCRUMB_OP_SETPIPELINESTATE1	= 39,
         D3D12_AUTO_BREADCRUMB_OP_INITIALIZEEXTENSIONCOMMAND	= 40,
         D3D12_AUTO_BREADCRUMB_OP_EXECUTEEXTENSIONCOMMAND	= 41,
-        D3D12_AUTO_BREADCRUMB_OP_DISPATCHMESH	= 42
+        D3D12_AUTO_BREADCRUMB_OP_DISPATCHMESH	= 42,
+        D3D12_AUTO_BREADCRUMB_OP_ENCODEFRAME	= 43,
+        D3D12_AUTO_BREADCRUMB_OP_RESOLVEENCODEROUTPUTMETADATA	= 44
     } 	D3D12_AUTO_BREADCRUMB_OP;
 
 typedef struct D3D12_AUTO_BREADCRUMB_NODE
@@ -13340,7 +14182,8 @@ enum D3D12_DRED_VERSION
     {
         D3D12_DRED_VERSION_1_0	= 0x1,
         D3D12_DRED_VERSION_1_1	= 0x2,
-        D3D12_DRED_VERSION_1_2	= 0x3
+        D3D12_DRED_VERSION_1_2	= 0x3,
+        D3D12_DRED_VERSION_1_3	= 0x4
     } 	D3D12_DRED_VERSION;
 
 typedef 
@@ -13395,6 +14238,8 @@ enum D3D12_DRED_ALLOCATION_TYPE
         D3D12_DRED_ALLOCATION_TYPE_VIDEO_MOTION_ESTIMATOR	= 45,
         D3D12_DRED_ALLOCATION_TYPE_VIDEO_MOTION_VECTOR_HEAP	= 46,
         D3D12_DRED_ALLOCATION_TYPE_VIDEO_EXTENSION_COMMAND	= 47,
+        D3D12_DRED_ALLOCATION_TYPE_VIDEO_ENCODER	= 48,
+        D3D12_DRED_ALLOCATION_TYPE_VIDEO_ENCODER_HEAP	= 49,
         D3D12_DRED_ALLOCATION_TYPE_INVALID	= 0xffffffff
     } 	D3D12_DRED_ALLOCATION_TYPE;
 
@@ -13439,6 +14284,30 @@ typedef struct D3D12_DRED_PAGE_FAULT_OUTPUT1
     _Out_  const D3D12_DRED_ALLOCATION_NODE1 *pHeadRecentFreedAllocationNode;
     } 	D3D12_DRED_PAGE_FAULT_OUTPUT1;
 
+typedef 
+enum D3D12_DRED_PAGE_FAULT_FLAGS
+    {
+        D3D12_DRED_PAGE_FAULT_FLAGS_NONE	= 0
+    } 	D3D12_DRED_PAGE_FAULT_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS( D3D12_DRED_PAGE_FAULT_FLAGS );
+typedef 
+enum D3D12_DRED_DEVICE_STATE
+    {
+        D3D12_DRED_DEVICE_STATE_UNKNOWN	= 0,
+        D3D12_DRED_DEVICE_STATE_HUNG	= 3,
+        D3D12_DRED_DEVICE_STATE_FAULT	= 6,
+        D3D12_DRED_DEVICE_STATE_PAGEFAULT	= 7
+    } 	D3D12_DRED_DEVICE_STATE;
+
+typedef struct D3D12_DRED_PAGE_FAULT_OUTPUT2
+    {
+    D3D12_GPU_VIRTUAL_ADDRESS PageFaultVA;
+    _Out_  const D3D12_DRED_ALLOCATION_NODE1 *pHeadExistingAllocationNode;
+    _Out_  const D3D12_DRED_ALLOCATION_NODE1 *pHeadRecentFreedAllocationNode;
+    D3D12_DRED_PAGE_FAULT_FLAGS PageFaultFlags;
+    } 	D3D12_DRED_PAGE_FAULT_OUTPUT2;
+
 typedef struct D3D12_DEVICE_REMOVED_EXTENDED_DATA1
     {
     HRESULT DeviceRemovedReason;
@@ -13453,6 +14322,14 @@ typedef struct D3D12_DEVICE_REMOVED_EXTENDED_DATA2
     D3D12_DRED_PAGE_FAULT_OUTPUT1 PageFaultOutput;
     } 	D3D12_DEVICE_REMOVED_EXTENDED_DATA2;
 
+typedef struct D3D12_DEVICE_REMOVED_EXTENDED_DATA3
+    {
+    HRESULT DeviceRemovedReason;
+    D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 AutoBreadcrumbsOutput;
+    D3D12_DRED_PAGE_FAULT_OUTPUT2 PageFaultOutput;
+    D3D12_DRED_DEVICE_STATE DeviceState;
+    } 	D3D12_DEVICE_REMOVED_EXTENDED_DATA3;
+
 typedef struct D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA
     {
     D3D12_DRED_VERSION Version;
@@ -13461,6 +14338,7 @@ typedef struct D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA
         D3D12_DEVICE_REMOVED_EXTENDED_DATA Dred_1_0;
         D3D12_DEVICE_REMOVED_EXTENDED_DATA1 Dred_1_1;
         D3D12_DEVICE_REMOVED_EXTENDED_DATA2 Dred_1_2;
+        D3D12_DEVICE_REMOVED_EXTENDED_DATA3 Dred_1_3;
         } 	;
     } 	D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA;
 
@@ -13502,25 +14380,31 @@ EXTERN_C const IID IID_ID3D12DeviceRemovedExtendedDataSettings;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DeviceRemovedExtendedDataSettings * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DeviceRemovedExtendedDataSettings * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DeviceRemovedExtendedDataSettings * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings, SetAutoBreadcrumbsEnablement)
         void ( STDMETHODCALLTYPE *SetAutoBreadcrumbsEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings * This,
             D3D12_DRED_ENABLEMENT Enablement);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings, SetPageFaultEnablement)
         void ( STDMETHODCALLTYPE *SetPageFaultEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings * This,
             D3D12_DRED_ENABLEMENT Enablement);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings, SetWatsonDumpEnablement)
         void ( STDMETHODCALLTYPE *SetWatsonDumpEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings * This,
             D3D12_DRED_ENABLEMENT Enablement);
@@ -13595,29 +14479,36 @@ EXTERN_C const IID IID_ID3D12DeviceRemovedExtendedDataSettings1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings, SetAutoBreadcrumbsEnablement)
         void ( STDMETHODCALLTYPE *SetAutoBreadcrumbsEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This,
             D3D12_DRED_ENABLEMENT Enablement);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings, SetPageFaultEnablement)
         void ( STDMETHODCALLTYPE *SetPageFaultEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This,
             D3D12_DRED_ENABLEMENT Enablement);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings, SetWatsonDumpEnablement)
         void ( STDMETHODCALLTYPE *SetWatsonDumpEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This,
             D3D12_DRED_ENABLEMENT Enablement);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedDataSettings1, SetBreadcrumbContextEnablement)
         void ( STDMETHODCALLTYPE *SetBreadcrumbContextEnablement )( 
             ID3D12DeviceRemovedExtendedDataSettings1 * This,
             D3D12_DRED_ENABLEMENT Enablement);
@@ -13699,21 +14590,26 @@ EXTERN_C const IID IID_ID3D12DeviceRemovedExtendedData;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DeviceRemovedExtendedData * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DeviceRemovedExtendedData * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DeviceRemovedExtendedData * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData, GetAutoBreadcrumbsOutput)
         HRESULT ( STDMETHODCALLTYPE *GetAutoBreadcrumbsOutput )( 
             ID3D12DeviceRemovedExtendedData * This,
             _Out_  D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT *pOutput);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData, GetPageFaultAllocationOutput)
         HRESULT ( STDMETHODCALLTYPE *GetPageFaultAllocationOutput )( 
             ID3D12DeviceRemovedExtendedData * This,
             _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT *pOutput);
@@ -13788,29 +14684,36 @@ EXTERN_C const IID IID_ID3D12DeviceRemovedExtendedData1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DeviceRemovedExtendedData1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DeviceRemovedExtendedData1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DeviceRemovedExtendedData1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData, GetAutoBreadcrumbsOutput)
         HRESULT ( STDMETHODCALLTYPE *GetAutoBreadcrumbsOutput )( 
             ID3D12DeviceRemovedExtendedData1 * This,
             _Out_  D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT *pOutput);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData, GetPageFaultAllocationOutput)
         HRESULT ( STDMETHODCALLTYPE *GetPageFaultAllocationOutput )( 
             ID3D12DeviceRemovedExtendedData1 * This,
             _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT *pOutput);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData1, GetAutoBreadcrumbsOutput1)
         HRESULT ( STDMETHODCALLTYPE *GetAutoBreadcrumbsOutput1 )( 
             ID3D12DeviceRemovedExtendedData1 * This,
             _Out_  D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 *pOutput);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData1, GetPageFaultAllocationOutput1)
         HRESULT ( STDMETHODCALLTYPE *GetPageFaultAllocationOutput1 )( 
             ID3D12DeviceRemovedExtendedData1 * This,
             _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT1 *pOutput);
@@ -13862,7 +14765,133 @@ EXTERN_C const IID IID_ID3D12DeviceRemovedExtendedData1;
 #endif 	/* __ID3D12DeviceRemovedExtendedData1_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0039 */
+#ifndef __ID3D12DeviceRemovedExtendedData2_INTERFACE_DEFINED__
+#define __ID3D12DeviceRemovedExtendedData2_INTERFACE_DEFINED__
+
+/* interface ID3D12DeviceRemovedExtendedData2 */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12DeviceRemovedExtendedData2;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("67FC5816-E4CA-4915-BF18-42541272DA54")
+    ID3D12DeviceRemovedExtendedData2 : public ID3D12DeviceRemovedExtendedData1
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetPageFaultAllocationOutput2( 
+            _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT2 *pOutput) = 0;
+        
+        virtual D3D12_DRED_DEVICE_STATE STDMETHODCALLTYPE GetDeviceState( void) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12DeviceRemovedExtendedData2Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12DeviceRemovedExtendedData2 * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12DeviceRemovedExtendedData2 * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12DeviceRemovedExtendedData2 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData, GetAutoBreadcrumbsOutput)
+        HRESULT ( STDMETHODCALLTYPE *GetAutoBreadcrumbsOutput )( 
+            ID3D12DeviceRemovedExtendedData2 * This,
+            _Out_  D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT *pOutput);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData, GetPageFaultAllocationOutput)
+        HRESULT ( STDMETHODCALLTYPE *GetPageFaultAllocationOutput )( 
+            ID3D12DeviceRemovedExtendedData2 * This,
+            _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT *pOutput);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData1, GetAutoBreadcrumbsOutput1)
+        HRESULT ( STDMETHODCALLTYPE *GetAutoBreadcrumbsOutput1 )( 
+            ID3D12DeviceRemovedExtendedData2 * This,
+            _Out_  D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 *pOutput);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData1, GetPageFaultAllocationOutput1)
+        HRESULT ( STDMETHODCALLTYPE *GetPageFaultAllocationOutput1 )( 
+            ID3D12DeviceRemovedExtendedData2 * This,
+            _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT1 *pOutput);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData2, GetPageFaultAllocationOutput2)
+        HRESULT ( STDMETHODCALLTYPE *GetPageFaultAllocationOutput2 )( 
+            ID3D12DeviceRemovedExtendedData2 * This,
+            _Out_  D3D12_DRED_PAGE_FAULT_OUTPUT2 *pOutput);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceRemovedExtendedData2, GetDeviceState)
+        D3D12_DRED_DEVICE_STATE ( STDMETHODCALLTYPE *GetDeviceState )( 
+            ID3D12DeviceRemovedExtendedData2 * This);
+        
+        END_INTERFACE
+    } ID3D12DeviceRemovedExtendedData2Vtbl;
+
+    interface ID3D12DeviceRemovedExtendedData2
+    {
+        CONST_VTBL struct ID3D12DeviceRemovedExtendedData2Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12DeviceRemovedExtendedData2_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12DeviceRemovedExtendedData2_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12DeviceRemovedExtendedData2_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12DeviceRemovedExtendedData2_GetAutoBreadcrumbsOutput(This,pOutput)	\
+    ( (This)->lpVtbl -> GetAutoBreadcrumbsOutput(This,pOutput) ) 
+
+#define ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput(This,pOutput)	\
+    ( (This)->lpVtbl -> GetPageFaultAllocationOutput(This,pOutput) ) 
+
+
+#define ID3D12DeviceRemovedExtendedData2_GetAutoBreadcrumbsOutput1(This,pOutput)	\
+    ( (This)->lpVtbl -> GetAutoBreadcrumbsOutput1(This,pOutput) ) 
+
+#define ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput1(This,pOutput)	\
+    ( (This)->lpVtbl -> GetPageFaultAllocationOutput1(This,pOutput) ) 
+
+
+#define ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput2(This,pOutput)	\
+    ( (This)->lpVtbl -> GetPageFaultAllocationOutput2(This,pOutput) ) 
+
+#define ID3D12DeviceRemovedExtendedData2_GetDeviceState(This)	\
+    ( (This)->lpVtbl -> GetDeviceState(This) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12DeviceRemovedExtendedData2_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_d3d12_0000_0040 */
 /* [local] */ 
 
 typedef 
@@ -13885,8 +14914,8 @@ enum D3D12_MEASUREMENTS_ACTION
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0039_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0039_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0040_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0040_v0_0_s_ifspec;
 
 #ifndef __ID3D12Device6_INTERFACE_DEFINED__
 #define __ID3D12Device6_INTERFACE_DEFINED__
@@ -13918,65 +14947,78 @@ EXTERN_C const IID IID_ID3D12Device6;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device6 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device6 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device6 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device6 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device6 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device6 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device6 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device6 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device6 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device6 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device6 * This,
             _In_  UINT nodeMask,
@@ -13986,22 +15028,26 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device6 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device6 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device6 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device6 * This,
             _In_  UINT nodeMask,
@@ -14010,17 +15056,20 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device6 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device6 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device6 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -14028,23 +15077,27 @@ EXTERN_C const IID IID_ID3D12Device6;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device6 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device6 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device6 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device6 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -14055,6 +15108,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device6 * This,
             _In_  UINT NumDescriptors,
@@ -14062,17 +15116,22 @@ EXTERN_C const IID IID_ID3D12Device6;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device6 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device6 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device6 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -14083,12 +15142,14 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device6 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device6 * This,
             _In_  ID3D12Heap *pHeap,
@@ -14099,6 +15160,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device6 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -14107,6 +15169,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device6 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -14115,12 +15178,14 @@ EXTERN_C const IID IID_ID3D12Device6;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device6 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device6 * This,
             _In_  LPCWSTR Name,
@@ -14128,16 +15193,19 @@ EXTERN_C const IID IID_ID3D12Device6;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device6 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device6 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device6 * This,
             UINT64 InitialValue,
@@ -14145,9 +15213,11 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device6 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -14159,16 +15229,19 @@ EXTERN_C const IID IID_ID3D12Device6;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device6 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device6 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device6 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -14176,6 +15249,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device6 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -14186,9 +15260,12 @@ EXTERN_C const IID IID_ID3D12Device6;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device6 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device6 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device6 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -14196,6 +15273,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device6 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -14204,30 +15282,35 @@ EXTERN_C const IID IID_ID3D12Device6;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device6 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device6 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
             ID3D12Device6 * This,
             _In_  const void *pAddress,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
             ID3D12Device6 * This,
             _In_  HANDLE hFileMapping,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
         HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
             ID3D12Device6 * This,
             D3D12_RESIDENCY_FLAGS Flags,
@@ -14236,6 +15319,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             _In_  ID3D12Fence *pFenceToSignal,
             UINT64 FenceValueToSignal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommandList1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList1 )( 
             ID3D12Device6 * This,
             _In_  UINT nodeMask,
@@ -14244,12 +15328,14 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession )( 
             ID3D12Device6 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC *pDesc,
             _In_  REFIID riid,
             _COM_Outptr_  void **ppSession);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommittedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource1 )( 
             ID3D12Device6 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -14261,6 +15347,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateHeap1)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap1 )( 
             ID3D12Device6 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
@@ -14268,6 +15355,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateReservedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource1 )( 
             ID3D12Device6 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -14277,27 +15365,33 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
+        DECLSPEC_XFGVIRT(ID3D12Device4, GetResourceAllocationInfo1)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
             ID3D12Device6 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             UINT visibleMask,
             UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs,
             _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateLifetimeTracker)
         HRESULT ( STDMETHODCALLTYPE *CreateLifetimeTracker )( 
             ID3D12Device6 * This,
             _In_  ID3D12LifetimeOwner *pOwner,
             REFIID riid,
             _COM_Outptr_  void **ppvTracker);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, RemoveDevice)
         void ( STDMETHODCALLTYPE *RemoveDevice )( 
             ID3D12Device6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommands)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommands )( 
             ID3D12Device6 * This,
             _Inout_  UINT *pNumMetaCommands,
             _Out_writes_opt_(*pNumMetaCommands)  D3D12_META_COMMAND_DESC *pDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommandParameters)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommandParameters )( 
             ID3D12Device6 * This,
             _In_  REFGUID CommandId,
@@ -14306,6 +15400,7 @@ EXTERN_C const IID IID_ID3D12Device6;
             _Inout_  UINT *pParameterCount,
             _Out_writes_opt_(*pParameterCount)  D3D12_META_COMMAND_PARAMETER_DESC *pParameterDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateMetaCommand)
         HRESULT ( STDMETHODCALLTYPE *CreateMetaCommand )( 
             ID3D12Device6 * This,
             _In_  REFGUID CommandId,
@@ -14315,22 +15410,26 @@ EXTERN_C const IID IID_ID3D12Device6;
             REFIID riid,
             _COM_Outptr_  void **ppMetaCommand);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateStateObject)
         HRESULT ( STDMETHODCALLTYPE *CreateStateObject )( 
             ID3D12Device6 * This,
             const D3D12_STATE_OBJECT_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, GetRaytracingAccelerationStructurePrebuildInfo)
         void ( STDMETHODCALLTYPE *GetRaytracingAccelerationStructurePrebuildInfo )( 
             ID3D12Device6 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *pDesc,
             _Out_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO *pInfo);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CheckDriverMatchingIdentifier)
         D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS ( STDMETHODCALLTYPE *CheckDriverMatchingIdentifier )( 
             ID3D12Device6 * This,
             _In_  D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
             _In_  const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER *pIdentifierToCheck);
         
+        DECLSPEC_XFGVIRT(ID3D12Device6, SetBackgroundProcessingMode)
         HRESULT ( STDMETHODCALLTYPE *SetBackgroundProcessingMode )( 
             ID3D12Device6 * This,
             D3D12_BACKGROUND_PROCESSING_MODE Mode,
@@ -14428,11 +15527,11 @@ EXTERN_C const IID IID_ID3D12Device6;
 #define ID3D12Device6_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device6_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device6_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device6_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device6_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device6_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -14482,8 +15581,8 @@ EXTERN_C const IID IID_ID3D12Device6;
 #define ID3D12Device6_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device6_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device6_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device6_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -14525,8 +15624,8 @@ EXTERN_C const IID IID_ID3D12Device6;
 #define ID3D12Device6_CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource)	\
     ( (This)->lpVtbl -> CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource) ) 
 
-#define ID3D12Device6_GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+#define ID3D12Device6_GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
 
 
 #define ID3D12Device6_CreateLifetimeTracker(This,pOwner,riid,ppvTracker)	\
@@ -14568,7 +15667,7 @@ EXTERN_C const IID IID_ID3D12Device6;
 #endif 	/* __ID3D12Device6_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0040 */
+/* interface __MIDL_itf_d3d12_0000_0041 */
 /* [local] */ 
 
 DEFINE_GUID(D3D12_PROTECTED_RESOURCES_SESSION_HARDWARE_PROTECTED,                           0x62B0084E, 0xC70E, 0x4DAA, 0xA1, 0x09, 0x30, 0xFF, 0x8D, 0x5A, 0x04, 0x82); 
@@ -14594,8 +15693,8 @@ typedef struct D3D12_PROTECTED_RESOURCE_SESSION_DESC1
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0040_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0040_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0041_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0041_v0_0_s_ifspec;
 
 #ifndef __ID3D12ProtectedResourceSession1_INTERFACE_DEFINED__
 #define __ID3D12ProtectedResourceSession1_INTERFACE_DEFINED__
@@ -14623,56 +15722,70 @@ EXTERN_C const IID IID_ID3D12ProtectedResourceSession1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12ProtectedResourceSession1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12ProtectedResourceSession1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12ProtectedResourceSession1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12ProtectedResourceSession1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12ProtectedResourceSession1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12ProtectedResourceSession1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12ProtectedResourceSession1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12ProtectedResourceSession1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12ProtectedSession, GetStatusFence)
         HRESULT ( STDMETHODCALLTYPE *GetStatusFence )( 
             ID3D12ProtectedResourceSession1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12ProtectedSession, GetSessionStatus)
         D3D12_PROTECTED_SESSION_STATUS ( STDMETHODCALLTYPE *GetSessionStatus )( 
             ID3D12ProtectedResourceSession1 * This);
         
-        D3D12_PROTECTED_RESOURCE_SESSION_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12ProtectedResourceSession1 * This);
+        DECLSPEC_XFGVIRT(ID3D12ProtectedResourceSession, GetDesc)
+        D3D12_PROTECTED_RESOURCE_SESSION_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12ProtectedResourceSession1 * This,
+            D3D12_PROTECTED_RESOURCE_SESSION_DESC * RetVal);
         
-        D3D12_PROTECTED_RESOURCE_SESSION_DESC1 ( STDMETHODCALLTYPE *GetDesc1 )( 
-            ID3D12ProtectedResourceSession1 * This);
+        DECLSPEC_XFGVIRT(ID3D12ProtectedResourceSession1, GetDesc1)
+        D3D12_PROTECTED_RESOURCE_SESSION_DESC1 *( STDMETHODCALLTYPE *GetDesc1 )( 
+            ID3D12ProtectedResourceSession1 * This,
+            D3D12_PROTECTED_RESOURCE_SESSION_DESC1 * RetVal);
         
         END_INTERFACE
     } ID3D12ProtectedResourceSession1Vtbl;
@@ -14721,21 +15834,17 @@ EXTERN_C const IID IID_ID3D12ProtectedResourceSession1;
     ( (This)->lpVtbl -> GetSessionStatus(This) ) 
 
 
-#define ID3D12ProtectedResourceSession1_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12ProtectedResourceSession1_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 
-#define ID3D12ProtectedResourceSession1_GetDesc1(This)	\
-    ( (This)->lpVtbl -> GetDesc1(This) ) 
+#define ID3D12ProtectedResourceSession1_GetDesc1(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc1(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -14778,65 +15887,78 @@ EXTERN_C const IID IID_ID3D12Device7;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device7 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device7 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device7 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device7 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device7 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device7 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device7 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device7 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device7 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device7 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device7 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device7 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device7 * This,
             _In_  UINT nodeMask,
@@ -14846,22 +15968,26 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device7 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device7 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device7 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device7 * This,
             _In_  UINT nodeMask,
@@ -14870,17 +15996,20 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device7 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device7 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device7 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -14888,23 +16017,27 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device7 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device7 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device7 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device7 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -14915,6 +16048,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device7 * This,
             _In_  UINT NumDescriptors,
@@ -14922,17 +16056,22 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device7 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device7 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device7 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -14943,12 +16082,14 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device7 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device7 * This,
             _In_  ID3D12Heap *pHeap,
@@ -14959,6 +16100,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device7 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -14967,6 +16109,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device7 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -14975,12 +16118,14 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device7 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device7 * This,
             _In_  LPCWSTR Name,
@@ -14988,16 +16133,19 @@ EXTERN_C const IID IID_ID3D12Device7;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device7 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device7 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device7 * This,
             UINT64 InitialValue,
@@ -15005,9 +16153,11 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device7 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device7 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -15019,16 +16169,19 @@ EXTERN_C const IID IID_ID3D12Device7;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device7 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device7 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device7 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -15036,6 +16189,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device7 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -15046,9 +16200,12 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device7 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device7 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device7 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -15056,6 +16213,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device7 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -15064,30 +16222,35 @@ EXTERN_C const IID IID_ID3D12Device7;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device7 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device7 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
             ID3D12Device7 * This,
             _In_  const void *pAddress,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
             ID3D12Device7 * This,
             _In_  HANDLE hFileMapping,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
         HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
             ID3D12Device7 * This,
             D3D12_RESIDENCY_FLAGS Flags,
@@ -15096,6 +16259,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_  ID3D12Fence *pFenceToSignal,
             UINT64 FenceValueToSignal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommandList1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList1 )( 
             ID3D12Device7 * This,
             _In_  UINT nodeMask,
@@ -15104,12 +16268,14 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession )( 
             ID3D12Device7 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC *pDesc,
             _In_  REFIID riid,
             _COM_Outptr_  void **ppSession);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommittedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource1 )( 
             ID3D12Device7 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -15121,6 +16287,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateHeap1)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap1 )( 
             ID3D12Device7 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
@@ -15128,6 +16295,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateReservedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource1 )( 
             ID3D12Device7 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -15137,27 +16305,33 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
+        DECLSPEC_XFGVIRT(ID3D12Device4, GetResourceAllocationInfo1)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
             ID3D12Device7 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             UINT visibleMask,
             UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs,
             _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateLifetimeTracker)
         HRESULT ( STDMETHODCALLTYPE *CreateLifetimeTracker )( 
             ID3D12Device7 * This,
             _In_  ID3D12LifetimeOwner *pOwner,
             REFIID riid,
             _COM_Outptr_  void **ppvTracker);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, RemoveDevice)
         void ( STDMETHODCALLTYPE *RemoveDevice )( 
             ID3D12Device7 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommands)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommands )( 
             ID3D12Device7 * This,
             _Inout_  UINT *pNumMetaCommands,
             _Out_writes_opt_(*pNumMetaCommands)  D3D12_META_COMMAND_DESC *pDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommandParameters)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommandParameters )( 
             ID3D12Device7 * This,
             _In_  REFGUID CommandId,
@@ -15166,6 +16340,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             _Inout_  UINT *pParameterCount,
             _Out_writes_opt_(*pParameterCount)  D3D12_META_COMMAND_PARAMETER_DESC *pParameterDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateMetaCommand)
         HRESULT ( STDMETHODCALLTYPE *CreateMetaCommand )( 
             ID3D12Device7 * This,
             _In_  REFGUID CommandId,
@@ -15175,22 +16350,26 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppMetaCommand);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateStateObject)
         HRESULT ( STDMETHODCALLTYPE *CreateStateObject )( 
             ID3D12Device7 * This,
             const D3D12_STATE_OBJECT_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, GetRaytracingAccelerationStructurePrebuildInfo)
         void ( STDMETHODCALLTYPE *GetRaytracingAccelerationStructurePrebuildInfo )( 
             ID3D12Device7 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *pDesc,
             _Out_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO *pInfo);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CheckDriverMatchingIdentifier)
         D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS ( STDMETHODCALLTYPE *CheckDriverMatchingIdentifier )( 
             ID3D12Device7 * This,
             _In_  D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
             _In_  const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER *pIdentifierToCheck);
         
+        DECLSPEC_XFGVIRT(ID3D12Device6, SetBackgroundProcessingMode)
         HRESULT ( STDMETHODCALLTYPE *SetBackgroundProcessingMode )( 
             ID3D12Device7 * This,
             D3D12_BACKGROUND_PROCESSING_MODE Mode,
@@ -15198,6 +16377,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             _In_opt_  HANDLE hEventToSignalUponCompletion,
             _Out_opt_  BOOL *pbFurtherMeasurementsDesired);
         
+        DECLSPEC_XFGVIRT(ID3D12Device7, AddToStateObject)
         HRESULT ( STDMETHODCALLTYPE *AddToStateObject )( 
             ID3D12Device7 * This,
             const D3D12_STATE_OBJECT_DESC *pAddition,
@@ -15205,6 +16385,7 @@ EXTERN_C const IID IID_ID3D12Device7;
             REFIID riid,
             _COM_Outptr_  void **ppNewStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12Device7, CreateProtectedResourceSession1)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession1 )( 
             ID3D12Device7 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC1 *pDesc,
@@ -15301,11 +16482,11 @@ EXTERN_C const IID IID_ID3D12Device7;
 #define ID3D12Device7_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device7_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device7_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device7_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device7_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device7_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -15355,8 +16536,8 @@ EXTERN_C const IID IID_ID3D12Device7;
 #define ID3D12Device7_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device7_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device7_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device7_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -15398,8 +16579,8 @@ EXTERN_C const IID IID_ID3D12Device7;
 #define ID3D12Device7_CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource)	\
     ( (This)->lpVtbl -> CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource) ) 
 
-#define ID3D12Device7_GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+#define ID3D12Device7_GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
 
 
 #define ID3D12Device7_CreateLifetimeTracker(This,pOwner,riid,ppvTracker)	\
@@ -15512,65 +16693,78 @@ EXTERN_C const IID IID_ID3D12Device8;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Device8 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Device8 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Device8 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Device8 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Device8 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Device8 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Device8 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
         UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
             ID3D12Device8 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
             ID3D12Device8 * This,
             _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppCommandQueue);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
             ID3D12Device8 * This,
             _In_  D3D12_COMMAND_LIST_TYPE type,
             REFIID riid,
             _COM_Outptr_  void **ppCommandAllocator);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
             ID3D12Device8 * This,
             _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
             ID3D12Device8 * This,
             _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
             ID3D12Device8 * This,
             _In_  UINT nodeMask,
@@ -15580,22 +16774,26 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
         HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
             ID3D12Device8 * This,
             D3D12_FEATURE Feature,
             _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
             UINT FeatureSupportDataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
             ID3D12Device8 * This,
             _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
         UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
             ID3D12Device8 * This,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
             ID3D12Device8 * This,
             _In_  UINT nodeMask,
@@ -15604,17 +16802,20 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppvRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
         void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
             ID3D12Device8 * This,
             _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
         void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
             ID3D12Device8 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
             ID3D12Device8 * This,
             _In_opt_  ID3D12Resource *pResource,
@@ -15622,23 +16823,27 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
         void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
             ID3D12Device8 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
         void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
             ID3D12Device8 * This,
             _In_opt_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
         void ( STDMETHODCALLTYPE *CreateSampler )( 
             ID3D12Device8 * This,
             _In_  const D3D12_SAMPLER_DESC *pDesc,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
         void ( STDMETHODCALLTYPE *CopyDescriptors )( 
             ID3D12Device8 * This,
             _In_  UINT NumDestDescriptorRanges,
@@ -15649,6 +16854,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
         void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
             ID3D12Device8 * This,
             _In_  UINT NumDescriptors,
@@ -15656,17 +16862,22 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
             _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
             ID3D12Device8 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             _In_  UINT visibleMask,
             _In_  UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
         
-        D3D12_HEAP_PROPERTIES ( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
             ID3D12Device8 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
             _In_  UINT nodeMask,
             D3D12_HEAP_TYPE heapType);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
             ID3D12Device8 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -15677,12 +16888,14 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
             ID3D12Device8 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
             ID3D12Device8 * This,
             _In_  ID3D12Heap *pHeap,
@@ -15693,6 +16906,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
             ID3D12Device8 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -15701,6 +16915,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
             ID3D12Device8 * This,
             _In_  ID3D12DeviceChild *pObject,
@@ -15709,12 +16924,14 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_opt_  LPCWSTR Name,
             _Out_  HANDLE *pHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
             ID3D12Device8 * This,
             _In_  HANDLE NTHandle,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvObj);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
         HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
             ID3D12Device8 * This,
             _In_  LPCWSTR Name,
@@ -15722,16 +16939,19 @@ EXTERN_C const IID IID_ID3D12Device8;
             /* [annotation][out] */ 
             _Out_  HANDLE *pNTHandle);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
         HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
             ID3D12Device8 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
         HRESULT ( STDMETHODCALLTYPE *Evict )( 
             ID3D12Device8 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
         HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
             ID3D12Device8 * This,
             UINT64 InitialValue,
@@ -15739,9 +16959,11 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppFence);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
         HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
             ID3D12Device8 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
             ID3D12Device8 * This,
             _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
@@ -15753,16 +16975,19 @@ EXTERN_C const IID IID_ID3D12Device8;
             _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
             _Out_opt_  UINT64 *pTotalBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
         HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
             ID3D12Device8 * This,
             _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
         HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
             ID3D12Device8 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
             ID3D12Device8 * This,
             _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
@@ -15770,6 +16995,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvCommandSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
         void ( STDMETHODCALLTYPE *GetResourceTiling )( 
             ID3D12Device8 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -15780,9 +17006,12 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_  UINT FirstSubresourceTilingToGet,
             _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
         
-        LUID ( STDMETHODCALLTYPE *GetAdapterLuid )( 
-            ID3D12Device8 * This);
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device8 * This,
+            LUID * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
             ID3D12Device8 * This,
             _In_reads_(BlobLength)  const void *pLibraryBlob,
@@ -15790,6 +17019,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppPipelineLibrary);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
         HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
             ID3D12Device8 * This,
             _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
@@ -15798,30 +17028,35 @@ EXTERN_C const IID IID_ID3D12Device8;
             D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
             HANDLE hEvent);
         
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
         HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
             ID3D12Device8 * This,
             UINT NumObjects,
             _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
             _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
         
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
         HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
             ID3D12Device8 * This,
             const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
             ID3D12Device8 * This,
             _In_  const void *pAddress,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
         HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
             ID3D12Device8 * This,
             _In_  HANDLE hFileMapping,
             REFIID riid,
             _COM_Outptr_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
         HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
             ID3D12Device8 * This,
             D3D12_RESIDENCY_FLAGS Flags,
@@ -15830,6 +17065,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_  ID3D12Fence *pFenceToSignal,
             UINT64 FenceValueToSignal);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommandList1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommandList1 )( 
             ID3D12Device8 * This,
             _In_  UINT nodeMask,
@@ -15838,12 +17074,14 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession )( 
             ID3D12Device8 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC *pDesc,
             _In_  REFIID riid,
             _COM_Outptr_  void **ppSession);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommittedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource1 )( 
             ID3D12Device8 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -15855,6 +17093,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateHeap1)
         HRESULT ( STDMETHODCALLTYPE *CreateHeap1 )( 
             ID3D12Device8 * This,
             _In_  const D3D12_HEAP_DESC *pDesc,
@@ -15862,6 +17101,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvHeap);
         
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateReservedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreateReservedResource1 )( 
             ID3D12Device8 * This,
             _In_  const D3D12_RESOURCE_DESC *pDesc,
@@ -15871,27 +17111,33 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
+        DECLSPEC_XFGVIRT(ID3D12Device4, GetResourceAllocationInfo1)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
             ID3D12Device8 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             UINT visibleMask,
             UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs,
             _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateLifetimeTracker)
         HRESULT ( STDMETHODCALLTYPE *CreateLifetimeTracker )( 
             ID3D12Device8 * This,
             _In_  ID3D12LifetimeOwner *pOwner,
             REFIID riid,
             _COM_Outptr_  void **ppvTracker);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, RemoveDevice)
         void ( STDMETHODCALLTYPE *RemoveDevice )( 
             ID3D12Device8 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommands)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommands )( 
             ID3D12Device8 * This,
             _Inout_  UINT *pNumMetaCommands,
             _Out_writes_opt_(*pNumMetaCommands)  D3D12_META_COMMAND_DESC *pDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommandParameters)
         HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommandParameters )( 
             ID3D12Device8 * This,
             _In_  REFGUID CommandId,
@@ -15900,6 +17146,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             _Inout_  UINT *pParameterCount,
             _Out_writes_opt_(*pParameterCount)  D3D12_META_COMMAND_PARAMETER_DESC *pParameterDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateMetaCommand)
         HRESULT ( STDMETHODCALLTYPE *CreateMetaCommand )( 
             ID3D12Device8 * This,
             _In_  REFGUID CommandId,
@@ -15909,22 +17156,26 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppMetaCommand);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateStateObject)
         HRESULT ( STDMETHODCALLTYPE *CreateStateObject )( 
             ID3D12Device8 * This,
             const D3D12_STATE_OBJECT_DESC *pDesc,
             REFIID riid,
             _COM_Outptr_  void **ppStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, GetRaytracingAccelerationStructurePrebuildInfo)
         void ( STDMETHODCALLTYPE *GetRaytracingAccelerationStructurePrebuildInfo )( 
             ID3D12Device8 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *pDesc,
             _Out_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO *pInfo);
         
+        DECLSPEC_XFGVIRT(ID3D12Device5, CheckDriverMatchingIdentifier)
         D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS ( STDMETHODCALLTYPE *CheckDriverMatchingIdentifier )( 
             ID3D12Device8 * This,
             _In_  D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
             _In_  const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER *pIdentifierToCheck);
         
+        DECLSPEC_XFGVIRT(ID3D12Device6, SetBackgroundProcessingMode)
         HRESULT ( STDMETHODCALLTYPE *SetBackgroundProcessingMode )( 
             ID3D12Device8 * This,
             D3D12_BACKGROUND_PROCESSING_MODE Mode,
@@ -15932,6 +17183,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             _In_opt_  HANDLE hEventToSignalUponCompletion,
             _Out_opt_  BOOL *pbFurtherMeasurementsDesired);
         
+        DECLSPEC_XFGVIRT(ID3D12Device7, AddToStateObject)
         HRESULT ( STDMETHODCALLTYPE *AddToStateObject )( 
             ID3D12Device8 * This,
             const D3D12_STATE_OBJECT_DESC *pAddition,
@@ -15939,19 +17191,23 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_  void **ppNewStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12Device7, CreateProtectedResourceSession1)
         HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession1 )( 
             ID3D12Device8 * This,
             _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC1 *pDesc,
             _In_  REFIID riid,
             _COM_Outptr_  void **ppSession);
         
-        D3D12_RESOURCE_ALLOCATION_INFO ( STDMETHODCALLTYPE *GetResourceAllocationInfo2 )( 
+        DECLSPEC_XFGVIRT(ID3D12Device8, GetResourceAllocationInfo2)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo2 )( 
             ID3D12Device8 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
             UINT visibleMask,
             UINT numResourceDescs,
             _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC1 *pResourceDescs,
             _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
         
+        DECLSPEC_XFGVIRT(ID3D12Device8, CreateCommittedResource2)
         HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource2 )( 
             ID3D12Device8 * This,
             _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
@@ -15963,6 +17219,7 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riidResource,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device8, CreatePlacedResource1)
         HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource1 )( 
             ID3D12Device8 * This,
             _In_  ID3D12Heap *pHeap,
@@ -15973,12 +17230,14 @@ EXTERN_C const IID IID_ID3D12Device8;
             REFIID riid,
             _COM_Outptr_opt_  void **ppvResource);
         
+        DECLSPEC_XFGVIRT(ID3D12Device8, CreateSamplerFeedbackUnorderedAccessView)
         void ( STDMETHODCALLTYPE *CreateSamplerFeedbackUnorderedAccessView )( 
             ID3D12Device8 * This,
             _In_opt_  ID3D12Resource *pTargetedResource,
             _In_opt_  ID3D12Resource *pFeedbackResource,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12Device8, GetCopyableFootprints1)
         void ( STDMETHODCALLTYPE *GetCopyableFootprints1 )( 
             ID3D12Device8 * This,
             _In_  const D3D12_RESOURCE_DESC1 *pResourceDesc,
@@ -16080,11 +17339,11 @@ EXTERN_C const IID IID_ID3D12Device8;
 #define ID3D12Device8_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
     ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
 
-#define ID3D12Device8_GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,visibleMask,numResourceDescs,pResourceDescs) ) 
+#define ID3D12Device8_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
 
-#define ID3D12Device8_GetCustomHeapProperties(This,nodeMask,heapType)	\
-    ( (This)->lpVtbl -> GetCustomHeapProperties(This,nodeMask,heapType) ) 
+#define ID3D12Device8_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
 
 #define ID3D12Device8_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
@@ -16134,8 +17393,8 @@ EXTERN_C const IID IID_ID3D12Device8;
 #define ID3D12Device8_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
     ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
 
-#define ID3D12Device8_GetAdapterLuid(This)	\
-    ( (This)->lpVtbl -> GetAdapterLuid(This) ) 
+#define ID3D12Device8_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
 
 
 #define ID3D12Device8_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
@@ -16177,8 +17436,8 @@ EXTERN_C const IID IID_ID3D12Device8;
 #define ID3D12Device8_CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource)	\
     ( (This)->lpVtbl -> CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource) ) 
 
-#define ID3D12Device8_GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+#define ID3D12Device8_GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
 
 
 #define ID3D12Device8_CreateLifetimeTracker(This,pOwner,riid,ppvTracker)	\
@@ -16217,8 +17476,8 @@ EXTERN_C const IID IID_ID3D12Device8;
     ( (This)->lpVtbl -> CreateProtectedResourceSession1(This,pDesc,riid,ppSession) ) 
 
 
-#define ID3D12Device8_GetResourceAllocationInfo2(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
-    ( (This)->lpVtbl -> GetResourceAllocationInfo2(This,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+#define ID3D12Device8_GetResourceAllocationInfo2(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo2(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
 
 #define ID3D12Device8_CreateCommittedResource2(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,pProtectedSession,riidResource,ppvResource)	\
     ( (This)->lpVtbl -> CreateCommittedResource2(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,pProtectedSession,riidResource,ppvResource) ) 
@@ -16236,10 +17495,6 @@ EXTERN_C const IID IID_ID3D12Device8;
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -16275,60 +17530,74 @@ EXTERN_C const IID IID_ID3D12Resource1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Resource1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Resource1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Resource1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Resource1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Resource1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Resource1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Resource1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Resource1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, Map)
         HRESULT ( STDMETHODCALLTYPE *Map )( 
             ID3D12Resource1 * This,
             UINT Subresource,
             _In_opt_  const D3D12_RANGE *pReadRange,
             _Outptr_opt_result_bytebuffer_(_Inexpressible_("Dependent on resource"))  void **ppData);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, Unmap)
         void ( STDMETHODCALLTYPE *Unmap )( 
             ID3D12Resource1 * This,
             UINT Subresource,
             _In_opt_  const D3D12_RANGE *pWrittenRange);
         
-        D3D12_RESOURCE_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12Resource1 * This);
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetDesc)
+        D3D12_RESOURCE_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12Resource1 * This,
+            D3D12_RESOURCE_DESC * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetGPUVirtualAddress)
         D3D12_GPU_VIRTUAL_ADDRESS ( STDMETHODCALLTYPE *GetGPUVirtualAddress )( 
             ID3D12Resource1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, WriteToSubresource)
         HRESULT ( STDMETHODCALLTYPE *WriteToSubresource )( 
             ID3D12Resource1 * This,
             UINT DstSubresource,
@@ -16337,6 +17606,7 @@ EXTERN_C const IID IID_ID3D12Resource1;
             UINT SrcRowPitch,
             UINT SrcDepthPitch);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, ReadFromSubresource)
         HRESULT ( STDMETHODCALLTYPE *ReadFromSubresource )( 
             ID3D12Resource1 * This,
             _Out_  void *pDstData,
@@ -16345,11 +17615,13 @@ EXTERN_C const IID IID_ID3D12Resource1;
             UINT SrcSubresource,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetHeapProperties)
         HRESULT ( STDMETHODCALLTYPE *GetHeapProperties )( 
             ID3D12Resource1 * This,
             _Out_opt_  D3D12_HEAP_PROPERTIES *pHeapProperties,
             _Out_opt_  D3D12_HEAP_FLAGS *pHeapFlags);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource1, GetProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *GetProtectedResourceSession )( 
             ID3D12Resource1 * This,
             REFIID riid,
@@ -16402,8 +17674,8 @@ EXTERN_C const IID IID_ID3D12Resource1;
 #define ID3D12Resource1_Unmap(This,Subresource,pWrittenRange)	\
     ( (This)->lpVtbl -> Unmap(This,Subresource,pWrittenRange) ) 
 
-#define ID3D12Resource1_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12Resource1_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 #define ID3D12Resource1_GetGPUVirtualAddress(This)	\
     ( (This)->lpVtbl -> GetGPUVirtualAddress(This) ) 
@@ -16458,60 +17730,74 @@ EXTERN_C const IID IID_ID3D12Resource2;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Resource2 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Resource2 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Resource2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Resource2 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Resource2 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Resource2 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Resource2 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Resource2 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, Map)
         HRESULT ( STDMETHODCALLTYPE *Map )( 
             ID3D12Resource2 * This,
             UINT Subresource,
             _In_opt_  const D3D12_RANGE *pReadRange,
             _Outptr_opt_result_bytebuffer_(_Inexpressible_("Dependent on resource"))  void **ppData);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, Unmap)
         void ( STDMETHODCALLTYPE *Unmap )( 
             ID3D12Resource2 * This,
             UINT Subresource,
             _In_opt_  const D3D12_RANGE *pWrittenRange);
         
-        D3D12_RESOURCE_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12Resource2 * This);
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetDesc)
+        D3D12_RESOURCE_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12Resource2 * This,
+            D3D12_RESOURCE_DESC * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetGPUVirtualAddress)
         D3D12_GPU_VIRTUAL_ADDRESS ( STDMETHODCALLTYPE *GetGPUVirtualAddress )( 
             ID3D12Resource2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, WriteToSubresource)
         HRESULT ( STDMETHODCALLTYPE *WriteToSubresource )( 
             ID3D12Resource2 * This,
             UINT DstSubresource,
@@ -16520,6 +17806,7 @@ EXTERN_C const IID IID_ID3D12Resource2;
             UINT SrcRowPitch,
             UINT SrcDepthPitch);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, ReadFromSubresource)
         HRESULT ( STDMETHODCALLTYPE *ReadFromSubresource )( 
             ID3D12Resource2 * This,
             _Out_  void *pDstData,
@@ -16528,18 +17815,22 @@ EXTERN_C const IID IID_ID3D12Resource2;
             UINT SrcSubresource,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource, GetHeapProperties)
         HRESULT ( STDMETHODCALLTYPE *GetHeapProperties )( 
             ID3D12Resource2 * This,
             _Out_opt_  D3D12_HEAP_PROPERTIES *pHeapProperties,
             _Out_opt_  D3D12_HEAP_FLAGS *pHeapFlags);
         
+        DECLSPEC_XFGVIRT(ID3D12Resource1, GetProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *GetProtectedResourceSession )( 
             ID3D12Resource2 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppProtectedSession);
         
-        D3D12_RESOURCE_DESC1 ( STDMETHODCALLTYPE *GetDesc1 )( 
-            ID3D12Resource2 * This);
+        DECLSPEC_XFGVIRT(ID3D12Resource2, GetDesc1)
+        D3D12_RESOURCE_DESC1 *( STDMETHODCALLTYPE *GetDesc1 )( 
+            ID3D12Resource2 * This,
+            D3D12_RESOURCE_DESC1 * RetVal);
         
         END_INTERFACE
     } ID3D12Resource2Vtbl;
@@ -16588,8 +17879,8 @@ EXTERN_C const IID IID_ID3D12Resource2;
 #define ID3D12Resource2_Unmap(This,Subresource,pWrittenRange)	\
     ( (This)->lpVtbl -> Unmap(This,Subresource,pWrittenRange) ) 
 
-#define ID3D12Resource2_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12Resource2_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 #define ID3D12Resource2_GetGPUVirtualAddress(This)	\
     ( (This)->lpVtbl -> GetGPUVirtualAddress(This) ) 
@@ -16608,17 +17899,13 @@ EXTERN_C const IID IID_ID3D12Resource2;
     ( (This)->lpVtbl -> GetProtectedResourceSession(This,riid,ppProtectedSession) ) 
 
 
-#define ID3D12Resource2_GetDesc1(This)	\
-    ( (This)->lpVtbl -> GetDesc1(This) ) 
+#define ID3D12Resource2_GetDesc1(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc1(This,RetVal) ) 
 
 #endif /* COBJMACROS */
 
 
 #endif 	/* C style interface */
-
-
-
-
 
 
 
@@ -16654,46 +17941,57 @@ EXTERN_C const IID IID_ID3D12Heap1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Heap1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Heap1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Heap1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12Heap1 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12Heap1 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12Heap1 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12Heap1 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12Heap1 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
-        D3D12_HEAP_DESC ( STDMETHODCALLTYPE *GetDesc )( 
-            ID3D12Heap1 * This);
+        DECLSPEC_XFGVIRT(ID3D12Heap, GetDesc)
+        D3D12_HEAP_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12Heap1 * This,
+            D3D12_HEAP_DESC * RetVal);
         
+        DECLSPEC_XFGVIRT(ID3D12Heap1, GetProtectedResourceSession)
         HRESULT ( STDMETHODCALLTYPE *GetProtectedResourceSession )( 
             ID3D12Heap1 * This,
             REFIID riid,
@@ -16740,8 +18038,8 @@ EXTERN_C const IID IID_ID3D12Heap1;
 
 
 
-#define ID3D12Heap1_GetDesc(This)	\
-    ( (This)->lpVtbl -> GetDesc(This) ) 
+#define ID3D12Heap1_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
 
 
 #define ID3D12Heap1_GetProtectedResourceSession(This,riid,ppProtectedSession)	\
@@ -16785,58 +18083,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList3 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList3 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList3 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList3 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList3 * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT VertexCountPerInstance,
@@ -16844,6 +18155,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT IndexCountPerInstance,
@@ -16852,12 +18164,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -16866,6 +18180,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -16875,11 +18190,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -16889,6 +18206,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -16897,76 +18215,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList3 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList3 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList3 * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList3 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList3 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
@@ -16974,6 +18308,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
@@ -16981,52 +18316,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList3 * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -17034,6 +18379,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -17043,6 +18389,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -17050,6 +18397,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -17059,6 +18407,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -17068,23 +18417,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -17094,27 +18447,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList3 * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList3 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList3 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -17124,6 +18482,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_opt_  ID3D12Resource *pCountBuffer,
             _In_  UINT64 CountBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -17134,6 +18493,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT64)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT64 )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -17144,17 +18504,20 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, OMSetDepthBounds)
         void ( STDMETHODCALLTYPE *OMSetDepthBounds )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  FLOAT Min,
             _In_  FLOAT Max);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetSamplePositions)
         void ( STDMETHODCALLTYPE *SetSamplePositions )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT NumSamplesPerPixel,
             _In_  UINT NumPixels,
             _In_reads_(NumSamplesPerPixel*NumPixels)  D3D12_SAMPLE_POSITION *pSamplePositions);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, ResolveSubresourceRegion)
         void ( STDMETHODCALLTYPE *ResolveSubresourceRegion )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -17167,16 +18530,19 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
             _In_  DXGI_FORMAT Format,
             _In_  D3D12_RESOLVE_MODE ResolveMode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetViewInstanceMask)
         void ( STDMETHODCALLTYPE *SetViewInstanceMask )( 
             ID3D12GraphicsCommandList3 * This,
             _In_  UINT Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList2, WriteBufferImmediate)
         void ( STDMETHODCALLTYPE *WriteBufferImmediate )( 
             ID3D12GraphicsCommandList3 * This,
             UINT Count,
             _In_reads_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER *pParams,
             _In_reads_opt_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_MODE *pModes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList3, SetProtectedResourceSession)
         void ( STDMETHODCALLTYPE *SetProtectedResourceSession )( 
             ID3D12GraphicsCommandList3 * This,
             _In_opt_  ID3D12ProtectedResourceSession *pProtectedResourceSession);
@@ -17416,7 +18782,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList3;
 #endif 	/* __ID3D12GraphicsCommandList3_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0047 */
+/* interface __MIDL_itf_d3d12_0000_0048 */
 /* [local] */ 
 
 typedef 
@@ -17508,8 +18874,8 @@ enum D3D12_RENDER_PASS_FLAGS
 DEFINE_ENUM_FLAG_OPERATORS( D3D12_RENDER_PASS_FLAGS );
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0047_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0047_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0048_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0048_v0_0_s_ifspec;
 
 #ifndef __ID3D12MetaCommand_INTERFACE_DEFINED__
 #define __ID3D12MetaCommand_INTERFACE_DEFINED__
@@ -17539,43 +18905,52 @@ EXTERN_C const IID IID_ID3D12MetaCommand;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12MetaCommand * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12MetaCommand * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12MetaCommand * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12MetaCommand * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12MetaCommand * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12MetaCommand * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12MetaCommand * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12MetaCommand * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12MetaCommand, GetRequiredParameterResourceSize)
         UINT64 ( STDMETHODCALLTYPE *GetRequiredParameterResourceSize )( 
             ID3D12MetaCommand * This,
             _In_  D3D12_META_COMMAND_PARAMETER_STAGE Stage,
@@ -17636,7 +19011,7 @@ EXTERN_C const IID IID_ID3D12MetaCommand;
 #endif 	/* __ID3D12MetaCommand_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0048 */
+/* interface __MIDL_itf_d3d12_0000_0049 */
 /* [local] */ 
 
 typedef struct D3D12_DISPATCH_RAYS_DESC
@@ -17652,8 +19027,8 @@ typedef struct D3D12_DISPATCH_RAYS_DESC
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0048_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0048_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0049_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0049_v0_0_s_ifspec;
 
 #ifndef __ID3D12GraphicsCommandList4_INTERFACE_DEFINED__
 #define __ID3D12GraphicsCommandList4_INTERFACE_DEFINED__
@@ -17718,58 +19093,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList4 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList4 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList4 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList4 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList4 * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT VertexCountPerInstance,
@@ -17777,6 +19165,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT IndexCountPerInstance,
@@ -17785,12 +19174,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -17799,6 +19190,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -17808,11 +19200,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -17822,6 +19216,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -17830,76 +19225,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList4 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList4 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList4 * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList4 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList4 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
@@ -17907,6 +19318,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
@@ -17914,52 +19326,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList4 * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -17967,6 +19389,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -17976,6 +19399,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -17983,6 +19407,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -17992,6 +19417,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -18001,23 +19427,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -18027,27 +19457,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList4 * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList4 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList4 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -18057,6 +19492,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_opt_  ID3D12Resource *pCountBuffer,
             _In_  UINT64 CountBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -18067,6 +19503,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT64)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT64 )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -18077,17 +19514,20 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, OMSetDepthBounds)
         void ( STDMETHODCALLTYPE *OMSetDepthBounds )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  FLOAT Min,
             _In_  FLOAT Max);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetSamplePositions)
         void ( STDMETHODCALLTYPE *SetSamplePositions )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT NumSamplesPerPixel,
             _In_  UINT NumPixels,
             _In_reads_(NumSamplesPerPixel*NumPixels)  D3D12_SAMPLE_POSITION *pSamplePositions);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, ResolveSubresourceRegion)
         void ( STDMETHODCALLTYPE *ResolveSubresourceRegion )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -18100,20 +19540,24 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_  DXGI_FORMAT Format,
             _In_  D3D12_RESOLVE_MODE ResolveMode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetViewInstanceMask)
         void ( STDMETHODCALLTYPE *SetViewInstanceMask )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList2, WriteBufferImmediate)
         void ( STDMETHODCALLTYPE *WriteBufferImmediate )( 
             ID3D12GraphicsCommandList4 * This,
             UINT Count,
             _In_reads_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER *pParams,
             _In_reads_opt_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_MODE *pModes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList3, SetProtectedResourceSession)
         void ( STDMETHODCALLTYPE *SetProtectedResourceSession )( 
             ID3D12GraphicsCommandList4 * This,
             _In_opt_  ID3D12ProtectedResourceSession *pProtectedResourceSession);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, BeginRenderPass)
         void ( STDMETHODCALLTYPE *BeginRenderPass )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  UINT NumRenderTargets,
@@ -18121,43 +19565,51 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
             _In_opt_  const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC *pDepthStencil,
             D3D12_RENDER_PASS_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, EndRenderPass)
         void ( STDMETHODCALLTYPE *EndRenderPass )( 
             ID3D12GraphicsCommandList4 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, InitializeMetaCommand)
         void ( STDMETHODCALLTYPE *InitializeMetaCommand )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12MetaCommand *pMetaCommand,
             _In_reads_bytes_opt_(InitializationParametersDataSizeInBytes)  const void *pInitializationParametersData,
             _In_  SIZE_T InitializationParametersDataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, ExecuteMetaCommand)
         void ( STDMETHODCALLTYPE *ExecuteMetaCommand )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12MetaCommand *pMetaCommand,
             _In_reads_bytes_opt_(ExecutionParametersDataSizeInBytes)  const void *pExecutionParametersData,
             _In_  SIZE_T ExecutionParametersDataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, BuildRaytracingAccelerationStructure)
         void ( STDMETHODCALLTYPE *BuildRaytracingAccelerationStructure )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
             _In_  UINT NumPostbuildInfoDescs,
             _In_reads_opt_(NumPostbuildInfoDescs)  const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *pPostbuildInfoDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, EmitRaytracingAccelerationStructurePostbuildInfo)
         void ( STDMETHODCALLTYPE *EmitRaytracingAccelerationStructurePostbuildInfo )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *pDesc,
             _In_  UINT NumSourceAccelerationStructures,
             _In_reads_( NumSourceAccelerationStructures )  const D3D12_GPU_VIRTUAL_ADDRESS *pSourceAccelerationStructureData);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, CopyRaytracingAccelerationStructure)
         void ( STDMETHODCALLTYPE *CopyRaytracingAccelerationStructure )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS DestAccelerationStructureData,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS SourceAccelerationStructureData,
             _In_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, SetPipelineState1)
         void ( STDMETHODCALLTYPE *SetPipelineState1 )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  ID3D12StateObject *pStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, DispatchRays)
         void ( STDMETHODCALLTYPE *DispatchRays )( 
             ID3D12GraphicsCommandList4 * This,
             _In_  const D3D12_DISPATCH_RAYS_DESC *pDesc);
@@ -18425,6 +19877,1128 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList4;
 #endif 	/* __ID3D12GraphicsCommandList4_INTERFACE_DEFINED__ */
 
 
+/* interface __MIDL_itf_d3d12_0000_0050 */
+/* [local] */ 
+
+typedef 
+enum D3D12_SHADER_CACHE_MODE
+    {
+        D3D12_SHADER_CACHE_MODE_MEMORY	= 0,
+        D3D12_SHADER_CACHE_MODE_DISK	= ( D3D12_SHADER_CACHE_MODE_MEMORY + 1 ) 
+    } 	D3D12_SHADER_CACHE_MODE;
+
+typedef 
+enum D3D12_SHADER_CACHE_FLAGS
+    {
+        D3D12_SHADER_CACHE_FLAG_NONE	= 0,
+        D3D12_SHADER_CACHE_FLAG_DRIVER_VERSIONED	= 0x1,
+        D3D12_SHADER_CACHE_FLAG_USE_WORKING_DIR	= 0x2
+    } 	D3D12_SHADER_CACHE_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS( D3D12_SHADER_CACHE_FLAGS );
+typedef struct D3D12_SHADER_CACHE_SESSION_DESC
+    {
+    GUID Identifier;
+    D3D12_SHADER_CACHE_MODE Mode;
+    D3D12_SHADER_CACHE_FLAGS Flags;
+    UINT MaximumInMemoryCacheSizeBytes;
+    UINT MaximumInMemoryCacheEntries;
+    UINT MaximumValueFileSizeBytes;
+    UINT64 Version;
+    } 	D3D12_SHADER_CACHE_SESSION_DESC;
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0050_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0050_v0_0_s_ifspec;
+
+#ifndef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+#define __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+
+/* interface ID3D12ShaderCacheSession */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12ShaderCacheSession;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("28e2495d-0f64-4ae4-a6ec-129255dc49a8")
+    ID3D12ShaderCacheSession : public ID3D12DeviceChild
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE FindValue( 
+            /* [annotation][in] */ 
+            _In_reads_bytes_(KeySize)  const void *pKey,
+            UINT KeySize,
+            /* [annotation][out] */ 
+            _Out_writes_bytes_(*pValueSize)  void *pValue,
+            _Inout_  UINT *pValueSize) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE StoreValue( 
+            /* [annotation][in] */ 
+            _In_reads_bytes_(KeySize)  const void *pKey,
+            UINT KeySize,
+            /* [annotation][in] */ 
+            _In_reads_bytes_(ValueSize)  const void *pValue,
+            UINT ValueSize) = 0;
+        
+        virtual void STDMETHODCALLTYPE SetDeleteOnDestroy( void) = 0;
+        
+        virtual D3D12_SHADER_CACHE_SESSION_DESC STDMETHODCALLTYPE GetDesc( void) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12ShaderCacheSessionVtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12ShaderCacheSession * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12ShaderCacheSession * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12ShaderCacheSession * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
+        HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
+            ID3D12ShaderCacheSession * This,
+            _In_  REFGUID guid,
+            _Inout_  UINT *pDataSize,
+            _Out_writes_bytes_opt_( *pDataSize )  void *pData);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
+        HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
+            ID3D12ShaderCacheSession * This,
+            _In_  REFGUID guid,
+            _In_  UINT DataSize,
+            _In_reads_bytes_opt_( DataSize )  const void *pData);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
+        HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
+            ID3D12ShaderCacheSession * This,
+            _In_  REFGUID guid,
+            _In_opt_  const IUnknown *pData);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
+        HRESULT ( STDMETHODCALLTYPE *SetName )( 
+            ID3D12ShaderCacheSession * This,
+            _In_z_  LPCWSTR Name);
+        
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
+        HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
+            ID3D12ShaderCacheSession * This,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvDevice);
+        
+        DECLSPEC_XFGVIRT(ID3D12ShaderCacheSession, FindValue)
+        HRESULT ( STDMETHODCALLTYPE *FindValue )( 
+            ID3D12ShaderCacheSession * This,
+            /* [annotation][in] */ 
+            _In_reads_bytes_(KeySize)  const void *pKey,
+            UINT KeySize,
+            /* [annotation][out] */ 
+            _Out_writes_bytes_(*pValueSize)  void *pValue,
+            _Inout_  UINT *pValueSize);
+        
+        DECLSPEC_XFGVIRT(ID3D12ShaderCacheSession, StoreValue)
+        HRESULT ( STDMETHODCALLTYPE *StoreValue )( 
+            ID3D12ShaderCacheSession * This,
+            /* [annotation][in] */ 
+            _In_reads_bytes_(KeySize)  const void *pKey,
+            UINT KeySize,
+            /* [annotation][in] */ 
+            _In_reads_bytes_(ValueSize)  const void *pValue,
+            UINT ValueSize);
+        
+        DECLSPEC_XFGVIRT(ID3D12ShaderCacheSession, SetDeleteOnDestroy)
+        void ( STDMETHODCALLTYPE *SetDeleteOnDestroy )( 
+            ID3D12ShaderCacheSession * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12ShaderCacheSession, GetDesc)
+        D3D12_SHADER_CACHE_SESSION_DESC *( STDMETHODCALLTYPE *GetDesc )( 
+            ID3D12ShaderCacheSession * This,
+            D3D12_SHADER_CACHE_SESSION_DESC * RetVal);
+        
+        END_INTERFACE
+    } ID3D12ShaderCacheSessionVtbl;
+
+    interface ID3D12ShaderCacheSession
+    {
+        CONST_VTBL struct ID3D12ShaderCacheSessionVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12ShaderCacheSession_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12ShaderCacheSession_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12ShaderCacheSession_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12ShaderCacheSession_GetPrivateData(This,guid,pDataSize,pData)	\
+    ( (This)->lpVtbl -> GetPrivateData(This,guid,pDataSize,pData) ) 
+
+#define ID3D12ShaderCacheSession_SetPrivateData(This,guid,DataSize,pData)	\
+    ( (This)->lpVtbl -> SetPrivateData(This,guid,DataSize,pData) ) 
+
+#define ID3D12ShaderCacheSession_SetPrivateDataInterface(This,guid,pData)	\
+    ( (This)->lpVtbl -> SetPrivateDataInterface(This,guid,pData) ) 
+
+#define ID3D12ShaderCacheSession_SetName(This,Name)	\
+    ( (This)->lpVtbl -> SetName(This,Name) ) 
+
+
+#define ID3D12ShaderCacheSession_GetDevice(This,riid,ppvDevice)	\
+    ( (This)->lpVtbl -> GetDevice(This,riid,ppvDevice) ) 
+
+
+#define ID3D12ShaderCacheSession_FindValue(This,pKey,KeySize,pValue,pValueSize)	\
+    ( (This)->lpVtbl -> FindValue(This,pKey,KeySize,pValue,pValueSize) ) 
+
+#define ID3D12ShaderCacheSession_StoreValue(This,pKey,KeySize,pValue,ValueSize)	\
+    ( (This)->lpVtbl -> StoreValue(This,pKey,KeySize,pValue,ValueSize) ) 
+
+#define ID3D12ShaderCacheSession_SetDeleteOnDestroy(This)	\
+    ( (This)->lpVtbl -> SetDeleteOnDestroy(This) ) 
+
+#define ID3D12ShaderCacheSession_GetDesc(This,RetVal)	\
+    ( (This)->lpVtbl -> GetDesc(This,RetVal) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12ShaderCacheSession_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_d3d12_0000_0051 */
+/* [local] */ 
+
+typedef 
+enum D3D12_SHADER_CACHE_KIND_FLAGS
+    {
+        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CACHE_FOR_DRIVER	= 0x1,
+        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_D3D_CONVERSIONS	= 0x2,
+        D3D12_SHADER_CACHE_KIND_FLAG_IMPLICIT_DRIVER_MANAGED	= 0x4,
+        D3D12_SHADER_CACHE_KIND_FLAG_APPLICATION_MANAGED	= 0x8
+    } 	D3D12_SHADER_CACHE_KIND_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS( D3D12_SHADER_CACHE_KIND_FLAGS );
+typedef 
+enum D3D12_SHADER_CACHE_CONTROL_FLAGS
+    {
+        D3D12_SHADER_CACHE_CONTROL_FLAG_DISABLE	= 0x1,
+        D3D12_SHADER_CACHE_CONTROL_FLAG_ENABLE	= 0x2,
+        D3D12_SHADER_CACHE_CONTROL_FLAG_CLEAR	= 0x4
+    } 	D3D12_SHADER_CACHE_CONTROL_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS( D3D12_SHADER_CACHE_CONTROL_FLAGS );
+
+
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0051_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0051_v0_0_s_ifspec;
+
+#ifndef __ID3D12Device9_INTERFACE_DEFINED__
+#define __ID3D12Device9_INTERFACE_DEFINED__
+
+/* interface ID3D12Device9 */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12Device9;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("4c80e962-f032-4f60-bc9e-ebc2cfa1d83c")
+    ID3D12Device9 : public ID3D12Device8
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE CreateShaderCacheSession( 
+            _In_  const D3D12_SHADER_CACHE_SESSION_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvSession) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE ShaderCacheControl( 
+            D3D12_SHADER_CACHE_KIND_FLAGS Kinds,
+            D3D12_SHADER_CACHE_CONTROL_FLAGS Control) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE CreateCommandQueue1( 
+            _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
+            REFIID CreatorID,
+            REFIID riid,
+            _COM_Outptr_  void **ppCommandQueue) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12Device9Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12Device9 * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12Device9 * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12Device9 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
+        HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
+            ID3D12Device9 * This,
+            _In_  REFGUID guid,
+            _Inout_  UINT *pDataSize,
+            _Out_writes_bytes_opt_( *pDataSize )  void *pData);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
+        HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
+            ID3D12Device9 * This,
+            _In_  REFGUID guid,
+            _In_  UINT DataSize,
+            _In_reads_bytes_opt_( DataSize )  const void *pData);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
+        HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
+            ID3D12Device9 * This,
+            _In_  REFGUID guid,
+            _In_opt_  const IUnknown *pData);
+        
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
+        HRESULT ( STDMETHODCALLTYPE *SetName )( 
+            ID3D12Device9 * This,
+            _In_z_  LPCWSTR Name);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetNodeCount)
+        UINT ( STDMETHODCALLTYPE *GetNodeCount )( 
+            ID3D12Device9 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandQueue)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_  void **ppCommandQueue);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandAllocator)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommandAllocator )( 
+            ID3D12Device9 * This,
+            _In_  D3D12_COMMAND_LIST_TYPE type,
+            REFIID riid,
+            _COM_Outptr_  void **ppCommandAllocator);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateGraphicsPipelineState)
+        HRESULT ( STDMETHODCALLTYPE *CreateGraphicsPipelineState )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_GRAPHICS_PIPELINE_STATE_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_  void **ppPipelineState);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateComputePipelineState)
+        HRESULT ( STDMETHODCALLTYPE *CreateComputePipelineState )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_COMPUTE_PIPELINE_STATE_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_  void **ppPipelineState);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandList)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommandList )( 
+            ID3D12Device9 * This,
+            _In_  UINT nodeMask,
+            _In_  D3D12_COMMAND_LIST_TYPE type,
+            _In_  ID3D12CommandAllocator *pCommandAllocator,
+            _In_opt_  ID3D12PipelineState *pInitialState,
+            REFIID riid,
+            _COM_Outptr_  void **ppCommandList);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CheckFeatureSupport)
+        HRESULT ( STDMETHODCALLTYPE *CheckFeatureSupport )( 
+            ID3D12Device9 * This,
+            D3D12_FEATURE Feature,
+            _Inout_updates_bytes_(FeatureSupportDataSize)  void *pFeatureSupportData,
+            UINT FeatureSupportDataSize);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDescriptorHeap)
+        HRESULT ( STDMETHODCALLTYPE *CreateDescriptorHeap )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_DESCRIPTOR_HEAP_DESC *pDescriptorHeapDesc,
+            REFIID riid,
+            _COM_Outptr_  void **ppvHeap);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDescriptorHandleIncrementSize)
+        UINT ( STDMETHODCALLTYPE *GetDescriptorHandleIncrementSize )( 
+            ID3D12Device9 * This,
+            _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRootSignature)
+        HRESULT ( STDMETHODCALLTYPE *CreateRootSignature )( 
+            ID3D12Device9 * This,
+            _In_  UINT nodeMask,
+            _In_reads_(blobLengthInBytes)  const void *pBlobWithRootSignature,
+            _In_  SIZE_T blobLengthInBytes,
+            REFIID riid,
+            _COM_Outptr_  void **ppvRootSignature);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateConstantBufferView)
+        void ( STDMETHODCALLTYPE *CreateConstantBufferView )( 
+            ID3D12Device9 * This,
+            _In_opt_  const D3D12_CONSTANT_BUFFER_VIEW_DESC *pDesc,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateShaderResourceView)
+        void ( STDMETHODCALLTYPE *CreateShaderResourceView )( 
+            ID3D12Device9 * This,
+            _In_opt_  ID3D12Resource *pResource,
+            _In_opt_  const D3D12_SHADER_RESOURCE_VIEW_DESC *pDesc,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateUnorderedAccessView)
+        void ( STDMETHODCALLTYPE *CreateUnorderedAccessView )( 
+            ID3D12Device9 * This,
+            _In_opt_  ID3D12Resource *pResource,
+            _In_opt_  ID3D12Resource *pCounterResource,
+            _In_opt_  const D3D12_UNORDERED_ACCESS_VIEW_DESC *pDesc,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateRenderTargetView)
+        void ( STDMETHODCALLTYPE *CreateRenderTargetView )( 
+            ID3D12Device9 * This,
+            _In_opt_  ID3D12Resource *pResource,
+            _In_opt_  const D3D12_RENDER_TARGET_VIEW_DESC *pDesc,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateDepthStencilView)
+        void ( STDMETHODCALLTYPE *CreateDepthStencilView )( 
+            ID3D12Device9 * This,
+            _In_opt_  ID3D12Resource *pResource,
+            _In_opt_  const D3D12_DEPTH_STENCIL_VIEW_DESC *pDesc,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSampler)
+        void ( STDMETHODCALLTYPE *CreateSampler )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_SAMPLER_DESC *pDesc,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptors)
+        void ( STDMETHODCALLTYPE *CopyDescriptors )( 
+            ID3D12Device9 * This,
+            _In_  UINT NumDestDescriptorRanges,
+            _In_reads_(NumDestDescriptorRanges)  const D3D12_CPU_DESCRIPTOR_HANDLE *pDestDescriptorRangeStarts,
+            _In_reads_opt_(NumDestDescriptorRanges)  const UINT *pDestDescriptorRangeSizes,
+            _In_  UINT NumSrcDescriptorRanges,
+            _In_reads_(NumSrcDescriptorRanges)  const D3D12_CPU_DESCRIPTOR_HANDLE *pSrcDescriptorRangeStarts,
+            _In_reads_opt_(NumSrcDescriptorRanges)  const UINT *pSrcDescriptorRangeSizes,
+            _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CopyDescriptorsSimple)
+        void ( STDMETHODCALLTYPE *CopyDescriptorsSimple )( 
+            ID3D12Device9 * This,
+            _In_  UINT NumDescriptors,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptorRangeStart,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart,
+            _In_  D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceAllocationInfo)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo )( 
+            ID3D12Device9 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
+            _In_  UINT visibleMask,
+            _In_  UINT numResourceDescs,
+            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCustomHeapProperties)
+        D3D12_HEAP_PROPERTIES *( STDMETHODCALLTYPE *GetCustomHeapProperties )( 
+            ID3D12Device9 * This,
+            D3D12_HEAP_PROPERTIES * RetVal,
+            _In_  UINT nodeMask,
+            D3D12_HEAP_TYPE heapType);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommittedResource)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
+            D3D12_HEAP_FLAGS HeapFlags,
+            _In_  const D3D12_RESOURCE_DESC *pDesc,
+            D3D12_RESOURCE_STATES InitialResourceState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            REFIID riidResource,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateHeap)
+        HRESULT ( STDMETHODCALLTYPE *CreateHeap )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_HEAP_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvHeap);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreatePlacedResource)
+        HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource )( 
+            ID3D12Device9 * This,
+            _In_  ID3D12Heap *pHeap,
+            UINT64 HeapOffset,
+            _In_  const D3D12_RESOURCE_DESC *pDesc,
+            D3D12_RESOURCE_STATES InitialState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateReservedResource)
+        HRESULT ( STDMETHODCALLTYPE *CreateReservedResource )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_RESOURCE_DESC *pDesc,
+            D3D12_RESOURCE_STATES InitialState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateSharedHandle)
+        HRESULT ( STDMETHODCALLTYPE *CreateSharedHandle )( 
+            ID3D12Device9 * This,
+            _In_  ID3D12DeviceChild *pObject,
+            _In_opt_  const SECURITY_ATTRIBUTES *pAttributes,
+            DWORD Access,
+            _In_opt_  LPCWSTR Name,
+            _Out_  HANDLE *pHandle);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandle)
+        HRESULT ( STDMETHODCALLTYPE *OpenSharedHandle )( 
+            ID3D12Device9 * This,
+            _In_  HANDLE NTHandle,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvObj);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, OpenSharedHandleByName)
+        HRESULT ( STDMETHODCALLTYPE *OpenSharedHandleByName )( 
+            ID3D12Device9 * This,
+            _In_  LPCWSTR Name,
+            DWORD Access,
+            /* [annotation][out] */ 
+            _Out_  HANDLE *pNTHandle);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, MakeResident)
+        HRESULT ( STDMETHODCALLTYPE *MakeResident )( 
+            ID3D12Device9 * This,
+            UINT NumObjects,
+            _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, Evict)
+        HRESULT ( STDMETHODCALLTYPE *Evict )( 
+            ID3D12Device9 * This,
+            UINT NumObjects,
+            _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateFence)
+        HRESULT ( STDMETHODCALLTYPE *CreateFence )( 
+            ID3D12Device9 * This,
+            UINT64 InitialValue,
+            D3D12_FENCE_FLAGS Flags,
+            REFIID riid,
+            _COM_Outptr_  void **ppFence);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetDeviceRemovedReason)
+        HRESULT ( STDMETHODCALLTYPE *GetDeviceRemovedReason )( 
+            ID3D12Device9 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetCopyableFootprints)
+        void ( STDMETHODCALLTYPE *GetCopyableFootprints )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_RESOURCE_DESC *pResourceDesc,
+            _In_range_(0,D3D12_REQ_SUBRESOURCES)  UINT FirstSubresource,
+            _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource)  UINT NumSubresources,
+            UINT64 BaseOffset,
+            _Out_writes_opt_(NumSubresources)  D3D12_PLACED_SUBRESOURCE_FOOTPRINT *pLayouts,
+            _Out_writes_opt_(NumSubresources)  UINT *pNumRows,
+            _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
+            _Out_opt_  UINT64 *pTotalBytes);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateQueryHeap)
+        HRESULT ( STDMETHODCALLTYPE *CreateQueryHeap )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_QUERY_HEAP_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvHeap);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, SetStablePowerState)
+        HRESULT ( STDMETHODCALLTYPE *SetStablePowerState )( 
+            ID3D12Device9 * This,
+            BOOL Enable);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, CreateCommandSignature)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommandSignature )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_COMMAND_SIGNATURE_DESC *pDesc,
+            _In_opt_  ID3D12RootSignature *pRootSignature,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvCommandSignature);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetResourceTiling)
+        void ( STDMETHODCALLTYPE *GetResourceTiling )( 
+            ID3D12Device9 * This,
+            _In_  ID3D12Resource *pTiledResource,
+            _Out_opt_  UINT *pNumTilesForEntireResource,
+            _Out_opt_  D3D12_PACKED_MIP_INFO *pPackedMipDesc,
+            _Out_opt_  D3D12_TILE_SHAPE *pStandardTileShapeForNonPackedMips,
+            _Inout_opt_  UINT *pNumSubresourceTilings,
+            _In_  UINT FirstSubresourceTilingToGet,
+            _Out_writes_(*pNumSubresourceTilings)  D3D12_SUBRESOURCE_TILING *pSubresourceTilingsForNonPackedMips);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device, GetAdapterLuid)
+        LUID *( STDMETHODCALLTYPE *GetAdapterLuid )( 
+            ID3D12Device9 * This,
+            LUID * RetVal);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device1, CreatePipelineLibrary)
+        HRESULT ( STDMETHODCALLTYPE *CreatePipelineLibrary )( 
+            ID3D12Device9 * This,
+            _In_reads_(BlobLength)  const void *pLibraryBlob,
+            SIZE_T BlobLength,
+            REFIID riid,
+            _COM_Outptr_  void **ppPipelineLibrary);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetEventOnMultipleFenceCompletion)
+        HRESULT ( STDMETHODCALLTYPE *SetEventOnMultipleFenceCompletion )( 
+            ID3D12Device9 * This,
+            _In_reads_(NumFences)  ID3D12Fence *const *ppFences,
+            _In_reads_(NumFences)  const UINT64 *pFenceValues,
+            UINT NumFences,
+            D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
+            HANDLE hEvent);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device1, SetResidencyPriority)
+        HRESULT ( STDMETHODCALLTYPE *SetResidencyPriority )( 
+            ID3D12Device9 * This,
+            UINT NumObjects,
+            _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
+            _In_reads_(NumObjects)  const D3D12_RESIDENCY_PRIORITY *pPriorities);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device2, CreatePipelineState)
+        HRESULT ( STDMETHODCALLTYPE *CreatePipelineState )( 
+            ID3D12Device9 * This,
+            const D3D12_PIPELINE_STATE_STREAM_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_  void **ppPipelineState);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromAddress)
+        HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromAddress )( 
+            ID3D12Device9 * This,
+            _In_  const void *pAddress,
+            REFIID riid,
+            _COM_Outptr_  void **ppvHeap);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device3, OpenExistingHeapFromFileMapping)
+        HRESULT ( STDMETHODCALLTYPE *OpenExistingHeapFromFileMapping )( 
+            ID3D12Device9 * This,
+            _In_  HANDLE hFileMapping,
+            REFIID riid,
+            _COM_Outptr_  void **ppvHeap);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device3, EnqueueMakeResident)
+        HRESULT ( STDMETHODCALLTYPE *EnqueueMakeResident )( 
+            ID3D12Device9 * This,
+            D3D12_RESIDENCY_FLAGS Flags,
+            UINT NumObjects,
+            _In_reads_(NumObjects)  ID3D12Pageable *const *ppObjects,
+            _In_  ID3D12Fence *pFenceToSignal,
+            UINT64 FenceValueToSignal);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommandList1)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommandList1 )( 
+            ID3D12Device9 * This,
+            _In_  UINT nodeMask,
+            _In_  D3D12_COMMAND_LIST_TYPE type,
+            _In_  D3D12_COMMAND_LIST_FLAGS flags,
+            REFIID riid,
+            _COM_Outptr_  void **ppCommandList);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateProtectedResourceSession)
+        HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC *pDesc,
+            _In_  REFIID riid,
+            _COM_Outptr_  void **ppSession);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateCommittedResource1)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource1 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
+            D3D12_HEAP_FLAGS HeapFlags,
+            _In_  const D3D12_RESOURCE_DESC *pDesc,
+            D3D12_RESOURCE_STATES InitialResourceState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            _In_opt_  ID3D12ProtectedResourceSession *pProtectedSession,
+            REFIID riidResource,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateHeap1)
+        HRESULT ( STDMETHODCALLTYPE *CreateHeap1 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_HEAP_DESC *pDesc,
+            _In_opt_  ID3D12ProtectedResourceSession *pProtectedSession,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvHeap);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device4, CreateReservedResource1)
+        HRESULT ( STDMETHODCALLTYPE *CreateReservedResource1 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_RESOURCE_DESC *pDesc,
+            D3D12_RESOURCE_STATES InitialState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            _In_opt_  ID3D12ProtectedResourceSession *pProtectedSession,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device4, GetResourceAllocationInfo1)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo1 )( 
+            ID3D12Device9 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
+            UINT visibleMask,
+            UINT numResourceDescs,
+            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs,
+            _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateLifetimeTracker)
+        HRESULT ( STDMETHODCALLTYPE *CreateLifetimeTracker )( 
+            ID3D12Device9 * This,
+            _In_  ID3D12LifetimeOwner *pOwner,
+            REFIID riid,
+            _COM_Outptr_  void **ppvTracker);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, RemoveDevice)
+        void ( STDMETHODCALLTYPE *RemoveDevice )( 
+            ID3D12Device9 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommands)
+        HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommands )( 
+            ID3D12Device9 * This,
+            _Inout_  UINT *pNumMetaCommands,
+            _Out_writes_opt_(*pNumMetaCommands)  D3D12_META_COMMAND_DESC *pDescs);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, EnumerateMetaCommandParameters)
+        HRESULT ( STDMETHODCALLTYPE *EnumerateMetaCommandParameters )( 
+            ID3D12Device9 * This,
+            _In_  REFGUID CommandId,
+            _In_  D3D12_META_COMMAND_PARAMETER_STAGE Stage,
+            _Out_opt_  UINT *pTotalStructureSizeInBytes,
+            _Inout_  UINT *pParameterCount,
+            _Out_writes_opt_(*pParameterCount)  D3D12_META_COMMAND_PARAMETER_DESC *pParameterDescs);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateMetaCommand)
+        HRESULT ( STDMETHODCALLTYPE *CreateMetaCommand )( 
+            ID3D12Device9 * This,
+            _In_  REFGUID CommandId,
+            _In_  UINT NodeMask,
+            _In_reads_bytes_opt_(CreationParametersDataSizeInBytes)  const void *pCreationParametersData,
+            _In_  SIZE_T CreationParametersDataSizeInBytes,
+            REFIID riid,
+            _COM_Outptr_  void **ppMetaCommand);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, CreateStateObject)
+        HRESULT ( STDMETHODCALLTYPE *CreateStateObject )( 
+            ID3D12Device9 * This,
+            const D3D12_STATE_OBJECT_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_  void **ppStateObject);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, GetRaytracingAccelerationStructurePrebuildInfo)
+        void ( STDMETHODCALLTYPE *GetRaytracingAccelerationStructurePrebuildInfo )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS *pDesc,
+            _Out_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO *pInfo);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device5, CheckDriverMatchingIdentifier)
+        D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS ( STDMETHODCALLTYPE *CheckDriverMatchingIdentifier )( 
+            ID3D12Device9 * This,
+            _In_  D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
+            _In_  const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER *pIdentifierToCheck);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device6, SetBackgroundProcessingMode)
+        HRESULT ( STDMETHODCALLTYPE *SetBackgroundProcessingMode )( 
+            ID3D12Device9 * This,
+            D3D12_BACKGROUND_PROCESSING_MODE Mode,
+            D3D12_MEASUREMENTS_ACTION MeasurementsAction,
+            _In_opt_  HANDLE hEventToSignalUponCompletion,
+            _Out_opt_  BOOL *pbFurtherMeasurementsDesired);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device7, AddToStateObject)
+        HRESULT ( STDMETHODCALLTYPE *AddToStateObject )( 
+            ID3D12Device9 * This,
+            const D3D12_STATE_OBJECT_DESC *pAddition,
+            ID3D12StateObject *pStateObjectToGrowFrom,
+            REFIID riid,
+            _COM_Outptr_  void **ppNewStateObject);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device7, CreateProtectedResourceSession1)
+        HRESULT ( STDMETHODCALLTYPE *CreateProtectedResourceSession1 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_PROTECTED_RESOURCE_SESSION_DESC1 *pDesc,
+            _In_  REFIID riid,
+            _COM_Outptr_  void **ppSession);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device8, GetResourceAllocationInfo2)
+        D3D12_RESOURCE_ALLOCATION_INFO *( STDMETHODCALLTYPE *GetResourceAllocationInfo2 )( 
+            ID3D12Device9 * This,
+            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
+            UINT visibleMask,
+            UINT numResourceDescs,
+            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC1 *pResourceDescs,
+            _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device8, CreateCommittedResource2)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommittedResource2 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_HEAP_PROPERTIES *pHeapProperties,
+            D3D12_HEAP_FLAGS HeapFlags,
+            _In_  const D3D12_RESOURCE_DESC1 *pDesc,
+            D3D12_RESOURCE_STATES InitialResourceState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            _In_opt_  ID3D12ProtectedResourceSession *pProtectedSession,
+            REFIID riidResource,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device8, CreatePlacedResource1)
+        HRESULT ( STDMETHODCALLTYPE *CreatePlacedResource1 )( 
+            ID3D12Device9 * This,
+            _In_  ID3D12Heap *pHeap,
+            UINT64 HeapOffset,
+            _In_  const D3D12_RESOURCE_DESC1 *pDesc,
+            D3D12_RESOURCE_STATES InitialState,
+            _In_opt_  const D3D12_CLEAR_VALUE *pOptimizedClearValue,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvResource);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device8, CreateSamplerFeedbackUnorderedAccessView)
+        void ( STDMETHODCALLTYPE *CreateSamplerFeedbackUnorderedAccessView )( 
+            ID3D12Device9 * This,
+            _In_opt_  ID3D12Resource *pTargetedResource,
+            _In_opt_  ID3D12Resource *pFeedbackResource,
+            _In_  D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device8, GetCopyableFootprints1)
+        void ( STDMETHODCALLTYPE *GetCopyableFootprints1 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_RESOURCE_DESC1 *pResourceDesc,
+            _In_range_(0,D3D12_REQ_SUBRESOURCES)  UINT FirstSubresource,
+            _In_range_(0,D3D12_REQ_SUBRESOURCES-FirstSubresource)  UINT NumSubresources,
+            UINT64 BaseOffset,
+            _Out_writes_opt_(NumSubresources)  D3D12_PLACED_SUBRESOURCE_FOOTPRINT *pLayouts,
+            _Out_writes_opt_(NumSubresources)  UINT *pNumRows,
+            _Out_writes_opt_(NumSubresources)  UINT64 *pRowSizeInBytes,
+            _Out_opt_  UINT64 *pTotalBytes);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device9, CreateShaderCacheSession)
+        HRESULT ( STDMETHODCALLTYPE *CreateShaderCacheSession )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_SHADER_CACHE_SESSION_DESC *pDesc,
+            REFIID riid,
+            _COM_Outptr_opt_  void **ppvSession);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device9, ShaderCacheControl)
+        HRESULT ( STDMETHODCALLTYPE *ShaderCacheControl )( 
+            ID3D12Device9 * This,
+            D3D12_SHADER_CACHE_KIND_FLAGS Kinds,
+            D3D12_SHADER_CACHE_CONTROL_FLAGS Control);
+        
+        DECLSPEC_XFGVIRT(ID3D12Device9, CreateCommandQueue1)
+        HRESULT ( STDMETHODCALLTYPE *CreateCommandQueue1 )( 
+            ID3D12Device9 * This,
+            _In_  const D3D12_COMMAND_QUEUE_DESC *pDesc,
+            REFIID CreatorID,
+            REFIID riid,
+            _COM_Outptr_  void **ppCommandQueue);
+        
+        END_INTERFACE
+    } ID3D12Device9Vtbl;
+
+    interface ID3D12Device9
+    {
+        CONST_VTBL struct ID3D12Device9Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12Device9_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12Device9_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12Device9_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12Device9_GetPrivateData(This,guid,pDataSize,pData)	\
+    ( (This)->lpVtbl -> GetPrivateData(This,guid,pDataSize,pData) ) 
+
+#define ID3D12Device9_SetPrivateData(This,guid,DataSize,pData)	\
+    ( (This)->lpVtbl -> SetPrivateData(This,guid,DataSize,pData) ) 
+
+#define ID3D12Device9_SetPrivateDataInterface(This,guid,pData)	\
+    ( (This)->lpVtbl -> SetPrivateDataInterface(This,guid,pData) ) 
+
+#define ID3D12Device9_SetName(This,Name)	\
+    ( (This)->lpVtbl -> SetName(This,Name) ) 
+
+
+#define ID3D12Device9_GetNodeCount(This)	\
+    ( (This)->lpVtbl -> GetNodeCount(This) ) 
+
+#define ID3D12Device9_CreateCommandQueue(This,pDesc,riid,ppCommandQueue)	\
+    ( (This)->lpVtbl -> CreateCommandQueue(This,pDesc,riid,ppCommandQueue) ) 
+
+#define ID3D12Device9_CreateCommandAllocator(This,type,riid,ppCommandAllocator)	\
+    ( (This)->lpVtbl -> CreateCommandAllocator(This,type,riid,ppCommandAllocator) ) 
+
+#define ID3D12Device9_CreateGraphicsPipelineState(This,pDesc,riid,ppPipelineState)	\
+    ( (This)->lpVtbl -> CreateGraphicsPipelineState(This,pDesc,riid,ppPipelineState) ) 
+
+#define ID3D12Device9_CreateComputePipelineState(This,pDesc,riid,ppPipelineState)	\
+    ( (This)->lpVtbl -> CreateComputePipelineState(This,pDesc,riid,ppPipelineState) ) 
+
+#define ID3D12Device9_CreateCommandList(This,nodeMask,type,pCommandAllocator,pInitialState,riid,ppCommandList)	\
+    ( (This)->lpVtbl -> CreateCommandList(This,nodeMask,type,pCommandAllocator,pInitialState,riid,ppCommandList) ) 
+
+#define ID3D12Device9_CheckFeatureSupport(This,Feature,pFeatureSupportData,FeatureSupportDataSize)	\
+    ( (This)->lpVtbl -> CheckFeatureSupport(This,Feature,pFeatureSupportData,FeatureSupportDataSize) ) 
+
+#define ID3D12Device9_CreateDescriptorHeap(This,pDescriptorHeapDesc,riid,ppvHeap)	\
+    ( (This)->lpVtbl -> CreateDescriptorHeap(This,pDescriptorHeapDesc,riid,ppvHeap) ) 
+
+#define ID3D12Device9_GetDescriptorHandleIncrementSize(This,DescriptorHeapType)	\
+    ( (This)->lpVtbl -> GetDescriptorHandleIncrementSize(This,DescriptorHeapType) ) 
+
+#define ID3D12Device9_CreateRootSignature(This,nodeMask,pBlobWithRootSignature,blobLengthInBytes,riid,ppvRootSignature)	\
+    ( (This)->lpVtbl -> CreateRootSignature(This,nodeMask,pBlobWithRootSignature,blobLengthInBytes,riid,ppvRootSignature) ) 
+
+#define ID3D12Device9_CreateConstantBufferView(This,pDesc,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateConstantBufferView(This,pDesc,DestDescriptor) ) 
+
+#define ID3D12Device9_CreateShaderResourceView(This,pResource,pDesc,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateShaderResourceView(This,pResource,pDesc,DestDescriptor) ) 
+
+#define ID3D12Device9_CreateUnorderedAccessView(This,pResource,pCounterResource,pDesc,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateUnorderedAccessView(This,pResource,pCounterResource,pDesc,DestDescriptor) ) 
+
+#define ID3D12Device9_CreateRenderTargetView(This,pResource,pDesc,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateRenderTargetView(This,pResource,pDesc,DestDescriptor) ) 
+
+#define ID3D12Device9_CreateDepthStencilView(This,pResource,pDesc,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateDepthStencilView(This,pResource,pDesc,DestDescriptor) ) 
+
+#define ID3D12Device9_CreateSampler(This,pDesc,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateSampler(This,pDesc,DestDescriptor) ) 
+
+#define ID3D12Device9_CopyDescriptors(This,NumDestDescriptorRanges,pDestDescriptorRangeStarts,pDestDescriptorRangeSizes,NumSrcDescriptorRanges,pSrcDescriptorRangeStarts,pSrcDescriptorRangeSizes,DescriptorHeapsType)	\
+    ( (This)->lpVtbl -> CopyDescriptors(This,NumDestDescriptorRanges,pDestDescriptorRangeStarts,pDestDescriptorRangeSizes,NumSrcDescriptorRanges,pSrcDescriptorRangeStarts,pSrcDescriptorRangeSizes,DescriptorHeapsType) ) 
+
+#define ID3D12Device9_CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType)	\
+    ( (This)->lpVtbl -> CopyDescriptorsSimple(This,NumDescriptors,DestDescriptorRangeStart,SrcDescriptorRangeStart,DescriptorHeapsType) ) 
+
+#define ID3D12Device9_GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo(This,RetVal,visibleMask,numResourceDescs,pResourceDescs) ) 
+
+#define ID3D12Device9_GetCustomHeapProperties(This,RetVal,nodeMask,heapType)	\
+    ( (This)->lpVtbl -> GetCustomHeapProperties(This,RetVal,nodeMask,heapType) ) 
+
+#define ID3D12Device9_CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource)	\
+    ( (This)->lpVtbl -> CreateCommittedResource(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,riidResource,ppvResource) ) 
+
+#define ID3D12Device9_CreateHeap(This,pDesc,riid,ppvHeap)	\
+    ( (This)->lpVtbl -> CreateHeap(This,pDesc,riid,ppvHeap) ) 
+
+#define ID3D12Device9_CreatePlacedResource(This,pHeap,HeapOffset,pDesc,InitialState,pOptimizedClearValue,riid,ppvResource)	\
+    ( (This)->lpVtbl -> CreatePlacedResource(This,pHeap,HeapOffset,pDesc,InitialState,pOptimizedClearValue,riid,ppvResource) ) 
+
+#define ID3D12Device9_CreateReservedResource(This,pDesc,InitialState,pOptimizedClearValue,riid,ppvResource)	\
+    ( (This)->lpVtbl -> CreateReservedResource(This,pDesc,InitialState,pOptimizedClearValue,riid,ppvResource) ) 
+
+#define ID3D12Device9_CreateSharedHandle(This,pObject,pAttributes,Access,Name,pHandle)	\
+    ( (This)->lpVtbl -> CreateSharedHandle(This,pObject,pAttributes,Access,Name,pHandle) ) 
+
+#define ID3D12Device9_OpenSharedHandle(This,NTHandle,riid,ppvObj)	\
+    ( (This)->lpVtbl -> OpenSharedHandle(This,NTHandle,riid,ppvObj) ) 
+
+#define ID3D12Device9_OpenSharedHandleByName(This,Name,Access,pNTHandle)	\
+    ( (This)->lpVtbl -> OpenSharedHandleByName(This,Name,Access,pNTHandle) ) 
+
+#define ID3D12Device9_MakeResident(This,NumObjects,ppObjects)	\
+    ( (This)->lpVtbl -> MakeResident(This,NumObjects,ppObjects) ) 
+
+#define ID3D12Device9_Evict(This,NumObjects,ppObjects)	\
+    ( (This)->lpVtbl -> Evict(This,NumObjects,ppObjects) ) 
+
+#define ID3D12Device9_CreateFence(This,InitialValue,Flags,riid,ppFence)	\
+    ( (This)->lpVtbl -> CreateFence(This,InitialValue,Flags,riid,ppFence) ) 
+
+#define ID3D12Device9_GetDeviceRemovedReason(This)	\
+    ( (This)->lpVtbl -> GetDeviceRemovedReason(This) ) 
+
+#define ID3D12Device9_GetCopyableFootprints(This,pResourceDesc,FirstSubresource,NumSubresources,BaseOffset,pLayouts,pNumRows,pRowSizeInBytes,pTotalBytes)	\
+    ( (This)->lpVtbl -> GetCopyableFootprints(This,pResourceDesc,FirstSubresource,NumSubresources,BaseOffset,pLayouts,pNumRows,pRowSizeInBytes,pTotalBytes) ) 
+
+#define ID3D12Device9_CreateQueryHeap(This,pDesc,riid,ppvHeap)	\
+    ( (This)->lpVtbl -> CreateQueryHeap(This,pDesc,riid,ppvHeap) ) 
+
+#define ID3D12Device9_SetStablePowerState(This,Enable)	\
+    ( (This)->lpVtbl -> SetStablePowerState(This,Enable) ) 
+
+#define ID3D12Device9_CreateCommandSignature(This,pDesc,pRootSignature,riid,ppvCommandSignature)	\
+    ( (This)->lpVtbl -> CreateCommandSignature(This,pDesc,pRootSignature,riid,ppvCommandSignature) ) 
+
+#define ID3D12Device9_GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips)	\
+    ( (This)->lpVtbl -> GetResourceTiling(This,pTiledResource,pNumTilesForEntireResource,pPackedMipDesc,pStandardTileShapeForNonPackedMips,pNumSubresourceTilings,FirstSubresourceTilingToGet,pSubresourceTilingsForNonPackedMips) ) 
+
+#define ID3D12Device9_GetAdapterLuid(This,RetVal)	\
+    ( (This)->lpVtbl -> GetAdapterLuid(This,RetVal) ) 
+
+
+#define ID3D12Device9_CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary)	\
+    ( (This)->lpVtbl -> CreatePipelineLibrary(This,pLibraryBlob,BlobLength,riid,ppPipelineLibrary) ) 
+
+#define ID3D12Device9_SetEventOnMultipleFenceCompletion(This,ppFences,pFenceValues,NumFences,Flags,hEvent)	\
+    ( (This)->lpVtbl -> SetEventOnMultipleFenceCompletion(This,ppFences,pFenceValues,NumFences,Flags,hEvent) ) 
+
+#define ID3D12Device9_SetResidencyPriority(This,NumObjects,ppObjects,pPriorities)	\
+    ( (This)->lpVtbl -> SetResidencyPriority(This,NumObjects,ppObjects,pPriorities) ) 
+
+
+#define ID3D12Device9_CreatePipelineState(This,pDesc,riid,ppPipelineState)	\
+    ( (This)->lpVtbl -> CreatePipelineState(This,pDesc,riid,ppPipelineState) ) 
+
+
+#define ID3D12Device9_OpenExistingHeapFromAddress(This,pAddress,riid,ppvHeap)	\
+    ( (This)->lpVtbl -> OpenExistingHeapFromAddress(This,pAddress,riid,ppvHeap) ) 
+
+#define ID3D12Device9_OpenExistingHeapFromFileMapping(This,hFileMapping,riid,ppvHeap)	\
+    ( (This)->lpVtbl -> OpenExistingHeapFromFileMapping(This,hFileMapping,riid,ppvHeap) ) 
+
+#define ID3D12Device9_EnqueueMakeResident(This,Flags,NumObjects,ppObjects,pFenceToSignal,FenceValueToSignal)	\
+    ( (This)->lpVtbl -> EnqueueMakeResident(This,Flags,NumObjects,ppObjects,pFenceToSignal,FenceValueToSignal) ) 
+
+
+#define ID3D12Device9_CreateCommandList1(This,nodeMask,type,flags,riid,ppCommandList)	\
+    ( (This)->lpVtbl -> CreateCommandList1(This,nodeMask,type,flags,riid,ppCommandList) ) 
+
+#define ID3D12Device9_CreateProtectedResourceSession(This,pDesc,riid,ppSession)	\
+    ( (This)->lpVtbl -> CreateProtectedResourceSession(This,pDesc,riid,ppSession) ) 
+
+#define ID3D12Device9_CreateCommittedResource1(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,pProtectedSession,riidResource,ppvResource)	\
+    ( (This)->lpVtbl -> CreateCommittedResource1(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,pProtectedSession,riidResource,ppvResource) ) 
+
+#define ID3D12Device9_CreateHeap1(This,pDesc,pProtectedSession,riid,ppvHeap)	\
+    ( (This)->lpVtbl -> CreateHeap1(This,pDesc,pProtectedSession,riid,ppvHeap) ) 
+
+#define ID3D12Device9_CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource)	\
+    ( (This)->lpVtbl -> CreateReservedResource1(This,pDesc,InitialState,pOptimizedClearValue,pProtectedSession,riid,ppvResource) ) 
+
+#define ID3D12Device9_GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo1(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+
+
+#define ID3D12Device9_CreateLifetimeTracker(This,pOwner,riid,ppvTracker)	\
+    ( (This)->lpVtbl -> CreateLifetimeTracker(This,pOwner,riid,ppvTracker) ) 
+
+#define ID3D12Device9_RemoveDevice(This)	\
+    ( (This)->lpVtbl -> RemoveDevice(This) ) 
+
+#define ID3D12Device9_EnumerateMetaCommands(This,pNumMetaCommands,pDescs)	\
+    ( (This)->lpVtbl -> EnumerateMetaCommands(This,pNumMetaCommands,pDescs) ) 
+
+#define ID3D12Device9_EnumerateMetaCommandParameters(This,CommandId,Stage,pTotalStructureSizeInBytes,pParameterCount,pParameterDescs)	\
+    ( (This)->lpVtbl -> EnumerateMetaCommandParameters(This,CommandId,Stage,pTotalStructureSizeInBytes,pParameterCount,pParameterDescs) ) 
+
+#define ID3D12Device9_CreateMetaCommand(This,CommandId,NodeMask,pCreationParametersData,CreationParametersDataSizeInBytes,riid,ppMetaCommand)	\
+    ( (This)->lpVtbl -> CreateMetaCommand(This,CommandId,NodeMask,pCreationParametersData,CreationParametersDataSizeInBytes,riid,ppMetaCommand) ) 
+
+#define ID3D12Device9_CreateStateObject(This,pDesc,riid,ppStateObject)	\
+    ( (This)->lpVtbl -> CreateStateObject(This,pDesc,riid,ppStateObject) ) 
+
+#define ID3D12Device9_GetRaytracingAccelerationStructurePrebuildInfo(This,pDesc,pInfo)	\
+    ( (This)->lpVtbl -> GetRaytracingAccelerationStructurePrebuildInfo(This,pDesc,pInfo) ) 
+
+#define ID3D12Device9_CheckDriverMatchingIdentifier(This,SerializedDataType,pIdentifierToCheck)	\
+    ( (This)->lpVtbl -> CheckDriverMatchingIdentifier(This,SerializedDataType,pIdentifierToCheck) ) 
+
+
+#define ID3D12Device9_SetBackgroundProcessingMode(This,Mode,MeasurementsAction,hEventToSignalUponCompletion,pbFurtherMeasurementsDesired)	\
+    ( (This)->lpVtbl -> SetBackgroundProcessingMode(This,Mode,MeasurementsAction,hEventToSignalUponCompletion,pbFurtherMeasurementsDesired) ) 
+
+
+#define ID3D12Device9_AddToStateObject(This,pAddition,pStateObjectToGrowFrom,riid,ppNewStateObject)	\
+    ( (This)->lpVtbl -> AddToStateObject(This,pAddition,pStateObjectToGrowFrom,riid,ppNewStateObject) ) 
+
+#define ID3D12Device9_CreateProtectedResourceSession1(This,pDesc,riid,ppSession)	\
+    ( (This)->lpVtbl -> CreateProtectedResourceSession1(This,pDesc,riid,ppSession) ) 
+
+
+#define ID3D12Device9_GetResourceAllocationInfo2(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1)	\
+    ( (This)->lpVtbl -> GetResourceAllocationInfo2(This,RetVal,visibleMask,numResourceDescs,pResourceDescs,pResourceAllocationInfo1) ) 
+
+#define ID3D12Device9_CreateCommittedResource2(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,pProtectedSession,riidResource,ppvResource)	\
+    ( (This)->lpVtbl -> CreateCommittedResource2(This,pHeapProperties,HeapFlags,pDesc,InitialResourceState,pOptimizedClearValue,pProtectedSession,riidResource,ppvResource) ) 
+
+#define ID3D12Device9_CreatePlacedResource1(This,pHeap,HeapOffset,pDesc,InitialState,pOptimizedClearValue,riid,ppvResource)	\
+    ( (This)->lpVtbl -> CreatePlacedResource1(This,pHeap,HeapOffset,pDesc,InitialState,pOptimizedClearValue,riid,ppvResource) ) 
+
+#define ID3D12Device9_CreateSamplerFeedbackUnorderedAccessView(This,pTargetedResource,pFeedbackResource,DestDescriptor)	\
+    ( (This)->lpVtbl -> CreateSamplerFeedbackUnorderedAccessView(This,pTargetedResource,pFeedbackResource,DestDescriptor) ) 
+
+#define ID3D12Device9_GetCopyableFootprints1(This,pResourceDesc,FirstSubresource,NumSubresources,BaseOffset,pLayouts,pNumRows,pRowSizeInBytes,pTotalBytes)	\
+    ( (This)->lpVtbl -> GetCopyableFootprints1(This,pResourceDesc,FirstSubresource,NumSubresources,BaseOffset,pLayouts,pNumRows,pRowSizeInBytes,pTotalBytes) ) 
+
+
+#define ID3D12Device9_CreateShaderCacheSession(This,pDesc,riid,ppvSession)	\
+    ( (This)->lpVtbl -> CreateShaderCacheSession(This,pDesc,riid,ppvSession) ) 
+
+#define ID3D12Device9_ShaderCacheControl(This,Kinds,Control)	\
+    ( (This)->lpVtbl -> ShaderCacheControl(This,Kinds,Control) ) 
+
+#define ID3D12Device9_CreateCommandQueue1(This,pDesc,CreatorID,riid,ppCommandQueue)	\
+    ( (This)->lpVtbl -> CreateCommandQueue1(This,pDesc,CreatorID,riid,ppCommandQueue) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12Device9_INTERFACE_DEFINED__ */
+
+
 #ifndef __ID3D12Tools_INTERFACE_DEFINED__
 #define __ID3D12Tools_INTERFACE_DEFINED__
 
@@ -18454,21 +21028,26 @@ EXTERN_C const IID IID_ID3D12Tools;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Tools * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Tools * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Tools * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Tools, EnableShaderInstrumentation)
         void ( STDMETHODCALLTYPE *EnableShaderInstrumentation )( 
             ID3D12Tools * This,
             BOOL bEnable);
         
+        DECLSPEC_XFGVIRT(ID3D12Tools, ShaderInstrumentationEnabled)
         BOOL ( STDMETHODCALLTYPE *ShaderInstrumentationEnabled )( 
             ID3D12Tools * This);
         
@@ -18512,7 +21091,7 @@ EXTERN_C const IID IID_ID3D12Tools;
 #endif 	/* __ID3D12Tools_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0050 */
+/* interface __MIDL_itf_d3d12_0000_0053 */
 /* [local] */ 
 
 typedef struct D3D12_SUBRESOURCE_DATA
@@ -18595,9 +21174,9 @@ HRESULT WINAPI D3D12GetDebugInterface( _In_ REFIID riid, _COM_Outptr_opt_ void**
 // --------------------------------------------------------------------------------------------------------------------------------
 HRESULT WINAPI D3D12EnableExperimentalFeatures(
     UINT                                    NumFeatures,
-    __in_ecount(NumFeatures) const IID*     pIIDs,
-    __in_ecount_opt(NumFeatures) void*      pConfigurationStructs,
-    __in_ecount_opt(NumFeatures) UINT*      pConfigurationStructSizes);
+    _In_count_(NumFeatures) const IID*     pIIDs,
+    _In_opt_count_(NumFeatures) void*      pConfigurationStructs,
+    _In_opt_count_(NumFeatures) UINT*      pConfigurationStructSizes);
 
 // --------------------------------------------------------------------------------------------------------------------------------
 // Experimental Feature: D3D12ExperimentalShaderModels
@@ -18643,6 +21222,114 @@ static const UUID D3D12MetaCommand = { /* C734C97E-8077-48C8-9FDC-D9D1DD31DD77 *
     0x48c8,
     { 0x9f, 0xdc, 0xd9, 0xd1, 0xdd, 0x31, 0xdd, 0x77 }
 };
+// --------------------------------------------------------------------------------------------------------------------------------
+// D3D12GetInterface
+//
+// Retrieve Global D3D12 Interface.
+//
+
+DEFINE_GUID(CLSID_D3D12Debug,                        0xf2352aeb, 0xdd84, 0x49fe, 0xb9, 0x7b, 0xa9, 0xdc, 0xfd, 0xcc, 0x1b, 0x4f);
+DEFINE_GUID(CLSID_D3D12Tools,                        0xe38216b1, 0x3c8c, 0x4833, 0xaa, 0x09, 0x0a, 0x06, 0xb6, 0x5d, 0x96, 0xc8);
+DEFINE_GUID(CLSID_D3D12DeviceRemovedExtendedData,    0x4a75bbc4, 0x9ff4, 0x4ad8, 0x9f, 0x18, 0xab, 0xae, 0x84, 0xdc, 0x5f, 0xf2);
+DEFINE_GUID(CLSID_D3D12SDKConfiguration,             0x7cda6aca, 0xa03e, 0x49c8, 0x94, 0x58, 0x03, 0x34, 0xd2, 0x0e, 0x07, 0xce);
+
+typedef HRESULT (WINAPI* PFN_D3D12_GET_INTERFACE)( _In_ REFCLSID, _In_ REFIID, _COM_Outptr_opt_ void** );
+
+HRESULT WINAPI D3D12GetInterface( _In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_opt_ void** ppvDebug );
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0053_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0053_v0_0_s_ifspec;
+
+#ifndef __ID3D12SDKConfiguration_INTERFACE_DEFINED__
+#define __ID3D12SDKConfiguration_INTERFACE_DEFINED__
+
+/* interface ID3D12SDKConfiguration */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12SDKConfiguration;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("e9eb5314-33aa-42b2-a718-d77f58b1f1c7")
+    ID3D12SDKConfiguration : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE SetSDKVersion( 
+            UINT SDKVersion,
+            _In_z_  LPCSTR SDKPath) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12SDKConfigurationVtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12SDKConfiguration * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12SDKConfiguration * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12SDKConfiguration * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12SDKConfiguration, SetSDKVersion)
+        HRESULT ( STDMETHODCALLTYPE *SetSDKVersion )( 
+            ID3D12SDKConfiguration * This,
+            UINT SDKVersion,
+            _In_z_  LPCSTR SDKPath);
+        
+        END_INTERFACE
+    } ID3D12SDKConfigurationVtbl;
+
+    interface ID3D12SDKConfiguration
+    {
+        CONST_VTBL struct ID3D12SDKConfigurationVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12SDKConfiguration_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12SDKConfiguration_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12SDKConfiguration_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12SDKConfiguration_SetSDKVersion(This,SDKVersion,SDKPath)	\
+    ( (This)->lpVtbl -> SetSDKVersion(This,SDKVersion,SDKPath) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12SDKConfiguration_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_d3d12_0000_0054 */
+/* [local] */ 
+
 typedef 
 enum D3D12_AXIS_SHADING_RATE
     {
@@ -18680,8 +21367,8 @@ enum D3D12_SHADING_RATE_COMBINER
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0050_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0050_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0054_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0054_v0_0_s_ifspec;
 
 #ifndef __ID3D12GraphicsCommandList5_INTERFACE_DEFINED__
 #define __ID3D12GraphicsCommandList5_INTERFACE_DEFINED__
@@ -18714,58 +21401,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList5 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList5 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList5 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList5 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT VertexCountPerInstance,
@@ -18773,6 +21473,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT IndexCountPerInstance,
@@ -18781,12 +21482,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -18795,6 +21498,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -18804,11 +21508,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -18818,6 +21524,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -18826,76 +21533,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList5 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList5 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList5 * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
@@ -18903,6 +21626,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
@@ -18910,52 +21634,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -18963,6 +21697,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -18972,6 +21707,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -18979,6 +21715,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -18988,6 +21725,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -18997,23 +21735,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -19023,27 +21765,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList5 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList5 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -19053,6 +21800,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_opt_  ID3D12Resource *pCountBuffer,
             _In_  UINT64 CountBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -19063,6 +21811,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT64)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT64 )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -19073,17 +21822,20 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, OMSetDepthBounds)
         void ( STDMETHODCALLTYPE *OMSetDepthBounds )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  FLOAT Min,
             _In_  FLOAT Max);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetSamplePositions)
         void ( STDMETHODCALLTYPE *SetSamplePositions )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT NumSamplesPerPixel,
             _In_  UINT NumPixels,
             _In_reads_(NumSamplesPerPixel*NumPixels)  D3D12_SAMPLE_POSITION *pSamplePositions);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, ResolveSubresourceRegion)
         void ( STDMETHODCALLTYPE *ResolveSubresourceRegion )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -19096,20 +21848,24 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_  DXGI_FORMAT Format,
             _In_  D3D12_RESOLVE_MODE ResolveMode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetViewInstanceMask)
         void ( STDMETHODCALLTYPE *SetViewInstanceMask )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList2, WriteBufferImmediate)
         void ( STDMETHODCALLTYPE *WriteBufferImmediate )( 
             ID3D12GraphicsCommandList5 * This,
             UINT Count,
             _In_reads_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER *pParams,
             _In_reads_opt_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_MODE *pModes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList3, SetProtectedResourceSession)
         void ( STDMETHODCALLTYPE *SetProtectedResourceSession )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  ID3D12ProtectedResourceSession *pProtectedResourceSession);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, BeginRenderPass)
         void ( STDMETHODCALLTYPE *BeginRenderPass )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  UINT NumRenderTargets,
@@ -19117,52 +21873,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
             _In_opt_  const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC *pDepthStencil,
             D3D12_RENDER_PASS_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, EndRenderPass)
         void ( STDMETHODCALLTYPE *EndRenderPass )( 
             ID3D12GraphicsCommandList5 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, InitializeMetaCommand)
         void ( STDMETHODCALLTYPE *InitializeMetaCommand )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12MetaCommand *pMetaCommand,
             _In_reads_bytes_opt_(InitializationParametersDataSizeInBytes)  const void *pInitializationParametersData,
             _In_  SIZE_T InitializationParametersDataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, ExecuteMetaCommand)
         void ( STDMETHODCALLTYPE *ExecuteMetaCommand )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12MetaCommand *pMetaCommand,
             _In_reads_bytes_opt_(ExecutionParametersDataSizeInBytes)  const void *pExecutionParametersData,
             _In_  SIZE_T ExecutionParametersDataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, BuildRaytracingAccelerationStructure)
         void ( STDMETHODCALLTYPE *BuildRaytracingAccelerationStructure )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
             _In_  UINT NumPostbuildInfoDescs,
             _In_reads_opt_(NumPostbuildInfoDescs)  const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *pPostbuildInfoDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, EmitRaytracingAccelerationStructurePostbuildInfo)
         void ( STDMETHODCALLTYPE *EmitRaytracingAccelerationStructurePostbuildInfo )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *pDesc,
             _In_  UINT NumSourceAccelerationStructures,
             _In_reads_( NumSourceAccelerationStructures )  const D3D12_GPU_VIRTUAL_ADDRESS *pSourceAccelerationStructureData);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, CopyRaytracingAccelerationStructure)
         void ( STDMETHODCALLTYPE *CopyRaytracingAccelerationStructure )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS DestAccelerationStructureData,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS SourceAccelerationStructureData,
             _In_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, SetPipelineState1)
         void ( STDMETHODCALLTYPE *SetPipelineState1 )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  ID3D12StateObject *pStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, DispatchRays)
         void ( STDMETHODCALLTYPE *DispatchRays )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  const D3D12_DISPATCH_RAYS_DESC *pDesc);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList5, RSSetShadingRate)
         void ( STDMETHODCALLTYPE *RSSetShadingRate )( 
             ID3D12GraphicsCommandList5 * This,
             _In_  D3D12_SHADING_RATE baseShadingRate,
             _In_reads_opt_(D3D12_RS_SET_SHADING_RATE_COMBINER_COUNT)  const D3D12_SHADING_RATE_COMBINER *combiners);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList5, RSSetShadingRateImage)
         void ( STDMETHODCALLTYPE *RSSetShadingRateImage )( 
             ID3D12GraphicsCommandList5 * This,
             _In_opt_  ID3D12Resource *shadingRateImage);
@@ -19437,7 +22203,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList5;
 #endif 	/* __ID3D12GraphicsCommandList5_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0051 */
+/* interface __MIDL_itf_d3d12_0000_0055 */
 /* [local] */ 
 
 typedef struct D3D12_DISPATCH_MESH_ARGUMENTS
@@ -19449,8 +22215,8 @@ typedef struct D3D12_DISPATCH_MESH_ARGUMENTS
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0051_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0051_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0055_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0055_v0_0_s_ifspec;
 
 #ifndef __ID3D12GraphicsCommandList6_INTERFACE_DEFINED__
 #define __ID3D12GraphicsCommandList6_INTERFACE_DEFINED__
@@ -19481,58 +22247,71 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12GraphicsCommandList6 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12GraphicsCommandList6 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12GraphicsCommandList6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, GetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *GetPrivateData )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  REFGUID guid,
             _Inout_  UINT *pDataSize,
             _Out_writes_bytes_opt_( *pDataSize )  void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateData)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateData )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  REFGUID guid,
             _In_  UINT DataSize,
             _In_reads_bytes_opt_( DataSize )  const void *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetPrivateDataInterface)
         HRESULT ( STDMETHODCALLTYPE *SetPrivateDataInterface )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  REFGUID guid,
             _In_opt_  const IUnknown *pData);
         
+        DECLSPEC_XFGVIRT(ID3D12Object, SetName)
         HRESULT ( STDMETHODCALLTYPE *SetName )( 
             ID3D12GraphicsCommandList6 * This,
             _In_z_  LPCWSTR Name);
         
+        DECLSPEC_XFGVIRT(ID3D12DeviceChild, GetDevice)
         HRESULT ( STDMETHODCALLTYPE *GetDevice )( 
             ID3D12GraphicsCommandList6 * This,
             REFIID riid,
             _COM_Outptr_opt_  void **ppvDevice);
         
+        DECLSPEC_XFGVIRT(ID3D12CommandList, GetType)
         D3D12_COMMAND_LIST_TYPE ( STDMETHODCALLTYPE *GetType )( 
             ID3D12GraphicsCommandList6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Close)
         HRESULT ( STDMETHODCALLTYPE *Close )( 
             ID3D12GraphicsCommandList6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Reset)
         HRESULT ( STDMETHODCALLTYPE *Reset )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12CommandAllocator *pAllocator,
             _In_opt_  ID3D12PipelineState *pInitialState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearState)
         void ( STDMETHODCALLTYPE *ClearState )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawInstanced)
         void ( STDMETHODCALLTYPE *DrawInstanced )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT VertexCountPerInstance,
@@ -19540,6 +22319,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  UINT StartVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DrawIndexedInstanced)
         void ( STDMETHODCALLTYPE *DrawIndexedInstanced )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT IndexCountPerInstance,
@@ -19548,12 +22328,14 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  INT BaseVertexLocation,
             _In_  UINT StartInstanceLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, Dispatch)
         void ( STDMETHODCALLTYPE *Dispatch )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT ThreadGroupCountX,
             _In_  UINT ThreadGroupCountY,
             _In_  UINT ThreadGroupCountZ);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyBufferRegion)
         void ( STDMETHODCALLTYPE *CopyBufferRegion )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -19562,6 +22344,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             UINT64 SrcOffset,
             UINT64 NumBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTextureRegion)
         void ( STDMETHODCALLTYPE *CopyTextureRegion )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pDst,
@@ -19571,11 +22354,13 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  const D3D12_TEXTURE_COPY_LOCATION *pSrc,
             _In_opt_  const D3D12_BOX *pSrcBox);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyResource)
         void ( STDMETHODCALLTYPE *CopyResource )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pDstResource,
             _In_  ID3D12Resource *pSrcResource);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, CopyTiles)
         void ( STDMETHODCALLTYPE *CopyTiles )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pTiledResource,
@@ -19585,6 +22370,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             UINT64 BufferStartOffsetInBytes,
             D3D12_TILE_COPY_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveSubresource)
         void ( STDMETHODCALLTYPE *ResolveSubresource )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -19593,76 +22379,92 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  UINT SrcSubresource,
             _In_  DXGI_FORMAT Format);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetPrimitiveTopology)
         void ( STDMETHODCALLTYPE *IASetPrimitiveTopology )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetViewports)
         void ( STDMETHODCALLTYPE *RSSetViewports )( 
             ID3D12GraphicsCommandList6 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumViewports,
             _In_reads_( NumViewports)  const D3D12_VIEWPORT *pViewports);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, RSSetScissorRects)
         void ( STDMETHODCALLTYPE *RSSetScissorRects )( 
             ID3D12GraphicsCommandList6 * This,
             _In_range_(0, D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)  UINT NumRects,
             _In_reads_( NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetBlendFactor)
         void ( STDMETHODCALLTYPE *OMSetBlendFactor )( 
             ID3D12GraphicsCommandList6 * This,
             _In_reads_opt_(4)  const FLOAT BlendFactor[ 4 ]);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetStencilRef)
         void ( STDMETHODCALLTYPE *OMSetStencilRef )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT StencilRef);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPipelineState)
         void ( STDMETHODCALLTYPE *SetPipelineState )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12PipelineState *pPipelineState);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResourceBarrier)
         void ( STDMETHODCALLTYPE *ResourceBarrier )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT NumBarriers,
             _In_reads_(NumBarriers)  const D3D12_RESOURCE_BARRIER *pBarriers);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteBundle)
         void ( STDMETHODCALLTYPE *ExecuteBundle )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12GraphicsCommandList *pCommandList);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetDescriptorHeaps)
         void ( STDMETHODCALLTYPE *SetDescriptorHeaps )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT NumDescriptorHeaps,
             _In_reads_(NumDescriptorHeaps)  ID3D12DescriptorHeap *const *ppDescriptorHeaps);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootSignature)
         void ( STDMETHODCALLTYPE *SetComputeRootSignature )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootSignature)
         void ( STDMETHODCALLTYPE *SetGraphicsRootSignature )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  ID3D12RootSignature *pRootSignature);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetComputeRootDescriptorTable )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootDescriptorTable)
         void ( STDMETHODCALLTYPE *SetGraphicsRootDescriptorTable )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstant )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstant)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstant )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  UINT SrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetComputeRoot32BitConstants )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
@@ -19670,6 +22472,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRoot32BitConstants)
         void ( STDMETHODCALLTYPE *SetGraphicsRoot32BitConstants )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
@@ -19677,52 +22480,62 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_reads_(Num32BitValuesToSet*sizeof(UINT))  const void *pSrcData,
             _In_  UINT DestOffsetIn32BitValues);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetComputeRootConstantBufferView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootConstantBufferView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootConstantBufferView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetComputeRootShaderResourceView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootShaderResourceView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootShaderResourceView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetComputeRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetComputeRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetGraphicsRootUnorderedAccessView)
         void ( STDMETHODCALLTYPE *SetGraphicsRootUnorderedAccessView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT RootParameterIndex,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS BufferLocation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetIndexBuffer)
         void ( STDMETHODCALLTYPE *IASetIndexBuffer )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  const D3D12_INDEX_BUFFER_VIEW *pView);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, IASetVertexBuffers)
         void ( STDMETHODCALLTYPE *IASetVertexBuffers )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_VERTEX_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SOSetTargets)
         void ( STDMETHODCALLTYPE *SOSetTargets )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT StartSlot,
             _In_  UINT NumViews,
             _In_reads_opt_(NumViews)  const D3D12_STREAM_OUTPUT_BUFFER_VIEW *pViews);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, OMSetRenderTargets)
         void ( STDMETHODCALLTYPE *OMSetRenderTargets )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT NumRenderTargetDescriptors,
@@ -19730,6 +22543,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  BOOL RTsSingleHandleToDescriptorRange,
             _In_opt_  const D3D12_CPU_DESCRIPTOR_HANDLE *pDepthStencilDescriptor);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearDepthStencilView)
         void ( STDMETHODCALLTYPE *ClearDepthStencilView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView,
@@ -19739,6 +22553,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearRenderTargetView)
         void ( STDMETHODCALLTYPE *ClearRenderTargetView )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,
@@ -19746,6 +22561,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewUint)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewUint )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -19755,6 +22571,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ClearUnorderedAccessViewFloat)
         void ( STDMETHODCALLTYPE *ClearUnorderedAccessViewFloat )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap,
@@ -19764,23 +22581,27 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  UINT NumRects,
             _In_reads_(NumRects)  const D3D12_RECT *pRects);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, DiscardResource)
         void ( STDMETHODCALLTYPE *DiscardResource )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pResource,
             _In_opt_  const D3D12_DISCARD_REGION *pRegion);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginQuery)
         void ( STDMETHODCALLTYPE *BeginQuery )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndQuery)
         void ( STDMETHODCALLTYPE *EndQuery )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
             _In_  D3D12_QUERY_TYPE Type,
             _In_  UINT Index);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ResolveQueryData)
         void ( STDMETHODCALLTYPE *ResolveQueryData )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12QueryHeap *pQueryHeap,
@@ -19790,27 +22611,32 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  ID3D12Resource *pDestinationBuffer,
             _In_  UINT64 AlignedDestinationBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetPredication)
         void ( STDMETHODCALLTYPE *SetPredication )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  ID3D12Resource *pBuffer,
             _In_  UINT64 AlignedBufferOffset,
             _In_  D3D12_PREDICATION_OP Operation);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, SetMarker)
         void ( STDMETHODCALLTYPE *SetMarker )( 
             ID3D12GraphicsCommandList6 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, BeginEvent)
         void ( STDMETHODCALLTYPE *BeginEvent )( 
             ID3D12GraphicsCommandList6 * This,
             UINT Metadata,
             _In_reads_bytes_opt_(Size)  const void *pData,
             UINT Size);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, EndEvent)
         void ( STDMETHODCALLTYPE *EndEvent )( 
             ID3D12GraphicsCommandList6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList, ExecuteIndirect)
         void ( STDMETHODCALLTYPE *ExecuteIndirect )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12CommandSignature *pCommandSignature,
@@ -19820,6 +22646,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_opt_  ID3D12Resource *pCountBuffer,
             _In_  UINT64 CountBufferOffset);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -19830,6 +22657,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, AtomicCopyBufferUINT64)
         void ( STDMETHODCALLTYPE *AtomicCopyBufferUINT64 )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pDstBuffer,
@@ -19840,17 +22668,20 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_reads_(Dependencies)  ID3D12Resource *const *ppDependentResources,
             _In_reads_(Dependencies)  const D3D12_SUBRESOURCE_RANGE_UINT64 *pDependentSubresourceRanges);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, OMSetDepthBounds)
         void ( STDMETHODCALLTYPE *OMSetDepthBounds )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  FLOAT Min,
             _In_  FLOAT Max);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetSamplePositions)
         void ( STDMETHODCALLTYPE *SetSamplePositions )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT NumSamplesPerPixel,
             _In_  UINT NumPixels,
             _In_reads_(NumSamplesPerPixel*NumPixels)  D3D12_SAMPLE_POSITION *pSamplePositions);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, ResolveSubresourceRegion)
         void ( STDMETHODCALLTYPE *ResolveSubresourceRegion )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12Resource *pDstResource,
@@ -19863,20 +22694,24 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_  DXGI_FORMAT Format,
             _In_  D3D12_RESOLVE_MODE ResolveMode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList1, SetViewInstanceMask)
         void ( STDMETHODCALLTYPE *SetViewInstanceMask )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList2, WriteBufferImmediate)
         void ( STDMETHODCALLTYPE *WriteBufferImmediate )( 
             ID3D12GraphicsCommandList6 * This,
             UINT Count,
             _In_reads_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER *pParams,
             _In_reads_opt_(Count)  const D3D12_WRITEBUFFERIMMEDIATE_MODE *pModes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList3, SetProtectedResourceSession)
         void ( STDMETHODCALLTYPE *SetProtectedResourceSession )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  ID3D12ProtectedResourceSession *pProtectedResourceSession);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, BeginRenderPass)
         void ( STDMETHODCALLTYPE *BeginRenderPass )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT NumRenderTargets,
@@ -19884,56 +22719,67 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
             _In_opt_  const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC *pDepthStencil,
             D3D12_RENDER_PASS_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, EndRenderPass)
         void ( STDMETHODCALLTYPE *EndRenderPass )( 
             ID3D12GraphicsCommandList6 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, InitializeMetaCommand)
         void ( STDMETHODCALLTYPE *InitializeMetaCommand )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12MetaCommand *pMetaCommand,
             _In_reads_bytes_opt_(InitializationParametersDataSizeInBytes)  const void *pInitializationParametersData,
             _In_  SIZE_T InitializationParametersDataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, ExecuteMetaCommand)
         void ( STDMETHODCALLTYPE *ExecuteMetaCommand )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12MetaCommand *pMetaCommand,
             _In_reads_bytes_opt_(ExecutionParametersDataSizeInBytes)  const void *pExecutionParametersData,
             _In_  SIZE_T ExecutionParametersDataSizeInBytes);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, BuildRaytracingAccelerationStructure)
         void ( STDMETHODCALLTYPE *BuildRaytracingAccelerationStructure )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC *pDesc,
             _In_  UINT NumPostbuildInfoDescs,
             _In_reads_opt_(NumPostbuildInfoDescs)  const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *pPostbuildInfoDescs);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, EmitRaytracingAccelerationStructurePostbuildInfo)
         void ( STDMETHODCALLTYPE *EmitRaytracingAccelerationStructurePostbuildInfo )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC *pDesc,
             _In_  UINT NumSourceAccelerationStructures,
             _In_reads_( NumSourceAccelerationStructures )  const D3D12_GPU_VIRTUAL_ADDRESS *pSourceAccelerationStructureData);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, CopyRaytracingAccelerationStructure)
         void ( STDMETHODCALLTYPE *CopyRaytracingAccelerationStructure )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS DestAccelerationStructureData,
             _In_  D3D12_GPU_VIRTUAL_ADDRESS SourceAccelerationStructureData,
             _In_  D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, SetPipelineState1)
         void ( STDMETHODCALLTYPE *SetPipelineState1 )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  ID3D12StateObject *pStateObject);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList4, DispatchRays)
         void ( STDMETHODCALLTYPE *DispatchRays )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  const D3D12_DISPATCH_RAYS_DESC *pDesc);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList5, RSSetShadingRate)
         void ( STDMETHODCALLTYPE *RSSetShadingRate )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  D3D12_SHADING_RATE baseShadingRate,
             _In_reads_opt_(D3D12_RS_SET_SHADING_RATE_COMBINER_COUNT)  const D3D12_SHADING_RATE_COMBINER *combiners);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList5, RSSetShadingRateImage)
         void ( STDMETHODCALLTYPE *RSSetShadingRateImage )( 
             ID3D12GraphicsCommandList6 * This,
             _In_opt_  ID3D12Resource *shadingRateImage);
         
+        DECLSPEC_XFGVIRT(ID3D12GraphicsCommandList6, DispatchMesh)
         void ( STDMETHODCALLTYPE *DispatchMesh )( 
             ID3D12GraphicsCommandList6 * This,
             _In_  UINT ThreadGroupCountX,
@@ -20214,7 +23060,7 @@ EXTERN_C const IID IID_ID3D12GraphicsCommandList6;
 #endif 	/* __ID3D12GraphicsCommandList6_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12_0000_0052 */
+/* interface __MIDL_itf_d3d12_0000_0056 */
 /* [local] */ 
 
 #endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_GAMES) */
@@ -20258,6 +23104,7 @@ DEFINE_GUID(IID_ID3D12DeviceRemovedExtendedDataSettings,0x82BC481C,0x6B9B,0x4030
 DEFINE_GUID(IID_ID3D12DeviceRemovedExtendedDataSettings1,0xDBD5AE51,0x3317,0x4F0A,0xAD,0xF9,0x1D,0x7C,0xED,0xCA,0xAE,0x0B);
 DEFINE_GUID(IID_ID3D12DeviceRemovedExtendedData,0x98931D33,0x5AE8,0x4791,0xAA,0x3C,0x1A,0x73,0xA2,0x93,0x4E,0x71);
 DEFINE_GUID(IID_ID3D12DeviceRemovedExtendedData1,0x9727A022,0xCF1D,0x4DDA,0x9E,0xBA,0xEF,0xFA,0x65,0x3F,0xC5,0x06);
+DEFINE_GUID(IID_ID3D12DeviceRemovedExtendedData2,0x67FC5816,0xE4CA,0x4915,0xBF,0x18,0x42,0x54,0x12,0x72,0xDA,0x54);
 DEFINE_GUID(IID_ID3D12Device6,0xc70b221b,0x40e4,0x4a17,0x89,0xaf,0x02,0x5a,0x07,0x27,0xa6,0xdc);
 DEFINE_GUID(IID_ID3D12ProtectedResourceSession1,0xD6F12DD6,0x76FB,0x406E,0x89,0x61,0x42,0x96,0xEE,0xFC,0x04,0x09);
 DEFINE_GUID(IID_ID3D12Device7,0x5c014b53,0x68a1,0x4b9b,0x8b,0xd1,0xdd,0x60,0x46,0xb9,0x35,0x8b);
@@ -20268,13 +23115,16 @@ DEFINE_GUID(IID_ID3D12Heap1,0x572F7389,0x2168,0x49E3,0x96,0x93,0xD6,0xDF,0x58,0x
 DEFINE_GUID(IID_ID3D12GraphicsCommandList3,0x6FDA83A7,0xB84C,0x4E38,0x9A,0xC8,0xC7,0xBD,0x22,0x01,0x6B,0x3D);
 DEFINE_GUID(IID_ID3D12MetaCommand,0xDBB84C27,0x36CE,0x4FC9,0xB8,0x01,0xF0,0x48,0xC4,0x6A,0xC5,0x70);
 DEFINE_GUID(IID_ID3D12GraphicsCommandList4,0x8754318e,0xd3a9,0x4541,0x98,0xcf,0x64,0x5b,0x50,0xdc,0x48,0x74);
+DEFINE_GUID(IID_ID3D12ShaderCacheSession,0x28e2495d,0x0f64,0x4ae4,0xa6,0xec,0x12,0x92,0x55,0xdc,0x49,0xa8);
+DEFINE_GUID(IID_ID3D12Device9,0x4c80e962,0xf032,0x4f60,0xbc,0x9e,0xeb,0xc2,0xcf,0xa1,0xd8,0x3c);
 DEFINE_GUID(IID_ID3D12Tools,0x7071e1f0,0xe84b,0x4b33,0x97,0x4f,0x12,0xfa,0x49,0xde,0x65,0xc5);
+DEFINE_GUID(IID_ID3D12SDKConfiguration,0xe9eb5314,0x33aa,0x42b2,0xa7,0x18,0xd7,0x7f,0x58,0xb1,0xf1,0xc7);
 DEFINE_GUID(IID_ID3D12GraphicsCommandList5,0x55050859,0x4024,0x474c,0x87,0xf5,0x64,0x72,0xea,0xee,0x44,0xea);
 DEFINE_GUID(IID_ID3D12GraphicsCommandList6,0xc3827890,0xe548,0x4cfa,0x96,0xcf,0x56,0x89,0xa9,0x37,0x0f,0x80);
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0052_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0052_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0056_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12_0000_0056_v0_0_s_ifspec;
 
 /* Additional Prototypes for ALL interfaces */
 

--- a/util/test/demos/dx/official/d3d12sdklayers.h
+++ b/util/test/demos/dx/official/d3d12sdklayers.h
@@ -1,6 +1,7 @@
 /*-------------------------------------------------------------------------------------
  *
  * Copyright (c) Microsoft Corporation
+ * Licensed under the MIT license
  *
  *-------------------------------------------------------------------------------------*/
 
@@ -8,7 +9,7 @@
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 
 
- /* File created by MIDL compiler version 8.01.0622 */
+ /* File created by MIDL compiler version 8.01.0625 */
 
 
 
@@ -41,6 +42,14 @@
 #pragma once
 #endif
 
+#ifndef DECLSPEC_XFGVIRT
+#if _CONTROL_FLOW_GUARD_XFG
+#define DECLSPEC_XFGVIRT(base, func) __declspec(xfg_virtual(base, func))
+#else
+#define DECLSPEC_XFGVIRT(base, func)
+#endif
+#endif
+
 /* Forward Declarations */ 
 
 #ifndef __ID3D12Debug_FWD_DEFINED__
@@ -69,6 +78,20 @@ typedef interface ID3D12Debug2 ID3D12Debug2;
 typedef interface ID3D12Debug3 ID3D12Debug3;
 
 #endif 	/* __ID3D12Debug3_FWD_DEFINED__ */
+
+
+#ifndef __ID3D12Debug4_FWD_DEFINED__
+#define __ID3D12Debug4_FWD_DEFINED__
+typedef interface ID3D12Debug4 ID3D12Debug4;
+
+#endif 	/* __ID3D12Debug4_FWD_DEFINED__ */
+
+
+#ifndef __ID3D12Debug5_FWD_DEFINED__
+#define __ID3D12Debug5_FWD_DEFINED__
+typedef interface ID3D12Debug5 ID3D12Debug5;
+
+#endif 	/* __ID3D12Debug5_FWD_DEFINED__ */
 
 
 #ifndef __ID3D12DebugDevice1_FWD_DEFINED__
@@ -134,9 +157,16 @@ typedef interface ID3D12InfoQueue ID3D12InfoQueue;
 #endif 	/* __ID3D12InfoQueue_FWD_DEFINED__ */
 
 
+#ifndef __ID3D12InfoQueue1_FWD_DEFINED__
+#define __ID3D12InfoQueue1_FWD_DEFINED__
+typedef interface ID3D12InfoQueue1 ID3D12InfoQueue1;
+
+#endif 	/* __ID3D12InfoQueue1_FWD_DEFINED__ */
+
+
 /* header files for imported files */
-#include "oaidl.h"
-#include "ocidl.h"
+#include "OAIdl.h"
+#include "OCIdl.h"
 #include "d3d12.h"
 
 #ifdef __cplusplus
@@ -147,7 +177,7 @@ extern "C"{
 /* interface __MIDL_itf_d3d12sdklayers_0000_0000 */
 /* [local] */ 
 
-#include "winapifamily.h"
+#include <winapifamily.h>
 #pragma region App Family
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_GAMES)
 
@@ -181,17 +211,21 @@ EXTERN_C const IID IID_ID3D12Debug;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Debug * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Debug * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Debug * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug, EnableDebugLayer)
         void ( STDMETHODCALLTYPE *EnableDebugLayer )( 
             ID3D12Debug * This);
         
@@ -280,24 +314,30 @@ EXTERN_C const IID IID_ID3D12Debug1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Debug1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Debug1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Debug1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug1, EnableDebugLayer)
         void ( STDMETHODCALLTYPE *EnableDebugLayer )( 
             ID3D12Debug1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug1, SetEnableGPUBasedValidation)
         void ( STDMETHODCALLTYPE *SetEnableGPUBasedValidation )( 
             ID3D12Debug1 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug1, SetEnableSynchronizedCommandQueueValidation)
         void ( STDMETHODCALLTYPE *SetEnableSynchronizedCommandQueueValidation )( 
             ID3D12Debug1 * This,
             BOOL Enable);
@@ -372,17 +412,21 @@ EXTERN_C const IID IID_ID3D12Debug2;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Debug2 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Debug2 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Debug2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug2, SetGPUBasedValidationFlags)
         void ( STDMETHODCALLTYPE *SetGPUBasedValidationFlags )( 
             ID3D12Debug2 * This,
             D3D12_GPU_BASED_VALIDATION_FLAGS Flags);
@@ -457,28 +501,35 @@ EXTERN_C const IID IID_ID3D12Debug3;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12Debug3 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12Debug3 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12Debug3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug, EnableDebugLayer)
         void ( STDMETHODCALLTYPE *EnableDebugLayer )( 
             ID3D12Debug3 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetEnableGPUBasedValidation)
         void ( STDMETHODCALLTYPE *SetEnableGPUBasedValidation )( 
             ID3D12Debug3 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetEnableSynchronizedCommandQueueValidation)
         void ( STDMETHODCALLTYPE *SetEnableSynchronizedCommandQueueValidation )( 
             ID3D12Debug3 * This,
             BOOL Enable);
         
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetGPUBasedValidationFlags)
         void ( STDMETHODCALLTYPE *SetGPUBasedValidationFlags )( 
             ID3D12Debug3 * This,
             D3D12_GPU_BASED_VALIDATION_FLAGS Flags);
@@ -530,9 +581,248 @@ EXTERN_C const IID IID_ID3D12Debug3;
 #endif 	/* __ID3D12Debug3_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12sdklayers_0000_0004 */
+#ifndef __ID3D12Debug4_INTERFACE_DEFINED__
+#define __ID3D12Debug4_INTERFACE_DEFINED__
+
+/* interface ID3D12Debug4 */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12Debug4;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("014b816e-9ec5-4a2f-a845-ffbe441ce13a")
+    ID3D12Debug4 : public ID3D12Debug3
+    {
+    public:
+        virtual void STDMETHODCALLTYPE DisableDebugLayer( void) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12Debug4Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12Debug4 * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12Debug4 * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12Debug4 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug, EnableDebugLayer)
+        void ( STDMETHODCALLTYPE *EnableDebugLayer )( 
+            ID3D12Debug4 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetEnableGPUBasedValidation)
+        void ( STDMETHODCALLTYPE *SetEnableGPUBasedValidation )( 
+            ID3D12Debug4 * This,
+            BOOL Enable);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetEnableSynchronizedCommandQueueValidation)
+        void ( STDMETHODCALLTYPE *SetEnableSynchronizedCommandQueueValidation )( 
+            ID3D12Debug4 * This,
+            BOOL Enable);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetGPUBasedValidationFlags)
+        void ( STDMETHODCALLTYPE *SetGPUBasedValidationFlags )( 
+            ID3D12Debug4 * This,
+            D3D12_GPU_BASED_VALIDATION_FLAGS Flags);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug4, DisableDebugLayer)
+        void ( STDMETHODCALLTYPE *DisableDebugLayer )( 
+            ID3D12Debug4 * This);
+        
+        END_INTERFACE
+    } ID3D12Debug4Vtbl;
+
+    interface ID3D12Debug4
+    {
+        CONST_VTBL struct ID3D12Debug4Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12Debug4_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12Debug4_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12Debug4_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12Debug4_EnableDebugLayer(This)	\
+    ( (This)->lpVtbl -> EnableDebugLayer(This) ) 
+
+
+#define ID3D12Debug4_SetEnableGPUBasedValidation(This,Enable)	\
+    ( (This)->lpVtbl -> SetEnableGPUBasedValidation(This,Enable) ) 
+
+#define ID3D12Debug4_SetEnableSynchronizedCommandQueueValidation(This,Enable)	\
+    ( (This)->lpVtbl -> SetEnableSynchronizedCommandQueueValidation(This,Enable) ) 
+
+#define ID3D12Debug4_SetGPUBasedValidationFlags(This,Flags)	\
+    ( (This)->lpVtbl -> SetGPUBasedValidationFlags(This,Flags) ) 
+
+
+#define ID3D12Debug4_DisableDebugLayer(This)	\
+    ( (This)->lpVtbl -> DisableDebugLayer(This) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12Debug4_INTERFACE_DEFINED__ */
+
+
+#ifndef __ID3D12Debug5_INTERFACE_DEFINED__
+#define __ID3D12Debug5_INTERFACE_DEFINED__
+
+/* interface ID3D12Debug5 */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12Debug5;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("548d6b12-09fa-40e0-9069-5dcd589a52c9")
+    ID3D12Debug5 : public ID3D12Debug4
+    {
+    public:
+        virtual void STDMETHODCALLTYPE SetEnableAutoName( 
+            BOOL Enable) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12Debug5Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12Debug5 * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12Debug5 * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12Debug5 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug, EnableDebugLayer)
+        void ( STDMETHODCALLTYPE *EnableDebugLayer )( 
+            ID3D12Debug5 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetEnableGPUBasedValidation)
+        void ( STDMETHODCALLTYPE *SetEnableGPUBasedValidation )( 
+            ID3D12Debug5 * This,
+            BOOL Enable);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetEnableSynchronizedCommandQueueValidation)
+        void ( STDMETHODCALLTYPE *SetEnableSynchronizedCommandQueueValidation )( 
+            ID3D12Debug5 * This,
+            BOOL Enable);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug3, SetGPUBasedValidationFlags)
+        void ( STDMETHODCALLTYPE *SetGPUBasedValidationFlags )( 
+            ID3D12Debug5 * This,
+            D3D12_GPU_BASED_VALIDATION_FLAGS Flags);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug4, DisableDebugLayer)
+        void ( STDMETHODCALLTYPE *DisableDebugLayer )( 
+            ID3D12Debug5 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12Debug5, SetEnableAutoName)
+        void ( STDMETHODCALLTYPE *SetEnableAutoName )( 
+            ID3D12Debug5 * This,
+            BOOL Enable);
+        
+        END_INTERFACE
+    } ID3D12Debug5Vtbl;
+
+    interface ID3D12Debug5
+    {
+        CONST_VTBL struct ID3D12Debug5Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12Debug5_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12Debug5_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12Debug5_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12Debug5_EnableDebugLayer(This)	\
+    ( (This)->lpVtbl -> EnableDebugLayer(This) ) 
+
+
+#define ID3D12Debug5_SetEnableGPUBasedValidation(This,Enable)	\
+    ( (This)->lpVtbl -> SetEnableGPUBasedValidation(This,Enable) ) 
+
+#define ID3D12Debug5_SetEnableSynchronizedCommandQueueValidation(This,Enable)	\
+    ( (This)->lpVtbl -> SetEnableSynchronizedCommandQueueValidation(This,Enable) ) 
+
+#define ID3D12Debug5_SetGPUBasedValidationFlags(This,Flags)	\
+    ( (This)->lpVtbl -> SetGPUBasedValidationFlags(This,Flags) ) 
+
+
+#define ID3D12Debug5_DisableDebugLayer(This)	\
+    ( (This)->lpVtbl -> DisableDebugLayer(This) ) 
+
+
+#define ID3D12Debug5_SetEnableAutoName(This,Enable)	\
+    ( (This)->lpVtbl -> SetEnableAutoName(This,Enable) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12Debug5_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_d3d12sdklayers_0000_0006 */
 /* [local] */ 
 
+DEFINE_GUID(WKPDID_D3DAutoDebugObjectNameW, 0xd4902e36, 0x757a, 0x4942, 0x95, 0x94, 0xb6, 0x76, 0x9a, 0xfa, 0x43, 0xcd);
 typedef 
 enum D3D12_RLDO_FLAGS
     {
@@ -597,8 +887,8 @@ typedef struct D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0004_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0004_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0006_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0006_v0_0_s_ifspec;
 
 #ifndef __ID3D12DebugDevice1_INTERFACE_DEFINED__
 #define __ID3D12DebugDevice1_INTERFACE_DEFINED__
@@ -637,29 +927,35 @@ EXTERN_C const IID IID_ID3D12DebugDevice1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugDevice1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugDevice1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugDevice1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice1, SetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *SetDebugParameter )( 
             ID3D12DebugDevice1 * This,
             D3D12_DEBUG_DEVICE_PARAMETER_TYPE Type,
             _In_reads_bytes_(DataSize)  const void *pData,
             UINT DataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice1, GetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *GetDebugParameter )( 
             ID3D12DebugDevice1 * This,
             D3D12_DEBUG_DEVICE_PARAMETER_TYPE Type,
             _Out_writes_bytes_(DataSize)  void *pData,
             UINT DataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice1, ReportLiveDeviceObjects)
         HRESULT ( STDMETHODCALLTYPE *ReportLiveDeviceObjects )( 
             ID3D12DebugDevice1 * This,
             D3D12_RLDO_FLAGS Flags);
@@ -739,24 +1035,30 @@ EXTERN_C const IID IID_ID3D12DebugDevice;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugDevice * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugDevice * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugDevice * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice, SetFeatureMask)
         HRESULT ( STDMETHODCALLTYPE *SetFeatureMask )( 
             ID3D12DebugDevice * This,
             D3D12_DEBUG_FEATURE Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice, GetFeatureMask)
         D3D12_DEBUG_FEATURE ( STDMETHODCALLTYPE *GetFeatureMask )( 
             ID3D12DebugDevice * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice, ReportLiveDeviceObjects)
         HRESULT ( STDMETHODCALLTYPE *ReportLiveDeviceObjects )( 
             ID3D12DebugDevice * This,
             D3D12_RLDO_FLAGS Flags);
@@ -838,34 +1140,42 @@ EXTERN_C const IID IID_ID3D12DebugDevice2;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugDevice2 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugDevice2 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugDevice2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice, SetFeatureMask)
         HRESULT ( STDMETHODCALLTYPE *SetFeatureMask )( 
             ID3D12DebugDevice2 * This,
             D3D12_DEBUG_FEATURE Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice, GetFeatureMask)
         D3D12_DEBUG_FEATURE ( STDMETHODCALLTYPE *GetFeatureMask )( 
             ID3D12DebugDevice2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice, ReportLiveDeviceObjects)
         HRESULT ( STDMETHODCALLTYPE *ReportLiveDeviceObjects )( 
             ID3D12DebugDevice2 * This,
             D3D12_RLDO_FLAGS Flags);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice2, SetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *SetDebugParameter )( 
             ID3D12DebugDevice2 * This,
             D3D12_DEBUG_DEVICE_PARAMETER_TYPE Type,
             _In_reads_bytes_(DataSize)  const void *pData,
             UINT DataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugDevice2, GetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *GetDebugParameter )( 
             ID3D12DebugDevice2 * This,
             D3D12_DEBUG_DEVICE_PARAMETER_TYPE Type,
@@ -922,14 +1232,14 @@ EXTERN_C const IID IID_ID3D12DebugDevice2;
 #endif 	/* __ID3D12DebugDevice2_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12sdklayers_0000_0007 */
+/* interface __MIDL_itf_d3d12sdklayers_0000_0009 */
 /* [local] */ 
 
 DEFINE_GUID(DXGI_DEBUG_D3D12, 0xcf59a98c, 0xa950, 0x4326, 0x91, 0xef, 0x9b, 0xba, 0xa1, 0x7b, 0xfd, 0x95);
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0007_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0007_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0009_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0009_v0_0_s_ifspec;
 
 #ifndef __ID3D12DebugCommandQueue_INTERFACE_DEFINED__
 #define __ID3D12DebugCommandQueue_INTERFACE_DEFINED__
@@ -960,17 +1270,21 @@ EXTERN_C const IID IID_ID3D12DebugCommandQueue;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugCommandQueue * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugCommandQueue * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugCommandQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandQueue, AssertResourceState)
         BOOL ( STDMETHODCALLTYPE *AssertResourceState )( 
             ID3D12DebugCommandQueue * This,
             _In_  ID3D12Resource *pResource,
@@ -1014,7 +1328,7 @@ EXTERN_C const IID IID_ID3D12DebugCommandQueue;
 #endif 	/* __ID3D12DebugCommandQueue_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12sdklayers_0000_0008 */
+/* interface __MIDL_itf_d3d12sdklayers_0000_0010 */
 /* [local] */ 
 
 typedef 
@@ -1030,8 +1344,8 @@ typedef struct D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0008_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0008_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0010_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0010_v0_0_s_ifspec;
 
 #ifndef __ID3D12DebugCommandList1_INTERFACE_DEFINED__
 #define __ID3D12DebugCommandList1_INTERFACE_DEFINED__
@@ -1072,29 +1386,35 @@ EXTERN_C const IID IID_ID3D12DebugCommandList1;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugCommandList1 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugCommandList1 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList1, AssertResourceState)
         BOOL ( STDMETHODCALLTYPE *AssertResourceState )( 
             ID3D12DebugCommandList1 * This,
             _In_  ID3D12Resource *pResource,
             UINT Subresource,
             UINT State);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList1, SetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *SetDebugParameter )( 
             ID3D12DebugCommandList1 * This,
             D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE Type,
             _In_reads_bytes_(DataSize)  const void *pData,
             UINT DataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList1, GetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *GetDebugParameter )( 
             ID3D12DebugCommandList1 * This,
             D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE Type,
@@ -1178,27 +1498,33 @@ EXTERN_C const IID IID_ID3D12DebugCommandList;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugCommandList * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugCommandList * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugCommandList * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList, AssertResourceState)
         BOOL ( STDMETHODCALLTYPE *AssertResourceState )( 
             ID3D12DebugCommandList * This,
             _In_  ID3D12Resource *pResource,
             UINT Subresource,
             UINT State);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList, SetFeatureMask)
         HRESULT ( STDMETHODCALLTYPE *SetFeatureMask )( 
             ID3D12DebugCommandList * This,
             D3D12_DEBUG_FEATURE Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList, GetFeatureMask)
         D3D12_DEBUG_FEATURE ( STDMETHODCALLTYPE *GetFeatureMask )( 
             ID3D12DebugCommandList * This);
         
@@ -1279,36 +1605,44 @@ EXTERN_C const IID IID_ID3D12DebugCommandList2;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12DebugCommandList2 * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12DebugCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12DebugCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList, AssertResourceState)
         BOOL ( STDMETHODCALLTYPE *AssertResourceState )( 
             ID3D12DebugCommandList2 * This,
             _In_  ID3D12Resource *pResource,
             UINT Subresource,
             UINT State);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList, SetFeatureMask)
         HRESULT ( STDMETHODCALLTYPE *SetFeatureMask )( 
             ID3D12DebugCommandList2 * This,
             D3D12_DEBUG_FEATURE Mask);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList, GetFeatureMask)
         D3D12_DEBUG_FEATURE ( STDMETHODCALLTYPE *GetFeatureMask )( 
             ID3D12DebugCommandList2 * This);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList2, SetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *SetDebugParameter )( 
             ID3D12DebugCommandList2 * This,
             D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE Type,
             _In_reads_bytes_(DataSize)  const void *pData,
             UINT DataSize);
         
+        DECLSPEC_XFGVIRT(ID3D12DebugCommandList2, GetDebugParameter)
         HRESULT ( STDMETHODCALLTYPE *GetDebugParameter )( 
             ID3D12DebugCommandList2 * This,
             D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE Type,
@@ -1404,32 +1738,39 @@ EXTERN_C const IID IID_ID3D12SharingContract;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12SharingContract * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12SharingContract * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12SharingContract * This);
         
+        DECLSPEC_XFGVIRT(ID3D12SharingContract, Present)
         void ( STDMETHODCALLTYPE *Present )( 
             ID3D12SharingContract * This,
             _In_  ID3D12Resource *pResource,
             UINT Subresource,
             _In_  HWND window);
         
+        DECLSPEC_XFGVIRT(ID3D12SharingContract, SharedFenceSignal)
         void ( STDMETHODCALLTYPE *SharedFenceSignal )( 
             ID3D12SharingContract * This,
             _In_  ID3D12Fence *pFence,
             UINT64 FenceValue);
         
+        DECLSPEC_XFGVIRT(ID3D12SharingContract, BeginCapturableWork)
         void ( STDMETHODCALLTYPE *BeginCapturableWork )( 
             ID3D12SharingContract * This,
             _In_  REFGUID guid);
         
+        DECLSPEC_XFGVIRT(ID3D12SharingContract, EndCapturableWork)
         void ( STDMETHODCALLTYPE *EndCapturableWork )( 
             ID3D12SharingContract * This,
             _In_  REFGUID guid);
@@ -1480,7 +1821,7 @@ EXTERN_C const IID IID_ID3D12SharingContract;
 #endif 	/* __ID3D12SharingContract_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12sdklayers_0000_0012 */
+/* interface __MIDL_itf_d3d12sdklayers_0000_0014 */
 /* [local] */ 
 
 typedef 
@@ -2355,7 +2696,55 @@ enum D3D12_MESSAGE_ID
         D3D12_MESSAGE_ID_CREATE_ROOT_SIGNATURE_UNBOUNDED_STATIC_DESCRIPTORS	= 1277,
         D3D12_MESSAGE_ID_CREATEAMPLIFICATIONSHADER_INVALIDSHADERBYTECODE	= 1278,
         D3D12_MESSAGE_ID_CREATEAMPLIFICATIONSHADER_OUTOFMEMORY	= 1279,
-        D3D12_MESSAGE_ID_D3D12_MESSAGES_END	= ( D3D12_MESSAGE_ID_CREATEAMPLIFICATIONSHADER_OUTOFMEMORY + 1 ) 
+        D3D12_MESSAGE_ID_CREATE_SHADERCACHESESSION	= 1280,
+        D3D12_MESSAGE_ID_LIVE_SHADERCACHESESSION	= 1281,
+        D3D12_MESSAGE_ID_DESTROY_SHADERCACHESESSION	= 1282,
+        D3D12_MESSAGE_ID_CREATESHADERCACHESESSION_INVALIDARGS	= 1283,
+        D3D12_MESSAGE_ID_CREATESHADERCACHESESSION_DISABLED	= 1284,
+        D3D12_MESSAGE_ID_CREATESHADERCACHESESSION_ALREADYOPEN	= 1285,
+        D3D12_MESSAGE_ID_SHADERCACHECONTROL_DEVELOPERMODE	= 1286,
+        D3D12_MESSAGE_ID_SHADERCACHECONTROL_INVALIDFLAGS	= 1287,
+        D3D12_MESSAGE_ID_SHADERCACHECONTROL_STATEALREADYSET	= 1288,
+        D3D12_MESSAGE_ID_SHADERCACHECONTROL_IGNOREDFLAG	= 1289,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_STOREVALUE_ALREADYPRESENT	= 1290,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_STOREVALUE_HASHCOLLISION	= 1291,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_STOREVALUE_CACHEFULL	= 1292,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_FINDVALUE_NOTFOUND	= 1293,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_CORRUPT	= 1294,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_DISABLED	= 1295,
+        D3D12_MESSAGE_ID_OVERSIZED_DISPATCH	= 1296,
+        D3D12_MESSAGE_ID_CREATE_VIDEOENCODER	= 1297,
+        D3D12_MESSAGE_ID_LIVE_VIDEOENCODER	= 1298,
+        D3D12_MESSAGE_ID_DESTROY_VIDEOENCODER	= 1299,
+        D3D12_MESSAGE_ID_CREATE_VIDEOENCODERHEAP	= 1300,
+        D3D12_MESSAGE_ID_LIVE_VIDEOENCODERHEAP	= 1301,
+        D3D12_MESSAGE_ID_DESTROY_VIDEOENCODERHEAP	= 1302,
+        D3D12_MESSAGE_ID_COPYTEXTUREREGION_MISMATCH_ENCODE_REFERENCE_ONLY_FLAG	= 1303,
+        D3D12_MESSAGE_ID_COPYRESOURCE_MISMATCH_ENCODE_REFERENCE_ONLY_FLAG	= 1304,
+        D3D12_MESSAGE_ID_ENCODE_FRAME_INVALID_PARAMETERS	= 1305,
+        D3D12_MESSAGE_ID_ENCODE_FRAME_UNSUPPORTED_PARAMETERS	= 1306,
+        D3D12_MESSAGE_ID_RESOLVE_ENCODER_OUTPUT_METADATA_INVALID_PARAMETERS	= 1307,
+        D3D12_MESSAGE_ID_RESOLVE_ENCODER_OUTPUT_METADATA_UNSUPPORTED_PARAMETERS	= 1308,
+        D3D12_MESSAGE_ID_CREATE_VIDEO_ENCODER_INVALID_PARAMETERS	= 1309,
+        D3D12_MESSAGE_ID_CREATE_VIDEO_ENCODER_UNSUPPORTED_PARAMETERS	= 1310,
+        D3D12_MESSAGE_ID_CREATE_VIDEO_ENCODER_HEAP_INVALID_PARAMETERS	= 1311,
+        D3D12_MESSAGE_ID_CREATE_VIDEO_ENCODER_HEAP_UNSUPPORTED_PARAMETERS	= 1312,
+        D3D12_MESSAGE_ID_CREATECOMMANDLIST_NULL_COMMANDALLOCATOR	= 1313,
+        D3D12_MESSAGE_ID_CLEAR_UNORDERED_ACCESS_VIEW_INVALID_DESCRIPTOR_HANDLE	= 1314,
+        D3D12_MESSAGE_ID_DESCRIPTOR_HEAP_NOT_SHADER_VISIBLE	= 1315,
+        D3D12_MESSAGE_ID_CREATEBLENDSTATE_BLENDOP_WARNING	= 1316,
+        D3D12_MESSAGE_ID_CREATEBLENDSTATE_BLENDOPALPHA_WARNING	= 1317,
+        D3D12_MESSAGE_ID_WRITE_COMBINE_PERFORMANCE_WARNING	= 1318,
+        D3D12_MESSAGE_ID_RESOLVE_QUERY_INVALID_QUERY_STATE	= 1319,
+        D3D12_MESSAGE_ID_SETPRIVATEDATA_NO_ACCESS	= 1320,
+        D3D12_MESSAGE_ID_COMMAND_LIST_STATIC_DESCRIPTOR_SAMPLER_MODE_MISMATCH	= 1321,
+        D3D12_MESSAGE_ID_GETCOPYABLEFOOTPRINTS_UNSUPPORTED_BUFFER_WIDTH	= 1322,
+        D3D12_MESSAGE_ID_CREATEMESHSHADER_TOPOLOGY_MISMATCH	= 1323,
+        D3D12_MESSAGE_ID_VRS_SUM_COMBINER_REQUIRES_CAPABILITY	= 1324,
+        D3D12_MESSAGE_ID_SETTING_SHADING_RATE_FROM_MS_REQUIRES_CAPABILITY	= 1325,
+        D3D12_MESSAGE_ID_SHADERCACHESESSION_SHADERCACHEDELETE_NOTSUPPORTED	= 1326,
+        D3D12_MESSAGE_ID_SHADERCACHECONTROL_SHADERCACHECLEAR_NOTSUPPORTED	= 1327,
+        D3D12_MESSAGE_ID_D3D12_MESSAGES_END	= ( D3D12_MESSAGE_ID_SHADERCACHECONTROL_SHADERCACHECLEAR_NOTSUPPORTED + 1 ) 
     } 	D3D12_MESSAGE_ID;
 
 typedef struct D3D12_MESSAGE
@@ -2386,8 +2775,8 @@ typedef struct D3D12_INFO_QUEUE_FILTER
 #define D3D12_INFO_QUEUE_DEFAULT_MESSAGE_COUNT_LIMIT 1024
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0012_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0012_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0014_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0014_v0_0_s_ifspec;
 
 #ifndef __ID3D12InfoQueue_INTERFACE_DEFINED__
 #define __ID3D12InfoQueue_INTERFACE_DEFINED__
@@ -2511,104 +2900,133 @@ EXTERN_C const IID IID_ID3D12InfoQueue;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D12InfoQueue * This,
             REFIID riid,
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetMessageCountLimit)
         HRESULT ( STDMETHODCALLTYPE *SetMessageCountLimit )( 
             ID3D12InfoQueue * This,
             _In_  UINT64 MessageCountLimit);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, ClearStoredMessages)
         void ( STDMETHODCALLTYPE *ClearStoredMessages )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetMessage)
         HRESULT ( STDMETHODCALLTYPE *GetMessage )( 
             ID3D12InfoQueue * This,
             _In_  UINT64 MessageIndex,
             _Out_writes_bytes_opt_(*pMessageByteLength)  D3D12_MESSAGE *pMessage,
             _Inout_  SIZE_T *pMessageByteLength);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumMessagesAllowedByStorageFilter)
         UINT64 ( STDMETHODCALLTYPE *GetNumMessagesAllowedByStorageFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumMessagesDeniedByStorageFilter)
         UINT64 ( STDMETHODCALLTYPE *GetNumMessagesDeniedByStorageFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumStoredMessages)
         UINT64 ( STDMETHODCALLTYPE *GetNumStoredMessages )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumStoredMessagesAllowedByRetrievalFilter)
         UINT64 ( STDMETHODCALLTYPE *GetNumStoredMessagesAllowedByRetrievalFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumMessagesDiscardedByMessageCountLimit)
         UINT64 ( STDMETHODCALLTYPE *GetNumMessagesDiscardedByMessageCountLimit )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetMessageCountLimit)
         UINT64 ( STDMETHODCALLTYPE *GetMessageCountLimit )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddStorageFilterEntries)
         HRESULT ( STDMETHODCALLTYPE *AddStorageFilterEntries )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetStorageFilter)
         HRESULT ( STDMETHODCALLTYPE *GetStorageFilter )( 
             ID3D12InfoQueue * This,
             _Out_writes_bytes_opt_(*pFilterByteLength)  D3D12_INFO_QUEUE_FILTER *pFilter,
             _Inout_  SIZE_T *pFilterByteLength);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, ClearStorageFilter)
         void ( STDMETHODCALLTYPE *ClearStorageFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushEmptyStorageFilter)
         HRESULT ( STDMETHODCALLTYPE *PushEmptyStorageFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushCopyOfStorageFilter)
         HRESULT ( STDMETHODCALLTYPE *PushCopyOfStorageFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushStorageFilter)
         HRESULT ( STDMETHODCALLTYPE *PushStorageFilter )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PopStorageFilter)
         void ( STDMETHODCALLTYPE *PopStorageFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetStorageFilterStackSize)
         UINT ( STDMETHODCALLTYPE *GetStorageFilterStackSize )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddRetrievalFilterEntries)
         HRESULT ( STDMETHODCALLTYPE *AddRetrievalFilterEntries )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetRetrievalFilter)
         HRESULT ( STDMETHODCALLTYPE *GetRetrievalFilter )( 
             ID3D12InfoQueue * This,
             _Out_writes_bytes_opt_(*pFilterByteLength)  D3D12_INFO_QUEUE_FILTER *pFilter,
             _Inout_  SIZE_T *pFilterByteLength);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, ClearRetrievalFilter)
         void ( STDMETHODCALLTYPE *ClearRetrievalFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushEmptyRetrievalFilter)
         HRESULT ( STDMETHODCALLTYPE *PushEmptyRetrievalFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushCopyOfRetrievalFilter)
         HRESULT ( STDMETHODCALLTYPE *PushCopyOfRetrievalFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushRetrievalFilter)
         HRESULT ( STDMETHODCALLTYPE *PushRetrievalFilter )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PopRetrievalFilter)
         void ( STDMETHODCALLTYPE *PopRetrievalFilter )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetRetrievalFilterStackSize)
         UINT ( STDMETHODCALLTYPE *GetRetrievalFilterStackSize )( 
             ID3D12InfoQueue * This);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddMessage)
         HRESULT ( STDMETHODCALLTYPE *AddMessage )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_CATEGORY Category,
@@ -2616,42 +3034,51 @@ EXTERN_C const IID IID_ID3D12InfoQueue;
             _In_  D3D12_MESSAGE_ID ID,
             _In_  LPCSTR pDescription);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddApplicationMessage)
         HRESULT ( STDMETHODCALLTYPE *AddApplicationMessage )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_SEVERITY Severity,
             _In_  LPCSTR pDescription);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetBreakOnCategory)
         HRESULT ( STDMETHODCALLTYPE *SetBreakOnCategory )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_CATEGORY Category,
             _In_  BOOL bEnable);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetBreakOnSeverity)
         HRESULT ( STDMETHODCALLTYPE *SetBreakOnSeverity )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_SEVERITY Severity,
             _In_  BOOL bEnable);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetBreakOnID)
         HRESULT ( STDMETHODCALLTYPE *SetBreakOnID )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_ID ID,
             _In_  BOOL bEnable);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetBreakOnCategory)
         BOOL ( STDMETHODCALLTYPE *GetBreakOnCategory )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_CATEGORY Category);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetBreakOnSeverity)
         BOOL ( STDMETHODCALLTYPE *GetBreakOnSeverity )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_SEVERITY Severity);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetBreakOnID)
         BOOL ( STDMETHODCALLTYPE *GetBreakOnID )( 
             ID3D12InfoQueue * This,
             _In_  D3D12_MESSAGE_ID ID);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetMuteDebugOutput)
         void ( STDMETHODCALLTYPE *SetMuteDebugOutput )( 
             ID3D12InfoQueue * This,
             _In_  BOOL bMute);
         
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetMuteDebugOutput)
         BOOL ( STDMETHODCALLTYPE *GetMuteDebugOutput )( 
             ID3D12InfoQueue * This);
         
@@ -2794,7 +3221,404 @@ EXTERN_C const IID IID_ID3D12InfoQueue;
 #endif 	/* __ID3D12InfoQueue_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_d3d12sdklayers_0000_0013 */
+/* interface __MIDL_itf_d3d12sdklayers_0000_0015 */
+/* [local] */ 
+
+typedef 
+enum D3D12_MESSAGE_CALLBACK_FLAGS
+    {
+        D3D12_MESSAGE_CALLBACK_FLAG_NONE	= 0,
+        D3D12_MESSAGE_CALLBACK_IGNORE_FILTERS	= 0x1
+    } 	D3D12_MESSAGE_CALLBACK_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS(D3D12_MESSAGE_CALLBACK_FLAGS)
+typedef void ( __stdcall *D3D12MessageFunc )( 
+    D3D12_MESSAGE_CATEGORY Category,
+    D3D12_MESSAGE_SEVERITY Severity,
+    D3D12_MESSAGE_ID ID,
+    LPCSTR pDescription,
+    void *pContext);
+
+
+
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0015_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0015_v0_0_s_ifspec;
+
+#ifndef __ID3D12InfoQueue1_INTERFACE_DEFINED__
+#define __ID3D12InfoQueue1_INTERFACE_DEFINED__
+
+/* interface ID3D12InfoQueue1 */
+/* [unique][local][object][uuid] */ 
+
+
+EXTERN_C const IID IID_ID3D12InfoQueue1;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("2852dd88-b484-4c0c-b6b1-67168500e600")
+    ID3D12InfoQueue1 : public ID3D12InfoQueue
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE RegisterMessageCallback( 
+            _In_  D3D12MessageFunc CallbackFunc,
+            _In_  D3D12_MESSAGE_CALLBACK_FLAGS CallbackFilterFlags,
+            _In_  void *pContext,
+            _Inout_  DWORD *pCallbackCookie) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE UnregisterMessageCallback( 
+            _In_  DWORD CallbackCookie) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ID3D12InfoQueue1Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ID3D12InfoQueue1 * This,
+            REFIID riid,
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetMessageCountLimit)
+        HRESULT ( STDMETHODCALLTYPE *SetMessageCountLimit )( 
+            ID3D12InfoQueue1 * This,
+            _In_  UINT64 MessageCountLimit);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, ClearStoredMessages)
+        void ( STDMETHODCALLTYPE *ClearStoredMessages )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetMessage)
+        HRESULT ( STDMETHODCALLTYPE *GetMessage )( 
+            ID3D12InfoQueue1 * This,
+            _In_  UINT64 MessageIndex,
+            _Out_writes_bytes_opt_(*pMessageByteLength)  D3D12_MESSAGE *pMessage,
+            _Inout_  SIZE_T *pMessageByteLength);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumMessagesAllowedByStorageFilter)
+        UINT64 ( STDMETHODCALLTYPE *GetNumMessagesAllowedByStorageFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumMessagesDeniedByStorageFilter)
+        UINT64 ( STDMETHODCALLTYPE *GetNumMessagesDeniedByStorageFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumStoredMessages)
+        UINT64 ( STDMETHODCALLTYPE *GetNumStoredMessages )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumStoredMessagesAllowedByRetrievalFilter)
+        UINT64 ( STDMETHODCALLTYPE *GetNumStoredMessagesAllowedByRetrievalFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetNumMessagesDiscardedByMessageCountLimit)
+        UINT64 ( STDMETHODCALLTYPE *GetNumMessagesDiscardedByMessageCountLimit )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetMessageCountLimit)
+        UINT64 ( STDMETHODCALLTYPE *GetMessageCountLimit )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddStorageFilterEntries)
+        HRESULT ( STDMETHODCALLTYPE *AddStorageFilterEntries )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetStorageFilter)
+        HRESULT ( STDMETHODCALLTYPE *GetStorageFilter )( 
+            ID3D12InfoQueue1 * This,
+            _Out_writes_bytes_opt_(*pFilterByteLength)  D3D12_INFO_QUEUE_FILTER *pFilter,
+            _Inout_  SIZE_T *pFilterByteLength);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, ClearStorageFilter)
+        void ( STDMETHODCALLTYPE *ClearStorageFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushEmptyStorageFilter)
+        HRESULT ( STDMETHODCALLTYPE *PushEmptyStorageFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushCopyOfStorageFilter)
+        HRESULT ( STDMETHODCALLTYPE *PushCopyOfStorageFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushStorageFilter)
+        HRESULT ( STDMETHODCALLTYPE *PushStorageFilter )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PopStorageFilter)
+        void ( STDMETHODCALLTYPE *PopStorageFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetStorageFilterStackSize)
+        UINT ( STDMETHODCALLTYPE *GetStorageFilterStackSize )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddRetrievalFilterEntries)
+        HRESULT ( STDMETHODCALLTYPE *AddRetrievalFilterEntries )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetRetrievalFilter)
+        HRESULT ( STDMETHODCALLTYPE *GetRetrievalFilter )( 
+            ID3D12InfoQueue1 * This,
+            _Out_writes_bytes_opt_(*pFilterByteLength)  D3D12_INFO_QUEUE_FILTER *pFilter,
+            _Inout_  SIZE_T *pFilterByteLength);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, ClearRetrievalFilter)
+        void ( STDMETHODCALLTYPE *ClearRetrievalFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushEmptyRetrievalFilter)
+        HRESULT ( STDMETHODCALLTYPE *PushEmptyRetrievalFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushCopyOfRetrievalFilter)
+        HRESULT ( STDMETHODCALLTYPE *PushCopyOfRetrievalFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PushRetrievalFilter)
+        HRESULT ( STDMETHODCALLTYPE *PushRetrievalFilter )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_INFO_QUEUE_FILTER *pFilter);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, PopRetrievalFilter)
+        void ( STDMETHODCALLTYPE *PopRetrievalFilter )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetRetrievalFilterStackSize)
+        UINT ( STDMETHODCALLTYPE *GetRetrievalFilterStackSize )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddMessage)
+        HRESULT ( STDMETHODCALLTYPE *AddMessage )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_CATEGORY Category,
+            _In_  D3D12_MESSAGE_SEVERITY Severity,
+            _In_  D3D12_MESSAGE_ID ID,
+            _In_  LPCSTR pDescription);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, AddApplicationMessage)
+        HRESULT ( STDMETHODCALLTYPE *AddApplicationMessage )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_SEVERITY Severity,
+            _In_  LPCSTR pDescription);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetBreakOnCategory)
+        HRESULT ( STDMETHODCALLTYPE *SetBreakOnCategory )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_CATEGORY Category,
+            _In_  BOOL bEnable);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetBreakOnSeverity)
+        HRESULT ( STDMETHODCALLTYPE *SetBreakOnSeverity )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_SEVERITY Severity,
+            _In_  BOOL bEnable);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetBreakOnID)
+        HRESULT ( STDMETHODCALLTYPE *SetBreakOnID )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_ID ID,
+            _In_  BOOL bEnable);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetBreakOnCategory)
+        BOOL ( STDMETHODCALLTYPE *GetBreakOnCategory )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_CATEGORY Category);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetBreakOnSeverity)
+        BOOL ( STDMETHODCALLTYPE *GetBreakOnSeverity )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_SEVERITY Severity);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetBreakOnID)
+        BOOL ( STDMETHODCALLTYPE *GetBreakOnID )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12_MESSAGE_ID ID);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, SetMuteDebugOutput)
+        void ( STDMETHODCALLTYPE *SetMuteDebugOutput )( 
+            ID3D12InfoQueue1 * This,
+            _In_  BOOL bMute);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue, GetMuteDebugOutput)
+        BOOL ( STDMETHODCALLTYPE *GetMuteDebugOutput )( 
+            ID3D12InfoQueue1 * This);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue1, RegisterMessageCallback)
+        HRESULT ( STDMETHODCALLTYPE *RegisterMessageCallback )( 
+            ID3D12InfoQueue1 * This,
+            _In_  D3D12MessageFunc CallbackFunc,
+            _In_  D3D12_MESSAGE_CALLBACK_FLAGS CallbackFilterFlags,
+            _In_  void *pContext,
+            _Inout_  DWORD *pCallbackCookie);
+        
+        DECLSPEC_XFGVIRT(ID3D12InfoQueue1, UnregisterMessageCallback)
+        HRESULT ( STDMETHODCALLTYPE *UnregisterMessageCallback )( 
+            ID3D12InfoQueue1 * This,
+            _In_  DWORD CallbackCookie);
+        
+        END_INTERFACE
+    } ID3D12InfoQueue1Vtbl;
+
+    interface ID3D12InfoQueue1
+    {
+        CONST_VTBL struct ID3D12InfoQueue1Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ID3D12InfoQueue1_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ID3D12InfoQueue1_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ID3D12InfoQueue1_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ID3D12InfoQueue1_SetMessageCountLimit(This,MessageCountLimit)	\
+    ( (This)->lpVtbl -> SetMessageCountLimit(This,MessageCountLimit) ) 
+
+#define ID3D12InfoQueue1_ClearStoredMessages(This)	\
+    ( (This)->lpVtbl -> ClearStoredMessages(This) ) 
+
+#define ID3D12InfoQueue1_GetMessage(This,MessageIndex,pMessage,pMessageByteLength)	\
+    ( (This)->lpVtbl -> GetMessage(This,MessageIndex,pMessage,pMessageByteLength) ) 
+
+#define ID3D12InfoQueue1_GetNumMessagesAllowedByStorageFilter(This)	\
+    ( (This)->lpVtbl -> GetNumMessagesAllowedByStorageFilter(This) ) 
+
+#define ID3D12InfoQueue1_GetNumMessagesDeniedByStorageFilter(This)	\
+    ( (This)->lpVtbl -> GetNumMessagesDeniedByStorageFilter(This) ) 
+
+#define ID3D12InfoQueue1_GetNumStoredMessages(This)	\
+    ( (This)->lpVtbl -> GetNumStoredMessages(This) ) 
+
+#define ID3D12InfoQueue1_GetNumStoredMessagesAllowedByRetrievalFilter(This)	\
+    ( (This)->lpVtbl -> GetNumStoredMessagesAllowedByRetrievalFilter(This) ) 
+
+#define ID3D12InfoQueue1_GetNumMessagesDiscardedByMessageCountLimit(This)	\
+    ( (This)->lpVtbl -> GetNumMessagesDiscardedByMessageCountLimit(This) ) 
+
+#define ID3D12InfoQueue1_GetMessageCountLimit(This)	\
+    ( (This)->lpVtbl -> GetMessageCountLimit(This) ) 
+
+#define ID3D12InfoQueue1_AddStorageFilterEntries(This,pFilter)	\
+    ( (This)->lpVtbl -> AddStorageFilterEntries(This,pFilter) ) 
+
+#define ID3D12InfoQueue1_GetStorageFilter(This,pFilter,pFilterByteLength)	\
+    ( (This)->lpVtbl -> GetStorageFilter(This,pFilter,pFilterByteLength) ) 
+
+#define ID3D12InfoQueue1_ClearStorageFilter(This)	\
+    ( (This)->lpVtbl -> ClearStorageFilter(This) ) 
+
+#define ID3D12InfoQueue1_PushEmptyStorageFilter(This)	\
+    ( (This)->lpVtbl -> PushEmptyStorageFilter(This) ) 
+
+#define ID3D12InfoQueue1_PushCopyOfStorageFilter(This)	\
+    ( (This)->lpVtbl -> PushCopyOfStorageFilter(This) ) 
+
+#define ID3D12InfoQueue1_PushStorageFilter(This,pFilter)	\
+    ( (This)->lpVtbl -> PushStorageFilter(This,pFilter) ) 
+
+#define ID3D12InfoQueue1_PopStorageFilter(This)	\
+    ( (This)->lpVtbl -> PopStorageFilter(This) ) 
+
+#define ID3D12InfoQueue1_GetStorageFilterStackSize(This)	\
+    ( (This)->lpVtbl -> GetStorageFilterStackSize(This) ) 
+
+#define ID3D12InfoQueue1_AddRetrievalFilterEntries(This,pFilter)	\
+    ( (This)->lpVtbl -> AddRetrievalFilterEntries(This,pFilter) ) 
+
+#define ID3D12InfoQueue1_GetRetrievalFilter(This,pFilter,pFilterByteLength)	\
+    ( (This)->lpVtbl -> GetRetrievalFilter(This,pFilter,pFilterByteLength) ) 
+
+#define ID3D12InfoQueue1_ClearRetrievalFilter(This)	\
+    ( (This)->lpVtbl -> ClearRetrievalFilter(This) ) 
+
+#define ID3D12InfoQueue1_PushEmptyRetrievalFilter(This)	\
+    ( (This)->lpVtbl -> PushEmptyRetrievalFilter(This) ) 
+
+#define ID3D12InfoQueue1_PushCopyOfRetrievalFilter(This)	\
+    ( (This)->lpVtbl -> PushCopyOfRetrievalFilter(This) ) 
+
+#define ID3D12InfoQueue1_PushRetrievalFilter(This,pFilter)	\
+    ( (This)->lpVtbl -> PushRetrievalFilter(This,pFilter) ) 
+
+#define ID3D12InfoQueue1_PopRetrievalFilter(This)	\
+    ( (This)->lpVtbl -> PopRetrievalFilter(This) ) 
+
+#define ID3D12InfoQueue1_GetRetrievalFilterStackSize(This)	\
+    ( (This)->lpVtbl -> GetRetrievalFilterStackSize(This) ) 
+
+#define ID3D12InfoQueue1_AddMessage(This,Category,Severity,ID,pDescription)	\
+    ( (This)->lpVtbl -> AddMessage(This,Category,Severity,ID,pDescription) ) 
+
+#define ID3D12InfoQueue1_AddApplicationMessage(This,Severity,pDescription)	\
+    ( (This)->lpVtbl -> AddApplicationMessage(This,Severity,pDescription) ) 
+
+#define ID3D12InfoQueue1_SetBreakOnCategory(This,Category,bEnable)	\
+    ( (This)->lpVtbl -> SetBreakOnCategory(This,Category,bEnable) ) 
+
+#define ID3D12InfoQueue1_SetBreakOnSeverity(This,Severity,bEnable)	\
+    ( (This)->lpVtbl -> SetBreakOnSeverity(This,Severity,bEnable) ) 
+
+#define ID3D12InfoQueue1_SetBreakOnID(This,ID,bEnable)	\
+    ( (This)->lpVtbl -> SetBreakOnID(This,ID,bEnable) ) 
+
+#define ID3D12InfoQueue1_GetBreakOnCategory(This,Category)	\
+    ( (This)->lpVtbl -> GetBreakOnCategory(This,Category) ) 
+
+#define ID3D12InfoQueue1_GetBreakOnSeverity(This,Severity)	\
+    ( (This)->lpVtbl -> GetBreakOnSeverity(This,Severity) ) 
+
+#define ID3D12InfoQueue1_GetBreakOnID(This,ID)	\
+    ( (This)->lpVtbl -> GetBreakOnID(This,ID) ) 
+
+#define ID3D12InfoQueue1_SetMuteDebugOutput(This,bMute)	\
+    ( (This)->lpVtbl -> SetMuteDebugOutput(This,bMute) ) 
+
+#define ID3D12InfoQueue1_GetMuteDebugOutput(This)	\
+    ( (This)->lpVtbl -> GetMuteDebugOutput(This) ) 
+
+
+#define ID3D12InfoQueue1_RegisterMessageCallback(This,CallbackFunc,CallbackFilterFlags,pContext,pCallbackCookie)	\
+    ( (This)->lpVtbl -> RegisterMessageCallback(This,CallbackFunc,CallbackFilterFlags,pContext,pCallbackCookie) ) 
+
+#define ID3D12InfoQueue1_UnregisterMessageCallback(This,CallbackCookie)	\
+    ( (This)->lpVtbl -> UnregisterMessageCallback(This,CallbackCookie) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ID3D12InfoQueue1_INTERFACE_DEFINED__ */
+
+
+/* interface __MIDL_itf_d3d12sdklayers_0000_0016 */
 /* [local] */ 
 
 #endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_GAMES) */
@@ -2803,6 +3627,8 @@ DEFINE_GUID(IID_ID3D12Debug,0x344488b7,0x6846,0x474b,0xb9,0x89,0xf0,0x27,0x44,0x
 DEFINE_GUID(IID_ID3D12Debug1,0xaffaa4ca,0x63fe,0x4d8e,0xb8,0xad,0x15,0x90,0x00,0xaf,0x43,0x04);
 DEFINE_GUID(IID_ID3D12Debug2,0x93a665c4,0xa3b2,0x4e5d,0xb6,0x92,0xa2,0x6a,0xe1,0x4e,0x33,0x74);
 DEFINE_GUID(IID_ID3D12Debug3,0x5cf4e58f,0xf671,0x4ff1,0xa5,0x42,0x36,0x86,0xe3,0xd1,0x53,0xd1);
+DEFINE_GUID(IID_ID3D12Debug4,0x014b816e,0x9ec5,0x4a2f,0xa8,0x45,0xff,0xbe,0x44,0x1c,0xe1,0x3a);
+DEFINE_GUID(IID_ID3D12Debug5,0x548d6b12,0x09fa,0x40e0,0x90,0x69,0x5d,0xcd,0x58,0x9a,0x52,0xc9);
 DEFINE_GUID(IID_ID3D12DebugDevice1,0xa9b71770,0xd099,0x4a65,0xa6,0x98,0x3d,0xee,0x10,0x02,0x0f,0x88);
 DEFINE_GUID(IID_ID3D12DebugDevice,0x3febd6dd,0x4973,0x4787,0x81,0x94,0xe4,0x5f,0x9e,0x28,0x92,0x3e);
 DEFINE_GUID(IID_ID3D12DebugDevice2,0x60eccbc1,0x378d,0x4df1,0x89,0x4c,0xf8,0xac,0x5c,0xe4,0xd7,0xdd);
@@ -2812,10 +3638,11 @@ DEFINE_GUID(IID_ID3D12DebugCommandList,0x09e0bf36,0x54ac,0x484f,0x88,0x47,0x4b,0
 DEFINE_GUID(IID_ID3D12DebugCommandList2,0xaeb575cf,0x4e06,0x48be,0xba,0x3b,0xc4,0x50,0xfc,0x96,0x65,0x2e);
 DEFINE_GUID(IID_ID3D12SharingContract,0x0adf7d52,0x929c,0x4e61,0xad,0xdb,0xff,0xed,0x30,0xde,0x66,0xef);
 DEFINE_GUID(IID_ID3D12InfoQueue,0x0742a90b,0xc387,0x483f,0xb9,0x46,0x30,0xa7,0xe4,0xe6,0x14,0x58);
+DEFINE_GUID(IID_ID3D12InfoQueue1,0x2852dd88,0xb484,0x4c0c,0xb6,0xb1,0x67,0x16,0x85,0x00,0xe6,0x00);
 
 
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0013_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0013_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0016_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_d3d12sdklayers_0000_0016_v0_0_s_ifspec;
 
 /* Additional Prototypes for ALL interfaces */
 

--- a/util/test/demos/dx/official/d3dcommon.h
+++ b/util/test/demos/dx/official/d3dcommon.h
@@ -1,9 +1,15 @@
+/*-------------------------------------------------------------------------------------
+ *
+ * Copyright (c) Microsoft Corporation
+ * Licensed under the MIT license
+ *
+ *-------------------------------------------------------------------------------------*/
 
 
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 
 
- /* File created by MIDL compiler version 8.01.0622 */
+ /* File created by MIDL compiler version 8.01.0625 */
 /* @@MIDL_FILE_HEADING(  ) */
 
 
@@ -37,6 +43,14 @@
 #pragma once
 #endif
 
+#ifndef DECLSPEC_XFGVIRT
+#if _CONTROL_FLOW_GUARD_XFG
+#define DECLSPEC_XFGVIRT(base, func) __declspec(xfg_virtual(base, func))
+#else
+#define DECLSPEC_XFGVIRT(base, func)
+#endif
+#endif
+
 /* Forward Declarations */ 
 
 #ifndef __ID3D10Blob_FWD_DEFINED__
@@ -54,8 +68,8 @@ typedef interface ID3DDestructionNotifier ID3DDestructionNotifier;
 
 
 /* header files for imported files */
-#include "oaidl.h"
-#include "ocidl.h"
+#include "OAIdl.h"
+#include "OCIdl.h"
 
 #ifdef __cplusplus
 extern "C"{
@@ -88,7 +102,8 @@ enum D3D_FEATURE_LEVEL
         D3D_FEATURE_LEVEL_11_0	= 0xb000,
         D3D_FEATURE_LEVEL_11_1	= 0xb100,
         D3D_FEATURE_LEVEL_12_0	= 0xc000,
-        D3D_FEATURE_LEVEL_12_1	= 0xc100
+        D3D_FEATURE_LEVEL_12_1	= 0xc100,
+        D3D_FEATURE_LEVEL_12_2	= 0xc200
     } 	D3D_FEATURE_LEVEL;
 
 #define D3D_FL9_1_REQ_TEXTURE1D_U_DIMENSION          2048
@@ -342,6 +357,35 @@ enum D3D_SRV_DIMENSION
         D3D11_SRV_DIMENSION_BUFFEREX	= D3D_SRV_DIMENSION_BUFFEREX
     } 	D3D_SRV_DIMENSION;
 
+#define D3D_SHADER_FEATURE_DOUBLES                                                        0x00001
+#define D3D_SHADER_FEATURE_COMPUTE_SHADERS_PLUS_RAW_AND_STRUCTURED_BUFFERS_VIA_SHADER_4_X 0x00002
+#define D3D_SHADER_FEATURE_UAVS_AT_EVERY_STAGE                                            0x00004
+#define D3D_SHADER_FEATURE_64_UAVS                                                        0x00008
+#define D3D_SHADER_FEATURE_MINIMUM_PRECISION                                              0x00010
+#define D3D_SHADER_FEATURE_11_1_DOUBLE_EXTENSIONS                                         0x00020
+#define D3D_SHADER_FEATURE_11_1_SHADER_EXTENSIONS                                         0x00040
+#define D3D_SHADER_FEATURE_LEVEL_9_COMPARISON_FILTERING                                   0x00080
+#define D3D_SHADER_FEATURE_TILED_RESOURCES                                                0x00100
+#define D3D_SHADER_FEATURE_STENCIL_REF                                                    0x00200
+#define D3D_SHADER_FEATURE_INNER_COVERAGE                                                 0x00400
+#define D3D_SHADER_FEATURE_TYPED_UAV_LOAD_ADDITIONAL_FORMATS                              0x00800
+#define D3D_SHADER_FEATURE_ROVS                                                           0x01000
+#define D3D_SHADER_FEATURE_VIEWPORT_AND_RT_ARRAY_INDEX_FROM_ANY_SHADER_FEEDING_RASTERIZER 0x02000
+#define D3D_SHADER_FEATURE_WAVE_OPS                                                       0x04000
+#define D3D_SHADER_FEATURE_INT64_OPS                                                      0x08000
+#define D3D_SHADER_FEATURE_VIEW_ID                                                        0x10000
+#define D3D_SHADER_FEATURE_BARYCENTRICS                                                   0x20000
+#define D3D_SHADER_FEATURE_NATIVE_16BIT_OPS                                               0x40000
+#define D3D_SHADER_FEATURE_SHADING_RATE                                                   0x80000
+#define D3D_SHADER_FEATURE_RAYTRACING_TIER_1_1                                            0x100000
+#define D3D_SHADER_FEATURE_SAMPLER_FEEDBACK                                               0x200000
+#define D3D_SHADER_FEATURE_ATOMIC_INT64_ON_TYPED_RESOURCE                                 0x400000
+#define D3D_SHADER_FEATURE_ATOMIC_INT64_ON_GROUP_SHARED                                   0x800000
+#define D3D_SHADER_FEATURE_DERIVATIVES_IN_MESH_AND_AMPLIFICATION_SHADERS                  0x1000000
+#define D3D_SHADER_FEATURE_RESOURCE_DESCRIPTOR_HEAP_INDEXING                              0x2000000
+#define D3D_SHADER_FEATURE_SAMPLER_DESCRIPTOR_HEAP_INDEXING                               0x4000000
+#define D3D_SHADER_FEATURE_WAVE_MMA                                                       0x8000000
+#define D3D_SHADER_FEATURE_ATOMIC_INT64_ON_DESCRIPTOR_HEAP_RESOURCE                       0x10000000
 typedef struct _D3D_SHADER_MACRO
     {
     LPCSTR Name;
@@ -384,21 +428,26 @@ EXTERN_C const IID IID_ID3D10Blob;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3D10Blob * This,
             /* [in] */ REFIID riid,
             /* [annotation][iid_is][out] */ 
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3D10Blob * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3D10Blob * This);
         
+        DECLSPEC_XFGVIRT(ID3D10Blob, GetBufferPointer)
         LPVOID ( STDMETHODCALLTYPE *GetBufferPointer )( 
             ID3D10Blob * This);
         
+        DECLSPEC_XFGVIRT(ID3D10Blob, GetBufferSize)
         SIZE_T ( STDMETHODCALLTYPE *GetBufferSize )( 
             ID3D10Blob * This);
         
@@ -494,18 +543,22 @@ EXTERN_C const IID IID_ID3DDestructionNotifier;
     {
         BEGIN_INTERFACE
         
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
         HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
             ID3DDestructionNotifier * This,
             /* [in] */ REFIID riid,
             /* [annotation][iid_is][out] */ 
             _COM_Outptr_  void **ppvObject);
         
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
         ULONG ( STDMETHODCALLTYPE *AddRef )( 
             ID3DDestructionNotifier * This);
         
+        DECLSPEC_XFGVIRT(IUnknown, Release)
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ID3DDestructionNotifier * This);
         
+        DECLSPEC_XFGVIRT(ID3DDestructionNotifier, RegisterDestructionCallback)
         HRESULT ( STDMETHODCALLTYPE *RegisterDestructionCallback )( 
             ID3DDestructionNotifier * This,
             /* [annotation] */ 
@@ -515,6 +568,7 @@ EXTERN_C const IID IID_ID3DDestructionNotifier;
             /* [annotation] */ 
             _Out_  UINT *pCallbackID);
         
+        DECLSPEC_XFGVIRT(ID3DDestructionNotifier, UnregisterDestructionCallback)
         HRESULT ( STDMETHODCALLTYPE *UnregisterDestructionCallback )( 
             ID3DDestructionNotifier * This,
             /* [annotation] */ 
@@ -985,6 +1039,7 @@ enum _D3D_PARAMETER_FLAGS
 DEFINE_GUID(WKPDID_D3DDebugObjectName,0x429b8c22,0x9188,0x4b0c,0x87,0x42,0xac,0xb0,0xbf,0x85,0xc2,0x00);
 DEFINE_GUID(WKPDID_D3DDebugObjectNameW,0x4cca5fd8,0x921f,0x42c8,0x85,0x66,0x70,0xca,0xf2,0xa9,0xb7,0x41);
 DEFINE_GUID(WKPDID_CommentStringW,0xd0149dc0,0x90e8,0x4ec8,0x81, 0x44, 0xe9, 0x00, 0xad, 0x26, 0x6b, 0xb2);
+DEFINE_GUID(WKPDID_D3D12UniqueObjectId, 0x1b39de15, 0xec04, 0x4bae, 0xba, 0x4d, 0x8c, 0xef, 0x79, 0xfc, 0x04, 0xc1);
 #define D3D_SET_OBJECT_NAME_N_A(pObject, Chars, pName) (pObject)->SetPrivateData(WKPDID_D3DDebugObjectName, Chars, pName)
 #define D3D_SET_OBJECT_NAME_A(pObject, pName) D3D_SET_OBJECT_NAME_N_A(pObject, lstrlenA(pName), pName)
 #define D3D_SET_OBJECT_NAME_N_W(pObject, Chars, pName) (pObject)->SetPrivateData(WKPDID_D3DDebugObjectNameW, Chars*2, pName)

--- a/util/test/tests/D3D12/D3D12_Descriptor_Indexing.py
+++ b/util/test/tests/D3D12/D3D12_Descriptor_Indexing.py
@@ -51,7 +51,7 @@ class D3D12_Descriptor_Indexing(rdtest.TestCase):
 
             # Check bindings:
             #   - buffer 8 in root range 0 should be statically used (single fixed declaration) for the parameters
-            #     image 15 in root range 0 should also be statically used
+            #     image 12 in root range 0 should also be statically used
             #   - images 19, 20, 21 in root range 1 should be used for the non-uniform index
             #     images 49 & 59 in root range 1 should be used for a second array in the same range
             #     image 60 in root range 1 should be used for a fixed index in an array


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

This pull request will add support for shader model 6.6 to the bindless feedback and the pipeline state view.
It also fixes a bug in the current implementation of bindless feedback caused by an integer overflow and update the dx.op.annotateHandle instruction's disassembly to match the current DXC implementation.


Here you can see the before/after of updating dx.op.annotateHandle in the disassembly : 
![6_6_annotate](https://user-images.githubusercontent.com/3042591/152869086-57402b52-979f-4134-8841-004b31e72af4.jpg)


Here you can see the before/after of fixing the integer overflow using shadermodel 6.5 bindless : 
![6_5_overflow](https://user-images.githubusercontent.com/3042591/152869102-5fa71024-f3df-4ae9-aa19-3943e43e4b8d.jpg)


Here you can see the before/after of supporting classic and new bindless feedback in shadermodel 6.6 : 
![6_6_table](https://user-images.githubusercontent.com/3042591/152869129-fedc23e4-a012-46ae-9231-6c74dadaaf04.jpg)
![6_6_heap](https://user-images.githubusercontent.com/3042591/152869148-1e959a9d-4612-4680-9ec8-b8318bac5964.jpg)



### Implementation notes : 

* d3d12_shader_feedback.cpp : 
	Handling classic binding for shader model 6.6 basically consists in using createHandleFromBinding instead of createHandle
	
	To handle direct heap access I added one special D3D12FeedbackKey for resources and one for samplers for each shader stages that need them, then handle createHandleFromHeap when patching the shaders.
	After replaying the command, I iterate over those D3D12FeedbackKey and create a D3D12FeedbackBindIdentifier for each resource accessed.
	
	Since the disassembly doesn't give a way to get the name of the variable linked to a createHandleFromHeap, I only create one D3D12FeedbackKey slots per shader stage for all createHandleFromHeap instances instead of one slot per createHandleFromHeap instance ( contrary to createHandle/createHandleFromBinding ).
	If there was a way to to get the variable name ( maybe from the debug info ? ), this could easily be modified to add one D3D12FeedbackKey slot per createHandleFromHeap instances.
	

* d3d12_replay.cpp :
	I iterate over all the created D3D12FeedbackBindIdentifier usages and create/fill the necessary D3D12Pipe::RootSignatureRange.
	
* D3D12PipelineStateViewer.cpp :
	Mostly checking if the resources are directHeapAccess to avoid printing Space/Register that don't make sense in this case in the "Pipeline State" view
	
* dxil_disassemble.cpp
	When shadermodel 6.6 was added to DXC the arguments of the dx.op.annotateHandle instruction changed, which could lead to access to non-existent arguments and crash.
	I updated the disassembly to string function to reflect those changes.
	