### PR TITLE
lazily fetch subsamples in MSAA textures

### DIFF
--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -2447,11 +2447,14 @@ void ReplayProxy::EnsureTexCached(ResourceId &texid, CompType &typeCast, const S
     }
 
     const ProxyTextureProperties &proxy = proxyit->second;
+    const bool allSamples = sub.sample == ~0U;
 
-    for(uint32_t sample = 0; sample < proxy.msSamp; sample++)
+    uint32_t numSamplesToFetch = allSamples ? proxy.msSamp : 1;
+    for(uint32_t sample = 0; sample < numSamplesToFetch; sample++)
     {
       Subresource s = sub;
-      s.sample = sample;
+      if(allSamples)
+        s.sample = sample;
 
       TextureCacheEntry sampleArrayEntry = {texid, s};
 

--- a/renderdoc/core/replay_proxy.h
+++ b/renderdoc/core/replay_proxy.h
@@ -430,7 +430,12 @@ public:
   {
     if(m_Proxy)
     {
-      EnsureTexCached(display.resourceId, display.typeCast, display.subresource);
+      Subresource customShaderSubresource = display.subresource;
+      // fetch all subsamples in case the custom shader wants to fetch more than simply the active
+      // subsample
+      customShaderSubresource.sample = ~0U;
+
+      EnsureTexCached(display.resourceId, display.typeCast, customShaderSubresource);
 
       if(display.resourceId == ResourceId())
         return ResourceId();

--- a/renderdoc/replay/replay_output.cpp
+++ b/renderdoc/replay/replay_output.cpp
@@ -691,7 +691,7 @@ void ReplayOutput::Display()
     disp.linearDisplayAsGamma = true;
     disp.flipY = false;
     disp.subresource = m_Thumbnails[i].sub;
-    disp.subresource.sample = ~0U;
+    disp.subresource.sample = 0;
     disp.customShaderId = ResourceId();
     disp.resourceId = m_pDevice->GetLiveID(m_Thumbnails[i].texture);
     disp.typeCast = m_Thumbnails[i].typeCast;


### PR DESCRIPTION
Change the replay_proxy behavior to lazily fetch subsamples when previewing an MSAA texture : if only Sample0 is viewed in texture viewer, only sample0 will be fetched. Also moves thumbnails to sample from subsample 0 instead of 0U (average), as pulling 4 subsamples is expensive on high-resolution mobile devices. 

forces all subsamples to be fetched for custom shaders in case the custom shader wants to fetch more than subsample 0. 

Tested on Oculus Quest2, with a SCOPED_TIMER in GetTextureData, only 2 Gets are executed on the proxy when previewing an MSAA app in subsample 0 (one for color, one for depth, color reused for thumbnail). ~3x faster from clicking on a draw to renderdoc being done with the work. 

Verified that this doesn't impact histogram, minmax, texture-to-disk paths. 