### PR TITLE
add support for VK_QCOM_render_pass_shader_resolve

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1456,6 +1456,10 @@ static const VkExtensionProperties supportedExtensions[] = {
         VK_NV_WIN32_KEYED_MUTEX_EXTENSION_NAME, VK_NV_WIN32_KEYED_MUTEX_SPEC_VERSION,
     },
 #endif
+    {
+        VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME,
+        VK_QCOM_RENDER_PASS_SHADER_RESOLVE_SPEC_VERSION,
+    },
 };
 
 // this is the list of extensions we provide - regardless of whether the ICD supports them


### PR DESCRIPTION
Moving support for VK_QCOM_render_pass_shader_resolve to its own PR to distinguish it from the FDM one (that needs more commits). 

Simple extension ( https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_QCOM_render_pass_shader_resolve.html ) with no structures, so no changes to serialization, only enables access to flags. 