### PR TITLE
add dimensions and offset info to HTML pipeline

### DIFF
--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -4045,17 +4045,19 @@ void VulkanPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const VKPipe::
 
       QString name = m_Ctx.GetResourceName(a.imageResourceId);
 
-      rows.push_back({i, name, a.firstMip, a.numMips, a.firstSlice, a.numSlices});
+      rows.push_back({i, name, tex->width, tex->height, tex->depth, tex->arraysize, a.firstMip,
+                      a.numMips, a.firstSlice, a.numSlices});
 
       i++;
     }
 
-    m_Common.exportHTMLTable(xml,
-                             {
-                                 tr("Slot"), tr("Image"), tr("First mip"), tr("Number of mips"),
-                                 tr("First array layer"), tr("Number of layers"),
-                             },
-                             rows);
+    m_Common.exportHTMLTable(
+        xml,
+        {
+            tr("Slot"), tr("Image"), tr("Width"), tr("Height"), tr("Depth"), tr("Array Size"),
+            tr("First mip"), tr("Number of mips"), tr("First array layer"), tr("Number of layers"),
+        },
+        rows);
   }
 
   {
@@ -4097,6 +4099,23 @@ void VulkanPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const VKPipe::
       xml.writeEndElement();
     }
 
+    if(!pass.renderpass.resolveAttachments.isEmpty())
+    {
+      QList<QVariantList> resolves;
+
+      for(int i = 0; i < pass.renderpass.resolveAttachments.count(); i++)
+        resolves.push_back({pass.renderpass.resolveAttachments[i]});
+
+      m_Common.exportHTMLTable(xml,
+                               {
+                                   tr("Resolve Attachment"),
+                               },
+                               resolves);
+
+      xml.writeStartElement(lit("p"));
+      xml.writeEndElement();
+    }
+
     if(pass.renderpass.depthstencilAttachment >= 0)
     {
       xml.writeStartElement(lit("p"));
@@ -4118,6 +4137,19 @@ void VulkanPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const VKPipe::
       xml.writeStartElement(lit("p"));
       xml.writeCharacters(
           tr("Fragment Density Attachment: %1").arg(pass.renderpass.fragmentDensityAttachment));
+      if(pass.renderpass.fragmentDensityOffsets.size() > 0)
+      {
+        xml.writeCharacters(
+            tr(". Rendering with %1 offsets : ").arg(pass.renderpass.fragmentDensityOffsets.size()));
+        for(uint32_t j = 0; j < pass.renderpass.fragmentDensityOffsets.size(); j++)
+        {
+          const Offset &o = pass.renderpass.fragmentDensityOffsets[j];
+          if(j > 0)
+            xml.writeCharacters(tr(", "));
+
+          xml.writeCharacters(tr(" %1x%2").arg(o.x).arg(o.y));
+        }
+      }
       xml.writeEndElement();
     }
 

--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -937,6 +937,8 @@ void VulkanCreationInfo::RenderPass::Init(VulkanResourceManager *resourceMan,
     if(dst.depthstencilAttachment >= 0)
       attachments[dst.depthstencilAttachment].used = true;
 
+    dst.depthstencilResolveAttachment = -1;
+
     dst.fragmentDensityAttachment =
         (fragmentDensity &&
                  fragmentDensity->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED


### PR DESCRIPTION
Modifies HTML pipeline exporter to add dimensions of framebuffer attachment, resolve attachments and FDM offsets. 
![result](https://user-images.githubusercontent.com/644891/153976306-d9bb22d6-d014-4d02-a7a3-9fdade779a50.PNG)

Also fixes *depthstencilResolveAttachment* being uninitialized for renderpass1 usecases, which was initializing it to 0 (which is a valid attachment ID), and printing it as such in the HTML exporter.