### PR TITLE
remove QCOM workarounds on newer driver

### DIFF
--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -1017,10 +1017,16 @@ VkDriverInfo::VkDriverInfo(const VkPhysicalDeviceProperties &physProps, bool act
       RDCLOG("Enabling Qualcomm driver workarounds");
 
     // not fixed yet that I know of, or unknown driver with fixes
-    qualcommLeakingUBOOffsets = true;
     qualcommDrefNon2DCompileCrash = true;
     qualcommLineWidthCrash = true;
-    bdaBrokenDriver = true;
+
+    // KHR_buffer_device_address has been tested on 622 (Quest2)
+    // UBO dynamic offset leak has been fixed in early 2020, 622 tested.
+    if(physProps.driverVersion < VK_MAKE_VERSION(512, 622, 0))
+    {
+      bdaBrokenDriver = true;
+      qualcommLeakingUBOOffsets = true;
+    }
   }
 }
 


### PR DESCRIPTION
I tested BDA on driver 622 on Quest2, both on pixel debugging and postvs (debugPrintf can't use it due to lack of shaderInt64 anyway). Seems to work just fine, no crashes and valid data all around. 

The UBO dynamicOffset fix is known and got fixed way before 622, but I don't have an exact driver version. It was needed to ship EchoVR on Quest1. We... should have asked you, I believe you may have been the first one encountering it based on your original CL ^^.