### PR TITLE
Fix capturing on Apple OSX 12

### DIFF
--- a/renderdoc/driver/gl/CMakeLists.txt
+++ b/renderdoc/driver/gl/CMakeLists.txt
@@ -54,6 +54,7 @@ list(APPEND sources gl_hooks.cpp)
 if(APPLE)
     list(APPEND sources
         apple_gl_hook_defs.h
+        apple_gl_hook_defs.cpp
         cgl_dispatch_table.h
         cgl_platform_helpers.mm
         cgl_platform.cpp

--- a/renderdoc/driver/gl/apple_gl_hook_defs.cpp
+++ b/renderdoc/driver/gl/apple_gl_hook_defs.cpp
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "apple_gl_hook_defs.h"
+#include "common/common.h"
+
+#define GL_GLEXT_PROTOTYPES
+
+#include "official/glcorearb.h"
+#include "official/glext.h"
+
+extern void AppleRegisterRealSymbol(const char *functionName, void *address);
+
+void RegisterAppleGLSymbols()
+{
+#define APPLE_FUNC(function) AppleRegisterRealSymbol(STRINGIZE(function), (void *)&::function);
+
+  ForEachAppleSupported();
+#undef APPLE_FUNC
+}

--- a/renderdoc/driver/gl/cgl_hooks.cpp
+++ b/renderdoc/driver/gl/cgl_hooks.cpp
@@ -199,6 +199,9 @@ DECL_HOOK_EXPORT(CGLCreateContext);
 DECL_HOOK_EXPORT(CGLSetCurrentContext);
 DECL_HOOK_EXPORT(CGLFlushDrawable);
 
+extern void RegisterAppleGLSymbols();
+extern void AppleRegisterRealSymbol(const char *functionName, void *address);
+
 static void CGLHooked(void *handle)
 {
   RDCDEBUG("CGL library hooked");
@@ -207,6 +210,7 @@ static void CGLHooked(void *handle)
   // pointers
   cglhook.handle = handle;
 
+  RegisterAppleGLSymbols();
   // enable hooks immediately, we'll suppress them when calling into CGL
   EnableGLHooks();
 
@@ -229,8 +233,9 @@ void CGLHook::RegisterHooks()
   LibraryHooks::RegisterLibraryHook("libGL.dylib", NULL);
 
 // register CGL hooks
-#define CGL_REGISTER(func)            \
-  LibraryHooks::RegisterFunctionHook( \
+#define CGL_REGISTER(func)                                   \
+  AppleRegisterRealSymbol(STRINGIZE(func), (void *)&::func); \
+  LibraryHooks::RegisterFunctionHook(                        \
       "OpenGL", FunctionHook(STRINGIZE(func), (void **)&CGL.func, (void *)&GL_EXPORT_NAME(func)));
   CGL_HOOKED_SYMBOLS(CGL_REGISTER)
 #undef CGL_REGISTER

--- a/renderdoc/os/posix/apple/apple_process.cpp
+++ b/renderdoc/os/posix/apple/apple_process.cpp
@@ -68,8 +68,8 @@ int GetIdentPort(pid_t childPid)
   rdcstr lsof = StringFormat::Fmt("lsof -p %d -a -i 4 -F n", (int)childPid);
   rdcstr result;
   uint32_t wait = 1;
-  // Wait for a maximum of ~8 seconds
-  for(int i = 0; i < 13; ++i)
+  // Wait for a maximum of ~16 seconds
+  for(int i = 0; i < 14; ++i)
   {
     result = execcmd(lsof.c_str());
     if(!result.empty())


### PR DESCRIPTION
## Description

Change hooking to use link time symbol address instead of runtime `dlsym`
`OSX 12` introduced a new version of `dyld` system and in that version 
`dlsym(RTLD_NEXT,...)` returns the interposed symbol not the real symbol.

On Apple increase the amount of time to ~16 seconds to wait for application launch.
On Apple Silicon it can take ~10 seconds for the OS to launch an Intel x64 process because the Intel executable is translated on launch using Rosetta.

## Testing

Capturing on OSX 12 (M1 Mac Pro 2021) and on OSX 10.15 (Mac Air 2013)