### PR TITLE
add VR thumbnail support on vulkan backend

### DIFF
--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -86,6 +86,9 @@ typedef VkPhysicalDeviceBufferDeviceAddressFeatures VkPhysicalDeviceBufferDevice
 // happening
 #define VERBOSE_PARTIAL_REPLAY OPTION_OFF
 
+// UUID shared with VR runtimes to specify which vkImage is currently presented to the screen
+#define VR_ThumbnailTag_UUID 0x94F5B9E495BCC552ULL
+
 ResourceFormat MakeResourceFormat(VkFormat fmt);
 VkFormat MakeVkFormat(ResourceFormat fmt);
 Topology MakePrimitiveTopology(VkPrimitiveTopology Topo, uint32_t patchControlPoints);

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -772,6 +772,11 @@ private:
 
   ResourceId m_LastSwap;
 
+  // When capturing in VR mode (no conventional present), resource of the vkImage that the VR
+  // runtime
+  // specifies as last backbuffer through the VR backbuffer tag
+  ResourceId m_CurrentVRBackbuffer;
+
   // hold onto device address resources (buffers and memories) so that if one is destroyed
   // mid-capture we can hold onto it until the capture is complete.
   struct

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -2123,6 +2123,11 @@ VkResult WrappedVulkan::vkDebugMarkerSetObjectTagEXT(VkDevice device,
       Serialise_SetShaderDebugPath(ser, (VkShaderModule)(uint64_t)data.record->Resource, DebugPath);
       data.record->AddChunk(scope.Get());
     }
+    else if(data.record && pTagInfo->tagName == VR_ThumbnailTag_UUID &&
+            pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT)
+    {
+      m_CurrentVRBackbuffer = data.record->GetResourceID();
+    }
     else if(ObjDisp(device)->DebugMarkerSetObjectTagEXT)
     {
       VkDebugMarkerObjectTagInfoEXT unwrapped = *pTagInfo;
@@ -2462,6 +2467,11 @@ VkResult WrappedVulkan::vkSetDebugUtilsObjectTagEXT(VkDevice device,
       SCOPED_SERIALISE_CHUNK(VulkanChunk::SetShaderDebugPath);
       Serialise_SetShaderDebugPath(ser, (VkShaderModule)(uint64_t)data.record->Resource, DebugPath);
       data.record->AddChunk(scope.Get());
+    }
+    else if(data.record && pTagInfo->tagName == VR_ThumbnailTag_UUID &&
+            pTagInfo->objectType == VK_OBJECT_TYPE_IMAGE)
+    {
+      m_CurrentVRBackbuffer = data.record->GetResourceID();
     }
     else if(ObjDisp(device)->SetDebugUtilsObjectTagEXT)
     {


### PR DESCRIPTION
Adds VR thumbnail support if the VR app submitted a EXT_debug_utils/report tag named VR_ThumbnailTag_UUID on the vkImage that is to be presented to the VR screen (and therefore should be used as thumbnail). 

Reworks the EndFrameCapture function to make the thumbnail getters not swapchain-specific.

![fuckyeah](https://user-images.githubusercontent.com/644891/154423390-52188666-6b44-4be8-ba15-c2fdcb5287e5.PNG)

Tested on Quest2 with modified VR runtime emitting the VR thumbnail UUID, on multiple engines (unity/UE4/native). 
 