### PR TITLE
Apple tidy up of building requirements and cmake file checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 if(APPLE)
+  # Building for Apple requires at least CMake 3.20.0
+  cmake_minimum_required(VERSION 3.20.0)
+
   SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
   SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum SDK for Mac OS X" FORCE)
   SET(CMAKE_XCODE_GENERATE_SCHEME ON)
@@ -193,6 +196,12 @@ option(ENABLE_GGP "Enable GGP support" OFF)
 option(ENABLE_ASAN "Enable address sanitizer" OFF)
 option(ENABLE_TSAN "Enable thread sanitizer" OFF)
 option(ENABLE_MSAN "Enable memory sanitizer" OFF)
+
+if(APPLE)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
+    message(FATAL_ERROR "Xcode 12.2 or newer is required to build for Apple")
+  endif()
+endif()
 
 if(ENABLE_ASAN)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")

--- a/docs/CONTRIBUTING/Compiling.md
+++ b/docs/CONTRIBUTING/Compiling.md
@@ -37,6 +37,8 @@ To build with Xcode, use the cmake Xcode generator to create the Xcode project:
 cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild -H. -GXcode
 ```
 
+Building for Mac requires a C++17 compliant compiler i.e. the Xcode clang compiler.
+
 ## Android
 
 First check that you have all of the [required dependencies](Dependencies.md#android).

--- a/docs/CONTRIBUTING/Compiling.md
+++ b/docs/CONTRIBUTING/Compiling.md
@@ -27,7 +27,15 @@ Configuration is available for cmake, [documented elsewhere](https://cmake.org/d
 
 First check that you have all of the [required dependencies](Dependencies.md#mac).
 
-Mac support is pretty early and while it will compile, it's not usable for debugging yet and is not officially supported. Builds happen with cmake the same way as Linux.
+Mac support is pretty early and while it will compile, it's not usable for debugging yet and is not officially supported. 
+
+To build with make, use cmake the same way as Linux.
+
+To build with Xcode, use the cmake Xcode generator to create the Xcode project:
+
+```
+cmake -DCMAKE_BUILD_TYPE=Debug -Bbuild -H. -GXcode
+```
 
 ## Android
 

--- a/docs/CONTRIBUTING/Dependencies.md
+++ b/docs/CONTRIBUTING/Dependencies.md
@@ -95,7 +95,7 @@ sudo apt-get install libx11-dev libx11-xcb-dev mesa-common-dev libgl1-mesa-dev l
 
 ## Mac
 
-Mac requires a recent version of CMake, and the same Qt version as the other platforms (at least 5.6.2). If you're using [homebrew](http://brew.sh) then this will do the trick:
+Mac requires Xcode version 12.2 or newer, CMake version 3.20 or newer, and Qt5 version 5.15.2 or newer. If you're using [homebrew](http://brew.sh) then this will do the trick:
 
 ```
 brew install cmake qt5

--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -330,7 +330,7 @@ add_custom_command(OUTPUT QRenderDoc
     DEPENDS RenderDoc.icns)
 add_custom_target(build-qrenderdoc ALL DEPENDS QRenderDoc DEPENDS renderdoc DEPENDS swig-bindings)
 
-if(APPLE)
+if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
     set_target_properties(build-qrenderdoc PROPERTIES XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING OFF)
     set_target_properties(build-qrenderdoc PROPERTIES XCODE_SCHEME_EXECUTABLE ${CMAKE_BINARY_DIR}/bin/qrenderdoc.app)
 


### PR DESCRIPTION
## Description

Update the Apple build documentation with the minimum required versions 
* Xcode 12.2
* CMake 3.20.0
* Qt 5.15.2

Validate clang and cmake minimum versions when building for Apple.

## Testing

Locally using cmake v3.20.0 generating makefiles and Xcode projects