### PR TITLE
Simplify MS GetTextureData by directly copying to Buffer using Compute

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -446,6 +446,8 @@ set(data
     data/glsl/deptharr2ms.frag
     data/glsl/depthms2arr.frag
     data/glsl/discard.frag
+    data/glsl/ms2buffer.comp
+    data/glsl/depthms2buffer.comp
     data/sourcecodepro.ttf
     driver/vulkan/renderdoc.json)
 

--- a/renderdoc/data/embedded_files.h
+++ b/renderdoc/data/embedded_files.h
@@ -69,5 +69,7 @@ DECLARE_EMBED(glsl_pixelhistory_primid_frag);
 DECLARE_EMBED(glsl_shaderdebug_sample_vert);
 DECLARE_EMBED(glsl_texremap_frag);
 DECLARE_EMBED(glsl_discard_frag);
+DECLARE_EMBED(glsl_ms2buffer_comp);
+DECLARE_EMBED(glsl_depthms2buffer_comp);
 
 #undef DECLARE_EMBED

--- a/renderdoc/data/glsl/depthms2buffer.comp
+++ b/renderdoc/data/glsl/depthms2buffer.comp
@@ -1,0 +1,134 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#if defined(OPENGL_CORE)
+#extension GL_ARB_compute_shader : require
+
+// safe to assume this extension in compute shaders as it pre-dates compute shaders
+#extension GL_ARB_shading_language_420pack : require
+#endif
+
+#include "glsl_globals.h"
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) uniform PRECISION sampler2DMSArray srcDepthMS;
+layout(binding = 1) uniform PRECISION usampler2DMSArray srcStencilMS;
+
+layout(binding = 2, std430) writeonly buffer dstBuf
+{
+  uint result[];
+};
+
+#define D16_UNORM 0
+#define D16_UNORM_S8_UINT 1
+#define X8_D24_UNORM_PACK32 2
+#define D24_UNORM_S8_UINT 3
+#define D32_SFLOAT 4
+#define D32_SFLOAT_S8_UINT 5
+
+#define MAX_D16 ((1 << 16) - 1)
+#define MAX_D24 ((1 << 24) - 1)
+
+#define floatToD16(depth) uint(MAX_D16 *depth)
+#define floatToD24(depth) uint(MAX_D24 *depth)
+
+#ifdef VULKAN
+
+layout(push_constant) uniform multisamplePush
+{
+  int numMultiSamples;
+  int baseSlice;
+  int baseSample;
+  int format;
+}
+mscopy;
+
+#define numMultiSamples (mscopy.numMultiSamples)
+#define baseSlice (mscopy.baseSlice)
+#define baseSample (mscopy.baseSample)
+#define format (mscopy.format)
+
+#else
+
+uniform ivec4 mscopy;
+
+#define numMultiSamples (mscopy.x)
+#define baseSlice (mscopy.y)
+#define baseSample (mscopy.z)
+#define format (mscopy.w)
+
+#endif
+
+void main()
+{
+  ivec3 id = ivec3(gl_GlobalInvocationID);
+  int slice = baseSlice + int(id.z / numMultiSamples);
+  int sampleIdx = baseSample + int(id.z % numMultiSamples);
+  uint idx = id.x + gl_NumWorkGroups.x * (id.y + (gl_NumWorkGroups.y * id.z));
+
+  // For D16, we need to sample 2 pixels at a time
+  if(format == D16_UNORM)
+  {
+    int w = int(textureSize(srcDepthMS).x);
+    int pxIdx = int(idx * 2);
+    int x0 = (pxIdx + 0) % w;
+    int y0 = (pxIdx + 0) / w;
+    int x1 = (pxIdx + 1) % w;
+    int y1 = (pxIdx + 1) / w;
+
+    vec2 depth = vec2(texelFetch(srcDepthMS, ivec3(x0, y0, slice), sampleIdx).x,
+                      texelFetch(srcDepthMS, ivec3(x1, y1, slice), sampleIdx).x);
+    result[idx] = (floatToD16(depth.x) << 0) | (floatToD16(depth.y) << 16);
+  }
+  else if(format == D16_UNORM_S8_UINT)
+  {
+    float depth = texelFetch(srcDepthMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    uint stencil = texelFetch(srcStencilMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    result[idx] = (floatToD16(depth) << 0) | (stencil << 16);
+  }
+  else if(format == X8_D24_UNORM_PACK32)
+  {
+    float depth = texelFetch(srcDepthMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    result[idx] = (floatToD24(depth) << 8);
+  }
+  else if(format == D24_UNORM_S8_UINT)
+  {
+    float depth = texelFetch(srcDepthMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    uint stencil = texelFetch(srcStencilMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    result[idx] = (floatToD24(depth) << 0) | (stencil << 24);
+  }
+  else if(format == D32_SFLOAT)
+  {
+    float depth = texelFetch(srcDepthMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    result[idx] = floatBitsToUint(depth);
+  }
+  else if(format == D32_SFLOAT_S8_UINT)
+  {
+    float depth = texelFetch(srcDepthMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    uint stencil = texelFetch(srcStencilMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    result[idx * 2 + 0] = floatBitsToUint(depth);
+    result[idx * 2 + 1] = stencil;
+  }
+}

--- a/renderdoc/data/glsl/ms2buffer.comp
+++ b/renderdoc/data/glsl/ms2buffer.comp
@@ -1,0 +1,130 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#if defined(OPENGL_CORE)
+#extension GL_ARB_compute_shader : require
+
+// safe to assume this extension in compute shaders as it pre-dates compute shaders
+#extension GL_ARB_shading_language_420pack : require
+#endif
+
+#include "glsl_globals.h"
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) uniform PRECISION usampler2DMSArray srcMS;
+// binding = 1 used as stencil read in the depth-stencil copy fragment shaders
+
+layout(binding = 2, std430) writeonly buffer dstBuf
+{
+  uint result[];
+};
+
+#ifdef VULKAN
+
+layout(push_constant) uniform multisamplePush
+{
+  int numMultiSamples;
+  int baseSlice;
+  int baseSample;
+  int byteSize;
+}
+mscopy;
+
+#define numMultiSamples (mscopy.numMultiSamples)
+#define baseSlice (mscopy.baseSlice)
+#define baseSample (mscopy.baseSample)
+#define byteSize (mscopy.byteSize)
+
+#else
+
+uniform ivec4 mscopy;
+
+#define numMultiSamples (mscopy.x)
+#define baseSlice (mscopy.y)
+#define baseSample (mscopy.z)
+#define byteSize (mscopy.w)
+
+#endif
+
+void main()
+{
+  ivec3 id = ivec3(gl_GlobalInvocationID);
+  int slice = baseSlice + int(id.z / numMultiSamples);
+  int sampleIdx = baseSample + int(id.z % numMultiSamples);
+  uint idx = id.x + gl_NumWorkGroups.x * (id.y + (gl_NumWorkGroups.y * id.z));
+
+  // for byteSize < 4, we sample multiple pixels to fill a single output buffer element
+  if(byteSize == 1)
+  {
+    int w = int(textureSize(srcMS).x);
+    int pxIdx = int(idx * 4);
+    int x0 = (pxIdx + 0) % w;
+    int y0 = (pxIdx + 0) / w;
+    int x1 = (pxIdx + 1) % w;
+    int y1 = (pxIdx + 1) / w;
+    int x2 = (pxIdx + 2) % w;
+    int y2 = (pxIdx + 2) / w;
+    int x3 = (pxIdx + 3) % w;
+    int y3 = (pxIdx + 3) / w;
+
+    uvec4 data = uvec4(texelFetch(srcMS, ivec3(x0, y0, slice), sampleIdx).x,
+                       texelFetch(srcMS, ivec3(x1, y1, slice), sampleIdx).x,
+                       texelFetch(srcMS, ivec3(x2, y2, slice), sampleIdx).x,
+                       texelFetch(srcMS, ivec3(x3, y3, slice), sampleIdx).x);
+    result[idx] = (data.x << 0 | data.y << 8 | data.z << 16 | data.w << 24);
+  }
+  else if(byteSize == 2)
+  {
+    int w = int(textureSize(srcMS).x);
+    int pxIdx = int(idx * 2);
+    int x0 = (pxIdx + 0) % w;
+    int y0 = (pxIdx + 0) / w;
+    int x1 = (pxIdx + 1) % w;
+    int y1 = (pxIdx + 1) / w;
+
+    uvec2 data = uvec2(texelFetch(srcMS, ivec3(x0, y0, slice), sampleIdx).x,
+                       texelFetch(srcMS, ivec3(x1, y1, slice), sampleIdx).x);
+    result[idx] = (data.x << 0 | data.y << 16);
+  }
+  else if(byteSize == 4)
+  {
+    uint data = texelFetch(srcMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).x;
+    result[idx] = data;
+  }
+  else if(byteSize == 8)
+  {
+    uvec2 data = texelFetch(srcMS, ivec3(int(id.x), int(id.y), slice), sampleIdx).xy;
+    result[idx * 2] = data.x;
+    result[idx * 2 + 1] = data.y;
+  }
+  else if(byteSize == 16)
+  {
+    uvec4 data = texelFetch(srcMS, ivec3(int(id.x), int(id.y), slice), sampleIdx);
+    result[idx * 4] = data.x;
+    result[idx * 4 + 1] = data.y;
+    result[idx * 4 + 2] = data.z;
+    result[idx * 4 + 3] = data.w;
+  }
+}

--- a/renderdoc/data/renderdoc.rc
+++ b/renderdoc/data/renderdoc.rc
@@ -174,6 +174,8 @@ RESOURCE_glsl_glsl_globals_h           TYPE_EMBED   "glsl/glsl_globals.h"
 RESOURCE_glsl_texremap_frag            TYPE_EMBED   "glsl/texremap.frag"
 RESOURCE_glsl_shaderdebug_sample_vert  TYPE_EMBED   "glsl/shaderdebug_sample.vert"
 RESOURCE_glsl_discard_frag             TYPE_EMBED   "glsl/discard.frag"
+RESOURCE_glsl_ms2buffer_comp           TYPE_EMBED   "glsl/ms2buffer.comp" 
+RESOURCE_glsl_depthms2buffer_comp      TYPE_EMBED   "glsl/depthms2buffer.comp"
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////

--- a/renderdoc/data/resource.h
+++ b/renderdoc/data/resource.h
@@ -60,6 +60,8 @@
 #define RESOURCE_glsl_pixelhistory_primid_frag       444
 #define RESOURCE_glsl_shaderdebug_sample_vert        445
 #define RESOURCE_glsl_discard_frag                   446
+#define RESOURCE_glsl_ms2buffer_comp                 447
+#define RESOURCE_glsl_depthms2buffer_comp            448
 
 // Next default values for new objects
 // 

--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources
     vk_shader_feedback.cpp
     vk_overlay.cpp
     vk_msaa_array_conv.cpp
+    vk_msaa_buffer_conv.cpp
     vk_outputwindow.cpp
     vk_rendermesh.cpp
     vk_rendertexture.cpp

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
@@ -109,6 +109,7 @@
     <ClCompile Include="vk_apple.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="vk_msaa_buffer_conv.cpp" />
     <ClCompile Include="vk_shader_feedback.cpp" />
     <ClCompile Include="vk_image_states.cpp" />
     <ClCompile Include="vk_msaa_array_conv.cpp" />

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
@@ -151,6 +151,9 @@
     <ClCompile Include="vk_shader_feedback.cpp">
       <Filter>Replay</Filter>
     </ClCompile>
+    <ClCompile Include="vk_msaa_buffer_conv.cpp">
+      <Filter>Replay</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vk_replay.h">

--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -68,6 +68,9 @@ public:
   void CopyArrayToTex2DMS(VkImage destMS, VkImage srcArray, VkExtent3D extent, uint32_t layers,
                           uint32_t samples, VkFormat fmt);
 
+  void CopyTex2DMSToBuffer(VkBuffer destBuffer, VkImage srcMS, VkExtent3D extent, uint32_t slice,
+                           uint32_t sample, VkFormat fmt);
+
   void FillWithDiscardPattern(VkCommandBuffer cmd, DiscardType type, VkImage image,
                               VkImageLayout curLayout, VkImageSubresourceRange discardRange,
                               VkRect2D discardRect);
@@ -132,6 +135,15 @@ private:
   VkPipeline m_MS2ArrayPipe = VK_NULL_HANDLE;
   VkSampler m_ArrayMSSampler = VK_NULL_HANDLE;
 
+  // CopyTex2DMSToBuffer
+  VkDescriptorPool m_MS2BufferDescriptorPool;
+  VkDescriptorSetLayout m_MS2BufferDescSetLayout = VK_NULL_HANDLE;
+  VkPipelineLayout m_MS2BufferPipeLayout = VK_NULL_HANDLE;
+  // For now we only need a single descriptor set
+  VkDescriptorSet m_MS2BufferDescSet = VK_NULL_HANDLE;
+  VkPipeline m_MS2BufferPipe = VK_NULL_HANDLE;
+  VkPipeline m_DepthMS2BufferPipe = VK_NULL_HANDLE;
+
   // [0] = non-MSAA, [1] = MSAA
   VkDeviceMemory m_DummyStencilMemory = VK_NULL_HANDLE;
   VkImage m_DummyStencilImage[2] = {VK_NULL_HANDLE};
@@ -163,6 +175,9 @@ private:
                                uint32_t samples, VkFormat fmt);
   void CopyDepthArrayToTex2DMS(VkImage destMS, VkImage srcArray, VkExtent3D extent, uint32_t layers,
                                uint32_t samples, VkFormat fmt);
+
+  void CopyDepthTex2DMSToBuffer(VkBuffer destBuffer, VkImage srcMS, VkExtent3D extent,
+                                uint32_t slice, uint32_t sample, VkFormat fmt);
 
   WrappedVulkan *m_pDriver = NULL;
 

--- a/renderdoc/driver/vulkan/vk_msaa_buffer_conv.cpp
+++ b/renderdoc/driver/vulkan/vk_msaa_buffer_conv.cpp
@@ -1,0 +1,302 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2021 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "maths/matrix.h"
+#include "vk_core.h"
+#include "vk_debug.h"
+
+#define VULKAN 1
+#include "data/glsl/glsl_ubos_cpp.h"
+
+void VulkanDebugManager::CopyTex2DMSToBuffer(VkBuffer destBuffer, VkImage srcMS, VkExtent3D extent,
+                                             uint32_t slice, uint32_t sample, VkFormat fmt)
+{
+  if(IsDepthOrStencilFormat(fmt))
+  {
+    CopyDepthTex2DMSToBuffer(destBuffer, srcMS, extent, slice, sample, fmt);
+    return;
+  }
+
+  if(m_MS2BufferPipe == VK_NULL_HANDLE)
+    return;
+
+  VkDevice dev = m_Device;
+
+  VkResult vkr = VK_SUCCESS;
+
+  VkImageView srcView;
+
+  VkImageViewCreateInfo viewInfo = {
+      VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+      NULL,
+      0,
+      srcMS,
+      VK_IMAGE_VIEW_TYPE_2D_ARRAY,
+      VK_FORMAT_UNDEFINED,
+      {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+       VK_COMPONENT_SWIZZLE_IDENTITY},
+      {
+          VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
+      },
+  };
+
+  uint32_t bs = GetByteSize(1, 1, 1, fmt, 0);
+
+  if(bs == 1)
+    viewInfo.format = VK_FORMAT_R8_UINT;
+  else if(bs == 2)
+    viewInfo.format = VK_FORMAT_R16_UINT;
+  else if(bs == 4)
+    viewInfo.format = VK_FORMAT_R32_UINT;
+  else if(bs == 8)
+    viewInfo.format = VK_FORMAT_R32G32_UINT;
+  else if(bs == 16)
+    viewInfo.format = VK_FORMAT_R32G32B32A32_UINT;
+
+  if(viewInfo.format == VK_FORMAT_UNDEFINED)
+  {
+    RDCERR("Can't copy 2D to Buffer with format %s", ToStr(fmt).c_str());
+    return;
+  }
+
+  VkMarkerRegion region("CopyTex2DMSToBuffer");
+
+  if(IsStencilOnlyFormat(fmt))
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+
+  vkr = ObjDisp(dev)->CreateImageView(Unwrap(dev), &viewInfo, NULL, &srcView);
+  CheckVkResult(vkr);
+  NameUnwrappedVulkanObject(srcView, "MS -> Buffer srcView");
+
+  VkCommandBufferBeginInfo beginInfo = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL,
+                                        VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
+
+  VkCommandBuffer cmd = m_pDriver->GetNextCmd();
+
+  if(cmd == VK_NULL_HANDLE)
+    return;
+
+  ObjDisp(cmd)->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
+
+  ObjDisp(cmd)->CmdBindPipeline(Unwrap(cmd), VK_PIPELINE_BIND_POINT_COMPUTE, Unwrap(m_MS2BufferPipe));
+
+  VkDescriptorImageInfo srcdesc = {0};
+  srcdesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+  srcdesc.imageView = srcView;
+  srcdesc.sampler = Unwrap(m_ArrayMSSampler);    // not used - we use texelFetch
+
+  VkDescriptorBufferInfo destdesc = {0};
+  destdesc.buffer = destBuffer;
+  destdesc.range = VK_WHOLE_SIZE;
+
+  VkWriteDescriptorSet writeSet[] = {
+      {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, Unwrap(m_MS2BufferDescSet), 0, 0, 1,
+       VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &srcdesc, NULL, NULL},
+      {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, Unwrap(m_MS2BufferDescSet), 2, 0, 1,
+       VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, NULL, &destdesc, NULL},
+  };
+
+  ObjDisp(dev)->UpdateDescriptorSets(Unwrap(dev), ARRAY_COUNT(writeSet), writeSet, 0, NULL);
+
+  ObjDisp(cmd)->CmdBindDescriptorSets(Unwrap(cmd), VK_PIPELINE_BIND_POINT_COMPUTE,
+                                      Unwrap(m_MS2BufferPipeLayout), 0, 1,
+                                      UnwrapPtr(m_MS2BufferDescSet), 0, NULL);
+
+  Vec4u params = {1, slice, sample, bs};
+
+  ObjDisp(cmd)->CmdPushConstants(Unwrap(cmd), Unwrap(m_MS2BufferPipeLayout), VK_SHADER_STAGE_ALL, 0,
+                                 sizeof(Vec4u), &params);
+
+  // if the byte size is less than 4, we need to multisample.
+  if(bs < 4)
+  {
+    uint32_t ms = 4 / bs;
+    // Use a 1D workgroup size so that we don't have to worry about width or height
+    // being a multiple of our multisample size
+    ObjDisp(cmd)->CmdDispatch(Unwrap(cmd), AlignUp(extent.width * extent.height, ms) / ms, 1, 1);
+  }
+  else
+  {
+    ObjDisp(cmd)->CmdDispatch(Unwrap(cmd), extent.width, extent.height, 1);
+  }
+
+  // finished, submit and flush
+  ObjDisp(cmd)->EndCommandBuffer(Unwrap(cmd));
+
+  cmd = VK_NULL_HANDLE;
+
+  // submit cmds and wait for idle so we can readback
+  m_pDriver->SubmitCmds();
+  m_pDriver->FlushQ();
+
+  ObjDisp(dev)->DestroyImageView(Unwrap(dev), srcView, NULL);
+}
+
+void VulkanDebugManager::CopyDepthTex2DMSToBuffer(VkBuffer destBuffer, VkImage srcMS,
+                                                  VkExtent3D extent, uint32_t slice,
+                                                  uint32_t sample, VkFormat fmt)
+{
+  if(m_DepthMS2BufferPipe == VK_NULL_HANDLE)
+    return;
+
+  VkImageAspectFlags aspectFlags = VK_IMAGE_ASPECT_DEPTH_BIT;
+  uint32_t fmtIndex = 0;
+  switch(fmt)
+  {
+    case VK_FORMAT_D16_UNORM: fmtIndex = 0; break;
+    case VK_FORMAT_D16_UNORM_S8_UINT:
+      fmtIndex = 1;
+      aspectFlags |= VK_IMAGE_ASPECT_STENCIL_BIT;
+      break;
+    case VK_FORMAT_X8_D24_UNORM_PACK32: fmtIndex = 2; break;
+    case VK_FORMAT_D24_UNORM_S8_UINT:
+      fmtIndex = 3;
+      aspectFlags |= VK_IMAGE_ASPECT_STENCIL_BIT;
+      break;
+    case VK_FORMAT_D32_SFLOAT: fmtIndex = 4; break;
+    case VK_FORMAT_D32_SFLOAT_S8_UINT:
+      fmtIndex = 5;
+      aspectFlags |= VK_IMAGE_ASPECT_STENCIL_BIT;
+      break;
+    default: RDCERR("Unexpected depth format: %d", fmt); return;
+  }
+
+  VkDevice dev = m_Device;
+
+  VkResult vkr = VK_SUCCESS;
+
+  VkImageView srcDepthView = VK_NULL_HANDLE, srcStencilView = VK_NULL_HANDLE;
+
+  VkImageViewCreateInfo viewInfo = {
+      VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+      NULL,
+      0,
+      srcMS,
+      VK_IMAGE_VIEW_TYPE_2D_ARRAY,
+      fmt,
+      {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO,
+       VK_COMPONENT_SWIZZLE_ZERO},
+      {
+          VK_IMAGE_ASPECT_DEPTH_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS,
+      },
+  };
+
+  vkr = ObjDisp(dev)->CreateImageView(Unwrap(dev), &viewInfo, NULL, &srcDepthView);
+  CheckVkResult(vkr);
+  NameUnwrappedVulkanObject(srcDepthView, "Depth MS -> Array srcDepthView");
+
+  if(aspectFlags & VK_IMAGE_ASPECT_STENCIL_BIT)
+  {
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    vkr = ObjDisp(dev)->CreateImageView(Unwrap(dev), &viewInfo, NULL, &srcStencilView);
+    CheckVkResult(vkr);
+    NameUnwrappedVulkanObject(srcStencilView, "Depth MS -> Array srcStencilView");
+  }
+
+  VkCommandBufferBeginInfo beginInfo = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL,
+                                        VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
+
+  VkCommandBuffer cmd = m_pDriver->GetNextCmd();
+
+  if(cmd == VK_NULL_HANDLE)
+    return;
+
+  ObjDisp(cmd)->BeginCommandBuffer(Unwrap(cmd), &beginInfo);
+
+  ObjDisp(cmd)->CmdBindPipeline(Unwrap(cmd), VK_PIPELINE_BIND_POINT_COMPUTE,
+                                Unwrap(m_DepthMS2BufferPipe));
+
+  VkDescriptorImageInfo srcdesc[2];
+  srcdesc[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+  srcdesc[0].imageView = srcDepthView;
+  srcdesc[0].sampler = Unwrap(m_ArrayMSSampler);    // not used - we use texelFetch
+  srcdesc[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+  srcdesc[1].imageView = srcStencilView;
+  srcdesc[1].sampler = Unwrap(m_ArrayMSSampler);    // not used - we use texelFetch
+
+  if((aspectFlags & VK_IMAGE_ASPECT_STENCIL_BIT) == 0)
+  {
+    if(m_DummyStencilView[0] != VK_NULL_HANDLE)
+    {
+      srcdesc[1].imageView = Unwrap(m_DummyStencilView[0]);
+    }
+    else
+    {
+      // as a last fallback, hope that setting an incompatible view (float not int) will not break
+      // too badly. This only gets hit when the implementation has such poor format support that
+      // there are no uint formats that can be sampled as MSAA.
+      srcdesc[1].imageView = srcDepthView;
+    }
+  }
+
+  VkDescriptorBufferInfo destdesc = {0};
+  destdesc.buffer = destBuffer;
+  destdesc.range = VK_WHOLE_SIZE;
+
+  VkWriteDescriptorSet writeSet[] = {
+      {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, Unwrap(m_MS2BufferDescSet), 0, 0, 1,
+       VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &srcdesc[0], NULL, NULL},
+      {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, Unwrap(m_MS2BufferDescSet), 1, 0, 1,
+       VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &srcdesc[1], NULL, NULL},
+      {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, Unwrap(m_MS2BufferDescSet), 2, 0, 1,
+       VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, NULL, &destdesc, NULL},
+  };
+
+  ObjDisp(dev)->UpdateDescriptorSets(Unwrap(dev), ARRAY_COUNT(writeSet), writeSet, 0, NULL);
+
+  ObjDisp(cmd)->CmdBindDescriptorSets(Unwrap(cmd), VK_PIPELINE_BIND_POINT_COMPUTE,
+                                      Unwrap(m_MS2BufferPipeLayout), 0, 1,
+                                      UnwrapPtr(m_MS2BufferDescSet), 0, NULL);
+
+  Vec4u params = {1, slice, sample, fmtIndex};
+
+  ObjDisp(cmd)->CmdPushConstants(Unwrap(cmd), Unwrap(m_MS2BufferPipeLayout), VK_SHADER_STAGE_ALL, 0,
+                                 sizeof(Vec4u), &params);
+
+  // for D16 textures, we need to multisample.
+  if(fmtIndex == 0)
+  {
+    const uint32_t ms = 2;
+    // Use a 1D workgroup size so that we don't have to worry about width or height
+    // being a multiple of our multisample size
+    ObjDisp(cmd)->CmdDispatch(Unwrap(cmd), AlignUp(extent.width * extent.height, ms) / ms, 1, 1);
+  }
+  else
+  {
+    ObjDisp(cmd)->CmdDispatch(Unwrap(cmd), extent.width, extent.height, 1);
+  }
+
+  // finished, submit and flush
+  ObjDisp(cmd)->EndCommandBuffer(Unwrap(cmd));
+
+  cmd = VK_NULL_HANDLE;
+
+  // submit cmds and wait for idle so we can readback
+  m_pDriver->SubmitCmds();
+  m_pDriver->FlushQ();
+
+  ObjDisp(dev)->DestroyImageView(Unwrap(dev), srcDepthView, NULL);
+  if(srcStencilView != VK_NULL_HANDLE)
+    ObjDisp(dev)->DestroyImageView(Unwrap(dev), srcStencilView, NULL);
+}

--- a/renderdoc/driver/vulkan/vk_shader_cache.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_cache.cpp
@@ -132,6 +132,10 @@ static const BuiltinShaderConfig builtinShaders[] = {
     BuiltinShaderConfig(BuiltinShader::MinMaxResultCS, EmbeddedResource(glsl_minmaxresult_comp),
                         rdcspv::ShaderStage::Compute, FeatureCheck::NoCheck,
                         BuiltinShaderFlags::BaseTypeParameterised),
+    BuiltinShaderConfig(BuiltinShader::MS2BufferCS, EmbeddedResource(glsl_ms2buffer_comp),
+                        rdcspv::ShaderStage::Compute),
+    BuiltinShaderConfig(BuiltinShader::DepthMS2BufferCS, EmbeddedResource(glsl_depthms2buffer_comp),
+                        rdcspv::ShaderStage::Compute),
 };
 
 RDCCOMPILE_ASSERT(ARRAY_COUNT(builtinShaders) == arraydim<BuiltinShader>(),

--- a/renderdoc/driver/vulkan/vk_shader_cache.h
+++ b/renderdoc/driver/vulkan/vk_shader_cache.h
@@ -60,6 +60,8 @@ enum class BuiltinShader
   HistogramCS,
   MinMaxTileCS,
   MinMaxResultCS,
+  MS2BufferCS,
+  DepthMS2BufferCS,
   Count,
 };
 


### PR DESCRIPTION
## Description

- Created ms2buffer.comp and depthms2buffer.comp shaders to replicate the functionality of CmdCopyImageToBuffer for MS Texture Arrays.
- Created CopyTex2DMSToBuffer and CopyDepthTexMSToBuffer methods to invoke compute said compute shaders
- Updated GetTextureData to use CopyTex2DMSToBuffer instead of CopyTex2DMSToArray.

This change speeds up copying a multisample color buffer by about 3x and a multisample depth/stencil buffer by ~14x.