### PR TITLE
Hooking for MTLDevice basic new Library APIs

### DIFF
--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -20,6 +20,8 @@ set(sources
     metal_function.h
     metal_function_bridge.mm
     metal_common.h
+    metal_helpers_bridge.h
+    metal_helpers_bridge.mm
     official/metal-cpp.h
     official/metal-cpp.cpp)
 

--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -20,6 +20,11 @@ set(sources
     metal_function.h
     metal_function_bridge.mm
     metal_common.h
+    metal_core.cpp
+    metal_core.h
+    metal_manager.cpp
+    metal_manager.h
+    metal_init_state.cpp
     metal_helpers_bridge.h
     metal_helpers_bridge.mm
     official/metal-cpp.h

--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources
     metal_resources.h
     metal_types_bridge.mm
     metal_types_bridge.h
+    metal_types.cpp
     metal_types.h
     metal_library.cpp
     metal_library.h

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -26,9 +26,23 @@
 
 #include "api/replay/rdcstr.h"
 #include "common/common.h"
+#include "common/timing.h"
 #include "official/metal-cpp.h"
+#include "serialise/serialiser.h"
 #include "metal_resources.h"
 #include "metal_types.h"
+
+enum class MetalChunk : uint32_t
+{
+  MTLCreateSystemDefaultDevice = (uint32_t)SystemChunk::FirstDriverChunk,
+  Max
+};
+
+DECLARE_REFLECTION_ENUM(MetalChunk);
+
+#define INSTANTIATE_FUNCTION_SERIALISED(CLASS, func, ...)      \
+  template bool CLASS::func(ReadSerialiser &ser, __VA_ARGS__); \
+  template bool CLASS::func(WriteSerialiser &ser, __VA_ARGS__);
 
 #ifdef __OBJC__
 #define METAL_NOT_HOOKED()                                                             \
@@ -37,3 +51,21 @@
     RDCWARN("Metal %s %s not hooked", class_getName([self class]), sel_getName(_cmd)); \
   } while((void)0, 0)
 #endif
+
+// similar to RDCUNIMPLEMENTED but without the debugbreak
+#define METAL_NOT_IMPLEMENTED(...)                                            \
+  do                                                                          \
+  {                                                                           \
+    RDCWARN("Metal '%s' not implemented -" __VA_ARGS__, __PRETTY_FUNCTION__); \
+  } while((void)0, 0)
+
+// similar to RDCUNIMPLEMENTED but for things that are hit often so we don't want to fire the
+// debugbreak.
+#define METAL_NOT_IMPLEMENTED_ONCE(...)                                           \
+  do                                                                              \
+  {                                                                               \
+    static bool msgprinted = false;                                               \
+    if(!msgprinted)                                                               \
+      RDCDEBUG("Metal '%s' not implemented - " __VA_ARGS__, __PRETTY_FUNCTION__); \
+    msgprinted = true;                                                            \
+  } while((void)0, 0)

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -29,7 +29,6 @@
 #include "common/timing.h"
 #include "official/metal-cpp.h"
 #include "serialise/serialiser.h"
-#include "serialise/serialiser.h"
 #include "metal_resources.h"
 #include "metal_types.h"
 

--- a/renderdoc/driver/metal/metal_core.h
+++ b/renderdoc/driver/metal/metal_core.h
@@ -22,32 +22,14 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "metal_resources.h"
-#include "metal_device.h"
+#pragma once
 
-ResourceId GetResID(WrappedMTLObject *obj)
+#include "metal_common.h"
+
+struct MetalInitParams
 {
-  if(obj == NULL)
-    return ResourceId();
+  // check if a frame capture section version is supported
+  static const uint64_t CurrentVersion = 0x1;
+};
 
-  return obj->id;
-}
-
-void WrappedMTLObject::Dealloc()
-{
-  // TODO: call the wrapped object destructor
-}
-
-MetalResourceManager *WrappedMTLObject::GetResourceManager()
-{
-  return m_WrappedMTLDevice->GetResourceManager();
-}
-
-MTL::Device *WrappedMTLObject::GetObjCWrappedMTLDevice()
-{
-  return GetObjC<MTL::Device *>(m_WrappedMTLDevice);
-}
-
-MetalResourceRecord::~MetalResourceRecord()
-{
-}
+DECLARE_REFLECTION_STRUCT(MetalInitParams);

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -50,21 +50,14 @@ WrappedMTLDevice *WrappedMTLDevice::MTLCreateSystemDefaultDevice(MTL::Device *re
 template <typename SerialiserType>
 bool WrappedMTLDevice::Serialise_newDefaultLibrary(SerialiserType &ser, WrappedMTLLibrary *library)
 {
-  void *pData;
-  uint32_t bytesCount;
+  bytebuf buffer;
   if(ser.IsWriting())
   {
-    ObjC::Get_defaultLibraryData(pData, bytesCount);
+    ObjC::Get_defaultLibraryData(buffer);
   }
 
   SERIALISE_ELEMENT_LOCAL(Library, GetResID(library)).TypedAs("MTLLibrary"_lit);
-  SERIALISE_ELEMENT(bytesCount);
-  SERIALISE_ELEMENT_ARRAY(pData, bytesCount);
-
-  if(ser.IsWriting())
-  {
-    free(pData);
-  }
+  SERIALISE_ELEMENT(buffer);
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -23,12 +23,24 @@
  ******************************************************************************/
 
 #include "metal_device.h"
+#include "metal_manager.h"
 
 WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
     : WrappedMTLObject(realMTLDevice, objId, this, GetStateRef())
 {
   wrappedObjC = AllocateObjCWrapper(this);
+  Construct();
+  GetResourceManager()->AddCurrentResource(objId, this);
+}
+
+void WrappedMTLDevice::Construct()
+{
+  objc = AllocateObjCWrapper(this);
   m_WrappedMTLDevice = this;
+  threadSerialiserTLSSlot = Threading::AllocateTLSSlot();
+
+  m_ResourceManager = new MetalResourceManager(m_State, this);
+  RDCASSERT(m_WrappedMTLDevice == this);
 }
 
 MTL::Device *WrappedMTLDevice::MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice)

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -30,7 +30,7 @@
 WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
     : WrappedMTLObject(realMTLDevice, objId, this, GetStateRef())
 {
-  objc = AllocateObjCWrapper(this);
+  objcBridge = AllocateObjCBridge(this);
   m_WrappedMTLDevice = this;
   threadSerialiserTLSSlot = Threading::AllocateTLSSlot();
 
@@ -44,7 +44,6 @@ WrappedMTLDevice *WrappedMTLDevice::MTLCreateSystemDefaultDevice(MTL::Device *re
   ResourceId objId = ResourceIDGen::GetNewUniqueID();
   WrappedMTLDevice *wrappedMTLDevice = new WrappedMTLDevice(realMTLDevice, objId);
 
-  // return GetObjC<MTL::Device *>(wrappedMTLDevice);
   return wrappedMTLDevice;
 }
 
@@ -80,7 +79,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newDefaultLibrary()
 {
   MTL::Library *realMTLLibrary;
 
-  SERIALISE_TIME_CALL(realMTLLibrary = Unwrap(this)->newDefaultLibrary());
+  SERIALISE_TIME_CALL(realMTLLibrary = GetReal()->newDefaultLibrary());
   WrappedMTLLibrary *wrappedMTLLibrary;
   ResourceId id = GetResourceManager()->WrapResource(realMTLLibrary, wrappedMTLLibrary);
   if(IsCaptureMode(m_State))
@@ -127,7 +126,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newLibraryWithSource(NS::String *source,
                                                           NS::Error **error)
 {
   MTL::Library *realMTLLibrary;
-  SERIALISE_TIME_CALL(realMTLLibrary = Unwrap(this)->newLibrary(source, options, error));
+  SERIALISE_TIME_CALL(realMTLLibrary = GetReal()->newLibrary(source, options, error));
   WrappedMTLLibrary *wrappedMTLLibrary;
   ResourceId id = GetResourceManager()->WrapResource(realMTLLibrary, wrappedMTLLibrary);
   if(IsCaptureMode(m_State))

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -34,7 +34,17 @@ class WrappedMTLDevice : public WrappedMTLObject
 public:
   WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId);
   ~WrappedMTLDevice() {}
-  static MTL::Device *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
+  static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
+
+  WrappedMTLLibrary *newDefaultLibrary();
+  template <typename SerialiserType>
+  bool Serialise_newDefaultLibrary(SerialiserType &ser, WrappedMTLLibrary *library);
+
+  WrappedMTLLibrary *newLibraryWithSource(NS::String *source, MTL::CompileOptions *options,
+                                          NS::Error **error);
+  template <typename SerialiserType>
+  bool Serialise_newLibraryWithSource(SerialiserType &ser, WrappedMTLLibrary *library,
+                                      NS::String *source, MTL::CompileOptions *options);
 
   CaptureState &GetStateRef() { return m_State; }
   CaptureState GetState() { return m_State; }
@@ -47,8 +57,6 @@ public:
   };
 
 private:
-  void Construct();
-
   bool Prepare_InitialState(WrappedMTLObject *res);
   uint64_t GetSize_InitialState(ResourceId id, const MetalInitialContents &initial);
   template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -34,6 +34,7 @@ class WrappedMTLDevice : public WrappedMTLObject
 public:
   WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId);
   ~WrappedMTLDevice() {}
+  MTL::Device *GetReal() { return (MTL::Device *)real; }
   static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
   WrappedMTLLibrary *newDefaultLibrary();

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -24,6 +24,7 @@
 
 #include "metal_device.h"
 #include <Availability.h>
+#include "metal_library.h"
 #include "metal_types_bridge.h"
 
 // Define Mac SDK versions when compiling with earlier SDKs
@@ -284,8 +285,9 @@
 
 - (nullable id<MTLLibrary>)newDefaultLibrary
 {
-  METAL_NOT_HOOKED();
-  return [self.real newDefaultLibrary];
+  WrappedMTLLibrary *wrapped = self.wrappedCPP->newDefaultLibrary();
+  MTL::Library *objc = GetObjC<MTL::Library *>(wrapped);
+  return id<MTLLibrary>(objc);
 }
 
 - (nullable id<MTLLibrary>)newDefaultLibraryWithBundle:(NSBundle *)bundle
@@ -322,8 +324,10 @@
                                         options:(nullable MTLCompileOptions *)options
                                           error:(__autoreleasing NSError **)error
 {
-  METAL_NOT_HOOKED();
-  return [self.real newLibraryWithSource:source options:options error:error];
+  WrappedMTLLibrary *wrapped = self.wrappedCPP->newLibraryWithSource(
+      (NS::String *)source, (MTL::CompileOptions *)options, (NS::Error **)error);
+  MTL::Library *objc = GetObjC<MTL::Library *>(wrapped);
+  return (id<MTLLibrary>)(objc);
 }
 
 - (void)newLibraryWithSource:(NSString *)source

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -37,7 +37,7 @@
 // ObjCWrappedMTLDevice specific
 - (id<MTLDevice>)real
 {
-  MTL::Device *real = Unwrap<MTL::Device *>(self.wrappedCPP);
+  MTL::Device *real = Unwrap(self.wrappedCPP);
   return id<MTLDevice>(real);
 }
 

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -32,13 +32,13 @@
 #define __MAC_12_0 120000
 #endif
 
-// Wrapper for MTLDevice
-@implementation ObjCWrappedMTLDevice
+// Bridge for MTLDevice
+@implementation ObjCBridgeMTLDevice
 
-// ObjCWrappedMTLDevice specific
+// ObjCBridgeMTLDevice specific
 - (id<MTLDevice>)real
 {
-  MTL::Device *real = Unwrap(self.wrappedCPP);
+  MTL::Device *real = self.wrappedCPP->GetReal();
   return id<MTLDevice>(real);
 }
 
@@ -286,7 +286,7 @@
 - (nullable id<MTLLibrary>)newDefaultLibrary
 {
   WrappedMTLLibrary *wrapped = self.wrappedCPP->newDefaultLibrary();
-  MTL::Library *objc = GetObjC<MTL::Library *>(wrapped);
+  MTL::Library *objc = GetObjCBridge<MTL::Library *>(wrapped);
   return id<MTLLibrary>(objc);
 }
 
@@ -326,7 +326,7 @@
 {
   WrappedMTLLibrary *wrapped = self.wrappedCPP->newLibraryWithSource(
       (NS::String *)source, (MTL::CompileOptions *)options, (NS::Error **)error);
-  MTL::Library *objc = GetObjC<MTL::Library *>(wrapped);
+  MTL::Library *objc = GetObjCBridge<MTL::Library *>(wrapped);
   return (id<MTLLibrary>)(objc);
 }
 

--- a/renderdoc/driver/metal/metal_function.cpp
+++ b/renderdoc/driver/metal/metal_function.cpp
@@ -29,5 +29,5 @@ WrappedMTLFunction::WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceI
                                        WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLFunction, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  objc = AllocateObjCWrapper(this);
+  objcBridge = AllocateObjCBridge(this);
 }

--- a/renderdoc/driver/metal/metal_function.cpp
+++ b/renderdoc/driver/metal/metal_function.cpp
@@ -29,5 +29,5 @@ WrappedMTLFunction::WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceI
                                        WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLFunction, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  wrappedObjC = AllocateObjCWrapper(this);
+  objc = AllocateObjCWrapper(this);
 }

--- a/renderdoc/driver/metal/metal_function.h
+++ b/renderdoc/driver/metal/metal_function.h
@@ -32,6 +32,7 @@ public:
   WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceId objId,
                      WrappedMTLDevice *wrappedMTLDevice);
 
+  MTL::Function *GetReal() { return (MTL::Function *)real; }
   enum
   {
     TypeEnum = eResFunction

--- a/renderdoc/driver/metal/metal_function_bridge.mm
+++ b/renderdoc/driver/metal/metal_function_bridge.mm
@@ -25,13 +25,13 @@
 #include "metal_function.h"
 #include "metal_types_bridge.h"
 
-// Wrapper for MTLFunction
-@implementation ObjCWrappedMTLFunction
+// Bridge for MTLFunction
+@implementation ObjCBridgeMTLFunction
 
-// ObjCWrappedMTLFunction specific
+// ObjCBrdigeMTLFunction specific
 - (id<MTLFunction>)real
 {
-  MTL::Function *real = Unwrap(self.wrappedCPP);
+  MTL::Function *real = self.wrappedCPP->GetReal();
   return id<MTLFunction>(real);
 }
 
@@ -56,7 +56,7 @@
 
 - (id<MTLDevice>)device
 {
-  return id<MTLDevice>(self.wrappedCPP->GetObjCWrappedMTLDevice());
+  return id<MTLDevice>(self.wrappedCPP->GetObjCBridgeMTLDevice());
 }
 
 - (MTLFunctionType)functionType

--- a/renderdoc/driver/metal/metal_function_bridge.mm
+++ b/renderdoc/driver/metal/metal_function_bridge.mm
@@ -31,7 +31,7 @@
 // ObjCWrappedMTLFunction specific
 - (id<MTLFunction>)real
 {
-  MTL::Function *real = Unwrap<MTL::Function *>(self.wrappedCPP);
+  MTL::Function *real = Unwrap(self.wrappedCPP);
   return id<MTLFunction>(real);
 }
 

--- a/renderdoc/driver/metal/metal_helpers_bridge.h
+++ b/renderdoc/driver/metal/metal_helpers_bridge.h
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "metal_types.h"
+
+namespace ObjC
+{
+void Get_defaultLibraryData(void *&pData, uint32_t &bytesCount);
+};

--- a/renderdoc/driver/metal/metal_helpers_bridge.h
+++ b/renderdoc/driver/metal/metal_helpers_bridge.h
@@ -28,5 +28,5 @@
 
 namespace ObjC
 {
-void Get_defaultLibraryData(void *&pData, uint32_t &bytesCount);
+void Get_defaultLibraryData(bytebuf &buffer);
 };

--- a/renderdoc/driver/metal/metal_helpers_bridge.mm
+++ b/renderdoc/driver/metal/metal_helpers_bridge.mm
@@ -26,7 +26,7 @@
 #import <AppKit/AppKit.h>
 #import <Foundation/NSStream.h>
 
-void ObjC::Get_defaultLibraryData(void *&pData, uint32_t &bytesCount)
+void ObjC::Get_defaultLibraryData(bytebuf &buffer)
 {
   NSBundle *mainAppBundle = [NSBundle mainBundle];
   NSString *defaultLibaryPath = [mainAppBundle pathForResource:@"default" ofType:@"metallib"];
@@ -34,8 +34,7 @@ void ObjC::Get_defaultLibraryData(void *&pData, uint32_t &bytesCount)
   dispatch_data_t data = dispatch_data_create(
       myData.bytes, myData.length, dispatch_get_main_queue(), DISPATCH_DATA_DESTRUCTOR_DEFAULT);
   NSData *nsData = (NSData *)data;
-  pData = malloc(nsData.length);
-  memcpy(pData, nsData.bytes, nsData.length);
-  bytesCount = (uint32_t)nsData.length;
+  buffer.resize(nsData.length);
+  memcpy(buffer.data(), nsData.bytes, buffer.size());
   dispatch_release(data);
 }

--- a/renderdoc/driver/metal/metal_helpers_bridge.mm
+++ b/renderdoc/driver/metal/metal_helpers_bridge.mm
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_helpers_bridge.h"
+#import <AppKit/AppKit.h>
+#import <Foundation/NSStream.h>
+
+void ObjC::Get_defaultLibraryData(void *&pData, uint32_t &bytesCount)
+{
+  NSBundle *mainAppBundle = [NSBundle mainBundle];
+  NSString *defaultLibaryPath = [mainAppBundle pathForResource:@"default" ofType:@"metallib"];
+  NSData *myData = [NSData dataWithContentsOfFile:defaultLibaryPath];
+  dispatch_data_t data = dispatch_data_create(
+      myData.bytes, myData.length, dispatch_get_main_queue(), DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+  NSData *nsData = (NSData *)data;
+  pData = malloc(nsData.length);
+  memcpy(pData, nsData.bytes, nsData.length);
+  bytesCount = (uint32_t)nsData.length;
+  dispatch_release(data);
+}

--- a/renderdoc/driver/metal/metal_hook_bridge.mm
+++ b/renderdoc/driver/metal/metal_hook_bridge.mm
@@ -54,7 +54,8 @@ id<MTLDevice> METAL_EXPORT_NAME(MTLCreateSystemDefaultDevice)(void)
   }
 
   id<MTLDevice> device = METAL.MTLCreateSystemDefaultDevice();
-  return id<MTLDevice>(WrappedMTLDevice::MTLCreateSystemDefaultDevice((MTL::Device *)device));
+  WrappedMTLDevice *wrapped = WrappedMTLDevice::MTLCreateSystemDefaultDevice((MTL::Device *)device);
+  return id<MTLDevice>(GetObjC<MTL::Device *>(wrapped));
 }
 
 /*

--- a/renderdoc/driver/metal/metal_hook_bridge.mm
+++ b/renderdoc/driver/metal/metal_hook_bridge.mm
@@ -55,7 +55,7 @@ id<MTLDevice> METAL_EXPORT_NAME(MTLCreateSystemDefaultDevice)(void)
 
   id<MTLDevice> device = METAL.MTLCreateSystemDefaultDevice();
   WrappedMTLDevice *wrapped = WrappedMTLDevice::MTLCreateSystemDefaultDevice((MTL::Device *)device);
-  return id<MTLDevice>(GetObjC<MTL::Device *>(wrapped));
+  return id<MTLDevice>(GetObjCBridge<MTL::Device *>(wrapped));
 }
 
 /*

--- a/renderdoc/driver/metal/metal_init_state.cpp
+++ b/renderdoc/driver/metal/metal_init_state.cpp
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_common.h"
+#include "metal_device.h"
+
+bool WrappedMTLDevice::Prepare_InitialState(WrappedMTLObject *res)
+{
+  ResourceId id = GetResourceManager()->GetID(res);
+
+  MetalResourceType type = res->record->resType;
+  {
+    RDCERR("Unhandled resource type %d", type);
+  }
+
+  return false;
+}
+
+uint64_t WrappedMTLDevice::GetSize_InitialState(ResourceId id, const MetalInitialContents &initial)
+{
+  METAL_NOT_IMPLEMENTED();
+  return 128;
+}
+
+template <typename SerialiserType>
+bool WrappedMTLDevice::Serialise_InitialState(SerialiserType &ser, ResourceId id,
+                                              MetalResourceRecord *record,
+                                              const MetalInitialContents *initial)
+{
+  METAL_NOT_IMPLEMENTED();
+  return false;
+}
+
+void WrappedMTLDevice::Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData)
+{
+  METAL_NOT_IMPLEMENTED();
+}
+
+void WrappedMTLDevice::Apply_InitialState(WrappedMTLObject *live, const MetalInitialContents &initial)
+{
+  METAL_NOT_IMPLEMENTED();
+}
+
+template bool WrappedMTLDevice::Serialise_InitialState(ReadSerialiser &ser, ResourceId id,
+                                                       MetalResourceRecord *record,
+                                                       const MetalInitialContents *initial);
+template bool WrappedMTLDevice::Serialise_InitialState(WriteSerialiser &ser, ResourceId id,
+                                                       MetalResourceRecord *record,
+                                                       const MetalInitialContents *initial);

--- a/renderdoc/driver/metal/metal_library.cpp
+++ b/renderdoc/driver/metal/metal_library.cpp
@@ -30,5 +30,5 @@ WrappedMTLLibrary::WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId ob
                                      WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLLibrary, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  objc = AllocateObjCWrapper(this);
+  objcBridge = AllocateObjCBridge(this);
 }

--- a/renderdoc/driver/metal/metal_library.cpp
+++ b/renderdoc/driver/metal/metal_library.cpp
@@ -30,5 +30,5 @@ WrappedMTLLibrary::WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId ob
                                      WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLLibrary, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  wrappedObjC = AllocateObjCWrapper(this);
+  objc = AllocateObjCWrapper(this);
 }

--- a/renderdoc/driver/metal/metal_library.h
+++ b/renderdoc/driver/metal/metal_library.h
@@ -32,6 +32,7 @@ public:
   WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId objId,
                     WrappedMTLDevice *wrappedMTLDevice);
 
+  MTL::Library *GetReal() { return (MTL::Library *)real; }
   enum
   {
     TypeEnum = eResLibrary

--- a/renderdoc/driver/metal/metal_library_bridge.mm
+++ b/renderdoc/driver/metal/metal_library_bridge.mm
@@ -25,13 +25,13 @@
 #include "metal_library.h"
 #include "metal_types_bridge.h"
 
-// Wrapper for MTLLibrary
-@implementation ObjCWrappedMTLLibrary
+// Bridge for MTLLibrary
+@implementation ObjCBridgeMTLLibrary
 
-// ObjCWrappedMTLLibrary specific
+// ObjCBridgeMTLLibrary specific
 - (id<MTLLibrary>)real
 {
-  MTL::Library *real = Unwrap(self.wrappedCPP);
+  MTL::Library *real = self.wrappedCPP->GetReal();
   return id<MTLLibrary>(real);
 }
 
@@ -68,7 +68,7 @@
 
 - (id<MTLDevice>)device
 {
-  return id<MTLDevice>(self.wrappedCPP->GetObjCWrappedMTLDevice());
+  return id<MTLDevice>(self.wrappedCPP->GetObjCBridgeMTLDevice());
 }
 
 - (nullable id<MTLFunction>)newFunctionWithName:(NSString *)functionName

--- a/renderdoc/driver/metal/metal_library_bridge.mm
+++ b/renderdoc/driver/metal/metal_library_bridge.mm
@@ -31,7 +31,7 @@
 // ObjCWrappedMTLLibrary specific
 - (id<MTLLibrary>)real
 {
-  MTL::Library *real = Unwrap<MTL::Library *>(self.wrappedCPP);
+  MTL::Library *real = Unwrap(self.wrappedCPP);
   return id<MTLLibrary>(real);
 }
 

--- a/renderdoc/driver/metal/metal_manager.cpp
+++ b/renderdoc/driver/metal/metal_manager.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Baldur Karlsson
+ * Copyright (c) 2021 Baldur Karlsson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,32 +22,39 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "metal_resources.h"
+#include "metal_manager.h"
 #include "metal_device.h"
 
-ResourceId GetResID(WrappedMTLObject *obj)
+bool MetalResourceManager::ResourceTypeRelease(WrappedResourceType res)
 {
-  if(obj == NULL)
-    return ResourceId();
-
-  return obj->id;
+  METAL_NOT_IMPLEMENTED();
+  return false;
 }
 
-void WrappedMTLObject::Dealloc()
+bool MetalResourceManager::Prepare_InitialState(WrappedMTLObject *res)
 {
-  // TODO: call the wrapped object destructor
+  return m_WrappedMTLDevice->Prepare_InitialState(res);
 }
 
-MetalResourceManager *WrappedMTLObject::GetResourceManager()
+uint64_t MetalResourceManager::GetSize_InitialState(ResourceId id, const MetalInitialContents &initial)
 {
-  return m_WrappedMTLDevice->GetResourceManager();
+  return m_WrappedMTLDevice->GetSize_InitialState(id, initial);
 }
 
-MTL::Device *WrappedMTLObject::GetObjCWrappedMTLDevice()
+bool MetalResourceManager::Serialise_InitialState(WriteSerialiser &ser, ResourceId id,
+                                                  MetalResourceRecord *record,
+                                                  const MetalInitialContents *initial)
 {
-  return GetObjC<MTL::Device *>(m_WrappedMTLDevice);
+  return m_WrappedMTLDevice->Serialise_InitialState(ser, id, record, initial);
 }
 
-MetalResourceRecord::~MetalResourceRecord()
+void MetalResourceManager::Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData)
 {
+  return m_WrappedMTLDevice->Create_InitialState(id, live, hasData);
+}
+
+void MetalResourceManager::Apply_InitialState(WrappedMTLObject *live,
+                                              const MetalInitialContents &initial)
+{
+  return m_WrappedMTLDevice->Apply_InitialState(live, initial);
 }

--- a/renderdoc/driver/metal/metal_manager.h
+++ b/renderdoc/driver/metal/metal_manager.h
@@ -1,0 +1,151 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "core/resource_manager.h"
+#include "metal_resources.h"
+
+struct MetalInitialContents
+{
+  MetalInitialContents()
+  {
+    RDCCOMPILE_ASSERT(std::is_standard_layout<MetalInitialContents>::value,
+                      "MetalInitialContents must be POD");
+    memset(this, 0, sizeof(*this));
+  }
+
+  MetalInitialContents(MetalResourceType t)
+  {
+    memset(this, 0, sizeof(*this));
+    type = t;
+  }
+
+  template <typename Configuration>
+  void Free(ResourceManager<Configuration> *rm)
+  {
+    RDCASSERT(false);
+  }
+  bytebuf resourceContents;
+
+  // for plain resources, we store the resource type
+  MetalResourceType type;
+};
+
+struct MetalResourceManagerConfiguration
+{
+  typedef WrappedMTLObject *WrappedResourceType;
+  typedef void *RealResourceType;
+  typedef MetalResourceRecord RecordType;
+  typedef MetalInitialContents InitialContentData;
+};
+
+class MetalResourceManager : public ResourceManager<MetalResourceManagerConfiguration>
+{
+public:
+  MetalResourceManager(CaptureState &state, WrappedMTLDevice *device)
+      : ResourceManager(state), m_WrappedMTLDevice(device)
+  {
+  }
+  void SetState(CaptureState state) { m_State = state; }
+  CaptureState GetState() { return m_State; }
+  ~MetalResourceManager() {}
+  void ClearWithoutReleasing()
+  {
+    // if any objects leaked past, it's no longer safe to delete them as we would
+    // be calling Shutdown() after the device that owns them is destroyed. Instead
+    // we just have to leak ourselves.
+    RDCASSERT(m_LiveResourceMap.empty());
+    RDCASSERT(m_InitialContents.empty());
+    RDCASSERT(m_ResourceRecords.empty());
+    RDCASSERT(m_CurrentResourceMap.empty());
+    RDCASSERT(m_WrapperMap.empty());
+
+    m_LiveResourceMap.clear();
+    m_InitialContents.clear();
+    m_ResourceRecords.clear();
+    m_CurrentResourceMap.clear();
+    m_WrapperMap.clear();
+  }
+
+  // ResourceManager interface
+  ResourceId GetID(WrappedMTLObject *res)
+  {
+    if(res == NULL)
+      return ResourceId();
+
+    return res->id;
+  }
+  // ResourceManager interface
+
+  template <typename realtype>
+  ResourceId WrapResource(realtype obj, typename UnwrapHelper<realtype>::Outer *&wrapped)
+  {
+    RDCASSERT(obj != NULL);
+    RDCASSERT(m_WrappedMTLDevice != NULL);
+
+    ResourceId id = ResourceIDGen::GetNewUniqueID();
+    using WrappedType = typename UnwrapHelper<realtype>::Outer;
+    wrapped = new WrappedType(obj, id, m_WrappedMTLDevice);
+    wrapped->real = obj;
+    AddCurrentResource(id, wrapped);
+
+    // TODO: implement RD MTL replay
+    //    if(IsReplayMode(m_State))
+    //     AddWrapper(wrapMetalResourceManager(obj));
+    return id;
+  }
+
+  using ResourceManager::AddResourceRecord;
+
+  template <typename wrappedtype>
+  MetalResourceRecord *AddResourceRecord(wrappedtype *wrapped)
+  {
+    MetalResourceRecord *ret = wrapped->record = ResourceManager::AddResourceRecord(wrapped->id);
+
+    ret->Resource = (WrappedMTLObject *)wrapped;
+    ret->resType = (MetalResourceType)wrappedtype::TypeEnum;
+    return ret;
+  }
+
+  // ResourceRecordHandler interface implemented in ResourceManager
+  //  void MarkDirtyResource(ResourceId id);
+  //  void RemoveResourceRecord(ResourceId id);
+  //  void MarkResourceFrameReferenced(ResourceId id, FrameRefType refType);
+  //  void DestroyResourceRecord(ResourceRecord *record);
+  // ResourceRecordHandler interface
+
+private:
+  // ResourceManager interface
+  bool ResourceTypeRelease(WrappedMTLObject *res);
+  bool Prepare_InitialState(WrappedMTLObject *res);
+  uint64_t GetSize_InitialState(ResourceId id, const MetalInitialContents &initial);
+  bool Serialise_InitialState(WriteSerialiser &ser, ResourceId id, MetalResourceRecord *record,
+                              const MetalInitialContents *initial);
+  void Create_InitialState(ResourceId id, WrappedMTLObject *live, bool hasData);
+  void Apply_InitialState(WrappedMTLObject *live, const MetalInitialContents &initial);
+  // ResourceManager interface
+
+  WrappedMTLDevice *m_WrappedMTLDevice;
+};

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -25,6 +25,14 @@
 #include "metal_resources.h"
 #include "metal_device.h"
 
+ResourceId GetResID(WrappedMTLObject *obj)
+{
+  if(obj == NULL)
+    return ResourceId();
+
+  return obj->id;
+}
+
 void WrappedMTLObject::Dealloc()
 {
   // TODO: call the wrapped object destructor

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -34,3 +34,7 @@ MTL::Device *WrappedMTLObject::GetObjCWrappedMTLDevice()
 {
   return UnwrapObjC<MTL::Device *>(m_WrappedMTLDevice);
 }
+
+MetalResourceRecord::~MetalResourceRecord()
+{
+}

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -43,9 +43,9 @@ MetalResourceManager *WrappedMTLObject::GetResourceManager()
   return m_WrappedMTLDevice->GetResourceManager();
 }
 
-MTL::Device *WrappedMTLObject::GetObjCWrappedMTLDevice()
+MTL::Device *WrappedMTLObject::GetObjCBridgeMTLDevice()
 {
-  return GetObjC<MTL::Device *>(m_WrappedMTLDevice);
+  return GetObjCBridge<MTL::Device *>(m_WrappedMTLDevice);
 }
 
 MetalResourceRecord::~MetalResourceRecord()

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -27,6 +27,7 @@
 #include "core/resource_manager.h"
 #include "metal_common.h"
 
+struct MetalResourceRecord;
 class WrappedMTLDevice;
 
 enum MetalResourceType
@@ -43,7 +44,11 @@ struct WrappedMTLObject
 {
   WrappedMTLObject() = delete;
   WrappedMTLObject(WrappedMTLDevice *wrappedMTLDevice, CaptureState &captureState)
-      : wrappedObjC(NULL), real(NULL), m_WrappedMTLDevice(wrappedMTLDevice), m_State(captureState)
+      : wrappedObjC(NULL),
+        real(NULL),
+        record(NULL),
+        m_WrappedMTLDevice(wrappedMTLDevice),
+        m_State(captureState)
   {
   }
   WrappedMTLObject(void *mtlObject, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice,
@@ -51,6 +56,7 @@ struct WrappedMTLObject
       : wrappedObjC(NULL),
         real(mtlObject),
         id(objId),
+        record(NULL),
         m_WrappedMTLDevice(wrappedMTLDevice),
         m_State(captureState)
   {
@@ -64,6 +70,7 @@ struct WrappedMTLObject
   void *wrappedObjC;
   void *real;
   ResourceId id;
+  MetalResourceRecord *record;
   WrappedMTLDevice *m_WrappedMTLDevice;
   CaptureState &m_State;
 };
@@ -85,3 +92,26 @@ RealType UnwrapObjC(WrappedMTLObject *obj)
 
   return (RealType)obj->wrappedObjC;
 }
+
+struct MetalResourceRecord : public ResourceRecord
+{
+public:
+  enum
+  {
+    NullResource = NULL
+  };
+
+  MetalResourceRecord(ResourceId id)
+      : ResourceRecord(id, true), Resource(NULL), resType(eResUnknown), ptrUnion(NULL)
+  {
+  }
+  ~MetalResourceRecord();
+  WrappedMTLObject *Resource;
+  MetalResourceType resType;
+
+  // Each entry is only used by specific record types
+  union
+  {
+    void *ptrUnion;    // for initialisation to NULL
+  };
+};

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -46,7 +46,7 @@ struct WrappedMTLObject
 {
   WrappedMTLObject() = delete;
   WrappedMTLObject(WrappedMTLDevice *wrappedMTLDevice, CaptureState &captureState)
-      : objc(NULL),
+      : objcBridge(NULL),
         real(NULL),
         record(NULL),
         m_WrappedMTLDevice(wrappedMTLDevice),
@@ -55,7 +55,7 @@ struct WrappedMTLObject
   }
   WrappedMTLObject(void *mtlObject, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice,
                    CaptureState &captureState)
-      : objc(NULL),
+      : objcBridge(NULL),
         real(mtlObject),
         id(objId),
         record(NULL),
@@ -67,11 +67,11 @@ struct WrappedMTLObject
 
   void Dealloc();
 
-  MTL::Device *GetObjCWrappedMTLDevice();
+  MTL::Device *GetObjCBridgeMTLDevice();
 
   MetalResourceManager *GetResourceManager();
 
-  void *objc;
+  void *objcBridge;
   void *real;
   ResourceId id;
   MetalResourceRecord *record;
@@ -100,12 +100,12 @@ RealType Unwrap(WrappedMTLObject *obj)
 }
 
 template <typename RealType>
-RealType GetObjC(WrappedMTLObject *obj)
+RealType GetObjCBridge(WrappedMTLObject *obj)
 {
   if(obj == NULL)
     return RealType();
 
-  return (RealType)obj->objc;
+  return (RealType)obj->objcBridge;
 }
 
 // template magic voodoo to unwrap types

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -75,6 +75,8 @@ struct WrappedMTLObject
   CaptureState &m_State;
 };
 
+ResourceId GetResID(WrappedMTLObject *obj);
+
 template <typename RealType>
 RealType Unwrap(WrappedMTLObject *obj)
 {

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -22,26 +22,26 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#pragma once
+#include "metal_types.h"
 
-#include "metal_common.h"
+RDCCOMPILE_ASSERT(sizeof(NS::Integer) == sizeof(std::intptr_t), "NS::Integer size does not match");
+RDCCOMPILE_ASSERT(sizeof(NS::UInteger) == sizeof(std::uintptr_t),
+                  "NS::UInteger size does not match");
 
-#define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
-  FUNC(Device);                          \
-  FUNC(Function);                        \
-  FUNC(Library);
-
-#define DECLARE_OBJC_HELPERS(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;          \
-  extern MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrapped);
-
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
-#undef DECLARE_OBJC_HELPERS
-
-template <>
-inline rdcliteral TypeName<NS::String *>()
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, NS::String *&el)
 {
-  return "NSString"_lit;
+  rdcstr rdcStr;
+  if(el)
+  {
+    rdcStr = el->utf8String();
+  }
+  DoSerialise(ser, rdcStr);
+
+  if(ser.IsReading())
+  {
+    el = NS::String::string(rdcStr.data(), NS::UTF8StringEncoding);
+  }
 }
-template <class SerialiserType>
-void DoSerialise(SerialiserType &ser, NS::String *&el);
+
+INSTANTIATE_SERIALISE_TYPE(NS::String *);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -38,7 +38,7 @@
   extern WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *objCWrapped); \
   extern MTL::CPPTYPE *GetReal(MTL::CPPTYPE *objCWrapped);           \
   extern bool IsObjCWrapped(MTL::CPPTYPE *objCWrapped);              \
-  extern ResourceId GetId(MTL::CPPTYPE *objCWrapped);                \
+  extern ResourceId GetResId(MTL::CPPTYPE *objCWrapped);             \
   extern MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -33,8 +33,12 @@
   FUNC(Function);                        \
   FUNC(Library);
 
-#define DECLARE_OBJC_HELPERS(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;          \
+#define DECLARE_OBJC_HELPERS(CPPTYPE)                                \
+  class WrappedMTL##CPPTYPE;                                         \
+  extern WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *objCWrapped); \
+  extern MTL::CPPTYPE *GetReal(MTL::CPPTYPE *objCWrapped);           \
+  extern bool IsObjCWrapped(MTL::CPPTYPE *objCWrapped);              \
+  extern ResourceId GetId(MTL::CPPTYPE *objCWrapped);                \
   extern MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -38,7 +38,7 @@
   extern WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *objCWrapped); \
   extern MTL::CPPTYPE *GetReal(MTL::CPPTYPE *objCWrapped);           \
   extern bool IsObjCWrapped(MTL::CPPTYPE *objCWrapped);              \
-  extern ResourceId GetResId(MTL::CPPTYPE *objCWrapped);             \
+  extern ResourceId GetResID(MTL::CPPTYPE *objCWrapped);             \
   extern MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -35,7 +35,7 @@
 
 #define DECLARE_OBJC_HELPERS(CPPTYPE) \
   class WrappedMTL##CPPTYPE;          \
-  extern MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrapped);
+  extern MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_HELPERS)
 #undef DECLARE_OBJC_HELPERS

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
-#include "metal_common.h"
+#include "api/replay/rdcstr.h"
+#include "official/metal-cpp.h"
+#include "serialise/serialiser.h"
 
 #define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
   FUNC(Device);                          \

--- a/renderdoc/driver/metal/metal_types_bridge.h
+++ b/renderdoc/driver/metal/metal_types_bridge.h
@@ -31,7 +31,7 @@
 
 // clang-format off
 #define DECLARE_OBJC_WRAPPED_INTERFACES(CPPTYPE)              \
-  @interface ObjCWrappedMTL##CPPTYPE : NSObject<MTL##CPPTYPE> \
+  @interface ObjCBridgeMTL##CPPTYPE : NSObject<MTL##CPPTYPE> \
     @property(assign) WrappedMTL##CPPTYPE *wrappedCPP;        \
     @property(readonly) id<MTL##CPPTYPE> real;                \
   @end

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -28,34 +28,34 @@
 #include "metal_library.h"
 
 #define DEFINE_OBJC_HELPERS(CPPTYPE)                                               \
-  static ObjCWrappedMTL##CPPTYPE *GetObjC(MTL::CPPTYPE *cppType)                   \
+  static ObjCBridgeMTL##CPPTYPE *GetObjCBridge(MTL::CPPTYPE *cppType)              \
   {                                                                                \
     if(cppType == NULL)                                                            \
     {                                                                              \
       return NULL;                                                                 \
     }                                                                              \
-    ObjCWrappedMTL##CPPTYPE *objC = (ObjCWrappedMTL##CPPTYPE *)cppType;            \
-    RDCASSERT([objC isKindOfClass:[ObjCWrappedMTL##CPPTYPE class]]);               \
+    ObjCBridgeMTL##CPPTYPE *objC = (ObjCBridgeMTL##CPPTYPE *)cppType;              \
+    RDCASSERT([objC isKindOfClass:[ObjCBridgeMTL##CPPTYPE class]]);                \
     return objC;                                                                   \
   }                                                                                \
                                                                                    \
   WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *cppType)                           \
   {                                                                                \
-    ObjCWrappedMTL##CPPTYPE *objC = GetObjC(cppType);                              \
+    ObjCBridgeMTL##CPPTYPE *objC = GetObjCBridge(cppType);                         \
     return objC.wrappedCPP;                                                        \
   }                                                                                \
                                                                                    \
   MTL::CPPTYPE *GetReal(MTL::CPPTYPE *cppType)                                     \
   {                                                                                \
-    ObjCWrappedMTL##CPPTYPE *objC = GetObjC(cppType);                              \
+    ObjCBridgeMTL##CPPTYPE *objC = GetObjCBridge(cppType);                         \
     MTL::CPPTYPE *real = (MTL::CPPTYPE *)objC.real;                                \
     return real;                                                                   \
   }                                                                                \
                                                                                    \
-  bool IsObjCWrapped(MTL::CPPTYPE *cppType)                                        \
+  bool IsObjCBridge(MTL::CPPTYPE *cppType)                                         \
   {                                                                                \
-    ObjCWrappedMTL##CPPTYPE *objC = (ObjCWrappedMTL##CPPTYPE *)cppType;            \
-    return [objC isKindOfClass:[ObjCWrappedMTL##CPPTYPE class]];                   \
+    ObjCBridgeMTL##CPPTYPE *objC = (ObjCBridgeMTL##CPPTYPE *)cppType;              \
+    return [objC isKindOfClass:[ObjCBridgeMTL##CPPTYPE class]];                    \
   }                                                                                \
                                                                                    \
   ResourceId GetId(MTL::CPPTYPE *cppType)                                          \
@@ -68,9 +68,9 @@
     return wrappedCPP->id;                                                         \
   }                                                                                \
                                                                                    \
-  MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrappedCPP)               \
+  MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrappedCPP)                \
   {                                                                                \
-    ObjCWrappedMTL##CPPTYPE *objC = [ObjCWrappedMTL##CPPTYPE alloc];               \
+    ObjCBridgeMTL##CPPTYPE *objC = [ObjCBridgeMTL##CPPTYPE alloc];                 \
     objC.wrappedCPP = wrappedCPP;                                                  \
     MTL::CPPTYPE *real = (MTL::CPPTYPE *)objC.real;                                \
     if(real)                                                                       \

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -58,7 +58,7 @@
     return [objC isKindOfClass:[ObjCBridgeMTL##CPPTYPE class]];                    \
   }                                                                                \
                                                                                    \
-  ResourceId GetResId(MTL::CPPTYPE *cppType)                                       \
+  ResourceId GetResID(MTL::CPPTYPE *cppType)                                       \
   {                                                                                \
     WrappedMTL##CPPTYPE *wrappedCPP = GetWrapped(cppType);                         \
     if(wrappedCPP == NULL)                                                         \

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -58,7 +58,7 @@
     return [objC isKindOfClass:[ObjCBridgeMTL##CPPTYPE class]];                    \
   }                                                                                \
                                                                                    \
-  ResourceId GetId(MTL::CPPTYPE *cppType)                                          \
+  ResourceId GetResId(MTL::CPPTYPE *cppType)                                       \
   {                                                                                \
     WrappedMTL##CPPTYPE *wrappedCPP = GetWrapped(cppType);                         \
     if(wrappedCPP == NULL)                                                         \

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -24,9 +24,50 @@
 
 #include "metal_types_bridge.h"
 #include "metal_device.h"
+#include "metal_function.h"
 #include "metal_library.h"
 
 #define DEFINE_OBJC_HELPERS(CPPTYPE)                                               \
+  static ObjCWrappedMTL##CPPTYPE *GetObjC(MTL::CPPTYPE *cppType)                   \
+  {                                                                                \
+    if(cppType == NULL)                                                            \
+    {                                                                              \
+      return NULL;                                                                 \
+    }                                                                              \
+    ObjCWrappedMTL##CPPTYPE *objC = (ObjCWrappedMTL##CPPTYPE *)cppType;            \
+    RDCASSERT([objC isKindOfClass:[ObjCWrappedMTL##CPPTYPE class]]);               \
+    return objC;                                                                   \
+  }                                                                                \
+                                                                                   \
+  WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *cppType)                           \
+  {                                                                                \
+    ObjCWrappedMTL##CPPTYPE *objC = GetObjC(cppType);                              \
+    return objC.wrappedCPP;                                                        \
+  }                                                                                \
+                                                                                   \
+  MTL::CPPTYPE *GetReal(MTL::CPPTYPE *cppType)                                     \
+  {                                                                                \
+    ObjCWrappedMTL##CPPTYPE *objC = GetObjC(cppType);                              \
+    MTL::CPPTYPE *real = (MTL::CPPTYPE *)objC.real;                                \
+    return real;                                                                   \
+  }                                                                                \
+                                                                                   \
+  bool IsObjCWrapped(MTL::CPPTYPE *cppType)                                        \
+  {                                                                                \
+    ObjCWrappedMTL##CPPTYPE *objC = (ObjCWrappedMTL##CPPTYPE *)cppType;            \
+    return [objC isKindOfClass:[ObjCWrappedMTL##CPPTYPE class]];                   \
+  }                                                                                \
+                                                                                   \
+  ResourceId GetId(MTL::CPPTYPE *cppType)                                          \
+  {                                                                                \
+    WrappedMTL##CPPTYPE *wrappedCPP = GetWrapped(cppType);                         \
+    if(wrappedCPP == NULL)                                                         \
+    {                                                                              \
+      return ResourceId();                                                         \
+    }                                                                              \
+    return wrappedCPP->id;                                                         \
+  }                                                                                \
+                                                                                   \
   MTL::CPPTYPE *AllocateObjCWrapper(WrappedMTL##CPPTYPE *wrappedCPP)               \
   {                                                                                \
     ObjCWrappedMTL##CPPTYPE *objC = [ObjCWrappedMTL##CPPTYPE alloc];               \


### PR DESCRIPTION
## Description

Hooking and serialization for MTLDevice basic new Library APIs

MTLDevice::newDefaultLibrary
MTLDevice::newLibraryWithSource

The hooked APIs return wrapped MTLLibrary objects to the application

Includes
* basic serialization support methods for MTLDevice
* basic MetalResourceManager implementation
