### PR TITLE
Metal basic wrapping for MTLCommandQueue

### DIFF
--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -20,6 +20,9 @@ set(sources
     metal_function.h
     metal_function_bridge.mm
     metal_common.h
+    metal_command_queue.cpp
+    metal_command_queue.h
+    metal_command_queue_bridge.mm
     metal_core.cpp
     metal_core.h
     metal_manager.cpp

--- a/renderdoc/driver/metal/metal_command_queue.cpp
+++ b/renderdoc/driver/metal/metal_command_queue.cpp
@@ -22,19 +22,12 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#pragma once
+#include "metal_command_queue.h"
+#include "metal_device.h"
 
-#include "metal_types.h"
-
-#import <Metal/Metal.h>
-
-// clang-format off
-#define DECLARE_OBJC_WRAPPED_INTERFACES(CPPTYPE)              \
-  @interface ObjCBridgeMTL##CPPTYPE : NSObject<MTL##CPPTYPE> \
-    @property(assign) WrappedMTL##CPPTYPE *wrappedCPP;        \
-    @property(readonly) id<MTL##CPPTYPE> real;                \
-  @end
-// clang-format on
-
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_WRAPPED_INTERFACES)
-#undef DECLARE_OBJC_WRAPPED_INTERFACES
+WrappedMTLCommandQueue::WrappedMTLCommandQueue(MTL::CommandQueue *realMTLCommandQueue,
+                                               ResourceId objId, WrappedMTLDevice *wrappedMTLDevice)
+    : WrappedMTLObject(realMTLCommandQueue, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
+{
+  objcBridge = AllocateObjCBridge(this);
+}

--- a/renderdoc/driver/metal/metal_command_queue.h
+++ b/renderdoc/driver/metal/metal_command_queue.h
@@ -24,17 +24,19 @@
 
 #pragma once
 
-#include "metal_types.h"
+#include "metal_common.h"
 
-#import <Metal/Metal.h>
+class WrappedMTLCommandQueue : public WrappedMTLObject
+{
+public:
+  WrappedMTLCommandQueue(MTL::CommandQueue *realMTLCommandQueue, ResourceId objId,
+                         WrappedMTLDevice *wrappedMTLDevice);
 
-// clang-format off
-#define DECLARE_OBJC_WRAPPED_INTERFACES(CPPTYPE)              \
-  @interface ObjCBridgeMTL##CPPTYPE : NSObject<MTL##CPPTYPE> \
-    @property(assign) WrappedMTL##CPPTYPE *wrappedCPP;        \
-    @property(readonly) id<MTL##CPPTYPE> real;                \
-  @end
-// clang-format on
+  MTL::CommandQueue *GetReal() { return (MTL::CommandQueue *)real; }
+  enum
+  {
+    TypeEnum = eResCommandQueue
+  };
 
-METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_WRAPPED_INTERFACES)
-#undef DECLARE_OBJC_WRAPPED_INTERFACES
+private:
+};

--- a/renderdoc/driver/metal/metal_command_queue_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_queue_bridge.mm
@@ -1,0 +1,103 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_command_queue.h"
+#include "metal_types_bridge.h"
+
+// Bridge for MTLCommandQueue
+@implementation ObjCBridgeMTLCommandQueue
+
+// ObjCBridgeMTLCommandQueue specific
+- (id<MTLCommandQueue>)real
+{
+  MTL::CommandQueue *real = self.wrappedCPP->GetReal();
+  return id<MTLCommandQueue>(real);
+}
+
+// Use the real MTLCommandQueue to find methods from messages
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  id fwd = self.real;
+  return [fwd methodSignatureForSelector:aSelector];
+}
+
+// Forward any unknown messages to the real MTLCommandQueue
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  SEL aSelector = [invocation selector];
+
+  if([self.real respondsToSelector:aSelector])
+    [invocation invokeWithTarget:self.real];
+  else
+    [super forwardInvocation:invocation];
+}
+
+// MTLCommandQueue : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCommandQueue.h
+
+- (nullable NSString *)label
+{
+  return self.real.label;
+}
+
+- (void)setLabel:value
+{
+  self.real.label = value;
+}
+
+- (id<MTLDevice>)device
+{
+  return id<MTLDevice>(self.wrappedCPP->GetObjCBridgeMTLDevice());
+}
+
+- (nullable id<MTLCommandBuffer>)commandBuffer
+{
+  METAL_NOT_HOOKED();
+  return [self.real commandBuffer];
+}
+
+- (nullable id<MTLCommandBuffer>)commandBufferWithDescriptor:(MTLCommandBufferDescriptor *)descriptor
+    API_AVAILABLE(macos(11.0), ios(14.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real commandBufferWithDescriptor:descriptor];
+}
+
+- (nullable id<MTLCommandBuffer>)commandBufferWithUnretainedReferences
+{
+  METAL_NOT_HOOKED();
+  return [self.real commandBufferWithUnretainedReferences];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (void)insertDebugCaptureBoundary
+    API_DEPRECATED("Use MTLCaptureScope instead", macos(10.11, 10.13), ios(8.0, 11.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real insertDebugCaptureBoundary];
+}
+#pragma clang diagnostic pop
+
+@end

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -35,6 +35,7 @@
 enum class MetalChunk : uint32_t
 {
   MTLCreateSystemDefaultDevice = (uint32_t)SystemChunk::FirstDriverChunk,
+  MTLDevice_newCommandQueue,
   MTLDevice_newDefaultLibrary,
   MTLDevice_newLibraryWithSource,
   MTLLibrary_newFunctionWithName,
@@ -59,9 +60,18 @@ DECLARE_REFLECTION_ENUM(MetalChunk);
   template <typename SerialiserType>                \
   bool CONCAT(Serialise_, func(SerialiserType &ser, ##__VA_ARGS__));
 
-#define INSTANTIATE_FUNCTION_SERIALISED(CLASS, ret, func, ...)                     \
-  template bool CLASS::CONCAT(Serialise_, func(ReadSerialiser &ser, __VA_ARGS__)); \
-  template bool CLASS::CONCAT(Serialise_, func(WriteSerialiser &ser, __VA_ARGS__));
+#define INSTANTIATE_FUNCTION_SERIALISED(CLASS, ret, func, ...)                       \
+  template bool CLASS::CONCAT(Serialise_, func(ReadSerialiser &ser, ##__VA_ARGS__)); \
+  template bool CLASS::CONCAT(Serialise_, func(WriteSerialiser &ser, ##__VA_ARGS__));
+
+#define DECLARE_FUNCTION_WITH_RETURN_SERIALISED(ret, func, ...) \
+  ret func(__VA_ARGS__);                                        \
+  template <typename SerialiserType>                            \
+  bool CONCAT(Serialise_, func(SerialiserType &ser, ret, ##__VA_ARGS__));
+
+#define INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(CLASS, ret, func, ...)                \
+  template bool CLASS::CONCAT(Serialise_, func(ReadSerialiser &ser, ret, ##__VA_ARGS__)); \
+  template bool CLASS::CONCAT(Serialise_, func(WriteSerialiser &ser, ret, ##__VA_ARGS__));
 
 // A handy macro to say "is the serialiser reading and we're doing replay-mode stuff?"
 // The reason we check both is that checking the first allows the compiler to eliminate the other

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -140,7 +140,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newDefaultLibrary()
 template <typename SerialiserType>
 bool WrappedMTLDevice::Serialise_newLibraryWithSource(SerialiserType &ser,
                                                       WrappedMTLLibrary *library, NS::String *source,
-                                                      MTL::CompileOptions *options)
+                                                      MTL::CompileOptions *options, NS::Error **error)
 {
   SERIALISE_ELEMENT_LOCAL(Library, GetResID(library)).TypedAs("MTLLibrary"_lit);
   SERIALISE_ELEMENT(source);
@@ -169,7 +169,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newLibraryWithSource(NS::String *source,
     {
       CACHE_THREAD_SERIALISER();
       SCOPED_SERIALISE_CHUNK(MetalChunk::MTLDevice_newLibraryWithSource);
-      Serialise_newLibraryWithSource(ser, wrappedMTLLibrary, source, options);
+      Serialise_newLibraryWithSource(ser, wrappedMTLLibrary, source, options, error);
       chunk = scope.Get();
     }
     MetalResourceRecord *record = GetResourceManager()->AddResourceRecord(wrappedMTLLibrary);
@@ -186,17 +186,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newLibraryWithSource(NS::String *source,
 
 INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLDevice, WrappedMTLCommandQueue *,
                                             newCommandQueue);
-
-template bool WrappedMTLDevice::Serialise_newDefaultLibrary(ReadSerialiser &ser,
-                                                            WrappedMTLLibrary *library);
-template bool WrappedMTLDevice::Serialise_newDefaultLibrary(WriteSerialiser &ser,
-                                                            WrappedMTLLibrary *library);
-
-template bool WrappedMTLDevice::Serialise_newLibraryWithSource(ReadSerialiser &ser,
-                                                               WrappedMTLLibrary *library,
-                                                               NS::String *source,
-                                                               MTL::CompileOptions *options);
-template bool WrappedMTLDevice::Serialise_newLibraryWithSource(WriteSerialiser &ser,
-                                                               WrappedMTLLibrary *library,
-                                                               NS::String *source,
-                                                               MTL::CompileOptions *options);
+INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLDevice, WrappedMTLLibrary *, newDefaultLibrary);
+INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLDevice, WrappedMTLLibrary *,
+                                            newLibraryWithSource, NS::String *source,
+                                            MTL::CompileOptions *options, NS::Error **error);

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -38,16 +38,10 @@ public:
   static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLCommandQueue *, newCommandQueue);
-
-  WrappedMTLLibrary *newDefaultLibrary();
-  template <typename SerialiserType>
-  bool Serialise_newDefaultLibrary(SerialiserType &ser, WrappedMTLLibrary *library);
-
-  WrappedMTLLibrary *newLibraryWithSource(NS::String *source, MTL::CompileOptions *options,
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLLibrary *, newDefaultLibrary);
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLLibrary *, newLibraryWithSource,
+                                          NS::String *source, MTL::CompileOptions *options,
                                           NS::Error **error);
-  template <typename SerialiserType>
-  bool Serialise_newLibraryWithSource(SerialiserType &ser, WrappedMTLLibrary *library,
-                                      NS::String *source, MTL::CompileOptions *options);
 
   CaptureState &GetStateRef() { return m_State; }
   CaptureState GetState() { return m_State; }

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -37,6 +37,8 @@ public:
   MTL::Device *GetReal() { return (MTL::Device *)real; }
   static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLCommandQueue *, newCommandQueue);
+
   WrappedMTLLibrary *newDefaultLibrary();
   template <typename SerialiserType>
   bool Serialise_newDefaultLibrary(SerialiserType &ser, WrappedMTLLibrary *library);

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -24,6 +24,7 @@
 
 #include "metal_device.h"
 #include <Availability.h>
+#include "metal_command_queue.h"
 #include "metal_library.h"
 #include "metal_types_bridge.h"
 
@@ -182,8 +183,9 @@
 
 - (nullable id<MTLCommandQueue>)newCommandQueue
 {
-  METAL_NOT_HOOKED();
-  return [self.real newCommandQueue];
+  WrappedMTLCommandQueue *wrapped = self.wrappedCPP->newCommandQueue();
+  MTL::CommandQueue *objc = GetObjCBridge<MTL::CommandQueue *>(wrapped);
+  return id<MTLCommandQueue>(objc);
 }
 
 - (nullable id<MTLCommandQueue>)newCommandQueueWithMaxCommandBufferCount:(NSUInteger)maxCommandBufferCount

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -35,6 +35,7 @@ class MetalResourceManager;
 enum MetalResourceType
 {
   eResUnknown = 0,
+  eResCommandQueue,
   eResDevice,
   eResLibrary,
   eResFunction,

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -29,6 +29,7 @@
 #include "serialise/serialiser.h"
 
 #define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
+  FUNC(CommandQueue);                    \
   FUNC(Device);                          \
   FUNC(Function);                        \
   FUNC(Library);

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include "metal_types_bridge.h"
+#include "metal_command_queue.h"
 #include "metal_device.h"
 #include "metal_function.h"
 #include "metal_library.h"


### PR DESCRIPTION
## Description

Added `WrappedMTLCommandQueue` and bridge obj-c class `ObjCBridgeMTLCommandQueue`
`WrappedMTLCommandQueue` is created and return by the wrapped API `MTLDevice::newCommandQueue`

New macros to help declaring APIs which need to serialise their return value ie. Metal resource creation APIs
`DECLARE_FUNCTION_WITH_RETURN_SERIALISED`
`INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED`

Switched to use 
`#import <Metal/Metal.h>`
instead manually #import'ing each Metal header file as they become required

