### PR TITLE
Fix compile errors since Xcode 13.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,12 +376,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         -Wno-unused-variable
         -Wno-unused-parameter
         -Wno-unused-result
+        -Wno-unused-but-set-variable
+        -Wno-deprecated-copy
         -Wno-type-limits
         -Wno-missing-field-initializers
         -Wno-unknown-pragmas
         -Wno-reorder)
     if(CMAKE_COMPILER_IS_GNUCXX)
-        list(APPEND warning_flags -Wno-unused-but-set-variable -Wno-maybe-uninitialized -Wno-class-memaccess)
+        list(APPEND warning_flags -Wno-maybe-uninitialized -Wno-class-memaccess)
 
         # We keep the implicit fallthrough warning for now, but allow more
         # comments to silence it.


### PR DESCRIPTION
## Description

The Apple Xcode 13.3 included a newer version of Clang which had extra warnings enabled in it.

Disable two specific warnings which were causing compilation errors with the newer version of Clang.

Specifically:
-Wno-unused-but-set-variable : which was already set for GCC
-Wdeprecated-copy
