### PR TITLE
Fix compile errors since Xcode 13.3 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND warning_flags -Wno-unused-lambda-capture)
     endif()
 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+        list(APPEND warning_flags -Wno-unused-but-set-variable -Wno-deprecated-copy)
+    endif()
+
     if(NOT RELEASE_MODE)
         list(APPEND warning_flags -Werror)
     endif()


### PR DESCRIPTION
## Description

The Apple Xcode 13.3 included a newer version of Clang which had extra warnings enabled in it.

Disable two specific warnings which were causing compilation errors with the newer version of Clang.

Specifically:
-Wno-unused-but-set-variable : which was already set for GCC
-Wdeprecated-copy
