### PR TITLE
Small tweaks and improvements to Metal wrapping helper APIs

### DIFF
--- a/renderdoc/driver/metal/metal_command_queue.h
+++ b/renderdoc/driver/metal/metal_command_queue.h
@@ -32,7 +32,6 @@ public:
   WrappedMTLCommandQueue(MTL::CommandQueue *realMTLCommandQueue, ResourceId objId,
                          WrappedMTLDevice *wrappedMTLDevice);
 
-  MTL::CommandQueue *GetReal() { return (MTL::CommandQueue *)real; }
   enum
   {
     TypeEnum = eResCommandQueue

--- a/renderdoc/driver/metal/metal_command_queue_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_queue_bridge.mm
@@ -31,8 +31,7 @@
 // ObjCBridgeMTLCommandQueue specific
 - (id<MTLCommandQueue>)real
 {
-  MTL::CommandQueue *real = self.wrappedCPP->GetReal();
-  return id<MTLCommandQueue>(real);
+  return id<MTLCommandQueue>(Unwrap(self.wrappedCPP));
 }
 
 // Use the real MTLCommandQueue to find methods from messages

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -65,7 +65,7 @@ bool WrappedMTLDevice::Serialise_newCommandQueue(SerialiserType &ser, WrappedMTL
 WrappedMTLCommandQueue *WrappedMTLDevice::newCommandQueue()
 {
   MTL::CommandQueue *realMTLCommandQueue;
-  SERIALISE_TIME_CALL(realMTLCommandQueue = GetReal()->newCommandQueue());
+  SERIALISE_TIME_CALL(realMTLCommandQueue = Unwrap(this)->newCommandQueue());
   WrappedMTLCommandQueue *wrappedMTLCommandQueue;
   ResourceId id = GetResourceManager()->WrapResource(realMTLCommandQueue, wrappedMTLCommandQueue);
   if(IsCaptureMode(m_State))
@@ -113,7 +113,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newDefaultLibrary()
 {
   MTL::Library *realMTLLibrary;
 
-  SERIALISE_TIME_CALL(realMTLLibrary = GetReal()->newDefaultLibrary());
+  SERIALISE_TIME_CALL(realMTLLibrary = Unwrap(this)->newDefaultLibrary());
   WrappedMTLLibrary *wrappedMTLLibrary;
   ResourceId id = GetResourceManager()->WrapResource(realMTLLibrary, wrappedMTLLibrary);
   if(IsCaptureMode(m_State))
@@ -160,7 +160,7 @@ WrappedMTLLibrary *WrappedMTLDevice::newLibraryWithSource(NS::String *source,
                                                           NS::Error **error)
 {
   MTL::Library *realMTLLibrary;
-  SERIALISE_TIME_CALL(realMTLLibrary = GetReal()->newLibrary(source, options, error));
+  SERIALISE_TIME_CALL(realMTLLibrary = Unwrap(this)->newLibrary(source, options, error));
   WrappedMTLLibrary *wrappedMTLLibrary;
   ResourceId id = GetResourceManager()->WrapResource(realMTLLibrary, wrappedMTLLibrary);
   if(IsCaptureMode(m_State))

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -34,7 +34,6 @@ class WrappedMTLDevice : public WrappedMTLObject
 public:
   WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId);
   ~WrappedMTLDevice() {}
-  MTL::Device *GetReal() { return (MTL::Device *)real; }
   static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLCommandQueue *, newCommandQueue);

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -39,8 +39,7 @@
 // ObjCBridgeMTLDevice specific
 - (id<MTLDevice>)real
 {
-  MTL::Device *real = self.wrappedCPP->GetReal();
-  return id<MTLDevice>(real);
+  return id<MTLDevice>(Unwrap(self.wrappedCPP));
 }
 
 // Use the real MTLDevice to find methods from messages
@@ -183,9 +182,7 @@
 
 - (nullable id<MTLCommandQueue>)newCommandQueue
 {
-  WrappedMTLCommandQueue *wrapped = self.wrappedCPP->newCommandQueue();
-  MTL::CommandQueue *objc = GetObjCBridge<MTL::CommandQueue *>(wrapped);
-  return id<MTLCommandQueue>(objc);
+  return id<MTLCommandQueue>(GetObjCBridge(self.wrappedCPP->newCommandQueue()));
 }
 
 - (nullable id<MTLCommandQueue>)newCommandQueueWithMaxCommandBufferCount:(NSUInteger)maxCommandBufferCount
@@ -287,9 +284,7 @@
 
 - (nullable id<MTLLibrary>)newDefaultLibrary
 {
-  WrappedMTLLibrary *wrapped = self.wrappedCPP->newDefaultLibrary();
-  MTL::Library *objc = GetObjCBridge<MTL::Library *>(wrapped);
-  return id<MTLLibrary>(objc);
+  return id<MTLLibrary>(GetObjCBridge(self.wrappedCPP->newDefaultLibrary()));
 }
 
 - (nullable id<MTLLibrary>)newDefaultLibraryWithBundle:(NSBundle *)bundle
@@ -326,10 +321,8 @@
                                         options:(nullable MTLCompileOptions *)options
                                           error:(__autoreleasing NSError **)error
 {
-  WrappedMTLLibrary *wrapped = self.wrappedCPP->newLibraryWithSource(
-      (NS::String *)source, (MTL::CompileOptions *)options, (NS::Error **)error);
-  MTL::Library *objc = GetObjCBridge<MTL::Library *>(wrapped);
-  return (id<MTLLibrary>)(objc);
+  return (id<MTLLibrary>)(GetObjCBridge(self.wrappedCPP->newLibraryWithSource(
+      (NS::String *)source, (MTL::CompileOptions *)options, (NS::Error **)error)));
 }
 
 - (void)newLibraryWithSource:(NSString *)source

--- a/renderdoc/driver/metal/metal_function.h
+++ b/renderdoc/driver/metal/metal_function.h
@@ -32,7 +32,6 @@ public:
   WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceId objId,
                      WrappedMTLDevice *wrappedMTLDevice);
 
-  MTL::Function *GetReal() { return (MTL::Function *)real; }
   enum
   {
     TypeEnum = eResFunction

--- a/renderdoc/driver/metal/metal_function_bridge.mm
+++ b/renderdoc/driver/metal/metal_function_bridge.mm
@@ -31,8 +31,7 @@
 // ObjCBrdigeMTLFunction specific
 - (id<MTLFunction>)real
 {
-  MTL::Function *real = self.wrappedCPP->GetReal();
-  return id<MTLFunction>(real);
+  return id<MTLFunction>(Unwrap(self.wrappedCPP));
 }
 
 - (void)dealloc

--- a/renderdoc/driver/metal/metal_hook_bridge.mm
+++ b/renderdoc/driver/metal/metal_hook_bridge.mm
@@ -54,8 +54,8 @@ id<MTLDevice> METAL_EXPORT_NAME(MTLCreateSystemDefaultDevice)(void)
   }
 
   id<MTLDevice> device = METAL.MTLCreateSystemDefaultDevice();
-  WrappedMTLDevice *wrapped = WrappedMTLDevice::MTLCreateSystemDefaultDevice((MTL::Device *)device);
-  return id<MTLDevice>(GetObjCBridge<MTL::Device *>(wrapped));
+  return id<MTLDevice>(
+      GetObjCBridge(WrappedMTLDevice::MTLCreateSystemDefaultDevice((MTL::Device *)device)));
 }
 
 /*

--- a/renderdoc/driver/metal/metal_library.h
+++ b/renderdoc/driver/metal/metal_library.h
@@ -32,7 +32,6 @@ public:
   WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId objId,
                     WrappedMTLDevice *wrappedMTLDevice);
 
-  MTL::Library *GetReal() { return (MTL::Library *)real; }
   enum
   {
     TypeEnum = eResLibrary

--- a/renderdoc/driver/metal/metal_library_bridge.mm
+++ b/renderdoc/driver/metal/metal_library_bridge.mm
@@ -31,8 +31,7 @@
 // ObjCBridgeMTLLibrary specific
 - (id<MTLLibrary>)real
 {
-  MTL::Library *real = self.wrappedCPP->GetReal();
-  return id<MTLLibrary>(real);
+  return id<MTLLibrary>(Unwrap(self.wrappedCPP));
 }
 
 // Use the real MTLLibrary to find methods from messages

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -23,7 +23,10 @@
  ******************************************************************************/
 
 #include "metal_resources.h"
+#include "metal_command_queue.h"
 #include "metal_device.h"
+#include "metal_function.h"
+#include "metal_library.h"
 
 ResourceId GetResID(WrappedMTLObject *obj)
 {
@@ -32,6 +35,16 @@ ResourceId GetResID(WrappedMTLObject *obj)
 
   return obj->id;
 }
+
+#define IMPLEMENT_WRAPPED_TYPE_HELPERS(CPPTYPE)                                          \
+  MTL::CPPTYPE *Unwrap(WrappedMTL##CPPTYPE *obj) { return Unwrap<MTL::CPPTYPE *>(obj); } \
+  MTL::CPPTYPE *GetObjCBridge(WrappedMTL##CPPTYPE *obj)                                  \
+  {                                                                                      \
+    return GetObjCBridge<MTL::CPPTYPE *>(obj);                                           \
+  }
+
+METALCPP_WRAPPED_PROTOCOLS(IMPLEMENT_WRAPPED_TYPE_HELPERS)
+#undef IMPLEMENT_WRAPPED_TYPE_HELPERS
 
 void WrappedMTLObject::Dealloc()
 {
@@ -45,7 +58,7 @@ MetalResourceManager *WrappedMTLObject::GetResourceManager()
 
 MTL::Device *WrappedMTLObject::GetObjCBridgeMTLDevice()
 {
-  return GetObjCBridge<MTL::Device *>(m_WrappedMTLDevice);
+  return GetObjCBridge(m_WrappedMTLDevice);
 }
 
 MetalResourceRecord::~MetalResourceRecord()

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -115,24 +115,17 @@ struct UnwrapHelper
 {
 };
 
-#define UNWRAP_HELPER(CPPTYPE)                 \
-  template <>                                  \
-  struct UnwrapHelper<MTL::CPPTYPE *>          \
-  {                                            \
-    typedef CONCAT(WrappedMTL, CPPTYPE) Outer; \
-  };
+#define WRAPPED_TYPE_HELPERS(CPPTYPE)                    \
+  template <>                                            \
+  struct UnwrapHelper<MTL::CPPTYPE *>                    \
+  {                                                      \
+    typedef CONCAT(WrappedMTL, CPPTYPE) Outer;           \
+  };                                                     \
+  extern MTL::CPPTYPE *Unwrap(WrappedMTL##CPPTYPE *obj); \
+  extern MTL::CPPTYPE *GetObjCBridge(WrappedMTL##CPPTYPE *obj);
 
-METALCPP_WRAPPED_PROTOCOLS(UNWRAP_HELPER)
-#undef UNWRAP_HELPER
-
-#define IMPLEMENT_WRAPPED_TYPE_UNWRAP(CPPTYPE)              \
-  inline MTL::CPPTYPE *Unwrap(WrappedMTL##CPPTYPE *obj)     \
-  {                                                         \
-    return Unwrap<MTL::CPPTYPE *>((WrappedMTLObject *)obj); \
-  }
-
-METALCPP_WRAPPED_PROTOCOLS(IMPLEMENT_WRAPPED_TYPE_UNWRAP)
-#undef IMPLEMENT_WRAPPED_TYPE_UNWRAP
+METALCPP_WRAPPED_PROTOCOLS(WRAPPED_TYPE_HELPERS)
+#undef WRAPPED_TYPE_HELPERS
 
 struct MetalResourceRecord : public ResourceRecord
 {

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -47,7 +47,7 @@ METALCPP_WRAPPED_PROTOCOLS(DECLARE_WRAPPED_TYPE_SERIALISE);
   class WrappedMTL##CPPTYPE;                                         \
   extern WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *objCWrapped); \
   extern MTL::CPPTYPE *GetReal(MTL::CPPTYPE *objCWrapped);           \
-  extern bool IsObjCWrapped(MTL::CPPTYPE *objCWrapped);              \
+  extern bool IsObjCBridge(MTL::CPPTYPE *objCWrapped);               \
   extern ResourceId GetResID(MTL::CPPTYPE *objCWrapped);             \
   extern MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrapped);
 

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -34,6 +34,15 @@
   FUNC(Function);                        \
   FUNC(Library);
 
+// These serialise overloads will fetch the ID during capture, serialise the ID
+// directly as-if it were the original type, then on replay load up the resource if available.
+#define DECLARE_WRAPPED_TYPE_SERIALISE(CPPTYPE) \
+  class WrappedMTL##CPPTYPE;                    \
+  DECLARE_REFLECTION_STRUCT(WrappedMTL##CPPTYPE *)
+
+METALCPP_WRAPPED_PROTOCOLS(DECLARE_WRAPPED_TYPE_SERIALISE);
+#undef DECLARE_WRAPPED_TYPE_SERIALISE
+
 #define DECLARE_OBJC_HELPERS(CPPTYPE)                                \
   class WrappedMTL##CPPTYPE;                                         \
   extern WrappedMTL##CPPTYPE *GetWrapped(MTL::CPPTYPE *objCWrapped); \


### PR DESCRIPTION
## Description

Added serialisation of WrappedMTL* types via IDs.
Use `Unwrap()` instead of class method `GetReal()` [if the performance of `Unwrap()` becomes a problem could use the member function `GetReal()` as an alternative]
Simplify code to get objc bridge from API result to single line instead of using a temporary variable.
Fix missing forward declaration for `bool IsObjCBridge(MTL::CPPTYPE *objCWrapped);`