### PR TITLE
Enable Metal builds for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       run: |
         mkdir build
         pushd build
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.type }} ..
+        cmake -DENABLE_METAL=On -DCMAKE_BUILD_TYPE=${{ matrix.type }} ..
         make -j2
         popd
     - if: matrix.type == 'Debug'

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -161,7 +161,11 @@
   return self.real.supportsQueryTextureLOD;
 }
 
-- (BOOL)supportsBCTextureCompression API_AVAILABLE(macos(11.0))API_UNAVAILABLE(ios)
+- (BOOL)supportsBCTextureCompression API_AVAILABLE(macos(11.0))
+// It is available for ios in SDK 11.1 and it is marked as unavailable in SDK 12
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
+    API_UNAVAILABLE(ios)
+#endif    // #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 {
   return self.real.supportsBCTextureCompression;
 }


### PR DESCRIPTION
## Description

By default Metal builds are disabled in the CMake files.
This PR enables Metal builds just for the Mac CI builders.

The Mac CI builders use SDK11.1 and SDK 11.1 and SDK 12 have different declaration for MTLDevice::supportsBCTextureCompression. 
On SDK 11.1 it is marked as API_AVAILABLE for ios and on SDK 12 is marked as API_UNAVAILABLE ios. 
Guard the API_UNAVAILABLE(ios) declaration to only be included when compiling for SDK 12.0 or above.

The compile error message before the fix was:

renderdoc/driver/metal/metal_device_bridge.mm:158:64: error: method cannot be unavailable on iOS when the protocol method it implements is available [-Werror,-Wavailability]
69
- (BOOL)supportsBCTextureCompression API_AVAILABLE(macos(11.0))API_UNAVAILABLE(ios)