### PR TITLE
Support VK_QCOM_render_pass_store_ops

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1464,6 +1464,9 @@ static const VkExtensionProperties supportedExtensions[] = {
         VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME,
         VK_QCOM_RENDER_PASS_SHADER_RESOLVE_SPEC_VERSION,
     },
+    {
+        VK_QCOM_RENDER_PASS_STORE_OPS_EXTENSION_NAME, VK_QCOM_RENDER_PASS_STORE_OPS_SPEC_VERSION,
+    },
 };
 
 // this is the list of extensions we provide - regardless of whether the ICD supports them


### PR DESCRIPTION
This extension is the origin of STORE_OP_NONE, which found its way to
VK_EXT_load_store_op_none and VK_KHR_dynamic_rendering.  RenderDoc
supports STORE_OP_NONE just fine, this change simply adds this extension
to RenderDoc's allowlist.
