### PR TITLE
vk_shader_feedback: Fix crash with dynamic rendering

### DIFF
--- a/renderdoc/driver/vulkan/vk_shader_feedback.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_feedback.cpp
@@ -1632,9 +1632,11 @@ void VulkanReplay::FetchShaderFeedback(uint32_t eventId)
     bool usePrimitiveID =
         !hasGeom && m_pDriver->GetDeviceEnabledFeatures().geometryShader != VK_FALSE;
 
-    bool usesMultiview =
-        creationInfo.m_RenderPass[state.GetRenderPass()].subpasses[state.subpass].multiviews.size() >
-        1;
+    bool usesMultiview = state.GetRenderPass() != ResourceId()
+                             ? creationInfo.m_RenderPass[state.GetRenderPass()]
+                                       .subpasses[state.subpass]
+                                       .multiviews.size() > 1
+                             : pipeInfo.viewMask != 0;
 
     for(uint32_t i = 0; i < graphicsInfo.stageCount; i++)
     {


### PR DESCRIPTION
RenderPass can be null handle when dynamic rendering is used. Retrieve the
respective information from pipeline info instead.
