### PR TITLE
Don't hook the same library twice

### DIFF
--- a/renderdoc/driver/gl/egl_hooks.cpp
+++ b/renderdoc/driver/gl/egl_hooks.cpp
@@ -138,10 +138,10 @@ static void EnsureRealLibraryLoaded()
     if(!RenderDoc::Inst().IsReplayApp())
       RDCLOG("Loading libEGL at the last second");
 
-    void *handle = Process::LoadModule("libEGL.so");
+    void *handle = Process::LoadModule("libEGL.so.1");
 
     if(!handle)
-      handle = Process::LoadModule("libEGL.so.1");
+      handle = Process::LoadModule("libEGL.so");
 
     if(RenderDoc::Inst().IsReplayApp())
       eglhook.handle = handle;

--- a/renderdoc/driver/gl/egl_platform.cpp
+++ b/renderdoc/driver/gl/egl_platform.cpp
@@ -46,10 +46,10 @@ static void *GetEGLHandle()
 
   return Process::LoadModule(libEGL);
 #else
-  void *handle = Process::LoadModule("libEGL.so");
+  void *handle = Process::LoadModule("libEGL.so.1");
 
   if(!handle)
-    handle = Process::LoadModule("libEGL.so.1");
+    handle = Process::LoadModule("libEGL.so");
 
   return handle;
 #endif


### PR DESCRIPTION
This PR fix a bug on Linux when both `libEGL.so.1` and `libEGL.so` are installed, with `libEGL.so` pointing to `libEGL.so.1`.
In this case, when the application loads `libEGL.so.1`, callbacks for it are fetched, and executed.
During `EGLHook` execution, functions pointers are fetched and libEGL tries to load a real implementation of EGL (`libEGL_nvidia.so` in my case).
This `dlopen` call is catched and `CheckLoadedLibraries` is called.
During this call, all hooks are iterated, and the function checks if `libEGL.so` is loaded.
`dlopen` considers it as loaded as it points to `libEGL.so.1` which has just been loaded.
`CheckLoadedLibraries` then runs `libEGL.so` hooks and `EGLHook` gets called again which leads to a deadlock because of a mutex in `libEGL.so`

This PR fixes this by iterating over all hooks and checks if any is loaded and matches the just loaded handle.
I suspect it caused problems with libGL.so too.

Finally, I correct the load module call to match the one of libGL (first try to load the so version then the generic one).