### PR TITLE
Fossilize: Fix multiple crash and bad exports

### DIFF
--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -4314,6 +4314,9 @@ void VulkanPipelineStateViewer::AddFossilizeNexts(QVariantMap &info, const SDObj
                     {"pDepthStencilResolveAttachment", "depthStencilResolveAttachment"},
                     // VkFragmentShadingRateAttachmentInfoKHR
                     {"pFragmentShadingRateAttachment", "fragmentShadingRateAttachment"},
+                    // VkPipelineRenderingCreateInfo
+                    {"colorAttachmentCount", ""},
+                    {"pColorAttachmentFormats", "colorAttachmentFormats"},
                 });
 
       QVariantMap &vm = (QVariantMap &)v.data_ptr();

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -4216,20 +4216,44 @@ QByteArray VulkanPipelineStateViewer::ReconstructSpecializationData(const VKPipe
 {
   bytebuf specData;
 
-  // reconstruct the original spec data as best as we can
+  if(mapEntries->NumChildren() == 0)
+    return specData;
+
+  if(sh.reflection == NULL)
+  {
+    qCritical("Tried to reconstruct specialization constants but reflection data is missing");
+    return specData;
+  }
+  auto specBlockIt =
+      std::find_if(sh.reflection->constantBlocks.begin(), sh.reflection->constantBlocks.end(),
+                   [](const ConstantBlock &block) { return block.compileConstants; });
+  if(specBlockIt == sh.reflection->constantBlocks.end())
+  {
+    qCritical("Cannot find the constant block for specialization constants");
+    return specData;
+  }
+  const rdcarray<ShaderConstant> &specVars = specBlockIt->variables;
+
+  // We don't have access to the buffers in the original creation info, so we try to reconstruct
+  // from our preprocessed pipeline state instead. Note that this data might have a different order
+  // from the original call or have unused entries eliminated based on shader reflection.
   const bytebuf &src = sh.specializationData;
 
   for(size_t i = 0; i < mapEntries->NumChildren(); i++)
   {
     const SDObject *map = mapEntries->GetChild(i);
 
-    size_t srcByteOffset = map->FindChild("constantID")->AsUInt32() * sizeof(uint64_t);
     size_t dstByteOffset = map->FindChild("offset")->AsUInt32();
     size_t size = map->FindChild("size")->AsUInt32();
+    specData.resize_for_index(dstByteOffset + size - 1);
 
+    uint32_t constantId = map->FindChild("constantID")->AsUInt32();
+    int32_t idx = sh.specializationIds.indexOf(constantId);
+    if(idx == -1)
+      continue;    // Entry was eliminated as it was probably unused --- skip it
+    size_t srcByteOffset = specVars[idx].byteOffset;
     Q_ASSERT(srcByteOffset + size <= src.size());
 
-    specData.resize_for_index(dstByteOffset + size - 1);
     memcpy(specData.data() + dstByteOffset, src.data() + srcByteOffset, size);
   }
 

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -4395,6 +4395,12 @@ QVariant VulkanPipelineStateViewer::ConvertSDObjectToFossilizeJSON(const SDObjec
 
       AddFossilizeNexts(map, obj);
 
+      if(map.contains(lit("sampleMask")))
+      {
+        QVariantList sampleMaskArray = QVariantList({map[lit("sampleMask")]});
+        map[lit("sampleMask")] = sampleMaskArray;
+      }
+
       return map;
     }
     case SDBasic::Null: break;

--- a/renderdoc/api/replay/vk_pipestate.h
+++ b/renderdoc/api/replay/vk_pipestate.h
@@ -596,6 +596,14 @@ value.
 :type: bytes
 )");
   bytebuf specializationData;
+
+  DOCUMENT(R"(The specialization constant ID for each entry in the specialization constant block of
+reflection info. This corresponds to the constantID in VkSpecializationMapEntry, while the offset
+and size into specializationData can be obtained from the reflection info.
+
+:type: List[int]
+)")
+  rdcarray<uint32_t> specializationIds;
 };
 
 DOCUMENT("Describes the state of the fixed-function tessellator.");

--- a/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
@@ -1178,12 +1178,6 @@ void Reflector::MakeReflection(const GraphicsAPI sourceAPI, const ShaderStage st
     bindmap.arraySize = 1;
     bindmap.used = true;
 
-    // sort by spec IDs
-    std::sort(specblock.variables.begin(), specblock.variables.end(),
-              [](const ShaderConstant &a, const ShaderConstant &b) {
-                return a.byteOffset < b.byteOffset;
-              });
-
     cblocks.push_back(cblockpair(bindmap, specblock));
   }
 

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -1160,6 +1160,8 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
         stage.specializationData.resize_for_index(offs + sizeof(uint64_t));
         memcpy(stage.specializationData.data() + offs, &s.value, s.dataSize);
       }
+      if(p.shaders[i].patchData)
+        stage.specializationIds = p.shaders[i].patchData->specIDs;
     }
   }
   else
@@ -1279,6 +1281,8 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
         stages[i]->specializationData.resize_for_index(offs + sizeof(uint64_t));
         memcpy(stages[i]->specializationData.data() + offs, &s.value, s.dataSize);
       }
+      if(p.shaders[i].patchData)
+        stages[i]->specializationIds = p.shaders[i].patchData->specIDs;
     }
 
     // Tessellation

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -2078,8 +2078,9 @@ void DoSerialise(SerialiserType &ser, VKPipe::Shader &el)
   SERIALISE_MEMBER(pushConstantRangeByteOffset);
   SERIALISE_MEMBER(pushConstantRangeByteSize);
   SERIALISE_MEMBER(specializationData);
+  SERIALISE_MEMBER(specializationIds);
 
-  SIZE_CHECK(200);
+  SIZE_CHECK(224);
 }
 
 template <typename SerialiserType>
@@ -2348,7 +2349,7 @@ void DoSerialise(SerialiserType &ser, VKPipe::State &el)
 
   SERIALISE_MEMBER(conditionalRendering);
 
-  SIZE_CHECK(2096);
+  SIZE_CHECK(2240);
 }
 
 #pragma endregion Vulkan pipeline state


### PR DESCRIPTION
## Description

Each change address a different issue that resulted in fossilize exports that either crashes or produce unintended results.

The code are tested, but I'm still not confident about the code structure:

- For `foz: Encode sampleMask as array`, is it a good idea to put the type conversion right inside `ConvertSDObjectToFossilizeJSON`?
- For `foz: Reconstruct specialization constants with correct layout`, should we instead make the SD reader export the spec constant buffers so we can export the pipeline byte-accurately?
