### PR TITLE
Fix crash when application is using unsupported function.

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -1011,8 +1011,12 @@ void WrappedOpenGL::UseUnusedSupportedFunction(const char *name)
       if(it->second.Modern())
       {
         RenderDoc::Inst().RemoveDeviceFrameCapturer(it->second.ctx);
-        for(auto wnd : it->second.windows)
-          it->second.UnassociateWindow(this, wnd.first);
+        for(auto wnd = it->second.windows.begin(); wnd != it->second.windows.end();)
+        {
+          void *wndHandle = wnd->first;
+          wnd++;
+          it->second.UnassociateWindow(this, wndHandle);
+        }
       }
     }
   }


### PR DESCRIPTION

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

The crash happens when the OpenGL application calls unsupported functions like `glEGLImageTargetTexture2DOES`
Here is the backtrace:
https://gist.github.com/achanot/7e0d25d1e5a619a61b688ec895c7a349

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
