### PR TITLE
Small changes to support landing Metal PRs

### DIFF
--- a/renderdoc/driver/metal/metal_command_buffer.cpp
+++ b/renderdoc/driver/metal/metal_command_buffer.cpp
@@ -31,7 +31,7 @@ WrappedMTLCommandBuffer::WrappedMTLCommandBuffer(MTL::CommandBuffer *realMTLComm
                                                  ResourceId objId, WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLCommandBuffer, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  objcBridge = AllocateObjCBridge(this);
+  m_ObjcBridge = AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>
@@ -104,7 +104,7 @@ void WrappedMTLCommandBuffer::commit()
     bool capframe = IsActiveCapturing(m_State);
     if(capframe)
     {
-      record->AddRef();
+      bufferRecord->AddRef();
       bufferRecord->MarkResourceFrameReferenced(GetResID(m_WrappedMTLCommandQueue), eFrameRef_Read);
       // pull in frame refs from this command buffer
       bufferRecord->AddResourceReferences(GetResourceManager());

--- a/renderdoc/driver/metal/metal_command_queue.cpp
+++ b/renderdoc/driver/metal/metal_command_queue.cpp
@@ -30,7 +30,7 @@ WrappedMTLCommandQueue::WrappedMTLCommandQueue(MTL::CommandQueue *realMTLCommand
                                                ResourceId objId, WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLCommandQueue, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  objcBridge = AllocateObjCBridge(this);
+  m_ObjcBridge = AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -48,6 +48,8 @@ WrappedMTLDevice *WrappedMTLDevice::MTLCreateSystemDefaultDevice(MTL::Device *re
   return wrappedMTLDevice;
 }
 
+// Serialised MTLDevice APIs
+
 template <typename SerialiserType>
 bool WrappedMTLDevice::Serialise_newCommandQueue(SerialiserType &ser, WrappedMTLCommandQueue *queue)
 {
@@ -186,6 +188,137 @@ WrappedMTLLibrary *WrappedMTLDevice::newLibraryWithSource(NS::String *source,
   }
   return wrappedMTLLibrary;
 }
+
+// Non-Serialised MTLDevice APIs
+
+bool WrappedMTLDevice::isDepth24Stencil8PixelFormatSupported()
+{
+  return Unwrap(this)->depth24Stencil8PixelFormatSupported();
+}
+
+MTL::ReadWriteTextureTier WrappedMTLDevice::readWriteTextureSupport()
+{
+  return Unwrap(this)->readWriteTextureSupport();
+}
+
+MTL::ArgumentBuffersTier WrappedMTLDevice::argumentBuffersSupport()
+{
+  return Unwrap(this)->argumentBuffersSupport();
+}
+
+bool WrappedMTLDevice::areRasterOrderGroupsSupported()
+{
+  return Unwrap(this)->rasterOrderGroupsSupported();
+}
+
+bool WrappedMTLDevice::supports32BitFloatFiltering()
+{
+  return Unwrap(this)->supports32BitFloatFiltering();
+}
+
+bool WrappedMTLDevice::supports32BitMSAA()
+{
+  return Unwrap(this)->supports32BitMSAA();
+}
+
+bool WrappedMTLDevice::supportsQueryTextureLOD()
+{
+  return Unwrap(this)->supportsQueryTextureLOD();
+}
+
+bool WrappedMTLDevice::supportsBCTextureCompression()
+{
+  return Unwrap(this)->supportsBCTextureCompression();
+}
+
+bool WrappedMTLDevice::supportsPullModelInterpolation()
+{
+  return Unwrap(this)->supportsPullModelInterpolation();
+}
+
+bool WrappedMTLDevice::areBarycentricCoordsSupported()
+{
+  return Unwrap(this)->barycentricCoordsSupported();
+}
+
+bool WrappedMTLDevice::supportsShaderBarycentricCoordinates()
+{
+  return Unwrap(this)->supportsShaderBarycentricCoordinates();
+}
+
+bool WrappedMTLDevice::supportsFeatureSet(MTL::FeatureSet featureSet)
+{
+  return Unwrap(this)->supportsFeatureSet(featureSet);
+}
+
+bool WrappedMTLDevice::supportsFamily(MTL::GPUFamily gpuFamily)
+{
+  return Unwrap(this)->supportsFamily(gpuFamily);
+}
+
+bool WrappedMTLDevice::supportsTextureSampleCount(NS::UInteger sampleCount)
+{
+  return Unwrap(this)->supportsTextureSampleCount(sampleCount);
+}
+
+bool WrappedMTLDevice::areProgrammableSamplePositionsSupported()
+{
+  return Unwrap(this)->programmableSamplePositionsSupported();
+}
+
+bool WrappedMTLDevice::supportsRasterizationRateMapWithLayerCount(NS::UInteger layerCount)
+{
+  return Unwrap(this)->supportsRasterizationRateMap(layerCount);
+}
+
+bool WrappedMTLDevice::supportsCounterSampling(MTL::CounterSamplingPoint samplingPoint)
+{
+  return Unwrap(this)->supportsCounterSampling(samplingPoint);
+}
+
+bool WrappedMTLDevice::supportsVertexAmplificationCount(NS::UInteger count)
+{
+  return Unwrap(this)->supportsVertexAmplificationCount(count);
+}
+
+bool WrappedMTLDevice::supportsDynamicLibraries()
+{
+  return Unwrap(this)->supportsDynamicLibraries();
+}
+
+bool WrappedMTLDevice::supportsRenderDynamicLibraries()
+{
+  return Unwrap(this)->supportsRenderDynamicLibraries();
+}
+
+bool WrappedMTLDevice::supportsRaytracing()
+{
+  // RD device does not support ray tracing
+  return false;
+}
+
+bool WrappedMTLDevice::supportsFunctionPointers()
+{
+  return Unwrap(this)->supportsFunctionPointers();
+}
+
+bool WrappedMTLDevice::supportsFunctionPointersFromRender()
+{
+  return Unwrap(this)->supportsFunctionPointersFromRender();
+}
+
+bool WrappedMTLDevice::supportsRaytracingFromRender()
+{
+  // RD device does not support ray tracing
+  return false;
+}
+
+bool WrappedMTLDevice::supportsPrimitiveMotionBlur()
+{
+  return Unwrap(this)->supportsPrimitiveMotionBlur();
+}
+
+// End of MTLDevice APIs
 
 INSTANTIATE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLDevice, WrappedMTLCommandQueue *,
                                             newCommandQueue);

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -31,7 +31,7 @@
 WrappedMTLDevice::WrappedMTLDevice(MTL::Device *realMTLDevice, ResourceId objId)
     : WrappedMTLObject(realMTLDevice, objId, this, GetStateRef())
 {
-  objcBridge = AllocateObjCBridge(this);
+  m_ObjcBridge = AllocateObjCBridge(this);
   m_WrappedMTLDevice = this;
   threadSerialiserTLSSlot = Threading::AllocateTLSSlot();
 

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -36,11 +36,39 @@ public:
   ~WrappedMTLDevice() {}
   static WrappedMTLDevice *MTLCreateSystemDefaultDevice(MTL::Device *realMTLDevice);
 
+  // Serialised MTLDevice APIs
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLCommandQueue *, newCommandQueue);
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLLibrary *, newDefaultLibrary);
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLLibrary *, newLibraryWithSource,
                                           NS::String *source, MTL::CompileOptions *options,
                                           NS::Error **error);
+  // Non-Serialised MTLDevice APIs
+  bool isDepth24Stencil8PixelFormatSupported();
+  MTL::ReadWriteTextureTier readWriteTextureSupport();
+  MTL::ArgumentBuffersTier argumentBuffersSupport();
+  bool areRasterOrderGroupsSupported();
+  bool supports32BitFloatFiltering();
+  bool supports32BitMSAA();
+  bool supportsQueryTextureLOD();
+  bool supportsBCTextureCompression();
+  bool supportsPullModelInterpolation();
+  bool areBarycentricCoordsSupported();
+  bool supportsShaderBarycentricCoordinates();
+  bool supportsFeatureSet(MTL::FeatureSet featureSet);
+  bool supportsFamily(MTL::GPUFamily gpuFamily);
+  bool supportsTextureSampleCount(NS::UInteger sampleCount);
+  bool areProgrammableSamplePositionsSupported();
+  bool supportsRasterizationRateMapWithLayerCount(NS::UInteger layerCount);
+  bool supportsCounterSampling(MTL::CounterSamplingPoint samplingPoint);
+  bool supportsVertexAmplificationCount(NS::UInteger count);
+  bool supportsDynamicLibraries();
+  bool supportsRenderDynamicLibraries();
+  bool supportsRaytracing();
+  bool supportsFunctionPointers();
+  bool supportsFunctionPointersFromRender();
+  bool supportsRaytracingFromRender();
+  bool supportsPrimitiveMotionBlur();
+  // End of MTLDevice APIs
 
   CaptureState &GetStateRef() { return m_State; }
   CaptureState GetState() { return m_State; }

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -128,37 +128,37 @@
 - (BOOL)isDepth24Stencil8PixelFormatSupported API_AVAILABLE(macos(10.11), macCatalyst(13.0))
     API_UNAVAILABLE(ios)
 {
-  return self.real.depth24Stencil8PixelFormatSupported;
+  return self.wrappedCPP->isDepth24Stencil8PixelFormatSupported();
 }
 
 - (MTLReadWriteTextureTier)readWriteTextureSupport API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  return self.real.readWriteTextureSupport;
+  return (MTLReadWriteTextureTier)self.wrappedCPP->readWriteTextureSupport();
 }
 
 - (MTLArgumentBuffersTier)argumentBuffersSupport API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  return self.real.argumentBuffersSupport;
+  return (MTLArgumentBuffersTier)self.wrappedCPP->argumentBuffersSupport();
 }
 
 - (BOOL)areRasterOrderGroupsSupported API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  return self.real.areRasterOrderGroupsSupported;
+  return self.wrappedCPP->areRasterOrderGroupsSupported();
 }
 
 - (BOOL)supports32BitFloatFiltering API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supports32BitFloatFiltering;
+  return self.wrappedCPP->supports32BitFloatFiltering();
 }
 
 - (BOOL)supports32BitMSAA API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supports32BitMSAA;
+  return self.wrappedCPP->supports32BitMSAA();
 }
 
 - (BOOL)supportsQueryTextureLOD API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supportsQueryTextureLOD;
+  return self.wrappedCPP->supportsQueryTextureLOD();
 }
 
 - (BOOL)supportsBCTextureCompression API_AVAILABLE(macos(11.0))
@@ -167,22 +167,21 @@
     API_UNAVAILABLE(ios)
 #endif    // #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 {
-  return self.real.supportsBCTextureCompression;
+  return self.wrappedCPP->supportsBCTextureCompression();
 }
 
 - (BOOL)supportsPullModelInterpolation API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supportsPullModelInterpolation;
+  return self.wrappedCPP->supportsPullModelInterpolation();
 }
-
 - (BOOL)areBarycentricCoordsSupported API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
 {
-  return self.real.barycentricCoordsSupported;
+  return self.wrappedCPP->areBarycentricCoordsSupported();
 }
 
 - (BOOL)supportsShaderBarycentricCoordinates API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
 {
-  return self.real.supportsShaderBarycentricCoordinates;
+  return self.wrappedCPP->supportsShaderBarycentricCoordinates();
 }
 
 - (NSUInteger)currentAllocatedSize API_AVAILABLE(macos(10.13), ios(11.0))
@@ -478,20 +477,17 @@ newComputePipelineStateWithDescriptor:(MTLComputePipelineDescriptor *)descriptor
 
 - (BOOL)supportsFeatureSet:(MTLFeatureSet)featureSet
 {
-  METAL_NOT_HOOKED();
-  return [self.real supportsFeatureSet:featureSet];
+  return self.wrappedCPP->supportsFeatureSet((MTL::FeatureSet)featureSet);
 }
 
 - (BOOL)supportsFamily:(MTLGPUFamily)gpuFamily API_AVAILABLE(macos(10.15), ios(13.0))
 {
-  METAL_NOT_HOOKED();
-  return [self.real supportsFamily:gpuFamily];
+  return self.wrappedCPP->supportsFamily((MTL::GPUFamily)gpuFamily);
 }
 
 - (BOOL)supportsTextureSampleCount:(NSUInteger)sampleCount API_AVAILABLE(macos(10.11), ios(9.0))
 {
-  METAL_NOT_HOOKED();
-  return [self.real supportsTextureSampleCount:sampleCount];
+  return self.wrappedCPP->supportsTextureSampleCount(sampleCount);
 }
 
 - (NSUInteger)minimumLinearTextureAlignmentForPixelFormat:(MTLPixelFormat)format
@@ -546,7 +542,7 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
 
 - (BOOL)areProgrammableSamplePositionsSupported API_AVAILABLE(macos(10.13), ios(11.0))
 {
-  return self.real.programmableSamplePositionsSupported;
+  return self.wrappedCPP->areProgrammableSamplePositionsSupported();
 }
 
 - (void)getDefaultSamplePositions:(MTLSamplePosition *)positions
@@ -566,8 +562,7 @@ newRenderPipelineStateWithTileDescriptor:(MTLTileRenderPipelineDescriptor *)desc
 - (BOOL)supportsRasterizationRateMapWithLayerCount:(NSUInteger)layerCount
     API_AVAILABLE(macos(10.15.4), ios(13.0), macCatalyst(13.4))
 {
-  METAL_NOT_HOOKED();
-  return [self.real supportsRasterizationRateMapWithLayerCount:layerCount];
+  return self.wrappedCPP->supportsRasterizationRateMapWithLayerCount(layerCount);
 }
 
 - (nullable id<MTLRasterizationRateMap>)newRasterizationRateMapWithDescriptor:
@@ -697,26 +692,24 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
 - (BOOL)supportsCounterSampling:(MTLCounterSamplingPoint)samplingPoint
     API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  METAL_NOT_HOOKED();
-  return [self.real supportsCounterSampling:samplingPoint];
+  return self.wrappedCPP->supportsCounterSampling((MTL::CounterSamplingPoint)samplingPoint);
 }
 
 - (BOOL)supportsVertexAmplificationCount:(NSUInteger)count
     API_AVAILABLE(macos(10.15.4), ios(13.0), macCatalyst(13.4))
 {
-  METAL_NOT_HOOKED();
-  return [self.real supportsVertexAmplificationCount:count];
+  return self.wrappedCPP->supportsVertexAmplificationCount(count);
 }
 
 - (BOOL)supportsDynamicLibraries API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supportsDynamicLibraries;
+  return self.wrappedCPP->supportsDynamicLibraries();
 }
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsRenderDynamicLibraries API_AVAILABLE(macos(12.0), ios(15.0))
 {
-  return self.real.supportsRenderDynamicLibraries;
+  return self.wrappedCPP->supportsRenderDynamicLibraries();
 }
 #endif
 
@@ -746,7 +739,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
 
 - (BOOL)supportsRaytracing API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supportsRaytracing;
+  return self.wrappedCPP->supportsRaytracing();
 }
 
 - (MTLAccelerationStructureSizes)accelerationStructureSizesWithDescriptor:
@@ -772,20 +765,20 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
 
 - (BOOL)supportsFunctionPointers API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supportsFunctionPointers;
+  return self.wrappedCPP->supportsFunctionPointers();
 }
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsFunctionPointersFromRender API_AVAILABLE(macos(12.0), ios(15.0))
 {
-  return self.real.supportsFunctionPointersFromRender;
+  return self.wrappedCPP->supportsFunctionPointersFromRender();
 }
 #endif
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsRaytracingFromRender API_AVAILABLE(macos(12.0), ios(15.0))
 {
-  return self.real.supportsRaytracingFromRender;
+  return self.wrappedCPP->supportsRaytracingFromRender();
 }
 #endif
 
@@ -794,7 +787,7 @@ newIndirectCommandBufferWithDescriptor:(MTLIndirectCommandBufferDescriptor *)des
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_12_0
 - (BOOL)supportsPrimitiveMotionBlur API_AVAILABLE(macos(11.0), ios(14.0))
 {
-  return self.real.supportsPrimitiveMotionBlur;
+  return self.wrappedCPP->supportsPrimitiveMotionBlur();
 }
 #endif
 

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -28,11 +28,6 @@
 #include "metal_library.h"
 #include "metal_types_bridge.h"
 
-// Define Mac SDK versions when compiling with earlier SDKs
-#ifndef __MAC_12_0
-#define __MAC_12_0 120000
-#endif
-
 // Bridge for MTLDevice
 @implementation ObjCBridgeMTLDevice
 

--- a/renderdoc/driver/metal/metal_function.cpp
+++ b/renderdoc/driver/metal/metal_function.cpp
@@ -29,5 +29,5 @@ WrappedMTLFunction::WrappedMTLFunction(MTL::Function *realMTLFunction, ResourceI
                                        WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLFunction, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  objcBridge = AllocateObjCBridge(this);
+  m_ObjcBridge = AllocateObjCBridge(this);
 }

--- a/renderdoc/driver/metal/metal_init_state.cpp
+++ b/renderdoc/driver/metal/metal_init_state.cpp
@@ -29,7 +29,7 @@ bool WrappedMTLDevice::Prepare_InitialState(WrappedMTLObject *res)
 {
   ResourceId id = GetResourceManager()->GetID(res);
 
-  MetalResourceType type = res->record->resType;
+  MetalResourceType type = res->m_Record->m_Type;
   {
     RDCERR("Unhandled resource type %d", type);
   }

--- a/renderdoc/driver/metal/metal_library.cpp
+++ b/renderdoc/driver/metal/metal_library.cpp
@@ -30,7 +30,7 @@ WrappedMTLLibrary::WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId ob
                                      WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLLibrary, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  objcBridge = AllocateObjCBridge(this);
+  m_ObjcBridge = AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_manager.h
+++ b/renderdoc/driver/metal/metal_manager.h
@@ -95,7 +95,7 @@ public:
     if(res == NULL)
       return ResourceId();
 
-    return res->id;
+    return res->m_ID;
   }
   // ResourceManager interface
 
@@ -108,7 +108,7 @@ public:
     ResourceId id = ResourceIDGen::GetNewUniqueID();
     using WrappedType = typename UnwrapHelper<realtype>::Outer;
     wrapped = new WrappedType(obj, id, m_WrappedMTLDevice);
-    wrapped->real = obj;
+    wrapped->m_Real = obj;
     AddCurrentResource(id, wrapped);
 
     // TODO: implement RD MTL replay
@@ -122,10 +122,10 @@ public:
   template <typename wrappedtype>
   MetalResourceRecord *AddResourceRecord(wrappedtype *wrapped)
   {
-    MetalResourceRecord *ret = wrapped->record = ResourceManager::AddResourceRecord(wrapped->id);
+    MetalResourceRecord *ret = wrapped->m_Record = ResourceManager::AddResourceRecord(wrapped->m_ID);
 
-    ret->Resource = (WrappedMTLObject *)wrapped;
-    ret->resType = (MetalResourceType)wrappedtype::TypeEnum;
+    ret->m_Resource = (WrappedMTLObject *)wrapped;
+    ret->m_Type = (MetalResourceType)wrappedtype::TypeEnum;
     return ret;
   }
 

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -34,7 +34,7 @@ ResourceId GetResID(WrappedMTLObject *obj)
   if(obj == NULL)
     return ResourceId();
 
-  return obj->id;
+  return obj->m_ID;
 }
 
 #define IMPLEMENT_WRAPPED_TYPE_HELPERS(CPPTYPE)                                          \
@@ -64,6 +64,6 @@ MTL::Device *WrappedMTLObject::GetObjCBridgeMTLDevice()
 
 MetalResourceRecord::~MetalResourceRecord()
 {
-  if(resType == eResCommandBuffer)
+  if(m_Type == eResCommandBuffer)
     SAFE_DELETE(cmdInfo);
 }

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -48,19 +48,19 @@ struct WrappedMTLObject
 {
   WrappedMTLObject() = delete;
   WrappedMTLObject(WrappedMTLDevice *wrappedMTLDevice, CaptureState &captureState)
-      : objcBridge(NULL),
-        real(NULL),
-        record(NULL),
+      : m_ObjcBridge(NULL),
+        m_Real(NULL),
+        m_Record(NULL),
         m_WrappedMTLDevice(wrappedMTLDevice),
         m_State(captureState)
   {
   }
   WrappedMTLObject(void *mtlObject, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice,
                    CaptureState &captureState)
-      : objcBridge(NULL),
-        real(mtlObject),
-        id(objId),
-        record(NULL),
+      : m_ObjcBridge(NULL),
+        m_Real(mtlObject),
+        m_ID(objId),
+        m_Record(NULL),
         m_WrappedMTLDevice(wrappedMTLDevice),
         m_State(captureState)
   {
@@ -73,10 +73,10 @@ struct WrappedMTLObject
 
   MetalResourceManager *GetResourceManager();
 
-  void *objcBridge;
-  void *real;
-  ResourceId id;
-  MetalResourceRecord *record;
+  void *m_ObjcBridge;
+  void *m_Real;
+  ResourceId m_ID;
+  MetalResourceRecord *m_Record;
   WrappedMTLDevice *m_WrappedMTLDevice;
   CaptureState &m_State;
 };
@@ -89,7 +89,7 @@ MetalResourceRecord *GetRecord(WrappedType *obj)
   if(obj == NULL)
     return NULL;
 
-  return obj->record;
+  return obj->m_Record;
 }
 
 template <typename RealType>
@@ -98,7 +98,7 @@ RealType Unwrap(WrappedMTLObject *obj)
   if(obj == NULL)
     return RealType();
 
-  return (RealType)obj->real;
+  return (RealType)obj->m_Real;
 }
 
 template <typename RealType>
@@ -107,7 +107,7 @@ RealType GetObjCBridge(WrappedMTLObject *obj)
   if(obj == NULL)
     return RealType();
 
-  return (RealType)obj->objcBridge;
+  return (RealType)obj->m_ObjcBridge;
 }
 
 // template magic voodoo to unwrap types
@@ -158,12 +158,12 @@ public:
   };
 
   MetalResourceRecord(ResourceId id)
-      : ResourceRecord(id, true), Resource(NULL), resType(eResUnknown), ptrUnion(NULL)
+      : ResourceRecord(id, true), m_Resource(NULL), m_Type(eResUnknown), ptrUnion(NULL)
   {
   }
   ~MetalResourceRecord();
-  WrappedMTLObject *Resource;
-  MetalResourceType resType;
+  WrappedMTLObject *m_Resource;
+  MetalResourceType m_Type;
 
   // Each entry is only used by specific record types
   union

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -37,9 +37,15 @@
 
 // These serialise overloads will fetch the ID during capture, serialise the ID
 // directly as-if it were the original type, then on replay load up the resource if available.
-#define DECLARE_WRAPPED_TYPE_SERIALISE(CPPTYPE) \
-  class WrappedMTL##CPPTYPE;                    \
-  DECLARE_REFLECTION_STRUCT(WrappedMTL##CPPTYPE *)
+#define DECLARE_WRAPPED_TYPE_SERIALISE(CPPTYPE)       \
+  class WrappedMTL##CPPTYPE;                          \
+  template <>                                         \
+  inline rdcliteral TypeName<WrappedMTL##CPPTYPE *>() \
+  {                                                   \
+    return STRING_LITERAL(STRINGIZE(MTL##CPPTYPE));   \
+  }                                                   \
+  template <class SerialiserType>                     \
+  void DoSerialise(SerialiserType &ser, WrappedMTL##CPPTYPE *&el);
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_WRAPPED_TYPE_SERIALISE);
 #undef DECLARE_WRAPPED_TYPE_SERIALISE

--- a/renderdoc/driver/metal/metal_types_bridge.h
+++ b/renderdoc/driver/metal/metal_types_bridge.h
@@ -38,3 +38,8 @@
 
 METALCPP_WRAPPED_PROTOCOLS(DECLARE_OBJC_WRAPPED_INTERFACES)
 #undef DECLARE_OBJC_WRAPPED_INTERFACES
+
+// Define Mac SDK versions when compiling with earlier SDKs
+#ifndef __MAC_12_0
+#define __MAC_12_0 120000
+#endif

--- a/renderdoc/driver/metal/metal_types_bridge.mm
+++ b/renderdoc/driver/metal/metal_types_bridge.mm
@@ -67,7 +67,7 @@
     {                                                                              \
       return ResourceId();                                                         \
     }                                                                              \
-    return wrappedCPP->id;                                                         \
+    return wrappedCPP->m_ID;                                                       \
   }                                                                                \
                                                                                    \
   MTL::CPPTYPE *AllocateObjCBridge(WrappedMTL##CPPTYPE *wrappedCPP)                \


### PR DESCRIPTION
## Description

Collection of small changes which if landed now makes landing future RenderDoc Metal PRs simpler (primarily for local development).

- Moved the OSX 12 #define to a header file to support reusing it in other objc .mm files (not just `metal_device_bridge.mm`).
- Tweaked the displayed serialized name for wrapped Metal objects ie. `WrappedMTLDevice*` -> `MTLDevice`.
- Added `MTLDevice` wrapping for feature-supported APIs.
- Renamed some member variables in the base Metal resource & object structs. This is to prevent accidentally writing to `id`, `record` in parent classes. `id` & `record` are likely common names (and there was code which had done this accidentally in `WrappedMTLCommandBuffer`.
  - `WrappedMTLObject`
    - `objcBridge` -> `ObjcBridge`
    - `real` -> `Real`
    - `id` -> `Id`
    - `record` -> `Record`
  - `MetalResourceRecord`
    - `resType` -> `Type` (primarily for style consistency)

Welcome more ideas on ways to solve this problem. Locally I experimented with `m_Id` and `m_Record` which felt a bit odd (and personally I prefer to use `m_` for class member variables and not struct member variables. Could also make the base struct member variables private and have get/set methods, that feels agisnt the spirit of a base data struct.