### PR TITLE
move ms/compute shader system to single descriptorset

### DIFF
--- a/renderdoc/data/glsl/vk_buffer2ms.comp
+++ b/renderdoc/data/glsl/vk_buffer2ms.comp
@@ -40,6 +40,7 @@ layout(push_constant) uniform multisamplePush
   int sampleOffset;
   int byteSize;
   int maxInvocationID;
+  int dispatchOffset;
 }
 mscopy;
 
@@ -48,6 +49,7 @@ mscopy;
 #define sampleOffset (mscopy.sampleOffset)
 #define byteSize (mscopy.byteSize)
 #define maxInvocationID (mscopy.maxInvocationID)
+#define dispatchOffset (mscopy.dispatchOffset)
 
 void main()
 {
@@ -64,7 +66,7 @@ void main()
   uvec4 data;
   if(byteSize == 1)
   {
-    data.x = srcData[idx];
+    data.x = srcData[dispatchOffset + idx];
     int pxIdx = int(idx * 4);
     int x0 = (pxIdx + 0) % texWidth;
     int y0 = (pxIdx + 0) / texWidth;
@@ -82,7 +84,7 @@ void main()
   }
   else if(byteSize == 2)
   {
-    data.x = srcData[idx];
+    data.x = srcData[dispatchOffset + idx];
     int pxIdx = int(idx * 2);
     int x0 = (pxIdx + 0) % texWidth;
     int y0 = (pxIdx + 0) / texWidth;
@@ -96,25 +98,25 @@ void main()
   {
     int x0 = int(idx) % texWidth;
     int y0 = int(idx) / texWidth;
-    data.x = srcData[idx];
+    data.x = srcData[dispatchOffset + idx];
     imageStore(dstMS, ivec3(x0, y0, slice), sampleIdx, data);
   }
   else if(byteSize == 8)
   {
     int x0 = int(idx) % texWidth;
     int y0 = int(idx) / texWidth;
-    data.x = srcData[idx * 2];
-    data.y = srcData[idx * 2 + 1];
+    data.x = srcData[dispatchOffset + (idx * 2)];
+    data.y = srcData[dispatchOffset + (idx * 2 + 1)];
     imageStore(dstMS, ivec3(x0, y0, slice), sampleIdx, data);
   }
   else if(byteSize == 16)
   {
     int x0 = int(idx) % texWidth;
     int y0 = int(idx) / texWidth;
-    data.x = srcData[idx * 4];
-    data.y = srcData[idx * 4 + 1];
-    data.z = srcData[idx * 4 + 2];
-    data.w = srcData[idx * 4 + 3];
+    data.x = srcData[dispatchOffset + (idx * 4)];
+    data.y = srcData[dispatchOffset + (idx * 4 + 1)];
+    data.z = srcData[dispatchOffset + (idx * 4 + 2)];
+    data.w = srcData[dispatchOffset + (idx * 4 + 3)];
     imageStore(dstMS, ivec3(x0, y0, slice), sampleIdx, data);
   }
 }

--- a/renderdoc/data/glsl/vk_depthms2buffer.comp
+++ b/renderdoc/data/glsl/vk_depthms2buffer.comp
@@ -48,6 +48,7 @@ layout(push_constant) uniform multisamplePush
   int baseSample;
   int format;
   int maxInvocationID;
+  int dispatchOffset;
 }
 mscopy;
 
@@ -56,6 +57,7 @@ mscopy;
 #define baseSample (mscopy.baseSample)
 #define format (mscopy.format)
 #define maxInvocationID (mscopy.maxInvocationID)
+#define dispatchOffset (mscopy.dispatchOffset)
 
 void main()
 {
@@ -82,35 +84,35 @@ void main()
 
     vec2 depth = vec2(texelFetch(srcDepthMS, ivec3(x0, y0, slice), sampleIdx).x,
                       texelFetch(srcDepthMS, ivec3(x1, y1, slice), sampleIdx).x);
-    result[idx] = (floatToD16(depth.x) << 0) | (floatToD16(depth.y) << 16);
+    result[dispatchOffset + idx] = (floatToD16(depth.x) << 0) | (floatToD16(depth.y) << 16);
   }
   else if(format == SHADER_D16_UNORM_S8_UINT)
   {
     float depth = texelFetch(srcDepthMS, coord, sampleIdx).x;
     uint stencil = texelFetch(srcStencilMS, coord, sampleIdx).x;
-    result[idx] = (floatToD16(depth) << 0) | (stencil << 16);
+    result[dispatchOffset + idx] = (floatToD16(depth) << 0) | (stencil << 16);
   }
   else if(format == SHADER_X8_D24_UNORM_PACK32)
   {
     float depth = texelFetch(srcDepthMS, coord, sampleIdx).x;
-    result[idx] = (floatToD24(depth) << 0);
+    result[dispatchOffset + idx] = (floatToD24(depth) << 0);
   }
   else if(format == SHADER_D24_UNORM_S8_UINT)
   {
     float depth = texelFetch(srcDepthMS, coord, sampleIdx).x;
     uint stencil = texelFetch(srcStencilMS, coord, sampleIdx).x;
-    result[idx] = (floatToD24(depth) << 0) | (stencil << 24);
+    result[dispatchOffset + idx] = (floatToD24(depth) << 0) | (stencil << 24);
   }
   else if(format == SHADER_D32_SFLOAT)
   {
     float depth = texelFetch(srcDepthMS, coord, sampleIdx).x;
-    result[idx] = floatBitsToUint(depth);
+    result[dispatchOffset + idx] = floatBitsToUint(depth);
   }
   else if(format == SHADER_D32_SFLOAT_S8_UINT)
   {
     float depth = texelFetch(srcDepthMS, coord, sampleIdx).x;
     uint stencil = texelFetch(srcStencilMS, coord, sampleIdx).x;
-    result[idx * 2 + 0] = floatBitsToUint(depth);
-    result[idx * 2 + 1] = stencil;
+    result[dispatchOffset + (idx * 2 + 0)] = floatBitsToUint(depth);
+    result[dispatchOffset + (idx * 2 + 1)] = stencil;
   }
 }

--- a/renderdoc/data/glsl/vk_ms2buffer.comp
+++ b/renderdoc/data/glsl/vk_ms2buffer.comp
@@ -42,6 +42,7 @@ layout(push_constant) uniform multisamplePush
   int baseSample;
   int byteSize;
   int maxInvocationID;
+  int dispatchOffset;
 }
 mscopy;
 
@@ -50,6 +51,7 @@ mscopy;
 #define baseSample (mscopy.baseSample)
 #define byteSize (mscopy.byteSize)
 #define maxInvocationID (mscopy.maxInvocationID)
+#define dispatchOffset (mscopy.dispatchOffset)
 
 void main()
 {
@@ -78,7 +80,7 @@ void main()
                        texelFetch(srcMS, ivec3(x1, y1, slice), sampleIdx).x,
                        texelFetch(srcMS, ivec3(x2, y2, slice), sampleIdx).x,
                        texelFetch(srcMS, ivec3(x3, y3, slice), sampleIdx).x);
-    result[idx] = (data.x << 0 | data.y << 8 | data.z << 16 | data.w << 24);
+    result[dispatchOffset + idx] = (data.x << 0 | data.y << 8 | data.z << 16 | data.w << 24);
   }
   else if(byteSize == 2)
   {
@@ -90,31 +92,31 @@ void main()
 
     uvec2 data = uvec2(texelFetch(srcMS, ivec3(x0, y0, slice), sampleIdx).x,
                        texelFetch(srcMS, ivec3(x1, y1, slice), sampleIdx).x);
-    result[idx] = (data.x << 0 | data.y << 16);
+    result[dispatchOffset + idx] = (data.x << 0 | data.y << 16);
   }
   else if(byteSize == 4)
   {
     int x0 = int(idx) % textureWidth;
     int y0 = int(idx) / textureWidth;
     uint data = texelFetch(srcMS, ivec3(x0, y0, slice), sampleIdx).x;
-    result[idx] = data;
+    result[dispatchOffset + idx] = data;
   }
   else if(byteSize == 8)
   {
     int x0 = int(idx) % textureWidth;
     int y0 = int(idx) / textureWidth;
     uvec2 data = texelFetch(srcMS, ivec3(x0, y0, slice), sampleIdx).xy;
-    result[idx * 2] = data.x;
-    result[idx * 2 + 1] = data.y;
+    result[dispatchOffset + (idx * 2)] = data.x;
+    result[dispatchOffset + (idx * 2 + 1)] = data.y;
   }
   else if(byteSize == 16)
   {
     int x0 = int(idx) % textureWidth;
     int y0 = int(idx) / textureWidth;
     uvec4 data = texelFetch(srcMS, ivec3(x0, y0, slice), sampleIdx);
-    result[idx * 4] = data.x;
-    result[idx * 4 + 1] = data.y;
-    result[idx * 4 + 2] = data.z;
-    result[idx * 4 + 3] = data.w;
+    result[dispatchOffset + (idx * 4)] = data.x;
+    result[dispatchOffset + (idx * 4 + 1)] = data.y;
+    result[dispatchOffset + (idx * 4 + 2)] = data.z;
+    result[dispatchOffset + (idx * 4 + 3)] = data.w;
   }
 }

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -374,16 +374,16 @@ VulkanDebugManager::VulkanDebugManager(WrappedVulkan *driver)
   //////////////////////////////////////////////////////////////////
   // Color MS <-> Buffer copy (via compute)
   VkDescriptorPoolSize bufferPoolTypes[] = {
-      {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 2 * ARRAY_COUNT(m_BufferMSDescSet)},
-      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1 * ARRAY_COUNT(m_BufferMSDescSet)},
-      {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1 * ARRAY_COUNT(m_BufferMSDescSet)},
+      {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 2},
+      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1},
+      {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1},
   };
 
   VkDescriptorPoolCreateInfo bufferPoolInfo = {
       VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
       NULL,
       0,
-      ARRAY_COUNT(m_BufferMSDescSet),
+      1,
       ARRAY_COUNT(bufferPoolTypes),
       &bufferPoolTypes[0],
   };
@@ -418,11 +418,8 @@ VulkanDebugManager::VulkanDebugManager(WrappedVulkan *driver)
   rm->SetInternalResource(GetResID(m_DepthMS2BufferPipe));
   rm->SetInternalResource(GetResID(m_Buffer2MSPipe));
 
-  for(size_t i = 0; i < ARRAY_COUNT(m_BufferMSDescSet); i++)
-  {
-    CREATE_OBJECT(m_BufferMSDescSet[i], m_BufferMSDescriptorPool, m_BufferMSDescSetLayout);
-    rm->SetInternalResource(GetResID(m_BufferMSDescSet[i]));
-  }
+  CREATE_OBJECT(m_BufferMSDescSet, m_BufferMSDescriptorPool, m_BufferMSDescSetLayout);
+  rm->SetInternalResource(GetResID(m_BufferMSDescSet));
 
   //////////////////////////////////////////////////////////////////
   // Depth MS to Buffer copy (via compute)

--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -128,8 +128,7 @@ private:
   VkDescriptorPool m_BufferMSDescriptorPool;
   VkDescriptorSetLayout m_BufferMSDescSetLayout = VK_NULL_HANDLE;
   VkPipelineLayout m_BufferMSPipeLayout = VK_NULL_HANDLE;
-  // 8 descriptor sets allows for 4x MSAA with 2 array slices, common for VR targets
-  VkDescriptorSet m_BufferMSDescSet[8] = {};
+  VkDescriptorSet m_BufferMSDescSet = VK_NULL_HANDLE;
   VkPipeline m_Buffer2MSPipe = VK_NULL_HANDLE;
   VkPipeline m_MS2BufferPipe = VK_NULL_HANDLE;
   VkPipeline m_DepthMS2BufferPipe = VK_NULL_HANDLE;


### PR DESCRIPTION
Attempts to fix https://github.com/baldurk/renderdoc/issues/2543 by, instead of having each slice/subsample have its own descriptorset-driven offset into the source (for buffer->texture) or destination (for texture->buffer) SSBO, have a single descriptor binding with offset=0/range=VK_WHOLE_SIZE, and manage the offset manually in the compute shader. I use the already-existing push constants for that. Offset will always be 0 now which inherently solves the minStorageBufferOffsetAlignment requirement. 

This was the only reason we had those 8 descriptorsets, which can now be a single descriptorset, and it cleans up the code by not requiring the batchSize=8 system, so cmdbufferbegin and flush are outside of the per-sample/slice loop.

Tested on sascha's deferredmultisampling on PC, both color and depth, initial states and during partial replay. Tested on Oculus Quest2's UE4-Vulkan-MSAA4x on color and depth. Tested on VK_Texture_Zoo.