### PR TITLE
Fix call to vkCreateImage with unsupported multi-sample format

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -3305,6 +3305,19 @@ void VulkanReplay::TextureRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
           imInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         }
 
+        // fall back to VK_SAMPLE_COUNT_1_BIT if multi-sample
+        // is not supported for this combination of parameters
+        if(sampleCounts[type] != VK_SAMPLE_COUNT_1_BIT)
+        {
+          VkImageFormatProperties imProp;
+          vkr = driver->vkGetPhysicalDeviceImageFormatProperties(
+              driver->GetPhysDev(), imInfo.format, imInfo.imageType, imInfo.tiling, imInfo.usage,
+              imInfo.flags, &imProp);
+          driver->CheckVkResult(vkr);
+          if((imProp.sampleCounts & sampleCounts[type]) == 0)
+            imInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+        }
+
         vkr = driver->vkCreateImage(driver->GetDev(), &imInfo, NULL, &DummyImages[fmt][type]);
         driver->CheckVkResult(vkr);
 


### PR DESCRIPTION
Certain Vulkan drivers do not support creating multi-sample images for
all predefined formats in VulkanReplay::TextureRendering::Init.
This causes a crash when attempting to load a capture.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
A check using vkGetPhysicalDeviceImageFormatProperties was added to ensure that vkCreateImage won't be called with an unsupported sample count. It falls back to a single sample when not supported.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
