### PR TITLE
split code path for glCopyImageSubDataEXT&glCopyImageSubData

### DIFF
--- a/renderdoc/driver/gl/gl_dispatch_table.h
+++ b/renderdoc/driver/gl/gl_dispatch_table.h
@@ -136,7 +136,8 @@ struct GLDispatchTable
   PFNGLTEXPARAMETERIIVPROC glTexParameterIiv;      // aliases glTexParameterIivEXT, glTexParameterIivOES
   PFNGLTEXPARAMETERIUIVPROC glTexParameterIuiv;    // aliases glTexParameterIuivEXT, glTexParameterIuivOES
   PFNGLGENERATEMIPMAPPROC glGenerateMipmap;        // aliases glGenerateMipmapEXT
-  PFNGLCOPYIMAGESUBDATAPROC glCopyImageSubData;    // aliases glCopyImageSubDataEXT, glCopyImageSubDataOES
+  PFNGLCOPYIMAGESUBDATAPROC glCopyImageSubData;    // aliases glCopyImageSubDataOES
+  PFNGLCOPYIMAGESUBDATAEXTPROC glCopyImageSubDataEXT;
   PFNGLCOPYTEXSUBIMAGE3DPROC glCopyTexSubImage3D;    // aliases glCopyTexSubImage3DOES
   PFNGLGETINTERNALFORMATIVPROC glGetInternalformativ;
   PFNGLGETINTERNALFORMATI64VPROC glGetInternalformati64v;

--- a/renderdoc/driver/gl/gl_dispatch_table_defs.h
+++ b/renderdoc/driver/gl/gl_dispatch_table_defs.h
@@ -149,7 +149,7 @@
   FUNC(glGenerateMipmap, glGenerateMipmap); \
   FUNC(glGenerateMipmap, glGenerateMipmapEXT); \
   FUNC(glCopyImageSubData, glCopyImageSubData); \
-  FUNC(glCopyImageSubData, glCopyImageSubDataEXT); \
+  FUNC(glCopyImageSubDataEXT, glCopyImageSubDataEXT); \
   FUNC(glCopyImageSubData, glCopyImageSubDataOES); \
   FUNC(glCopyTexSubImage3D, glCopyTexSubImage3D); \
   FUNC(glCopyTexSubImage3D, glCopyTexSubImage3DOES); \
@@ -1412,7 +1412,7 @@
   FuncWrapper1(void, glGenerateMipmap, GLenum, target); \
   AliasWrapper1(void, glGenerateMipmapEXT, glGenerateMipmap, GLenum, target); \
   FuncWrapper15(void, glCopyImageSubData, GLuint, srcName, GLenum, srcTarget, GLint, srcLevel, GLint, srcX, GLint, srcY, GLint, srcZ, GLuint, dstName, GLenum, dstTarget, GLint, dstLevel, GLint, dstX, GLint, dstY, GLint, dstZ, GLsizei, srcWidth, GLsizei, srcHeight, GLsizei, srcDepth); \
-  AliasWrapper15(void, glCopyImageSubDataEXT, glCopyImageSubData, GLuint, srcName, GLenum, srcTarget, GLint, srcLevel, GLint, srcX, GLint, srcY, GLint, srcZ, GLuint, dstName, GLenum, dstTarget, GLint, dstLevel, GLint, dstX, GLint, dstY, GLint, dstZ, GLsizei, srcWidth, GLsizei, srcHeight, GLsizei, srcDepth); \
+  FuncWrapper15(void, glCopyImageSubDataEXT, GLuint, srcName, GLenum, srcTarget, GLint, srcLevel, GLint, srcX, GLint, srcY, GLint, srcZ, GLuint, dstName, GLenum, dstTarget, GLint, dstLevel, GLint, dstX, GLint, dstY, GLint, dstZ, GLsizei, srcWidth, GLsizei, srcHeight, GLsizei, srcDepth); \
   AliasWrapper15(void, glCopyImageSubDataOES, glCopyImageSubData, GLuint, srcName, GLenum, srcTarget, GLint, srcLevel, GLint, srcX, GLint, srcY, GLint, srcZ, GLuint, dstName, GLenum, dstTarget, GLint, dstLevel, GLint, dstX, GLint, dstY, GLint, dstZ, GLsizei, srcWidth, GLsizei, srcHeight, GLsizei, srcDepth); \
   FuncWrapper9(void, glCopyTexSubImage3D, GLenum, target, GLint, level, GLint, xoffset, GLint, yoffset, GLint, zoffset, GLint, x, GLint, y, GLsizei, width, GLsizei, height); \
   AliasWrapper9(void, glCopyTexSubImage3DOES, glCopyTexSubImage3D, GLenum, target, GLint, level, GLint, xoffset, GLint, yoffset, GLint, zoffset, GLint, x, GLint, y, GLsizei, width, GLsizei, height); \

--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -1133,6 +1133,10 @@ public:
                                 GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName,
                                 GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY,
                                 GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
+  IMPLEMENT_FUNCTION_SERIALISED(void, glCopyImageSubDataEXT, GLuint srcName, GLenum srcTarget,
+                                GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName,
+                                GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY,
+                                GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
   IMPLEMENT_FUNCTION_SERIALISED(void, glCopyTexImage1D, GLenum target, GLint level,
                                 GLenum internalformat, GLint x, GLint y, GLsizei width, GLint border);
   IMPLEMENT_FUNCTION_SERIALISED(void, glCopyTexImage2D, GLenum target, GLint level,
@@ -1922,6 +1926,11 @@ public:
   // on the EXT_dsa interface, which takes the function parameters and a
   // GLResourceRecord* which does all the common tasks between all of these
   // functions.
+
+  void Common_glCopyImageSubDataEXT(GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX,
+                                    GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget,
+                                    GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ,
+                                    GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
 
   void Common_glGenerateTextureMipmapEXT(GLResourceRecord *record, GLenum target);
 

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -1312,11 +1312,8 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
 {
   CoherentMapImplicitBarrier();
 
-  GLResource srcRes = srcTarget == eGL_RENDERBUFFER ? RenderbufferRes(GetCtx(), srcName)
-                                                    : TextureRes(GetCtx(), srcName);
   GLResource dstRes = dstTarget == eGL_RENDERBUFFER ? RenderbufferRes(GetCtx(), dstName)
                                                     : TextureRes(GetCtx(), dstName);
-
   if(IsBackgroundCapturing(m_State))
   {
     GLResourceRecord *dstrecord = GetResourceManager()->GetResourceRecord(dstRes);
@@ -1329,6 +1326,47 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
   SERIALISE_TIME_CALL(GL.glCopyImageSubData(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName,
                                             dstTarget, dstLevel, dstX, dstY, dstZ, srcWidth,
                                             srcHeight, srcDepth));
+
+  Common_glCopyImageSubDataEXT(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget,
+                               dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+}
+
+void WrappedOpenGL::glCopyImageSubDataEXT(GLuint srcName, GLenum srcTarget, GLint srcLevel,
+                                          GLint srcX, GLint srcY, GLint srcZ, GLuint dstName,
+                                          GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY,
+                                          GLint dstZ, GLsizei srcWidth, GLsizei srcHeight,
+                                          GLsizei srcDepth)
+{
+  CoherentMapImplicitBarrier();
+
+  GLResource dstRes = dstTarget == eGL_RENDERBUFFER ? RenderbufferRes(GetCtx(), dstName)
+                                                    : TextureRes(GetCtx(), dstName);
+  if(IsBackgroundCapturing(m_State))
+  {
+    GLResourceRecord *dstrecord = GetResourceManager()->GetResourceRecord(dstRes);
+
+    if(dstrecord)
+      GetResourceManager()->MarkResourceFrameReferenced(dstrecord->GetResourceID(),
+                                                        eFrameRef_PartialWrite);
+  }
+
+  SERIALISE_TIME_CALL(GL.glCopyImageSubDataEXT(srcName, srcTarget, srcLevel, srcX, srcY, srcZ,
+                                               dstName, dstTarget, dstLevel, dstX, dstY, dstZ,
+                                               srcWidth, srcHeight, srcDepth));
+
+  Common_glCopyImageSubDataEXT(srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstName, dstTarget,
+                               dstLevel, dstX, dstY, dstZ, srcWidth, srcHeight, srcDepth);
+}
+void WrappedOpenGL::Common_glCopyImageSubDataEXT(GLuint srcName, GLenum srcTarget, GLint srcLevel,
+                                                 GLint srcX, GLint srcY, GLint srcZ, GLuint dstName,
+                                                 GLenum dstTarget, GLint dstLevel, GLint dstX,
+                                                 GLint dstY, GLint dstZ, GLsizei srcWidth,
+                                                 GLsizei srcHeight, GLsizei srcDepth)
+{
+  GLResource srcRes = srcTarget == eGL_RENDERBUFFER ? RenderbufferRes(GetCtx(), srcName)
+                                                    : TextureRes(GetCtx(), srcName);
+  GLResource dstRes = dstTarget == eGL_RENDERBUFFER ? RenderbufferRes(GetCtx(), dstName)
+                                                    : TextureRes(GetCtx(), dstName);
 
   if(IsActiveCapturing(m_State))
   {


### PR DESCRIPTION
This changes splits glCopyImageSubDataEXT&glCopyImageSubData (rather than aliasing).

Angle's Vulkan backend has already supported `glCopyImageSubDataEXT` and it works fine, but we cannot call `glCopyImageSubData` instead. Because currently Angle's max supported version is 3.1, and `glCopyImageSubData` validate context for 3.2. (which means we cannot find a way to take use the non-ext API for now).

So with RenderDoc attached, our code fails because call to `glCopyImageSubDataEXT`  is forced into `glCopyImageSubData` .