### PR TITLE
Metal capture support for wrapped MTLBuffer

### DIFF
--- a/renderdoc/driver/metal/CMakeLists.txt
+++ b/renderdoc/driver/metal/CMakeLists.txt
@@ -31,6 +31,9 @@ set(sources
     metal_texture.cpp
     metal_texture.h
     metal_texture_bridge.mm
+    metal_buffer.cpp
+    metal_buffer.h
+    metal_buffer_bridge.mm
     metal_render_command_encoder.cpp
     metal_render_command_encoder.h
     metal_render_command_encoder_bridge.mm

--- a/renderdoc/driver/metal/metal_buffer.h
+++ b/renderdoc/driver/metal/metal_buffer.h
@@ -22,42 +22,25 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
-#include "metal_resources.h"
-#include "metal_buffer.h"
-#include "metal_command_buffer.h"
-#include "metal_command_queue.h"
+#pragma once
+
+#include "metal_common.h"
 #include "metal_device.h"
-#include "metal_function.h"
-#include "metal_library.h"
-#include "metal_render_command_encoder.h"
-#include "metal_render_pipeline_state.h"
-#include "metal_texture.h"
+#include "metal_resources.h"
 
-ResourceId GetResID(WrappedMTLObject *obj)
+class WrappedMTLBuffer : public WrappedMTLObject
 {
-  if(obj == NULL)
-    return ResourceId();
+public:
+  WrappedMTLBuffer(MTL::Buffer *realMTLBuffer, ResourceId objId, WrappedMTLDevice *wrappedMTLDevice);
 
-  return obj->m_ID;
-}
+  void *contents();
 
-#define IMPLEMENT_WRAPPED_TYPE_HELPERS(CPPTYPE) \
-  MTL::CPPTYPE *Unwrap(WrappedMTL##CPPTYPE *obj) { return Unwrap<MTL::CPPTYPE *>(obj); }
-METALCPP_WRAPPED_PROTOCOLS(IMPLEMENT_WRAPPED_TYPE_HELPERS)
-#undef IMPLEMENT_WRAPPED_TYPE_HELPERS
+  DECLARE_FUNCTION_SERIALISED(void, didModifyRange, NS::Range &range);
 
-void WrappedMTLObject::Dealloc()
-{
-  // TODO: call the wrapped object destructor
-}
+  enum
+  {
+    TypeEnum = eResBuffer
+  };
 
-MetalResourceManager *WrappedMTLObject::GetResourceManager()
-{
-  return m_Device->GetResourceManager();
-}
-
-MetalResourceRecord::~MetalResourceRecord()
-{
-  if(m_Type == eResCommandBuffer)
-    SAFE_DELETE(cmdInfo);
-}
+private:
+};

--- a/renderdoc/driver/metal/metal_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_buffer_bridge.mm
@@ -1,0 +1,189 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "metal_buffer.h"
+#include "metal_types_bridge.h"
+
+// Bridge for MTLBuffer
+@implementation ObjCBridgeMTLBuffer
+
+// ObjCBridgeMTLBuffer specific
+- (id<MTLBuffer>)real
+{
+  return id<MTLBuffer>(Unwrap(GetWrapped(self)));
+}
+
+// Silence compiler warning
+// error: method possibly missing a [super dealloc] call [-Werror,-Wobjc-missing-super-calls]
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
+- (void)dealloc
+{
+  GetWrapped(self)->Dealloc();
+}
+#pragma clang diagnostic pop
+
+// Use the real MTLBuffer to find methods from messages
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  id fwd = self.real;
+  return [fwd methodSignatureForSelector:aSelector];
+}
+
+// Forward any unknown messages to the real MTLBuffer
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  SEL aSelector = [invocation selector];
+
+  if([self.real respondsToSelector:aSelector])
+    [invocation invokeWithTarget:self.real];
+  else
+    [super forwardInvocation:invocation];
+}
+
+// MTLResource : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLResource.h
+
+- (nullable NSString *)label
+{
+  return self.real.label;
+}
+
+- (void)setLabel:value
+{
+  self.real.label = value;
+}
+
+- (id<MTLDevice>)device
+{
+  return id<MTLDevice>(GetWrapped(self)->GetDevice());
+}
+
+- (MTLCPUCacheMode)cpuCacheMode
+{
+  return self.real.cpuCacheMode;
+}
+
+- (MTLStorageMode)storageMode API_AVAILABLE(macos(10.11), ios(9.0))
+{
+  return self.real.storageMode;
+}
+
+- (MTLHazardTrackingMode)hazardTrackingMode API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.hazardTrackingMode;
+}
+
+- (MTLResourceOptions)resourceOptions API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.resourceOptions;
+}
+
+- (MTLPurgeableState)setPurgeableState:(MTLPurgeableState)state
+{
+  METAL_NOT_HOOKED();
+  return [self.real setPurgeableState:state];
+}
+
+- (id<MTLHeap>)heap API_AVAILABLE(macos(10.13), ios(10.0))
+{
+  return self.real.heap;
+}
+
+- (NSUInteger)heapOffset API_AVAILABLE(macos(10.15), ios(13.0))
+{
+  return self.real.heapOffset;
+}
+
+- (NSUInteger)allocatedSize API_AVAILABLE(macos(10.13), ios(11.0))
+{
+  return self.real.allocatedSize;
+}
+
+- (void)makeAliasable API_AVAILABLE(macos(10.13), ios(10.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real makeAliasable];
+}
+
+- (BOOL)isAliasable API_AVAILABLE(macos(10.13), ios(10.0))
+{
+  return [self.real isAliasable];
+}
+
+// MTLBuffer : based on the protocol defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLBuffer.h
+
+- (NSUInteger)length
+{
+  return self.real.length;
+}
+
+- (void *)contents NS_RETURNS_INNER_POINTER
+{
+  return GetWrapped(self)->contents();
+}
+
+- (void)didModifyRange:(NSRange)range API_AVAILABLE(macos(10.11), macCatalyst(13.0))
+                           API_UNAVAILABLE(ios)
+{
+  return GetWrapped(self)->didModifyRange((NS::Range &)range);
+}
+
+- (nullable id<MTLTexture>)newTextureWithDescriptor:(MTLTextureDescriptor *)descriptor
+                                             offset:(NSUInteger)offset
+                                        bytesPerRow:(NSUInteger)bytesPerRow
+    API_AVAILABLE(macos(10.13), ios(8.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real newTextureWithDescriptor:descriptor offset:offset bytesPerRow:bytesPerRow];
+}
+
+- (void)addDebugMarker:(NSString *)marker
+                 range:(NSRange)range API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real addDebugMarker:marker range:range];
+}
+
+- (void)removeAllDebugMarkers API_AVAILABLE(macos(10.12), ios(10.0))
+{
+  METAL_NOT_HOOKED();
+  return [self.real removeAllDebugMarkers];
+}
+
+- (id<MTLBuffer>)remoteStorageBuffer API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
+{
+  // TODO: This should be the wrapped MTLBuffer
+  return self.real.remoteStorageBuffer;
+}
+
+- (nullable id<MTLBuffer>)newRemoteBufferViewForDevice:(id<MTLDevice>)device
+    API_AVAILABLE(macos(10.15))API_UNAVAILABLE(ios)
+{
+  METAL_NOT_HOOKED();
+  return [self.real newRemoteBufferViewForDevice:device];
+}
+
+@end

--- a/renderdoc/driver/metal/metal_common.h
+++ b/renderdoc/driver/metal/metal_common.h
@@ -223,6 +223,15 @@ enum class MetalChunk : uint32_t
   MTLRenderCommandEncoder_memoryBarrierWithScope,
   MTLRenderCommandEncoder_memoryBarrierWithResources,
   MTLRenderCommandEncoder_sampleCountersInBuffer,
+  MTLBuffer_setPurgeableState,
+  MTLBuffer_makeAliasable,
+  MTLBuffer_contents,
+  MTLBuffer_didModifyRange,
+  MTLBuffer_newTextureWithDescriptor,
+  MTLBuffer_addDebugMarker,
+  MTLBuffer_removeAllDebugMarkers,
+  MTLBuffer_remoteStorageBuffer,
+  MTLBuffer_newRemoteBufferViewForDevice,
   Max
 };
 

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -50,6 +50,9 @@ public:
                                               IOSurfaceRef iosurface, NS::UInteger plane);
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLTexture *, newTextureWithDescriptor,
                                           RDMTL::TextureDescriptor &descriptor);
+  WrappedMTLBuffer *newBufferWithLength(NS::UInteger length, MTL::ResourceOptions options);
+  DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLBuffer *, newBufferWithBytes, const void *pointer,
+                                          NS::UInteger length, MTL::ResourceOptions options);
 
   // Non-Serialised MTLDevice APIs
   bool isDepth24Stencil8PixelFormatSupported();
@@ -106,6 +109,8 @@ private:
   WrappedMTLTexture *Common_NewTexture(RDMTL::TextureDescriptor &descriptor, MetalChunk chunkType,
                                        bool ioSurfaceTexture, IOSurfaceRef iosurface,
                                        NS::UInteger plane);
+  WrappedMTLBuffer *Common_NewBuffer(bool withBytes, const void *pointer, NS::UInteger length,
+                                     MTL::ResourceOptions options);
 
   MetalResourceManager *m_ResourceManager;
 

--- a/renderdoc/driver/metal/metal_device_bridge.mm
+++ b/renderdoc/driver/metal/metal_device_bridge.mm
@@ -223,16 +223,15 @@
 
 - (nullable id<MTLBuffer>)newBufferWithLength:(NSUInteger)length options:(MTLResourceOptions)options
 {
-  METAL_NOT_HOOKED();
-  return [self.real newBufferWithLength:length options:options];
+  return id<MTLBuffer>(GetWrapped(self)->newBufferWithLength(length, (MTL::ResourceOptions)options));
 }
 
 - (nullable id<MTLBuffer>)newBufferWithBytes:(const void *)pointer
                                       length:(NSUInteger)length
                                      options:(MTLResourceOptions)options
 {
-  METAL_NOT_HOOKED();
-  return [self.real newBufferWithBytes:pointer length:length options:options];
+  return id<MTLBuffer>(
+      GetWrapped(self)->newBufferWithBytes(pointer, length, (MTL::ResourceOptions)options));
 }
 
 - (nullable id<MTLBuffer>)newBufferWithBytesNoCopy:(void *)pointer

--- a/renderdoc/driver/metal/metal_render_command_encoder.cpp
+++ b/renderdoc/driver/metal/metal_render_command_encoder.cpp
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include "metal_render_command_encoder.h"
+#include "metal_buffer.h"
 #include "metal_command_buffer.h"
 #include "metal_manager.h"
 #include "metal_render_pipeline_state.h"
@@ -69,6 +70,94 @@ void WrappedMTLRenderCommandEncoder::setRenderPipelineState(WrappedMTLRenderPipe
     MetalResourceRecord *bufferRecord = GetRecord(m_CommandBuffer);
     bufferRecord->AddChunk(chunk);
     bufferRecord->MarkResourceFrameReferenced(GetResID(pipelineState), eFrameRef_Read);
+  }
+  else
+  {
+    // TODO: implement RD MTL replay
+  }
+}
+
+template <typename SerialiserType>
+bool WrappedMTLRenderCommandEncoder::Serialise_setVertexBuffer(SerialiserType &ser,
+                                                               WrappedMTLBuffer *buffer,
+                                                               NS::UInteger offset,
+                                                               NS::UInteger index)
+{
+  SERIALISE_ELEMENT_LOCAL(RenderCommandEncoder, this);
+  SERIALISE_ELEMENT(buffer).Important();
+  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(index).Important();
+
+  SERIALISE_CHECK_READ_ERRORS();
+
+  // TODO: implement RD MTL replay
+  if(IsReplayingAndReading())
+  {
+  }
+  return true;
+}
+
+void WrappedMTLRenderCommandEncoder::setVertexBuffer(WrappedMTLBuffer *buffer, NS::UInteger offset,
+                                                     NS::UInteger index)
+{
+  SERIALISE_TIME_CALL(Unwrap(this)->setVertexBuffer(Unwrap(buffer), offset, index));
+
+  if(IsCaptureMode(m_State))
+  {
+    Chunk *chunk = NULL;
+    {
+      CACHE_THREAD_SERIALISER();
+      SCOPED_SERIALISE_CHUNK(MetalChunk::MTLRenderCommandEncoder_setVertexBuffer);
+      Serialise_setVertexBuffer(ser, buffer, offset, index);
+      chunk = scope.Get();
+    }
+    MetalResourceRecord *bufferRecord = GetRecord(m_CommandBuffer);
+    bufferRecord->AddChunk(chunk);
+    bufferRecord->MarkResourceFrameReferenced(GetResID(buffer), eFrameRef_Read);
+  }
+  else
+  {
+    // TODO: implement RD MTL replay
+  }
+}
+
+template <typename SerialiserType>
+bool WrappedMTLRenderCommandEncoder::Serialise_setFragmentBuffer(SerialiserType &ser,
+                                                                 WrappedMTLBuffer *buffer,
+                                                                 NS::UInteger offset,
+                                                                 NS::UInteger index)
+{
+  SERIALISE_ELEMENT_LOCAL(RenderCommandEncoder, this);
+  SERIALISE_ELEMENT(buffer).Important();
+  SERIALISE_ELEMENT(offset);
+  SERIALISE_ELEMENT(index).Important();
+
+  SERIALISE_CHECK_READ_ERRORS();
+
+  // TODO: implement RD MTL replay
+  if(IsReplayingAndReading())
+  {
+  }
+  return true;
+}
+
+void WrappedMTLRenderCommandEncoder::setFragmentBuffer(WrappedMTLBuffer *buffer,
+                                                       NS::UInteger offset, NS::UInteger index)
+{
+  SERIALISE_TIME_CALL(Unwrap(this)->setFragmentBuffer(Unwrap(buffer), offset, index));
+
+  if(IsCaptureMode(m_State))
+  {
+    Chunk *chunk = NULL;
+    {
+      CACHE_THREAD_SERIALISER();
+      SCOPED_SERIALISE_CHUNK(MetalChunk::MTLRenderCommandEncoder_setFragmentBuffer);
+      Serialise_setFragmentBuffer(ser, buffer, offset, index);
+      chunk = scope.Get();
+    }
+    MetalResourceRecord *bufferRecord = GetRecord(m_CommandBuffer);
+    bufferRecord->AddChunk(chunk);
+    bufferRecord->MarkResourceFrameReferenced(GetResID(buffer), eFrameRef_Read);
   }
   else
   {
@@ -258,6 +347,10 @@ void WrappedMTLRenderCommandEncoder::endEncoding()
 INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLRenderCommandEncoder, void, endEncoding);
 INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLRenderCommandEncoder, void, setRenderPipelineState,
                                 WrappedMTLRenderPipelineState *pipelineState);
+INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLRenderCommandEncoder, void, setVertexBuffer,
+                                WrappedMTLBuffer *buffer, NS::UInteger offset, NS::UInteger index);
+INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLRenderCommandEncoder, void, setFragmentBuffer,
+                                WrappedMTLBuffer *buffer, NS::UInteger offset, NS::UInteger index);
 INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLRenderCommandEncoder, void, setFragmentTexture,
                                 WrappedMTLTexture *texture, NS::UInteger index);
 INSTANTIATE_FUNCTION_SERIALISED(WrappedMTLRenderCommandEncoder, void, setViewport,

--- a/renderdoc/driver/metal/metal_render_command_encoder.h
+++ b/renderdoc/driver/metal/metal_render_command_encoder.h
@@ -37,6 +37,10 @@ public:
   void SetCommandBuffer(WrappedMTLCommandBuffer *commandBuffer) { m_CommandBuffer = commandBuffer; }
   DECLARE_FUNCTION_SERIALISED(void, setRenderPipelineState,
                               WrappedMTLRenderPipelineState *pipelineState);
+  DECLARE_FUNCTION_SERIALISED(void, setVertexBuffer, WrappedMTLBuffer *buffer, NS::UInteger offset,
+                              NS::UInteger index);
+  DECLARE_FUNCTION_SERIALISED(void, setFragmentBuffer, WrappedMTLBuffer *buffer,
+                              NS::UInteger offset, NS::UInteger index);
   DECLARE_FUNCTION_SERIALISED(void, setFragmentTexture, WrappedMTLTexture *texture,
                               NS::UInteger index);
   DECLARE_FUNCTION_SERIALISED(void, setViewport, MTL::Viewport &viewport);

--- a/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
+++ b/renderdoc/driver/metal/metal_render_command_encoder_bridge.mm
@@ -123,8 +123,7 @@
                  offset:(NSUInteger)offset
                 atIndex:(NSUInteger)index
 {
-  METAL_NOT_HOOKED();
-  return [self.real setVertexBuffer:buffer offset:offset atIndex:index];
+  GetWrapped(self)->setVertexBuffer(GetWrapped(buffer), offset, index);
 }
 
 - (void)setVertexBufferOffset:(NSUInteger)offset
@@ -318,8 +317,7 @@
                    offset:(NSUInteger)offset
                   atIndex:(NSUInteger)index
 {
-  METAL_NOT_HOOKED();
-  [self.real setFragmentBuffer:buffer offset:offset atIndex:index];
+  GetWrapped(self)->setFragmentBuffer(GetWrapped(buffer), offset, index);
 }
 
 - (void)setFragmentBufferOffset:(NSUInteger)offset

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -35,6 +35,7 @@ class MetalResourceManager;
 enum MetalResourceType
 {
   eResUnknown = 0,
+  eResBuffer,
   eResCommandBuffer,
   eResCommandQueue,
   eResDevice,

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -244,9 +244,9 @@ void DoSerialise(SerialiserType &ser, RDMTL::RenderPipelineDescriptor &el)
   SERIALISE_MEMBER(vertexBuffers);
   SERIALISE_MEMBER(fragmentBuffers);
   SERIALISE_MEMBER(supportIndirectCommandBuffers);
-  // TODO: will MTL::BinaryArchive need to be a wrapped resource
+  // TODO: when WrappedMTLBinaryArchive exists
   // SERIALISE_MEMBER(binaryArchives);
-  // TODO: will MTL::DynamicLibrary need to be a wrapped resource
+  // TODO: when WrappedMTLDynamicLibrary exists
   // SERIALISE_MEMBER(vertexPreloadedLibraries);
   // SERIALISE_MEMBER(fragmentPreloadedLibraries);
   SERIALISE_MEMBER(vertexLinkedFunctions);

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include "metal_buffer.h"
 #include "metal_command_buffer.h"
 #include "metal_command_queue.h"
 #include "metal_device.h"
@@ -92,6 +93,13 @@ void DoSerialise(SerialiserType &ser, NS::String *&el)
   {
     el = NS::String::string(rdcStr.data(), NS::UTF8StringEncoding);
   }
+}
+
+template <class SerialiserType>
+void DoSerialise(SerialiserType &ser, NS::Range &el)
+{
+  SERIALISE_MEMBER(location);
+  SERIALISE_MEMBER(length);
 }
 
 template <typename SerialiserType>
@@ -305,8 +313,7 @@ void DoSerialise(SerialiserType &ser, RDMTL::RenderPassDescriptor &el)
   SERIALISE_MEMBER(colorAttachments);
   SERIALISE_MEMBER(depthAttachment);
   SERIALISE_MEMBER(stencilAttachment);
-  // TODO: when WrappedMTLBuffer exists
-  // WrappedMTLBuffer *visibilityResultBuffer;
+  SERIALISE_MEMBER(visibilityResultBuffer);
   SERIALISE_MEMBER(renderTargetArrayLength);
   SERIALISE_MEMBER(imageblockSampleLength);
   SERIALISE_MEMBER(threadgroupMemoryLength);
@@ -322,6 +329,7 @@ void DoSerialise(SerialiserType &ser, RDMTL::RenderPassDescriptor &el)
 };
 
 INSTANTIATE_SERIALISE_TYPE(NS::String *);
+INSTANTIATE_SERIALISE_TYPE(NS::Range)
 INSTANTIATE_SERIALISE_TYPE(MTL::TextureSwizzleChannels);
 INSTANTIATE_SERIALISE_TYPE(MTL::ClearColor);
 INSTANTIATE_SERIALISE_TYPE(MTL::SamplePosition);

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include "metal_types.h"
+#include "metal_buffer.h"
 #include "metal_command_buffer.h"
 #include "metal_command_queue.h"
 #include "metal_device.h"
@@ -520,8 +521,7 @@ void RenderPassSampleBufferAttachmentDescriptor::CopyTo(
 RenderPassDescriptor::RenderPassDescriptor(MTL::RenderPassDescriptor *objc)
     : depthAttachment(objc->depthAttachment()),
       stencilAttachment(objc->stencilAttachment()),
-      // TODO: when WrappedMTLBuffer exists
-      // visibilityResultBuffer(GetWrapped(objc->visibilityResultBuffer())),
+      visibilityResultBuffer(GetWrapped(objc->visibilityResultBuffer())),
       renderTargetArrayLength(objc->renderTargetArrayLength()),
       imageblockSampleLength(objc->imageblockSampleLength()),
       threadgroupMemoryLength(objc->threadgroupMemoryLength()),
@@ -551,8 +551,7 @@ RenderPassDescriptor::operator MTL::RenderPassDescriptor *()
   COPYTOOBJCARRAY(RenderPassColorAttachmentDescriptor, colorAttachments);
   depthAttachment.CopyTo(objc->depthAttachment());
   stencilAttachment.CopyTo(objc->stencilAttachment());
-  // TODO: when WrappedMTLBuffer exists
-  // objc->setVisibilityResultBuffer(Unwrap(visibilityResultBuffer));
+  objc->setVisibilityResultBuffer(Unwrap(visibilityResultBuffer));
   objc->setRenderTargetArrayLength(renderTargetArrayLength);
   objc->setImageblockSampleLength(imageblockSampleLength);
   objc->setThreadgroupMemoryLength(threadgroupMemoryLength);

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -371,11 +371,11 @@ RenderPipelineDescriptor::RenderPipelineDescriptor(MTL::RenderPipelineDescriptor
                ValidData);
   GETOBJCARRAY(PipelineBufferDescriptor, MAX_RENDER_PASS_BUFFER_ATTACHMENTS, fragmentBuffers,
                ValidData);
-  // TODO: will MTL::BinaryArchive need to be a wrapped resource
-  // rdcarray<MTL::BinaryArchive*> binaryArchives;
-  // TODO: will MTL::DynamicLibrary need to be a wrapped resource
-  // rdcarray<MTL::DynamicLibrary*> vertexPreloadedLibraries;
-  // rdcarray<MTL::DynamicLibrary*> fragmentPreloadedLibraries;
+  // TODO: when WrappedMTLBinaryArchive exists
+  // GETWRAPPEDNSARRAY(BinaryArchive, binaryArchives);
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // GETWRAPPEDNSARRAY(DynamicLibrary, vertexPreloadedLibraries);
+  // GETWRAPPEDNSARRAY(DynamicLibrary, fragmentPreloadedLibraries);
 }
 
 RenderPipelineDescriptor::operator MTL::RenderPipelineDescriptor *()
@@ -408,11 +408,13 @@ RenderPipelineDescriptor::operator MTL::RenderPipelineDescriptor *()
   COPYTOOBJCARRAY(PipelineBufferDescriptor, vertexBuffers);
   COPYTOOBJCARRAY(PipelineBufferDescriptor, fragmentBuffers);
   objc->setSupportIndirectCommandBuffers(supportIndirectCommandBuffers);
-  // TODO: will MTL::BinaryArchive need to be a wrapped resource
-  // rdcarray<MTL::BinaryArchive*> binaryArchives;
-  // TODO: will MTL::DynamicLibrary need to be a wrapped resource
-  // rdcarray<MTL::DynamicLibrary*> vertexPreloadedLibraries;
-  // rdcarray<MTL::DynamicLibrary*> fragmentPreloadedLibraries;
+  // TODO: when WrappedMTLBinaryArchive exists
+  // objc->setBinaryArchives(CreateUnwrappedNSArray<MTL::BinaryArchive *>(binaryArchives));
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // objc->setVertexPreloadedLibraries(CreateUnwrappedNSArray<MTL::DynamicLibrary
+  // *>(vertexPreloadedLibraries));
+  // objc->setFragmentPreloadedLibraries(CreateUnwrappedNSArray<MTL::DynamicLibrary
+  // *>(fragmentPreloadedLibraries));
   vertexLinkedFunctions.CopyTo(objc->vertexLinkedFunctions());
   fragmentLinkedFunctions.CopyTo(objc->fragmentLinkedFunctions());
   objc->setSupportAddingVertexBinaryFunctions(supportAddingVertexBinaryFunctions);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -266,11 +266,11 @@ struct RenderPipelineDescriptor
   rdcarray<PipelineBufferDescriptor> vertexBuffers;
   rdcarray<PipelineBufferDescriptor> fragmentBuffers;
   bool supportIndirectCommandBuffers = false;
-  // TODO: will MTL::BinaryArchive need to be a wrapped resource
-  // rdcarray<MTL::BinaryArchive*> binaryArchives;
-  // TODO: will MTL::DynamicLibrary need to be a wrapped resource
-  // rdcarray<MTL::DynamicLibrary*> vertexPreloadedLibraries;
-  // rdcarray<MTL::DynamicLibrary*> fragmentPreloadedLibraries;
+  // TODO: when WrappedMTLBinaryArchive exists
+  // rdcarray<WrappedMTLBinaryArchive*> binaryArchives;
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // rdcarray<WrappedMTLDynamicLibrary*> vertexPreloadedLibraries;
+  // rdcarray<WrappedMTLDynamicLibrary*> fragmentPreloadedLibraries;
   LinkedFunctions vertexLinkedFunctions;
   LinkedFunctions fragmentLinkedFunctions;
   bool supportAddingVertexBinaryFunctions = false;

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -40,6 +40,7 @@ const uint32_t MAX_RENDER_PASS_SAMPLE_BUFFER_ATTACHMENTS = 4;
 #endif    // #ifndef MTLCounterDontSample
 
 #define METALCPP_WRAPPED_PROTOCOLS(FUNC) \
+  FUNC(Buffer);                          \
   FUNC(CommandBuffer);                   \
   FUNC(CommandQueue);                    \
   FUNC(Device);                          \
@@ -114,6 +115,14 @@ MTL_DECLARE_REFLECTION_TYPE(Viewport);
 MTL_DECLARE_REFLECTION_TYPE(MultisampleDepthResolveFilter);
 MTL_DECLARE_REFLECTION_TYPE(MultisampleStencilResolveFilter);
 MTL_DECLARE_REFLECTION_TYPE(SamplePosition);
+
+template <>
+inline rdcliteral TypeName<NS::Range>()
+{
+  return "NSRange"_lit;
+}
+template <class SerialiserType>
+void DoSerialise(SerialiserType &ser, NS::Range &el);
 
 namespace RDMTL
 {
@@ -358,8 +367,7 @@ struct RenderPassDescriptor
   rdcarray<RenderPassColorAttachmentDescriptor> colorAttachments;
   RenderPassDepthAttachmentDescriptor depthAttachment;
   RenderPassStencilAttachmentDescriptor stencilAttachment;
-  // TODO: when WrappedMTLBuffer exists
-  // WrappedMTLBuffer *visibilityResultBuffer;
+  WrappedMTLBuffer *visibilityResultBuffer = NULL;
   NS::UInteger renderTargetArrayLength = 0;
   NS::UInteger imageblockSampleLength = 0;
   NS::UInteger threadgroupMemoryLength = 0;


### PR DESCRIPTION
## Description

Added wrapped `MTLBuffer`.

This is the first Metal wrapped resource where most of its hooked APIs do not need to be serialized. 
Keen to get the design pattern for this type of wrapped resource robust to be used as a reference for future wrapped resources like this.

Implemented capture serialization for:
* `MTLBuffer::didModifyRange`
* `MTLDevice::newBufferWithBytes`
* `MTLDevice::newBufferWithLength`
* `MTLRenderCommandEncoder::setVertexBuffer`
* `MTLRenderCommandEncoder::setFragmentBuffer`

Implemented hooked but non-serialized APIs:
* `MTLBuffer::contents`
* `MTLBuffer::length`

Updated `RDMTL::RenderPassDescriptor` to serialise `visibilityResultBuffer` member using`WrappedMTLBuffer *`.

`MTLRenderCommandEncoder::setVertexBuffer` and `MTLRenderCommandEncoder:: setFragmentBuffer` mark the buffer resource as frame referenced in the command buffer record.

`MTLBuffer::contents` marks the buffer resource as dirty if the returned pointer is non-NULL.

Updated TODO's in `RenderPipelineDescriptor`.
* `binaryArchives` will need to use `WrappedMTLBinaryArchive` when it exists.
* `vertexPreloadedLibraries` and `fragmentPreloadedLibraries` will need to `WrappedMTLDynamicLibrary` when it exists.

Added serialization for `NS::Range`.
