### PR TITLE
Fix Capture  OPENGL glCopyImageSubData Crash

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -1359,6 +1359,12 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
     GLResourceRecord *srcrecord = GetResourceManager()->GetResourceRecord(srcRes);
     GLResourceRecord *dstrecord = GetResourceManager()->GetResourceRecord(dstRes);
 
+    RDCASSERTMSG("Couldn't identify src texture. Unbound or bad GLuint?", srcrecord, srcName);
+    RDCASSERTMSG("Couldn't identify dst texture. Unbound or bad GLuint?", dstrecord, dstName);
+
+    if(srcrecord == NULL || dstrecord == NULL)
+      return;
+
     GetResourceManager()->MarkDirtyResource(dstrecord->GetResourceID());
 
     // copy over compressed data, if it exists


### PR DESCRIPTION
Fix Capture  OPENGL glCopyImageSubData Crash



<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

When Capture OPENGL glCopyImageSubData api call like glCopyImageSubDa(srcName = 0, dstName = 0);  GLResourceRecord srcrecord or dstrecord will be nullptr;

so we add check here avoid the invalid api call parameter cause crash;
