### PR TITLE
Do not use inline asm for debugbreak on non i386/x86_64 targets

### DIFF
--- a/renderdoc/common/common.h
+++ b/renderdoc/common/common.h
@@ -48,7 +48,7 @@
 #include <stdlib.h>
 #define OS_DEBUG_BREAK() abort()
 
-#elif ENABLED(RDOC_LINUX)
+#elif ENABLED(RDOC_LINUX) && (defined(__i386__) || defined(__x86_64__))
 
 #define OS_DEBUG_BREAK()           \
   do                               \


### PR DESCRIPTION
## Description

Fixes compilation on non i386/x86_64 Linux targets.

Don't use arch specific assembly for other architectures because
in most cases it breaks gdb ability to do next step.