### PR TITLE
Fix typo in intercepted CreateCommittedResource

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device_wrap4.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap4.cpp
@@ -373,7 +373,7 @@ HRESULT WrappedID3D12Device::CreateCommittedResource1(
   void *realptr = NULL;
   HRESULT ret;
   SERIALISE_TIME_CALL(ret = m_pDevice4->CreateCommittedResource1(
-                          pHeapProperties, HeapFlags, pDesc, InitialResourceState,
+                          pHeapProperties, HeapFlags, pCreateDesc, InitialResourceState,
                           pOptimizedClearValue, Unwrap(pProtectedSession), riidResource, &realptr));
 
   ID3D12Resource *real = NULL;

--- a/renderdoc/driver/d3d12/d3d12_device_wrap8.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap8.cpp
@@ -197,7 +197,7 @@ HRESULT WrappedID3D12Device::CreateCommittedResource2(
   void *realptr = NULL;
   HRESULT ret;
   SERIALISE_TIME_CALL(ret = m_pDevice8->CreateCommittedResource2(
-                          pHeapProperties, HeapFlags, pDesc, InitialResourceState,
+                          pHeapProperties, HeapFlags, pCreateDesc, InitialResourceState,
                           pOptimizedClearValue, Unwrap(pProtectedSession), riidResource, &realptr));
 
   ID3D12Resource *real = NULL;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
Commit [028d71fced9ce5e9dce598d2ef2be4009ce4fead](https://github.com/baldurk/renderdoc/commit/028d71fced9ce5e9dce598d2ef2be4009ce4fead) added a code snippet to handle the D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE flag in WrappedID3D12Device::CreateCommittedResource1 and WrappedID3D12Device::CreateCommittedResource2. This is great but I believe there was a typo.


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
