### PR TITLE
Set the enable state for Save, Delete actions

### DIFF
--- a/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
@@ -1076,6 +1076,8 @@ void LiveCapture::on_captures_itemSelectionChanged()
   int numSelected = ui->captures->selectedItems().size();
 
   openButton->setEnabled(numSelected == 1);
+  saveAction->setEnabled(numSelected != 0);
+  deleteAction->setEnabled(numSelected != 0);
 
   if(ui->captures->selectedItems().size() == 1)
   {


### PR DESCRIPTION
## Description

Disable the LiveCapture Save and Delete actions when no captures are selected
Before this change:
* The "Save" action would appear to work by asking the user for a save file location and would silently not save the capture.
* The "Delete" action would do nothing.

Before

<img width="872" alt="image" src="https://user-images.githubusercontent.com/39392/174492005-49da5145-4a32-48ea-b92b-98627a3c0940.png">

After

<img width="868" alt="image" src="https://user-images.githubusercontent.com/39392/174491961-eaa799f8-389e-40cb-9344-0c448de81110.png">

After - selecting a capture

<img width="871" alt="image" src="https://user-images.githubusercontent.com/39392/174497982-bf3f1cc3-d63a-4a1e-9437-907bfb027064.png">



