### PR TITLE
Improve Xcode project generation for qrenderdoc

### DIFF
--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -320,22 +320,62 @@ add_custom_target(swig-bindings ALL DEPENDS ${swig_output})
 
 if(ENABLE_QRENDERDOC)
 
+set(QRD_DEPENDENCIES RenderDoc.icns)
+
+if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
+    file(GLOB_RECURSE CODE_FILES Code/*.h Code/*.cpp Code/*.mm Code/*.i)
+    list(SORT CODE_FILES COMPARE FILE_BASENAME)
+    list(APPEND QRD_XCODE_SOURCES ${CODE_FILES})
+
+    file(GLOB_RECURSE STYLES_FILES Styles/*.h Styles/*.cpp)
+    list(SORT STYLES_FILES COMPARE FILE_BASENAME)
+    list(APPEND QRD_XCODE_SOURCES ${STYLES_FILES})
+
+    file(GLOB_RECURSE WIDGETS_FILES Widgets/*.h Widgets/*.cpp)
+    list(SORT WIDGETS_FILES COMPARE FILE_BASENAME)
+    list(APPEND QRD_XCODE_SOURCES ${WIDGETS_FILES})
+
+    file(GLOB_RECURSE WINDOWS_FILES Windows/*.h Windows/*.cpp Windows/*.ui)
+    list(SORT WINDOWS_FILES COMPARE FILE_BASENAME)
+    list(APPEND QRD_XCODE_SOURCES ${WINDOWS_FILES})
+
+    file(GLOB_RECURSE THIRDPARTY_FILES 
+        3rdParty/toolwindowmanager/*.h
+        3rdParty/toolwindowmanager/*.cpp
+        3rdParty/flowlayout/*.h
+        3rdParty/flowlayout/*.cpp
+        3rdParty/scintilla/*.h
+        3rdParty/scintilla/*.cxx
+        3rdParty/scintilla/*.cpp)
+    list(SORT THIRDPARTY_FILES COMPARE FILE_BASENAME)
+    list(APPEND QRD_XCODE_SOURCES ${THIRDPARTY_FILES})
+
+    list(APPEND QRD_DEPENDENCIES ${CMAKE_BINARY_DIR}/qrenderdoc/renderdoc_python.cxx)
+    list(APPEND QRD_DEPENDENCIES ${CMAKE_BINARY_DIR}/qrenderdoc/qrenderdoc_python.cxx)
+    list(APPEND QRD_DEPENDENCIES ${QRD_XCODE_SOURCES})
+endif()
+
 # The case here is deliberately not matching the executable name
 # This means the custom command doesn't create this output file,
 # which causes CMake to rerun this target every time so that Qt
 # can do dependency checking and rebuild anything necessary.
+# Xcode does not match this behaviour. Add broad brush file dependencies.
+# Xcode has an option to match this behaviour (not exposed by cmake).
 add_custom_command(OUTPUT QRenderDoc
     COMMAND ${SET_SYSTEM_PATH_COMMAND} ${QMAKE_QT5_COMMAND} "CMAKE_DIR=${CMAKE_BINARY_DIR}" ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND ${GENERATOR_MAKE} ${GENERATOR_MAKE_PARAMS}
-    DEPENDS RenderDoc.icns)
+    DEPENDS ${QRD_DEPENDENCIES})
 add_custom_target(build-qrenderdoc ALL DEPENDS QRenderDoc DEPENDS renderdoc DEPENDS swig-bindings)
 
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
     set_target_properties(build-qrenderdoc PROPERTIES XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING OFF)
     set_target_properties(build-qrenderdoc PROPERTIES XCODE_SCHEME_EXECUTABLE ${CMAKE_BINARY_DIR}/bin/qrenderdoc.app)
-
-    file(GLOB_RECURSE QRD_CODE_FILES Code/*.[h|c|m]* Styles/*.[h|c|m]* Widgets/*.[h|c|m]* Windows/*.[h|c|m]*)
-    target_sources(build-qrenderdoc PRIVATE ${QRD_CODE_FILES})
+    target_sources(build-qrenderdoc PRIVATE ${QRD_XCODE_SOURCES})
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${CODE_FILES})
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${STYLES_FILES})
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${WIDGETS_FILES})
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${WINDOWS_FILES})
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${THIRDPARTY_FILES})
 endif()
 
 install (PROGRAMS ${CMAKE_BINARY_DIR}/bin/qrenderdoc DESTINATION bin)


### PR DESCRIPTION
## Description

For a few months have been noticing dependency issues when building the qrenderdoc project with Xcode which I attributed to Xcode build system problems.

Investigating this dependency issue in more detail and discovered it works fine when using the makefile generator.

Examining the generated Xcode project shows the only dependency is the `RenderDoc.icns` file.
The cmake file has this comment
```
# The case here is deliberately not matching the executable name
# This means the custom command doesn't create this output file,
# which causes CMake to rerun this target every time so that Qt
# can do dependency checking and rebuild anything necessary.
```
Xcode does not match this behaviour by default. 
There is an Xcode property to behave like this however, that is not exposed by cmake.
To improve the Xcode qrenderdoc project dependency support manually add broad-brush qrenderdoc source files as dependencies. This is not guaranteed to be foolproof or future-proof, for those situations the local user can manually set the Xcode property to always run the qrenderdoc build target.

Tweaked the Xcode project for qrenderdoc to add the files to the UI grouped by the file system folders using the cmake source_group(TREE *) command ie.
<img width="312" alt="image" src="https://user-images.githubusercontent.com/39392/175812529-2e5bf540-268a-4481-824c-a0db1d496335.png">
