### PR TITLE
fix preview window bug post-activity destruction

### DIFF
--- a/renderdoccmd/renderdoccmd_android.cpp
+++ b/renderdoccmd/renderdoccmd_android.cpp
@@ -126,10 +126,10 @@ void DisplayGenericSplash()
 
   EGLDisplay eglDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
-  ANativeWindow *previewWindow = android_state->window;
-
-  if(eglDisplay && previewWindow)
+  if(eglDisplay && android_state && android_state->window)
   {
+    ANativeWindow *previewWindow = android_state->window;
+
     int major = 0, minor = 0;
     EGLBoolean initialised = eglInitialize(eglDisplay, &major, &minor);
 
@@ -333,7 +333,7 @@ WindowingData DisplayRemoteServerPreview(bool active, const rdcarray<WindowingSy
 
   WindowingData ret = {WindowingSystem::Unknown};
 
-  if(android_state->window)
+  if(android_state && android_state->window)
     ret = CreateAndroidWindowingData(android_state->window);
 
   return ret;
@@ -491,4 +491,5 @@ void android_main(struct android_app *state)
   } while(android_state->destroyRequested == 0);
 
   ANDROID_LOG("android_main exiting");
+  android_state = NULL;
 }


### PR DESCRIPTION
renderdoccmd is separate from its main activity during replay : if the nativewindow is backgrounded, the activity can be stopped (and we'll receive a APP_CMD_DESTROY in

`void handle_cmd(android_app *app, int32_t cmd)`
)
although renderdoccmd still runs and gives all the replay data to the PC. 
When that happens, DisplayRemoteServerPreview cannot read from _android_state->window_ as _android_state_ is undefined post-CMD_DESTROY. Reading from it, and calling then _ANativeWindow_GetWidth()_ results in a *SIGBUS*