### PR TITLE
Fix Vulkan crash when viewing NV12 in TextureViewer

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -2411,6 +2411,7 @@ struct BlockShape
 };
 
 BlockShape GetBlockShape(VkFormat Format, uint32_t plane);
+VkExtent2D GetPlaneShape(uint32_t Width, uint32_t Height, VkFormat Format, uint32_t plane);
 
 uint32_t GetByteSize(uint32_t Width, uint32_t Height, uint32_t Depth, VkFormat Format, uint32_t mip);
 uint32_t GetPlaneByteSize(uint32_t Width, uint32_t Height, uint32_t Depth, VkFormat Format,


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

This fixes a Vulkan error when viewing an NV12 (aka. VK_FORMAT_G8_B8R8_2PLANE_420_UNORM) input texture in the TextureViewer. The root cause is attempting to copy a planar image with VK_IMAGE_ASPECT_COLOR_BIT, when instead there should be multiple copy regions with VK_IMAGE_ASPECT_PLANE_i_BIT for each plane. On my device this error subsequently causes a lost device / crash.
