### PR TITLE
Pre-requisites to support basic Metal capture 

### DIFF
--- a/renderdoc/driver/metal/metal_buffer.cpp
+++ b/renderdoc/driver/metal/metal_buffer.cpp
@@ -86,15 +86,12 @@ void WrappedMTLBuffer::didModifyRange(NS::Range &range)
   SERIALISE_TIME_CALL(Unwrap(this)->didModifyRange(range));
   if(IsCaptureMode(m_State))
   {
-    bool backframe = IsBackgroundCapturing(m_State);
-    if(backframe)
+    if(IsBackgroundCapturing(m_State))
     {
       // Snapshot potentially CPU modified buffer
       GetResourceManager()->MarkDirtyResource(m_ID);
     }
-
-    bool capframe = IsActiveCapturing(m_State);
-    if(capframe)
+    else
     {
       Chunk *chunk = NULL;
       {

--- a/renderdoc/driver/metal/metal_command_buffer.cpp
+++ b/renderdoc/driver/metal/metal_command_buffer.cpp
@@ -219,8 +219,7 @@ void WrappedMTLCommandBuffer::commit()
     MetalResourceRecord *bufferRecord = GetRecord(this);
     bufferRecord->AddChunk(chunk);
 
-    bool capframe = IsActiveCapturing(m_State);
-    if(capframe)
+    if(IsActiveCapturing(m_State))
     {
       bufferRecord->AddRef();
       bufferRecord->MarkResourceFrameReferenced(GetResID(m_CommandQueue), eFrameRef_Read);

--- a/renderdoc/driver/metal/metal_command_buffer.h
+++ b/renderdoc/driver/metal/metal_command_buffer.h
@@ -36,7 +36,7 @@ public:
                           WrappedMTLDevice *wrappedMTLDevice);
 
   void SetCommandQueue(WrappedMTLCommandQueue *commandQueue) { m_CommandQueue = commandQueue; }
-  MTL::CommandQueue *GetCommandQueue() { return (MTL::CommandQueue *)m_CommandQueue; }
+  WrappedMTLCommandQueue *GetCommandQueue() { return m_CommandQueue; }
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLBlitCommandEncoder *, blitCommandEncoder);
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLRenderCommandEncoder *,
                                           renderCommandEncoderWithDescriptor,

--- a/renderdoc/driver/metal/metal_command_buffer.h
+++ b/renderdoc/driver/metal/metal_command_buffer.h
@@ -43,6 +43,8 @@ public:
                                           RDMTL::RenderPassDescriptor &descriptor);
   DECLARE_FUNCTION_SERIALISED(void, presentDrawable, MTL::Drawable *drawable);
   DECLARE_FUNCTION_SERIALISED(void, commit);
+  DECLARE_FUNCTION_SERIALISED(void, enqueue);
+  DECLARE_FUNCTION_SERIALISED(void, waitUntilCompleted);
 
   enum
   {

--- a/renderdoc/driver/metal/metal_command_buffer_bridge.mm
+++ b/renderdoc/driver/metal/metal_command_buffer_bridge.mm
@@ -122,8 +122,7 @@
 
 - (void)enqueue
 {
-  METAL_NOT_HOOKED();
-  [self.real enqueue];
+  GetWrapped(self)->enqueue();
 }
 
 - (void)commit
@@ -170,8 +169,7 @@
 
 - (void)waitUntilCompleted
 {
-  METAL_NOT_HOOKED();
-  return [self.real waitUntilCompleted];
+  GetWrapped(self)->waitUntilCompleted();
 }
 
 - (MTLCommandBufferStatus)status

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -124,6 +124,17 @@ inline MTL::Resource *Unwrap(WrappedMTLResource *obj)
   return Unwrap<MTL::Resource *>((WrappedMTLObject *)obj);
 }
 
+enum class MetalCmdBufferStatus : uint32_t
+{
+  NoFlags = 0,
+  Enqueued = 1 << 0,
+  Committed = 1 << 1,
+  Submitted = 1 << 2,
+  Presented = 1 << 3,
+};
+
+BITMASK_OPERATORS(MetalCmdBufferStatus);
+
 struct MetalCmdBufferRecordingInfo
 {
   MetalCmdBufferRecordingInfo(WrappedMTLCommandQueue *parentQueue)

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -137,10 +137,7 @@ BITMASK_OPERATORS(MetalCmdBufferStatus);
 
 struct MetalCmdBufferRecordingInfo
 {
-  MetalCmdBufferRecordingInfo(WrappedMTLCommandQueue *parentQueue)
-      : queue(parentQueue), present(false), drawable(NULL)
-  {
-  }
+  MetalCmdBufferRecordingInfo(WrappedMTLCommandQueue *parentQueue) : queue(parentQueue) {}
   MetalCmdBufferRecordingInfo() = delete;
   MetalCmdBufferRecordingInfo(const MetalCmdBufferRecordingInfo &) = delete;
   MetalCmdBufferRecordingInfo(MetalCmdBufferRecordingInfo &&) = delete;
@@ -148,10 +145,11 @@ struct MetalCmdBufferRecordingInfo
   ~MetalCmdBufferRecordingInfo() {}
   WrappedMTLCommandQueue *queue;
 
-  // The drawable that present was called on
-  MTL::Drawable *drawable;
-  // AdvanceFrame/Present should be called after this buffer is committed.
-  bool present;
+  // The MetalLayer to present
+  CA::MetalLayer *outputLayer = NULL;
+  // The texture to present
+  WrappedMTLTexture *backBuffer = NULL;
+  MetalCmdBufferStatus flags = MetalCmdBufferStatus::NoFlags;
 };
 
 struct MetalResourceRecord : public ResourceRecord

--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1145,3 +1145,17 @@ rdcstr DoStringise(const MetalResourceType &el)
   }
   END_ENUM_STRINGISE();
 }
+
+template <>
+rdcstr DoStringise(const MetalCmdBufferStatus &el)
+{
+  BEGIN_BITFIELD_STRINGISE(MetalCmdBufferStatus)
+  {
+    STRINGISE_BITFIELD_CLASS_VALUE(NoFlags);
+    STRINGISE_BITFIELD_CLASS_BIT(Enqueued);
+    STRINGISE_BITFIELD_CLASS_BIT(Committed);
+    STRINGISE_BITFIELD_CLASS_BIT(Submitted);
+    STRINGISE_BITFIELD_CLASS_BIT(Presented);
+  }
+  END_BITFIELD_STRINGISE()
+}


### PR DESCRIPTION
## Description

Hooking and capture serialization for `MTLCommandBuffer` APIs `enqueue` and `waitUntilCompleted` (required to capture test programs with `enqueue` support). These chunks are added to the command buffer record in order that the chunks are only included in the capture when the command buffer is included. The replay support for these APIs treats them at the global scope and not replayed within the command buffer. The `enqueue` chunk might not be required or used by replay in the future (currently it is used to verify the order of command buffer reply matches what is expected).

Updated the `MetalCmdBufferRecordingInfo` struct to store the `CA::MetalLayer` & `WrappedMTLTexture` from the `MTL::Drawable` instead of the `MTL::Drawable`. This avoids validation asserts about accessing the texture of an `MTL::Drawable` after calling `MTLCommandBuffer::presentDrawable`. 

Changed member data `bool present` to `uint32_t flags` to be able to efficiently store more than one flag. Added `MetalCmdBufferStatus` enum to store different status flags.

Changed the return of `WrappedMTLCommandBuffer::GetCommandQueueReturn` to be a `WrappedMTLCommandQueue *` instead of `MTL::CommandQueue *`. It makes sense and is more natural to return the `m_CommandQueue` without casting it. The previous API usage was for the Objective C bridge layer which worked with `MTL::CommandQueue *. This is not required now the Objective C and C++ wrapping/unwrapping has been simplified.

This PR represents the final Objective C change in the current Metal development branch 🥳 
