### PR TITLE
Allow command line to override Apple cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,7 @@ if(APPLE)
   # Building for Apple requires at least CMake 3.20.0
   cmake_minimum_required(VERSION 3.20.0)
 
-  SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
-  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum SDK for Mac OS X" FORCE)
+  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum SDK for Mac OS X")
   SET(CMAKE_XCODE_GENERATE_SCHEME ON)
 endif()
 
@@ -308,10 +307,6 @@ if(APPLE)
 
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/lib")
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin")
-
-    # By default disable the python modules (brew python does not provide universal libraries)
-    message(STATUS "Disabling renderdoc python modules for Apple build")
-    set(ENABLE_PYRENDERDOC OFF CACHE BOOL "" FORCE)
 endif()
 
 if(ENABLE_GL)


### PR DESCRIPTION
## Description

On Apple allow the cmake command line to override default values for:

`CMAKE_OSX_ARCHITECTURES`
`ENABLE_PYRENDERDOC`
`CMAKE_OSX_DEPLOYMENT_TARGET`

`CMAKE_OSX_ARCHITECTURES` & `CMAKE_OSX_DEPLOYMENT_TARGET`: were mistakenly marked as `FORCE`, preventing the command line from setting the values.

`ENABLE_PYRENDERDOC`: is a bit more complicated. The `option` declaration sets it to `ON` and I have not found a way to determine if the value for `ENABLE_PYRENDERDOC` came from the command line, the cmake cache, or a setting in the cmake file. Hence the platform logic for setting `ENABLE_PYRENDERDOC` to `OFF` by default for Apple.