### PR TITLE
Add support for vulkan layer suffixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(RENDERDOC_APK_PATH "" CACHE STRING "Path to RenderDoc .apk files after insta
 
 set(LIB_SUFFIX "" CACHE STRING "Suffix for 'lib' folder in target directory structure. E.g. set to '64' to use /usr/local/lib64 instead of /usr/local/lib.")
 set(LIB_SUBFOLDER "" CACHE STRING "Subfolder under the 'lib' folder in target directory structure. E.g. set to 'renderdoc' to use /usr/local/lib/renderdoc instead of /usr/local/lib.")
+set(VULKAN_JSON_SUFFIX "" CACHE STRING "Suffix for the vulkan implicit_layer json file. E.g. set to '.x86_64' to use renderdoc_capture.x86_64.json instead of renderdoc_capture.json")
 
 if(NOT LIB_SUFFIX STREQUAL "")
     add_definitions(-DRENDERDOC_LIB_SUFFIX=${LIB_SUFFIX})
@@ -107,6 +108,8 @@ if(NOT LIB_SUBFOLDER STREQUAL "")
     add_definitions(-DRENDERDOC_LIB_SUBFOLDER=${LIB_SUBFOLDER})
     set(LIB_SUBFOLDER_TRAIL_SLASH "${LIB_SUBFOLDER}/")
 endif()
+
+add_definitions(-DRENDERDOC_VULKAN_JSON_SUFFIX=${VULKAN_JSON_SUFFIX})
 
 if(BUILD_VERSION_STABLE)
     add_definitions(-DRENDERDOC_STABLE_BUILD=1)

--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -125,7 +125,7 @@ elseif(UNIX)
     set(VULKAN_ENABLE_VAR "ENABLE_VULKAN_RENDERDOC_CAPTURE")
 
     set(json_in ${CMAKE_CURRENT_SOURCE_DIR}/renderdoc.json)
-    set(json_out ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/renderdoc_capture.json)
+    set(json_out ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/renderdoc_capture${VULKAN_JSON_SUFFIX}.json)
     
     configure_file(${json_in} ${json_out})
 

--- a/renderdoc/driver/vulkan/vk_posix.cpp
+++ b/renderdoc/driver/vulkan/vk_posix.cpp
@@ -365,17 +365,23 @@ rdcstr LayerRegistrationPath(LayerPath path)
 {
   switch(path)
   {
-    case LayerPath::usr: return "/usr/share/vulkan/implicit_layer.d/renderdoc_capture.json";
-    case LayerPath::etc: return "/etc/vulkan/implicit_layer.d/renderdoc_capture.json";
+    case LayerPath::usr:
+      return "/usr/share/vulkan/implicit_layer.d/renderdoc_capture" STRINGIZE(
+          RENDERDOC_VULKAN_JSON_SUFFIX) ".json";
+    case LayerPath::etc:
+      return "/etc/vulkan/implicit_layer.d/renderdoc_capture" STRINGIZE(
+          RENDERDOC_VULKAN_JSON_SUFFIX) ".json";
     case LayerPath::home:
     {
       const char *xdg = getenv("XDG_DATA_HOME");
       if(xdg && FileIO::exists(xdg))
-        return rdcstr(xdg) + "/vulkan/implicit_layer.d/renderdoc_capture.json";
+        return rdcstr(xdg) + "/vulkan/implicit_layer.d/renderdoc_capture" STRINGIZE(
+                                 RENDERDOC_VULKAN_JSON_SUFFIX) ".json";
 
       const char *home_path = getenv("HOME");
       return rdcstr(home_path != NULL ? home_path : "") +
-             "/.local/share/vulkan/implicit_layer.d/renderdoc_capture.json";
+             "/.local/share/vulkan/implicit_layer.d/renderdoc_capture" STRINGIZE(
+                 RENDERDOC_VULKAN_JSON_SUFFIX) ".json";
     }
     default: break;
   }


### PR DESCRIPTION
While Renderdoc already supported multiarch for where to install the
libraries with the LIB_SUFFIX option. The Vulkan layer was left out of
this loop.

Vulkan layers living in `/usr/share/vulkan/implicit_layer.d/` will use a
suffix before the `.json` to separate libraries of different
architectures. These layer files will then point to the architecture
specific `library_path` inside that json file.

Also updates the check in `LayerRegistrationPath` so it handles the
suffix as well. This way `renderdoccmd` won't complain about conflicting
json files.

This resolves an issue where only one bitness of renderdoc layer could be installed at a time even on a multiarch system. When the build environment is set up correctly, both an x86_64 and 32-bit x86 layer can be installed at the same time. Allowing one to debug both 32-bit and 64-bit versions of a Vulkan application without rebuilding renderdoc.