### PR TITLE
Fix arcball navigation by updating the basis matrix.

### DIFF
--- a/renderdoc/maths/camera.cpp
+++ b/renderdoc/maths/camera.cpp
@@ -102,6 +102,7 @@ void Camera::Update()
     Matrix4f d = Matrix4f::Translation(Vec3f(0.0f, 0.0f, dist));
 
     mat = d.Mul(r.Mul(p));
+    basis = mat.Transpose();
   }
 }
 


### PR DESCRIPTION
The ArcballWrapper uses the Camera::GetRight() and Camera::GetUp() function to pan the mesh in the Mesh Viewer. Since the Camera basis matrix is not initialized (only when used in Arcball mode), the GetRight() and GetUp() function return invalid vectors which result in random/no panning of the geometry preview. To fix the issue we update the basis matrix as it is done in the Flycam/FPSLook code path.