### PR TITLE
Fix new compile errors in Metal EndFrameCapture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
   macOS:
     name: Mac
     needs: [commit-msg, clang-format]
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND warning_flags -Wno-unused-lambda-capture)
     endif()
 
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0 AND NOT APPLE)
+        list(APPEND warning_flags -Wno-unused-but-set-variable -Wno-deprecated-copy)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.1 AND APPLE)
         list(APPEND warning_flags -Wno-unused-but-set-variable -Wno-deprecated-copy)
     endif()
 

--- a/renderdoc/driver/metal/metal_core.cpp
+++ b/renderdoc/driver/metal/metal_core.cpp
@@ -184,8 +184,8 @@ bool WrappedMTLDevice::EndFrameCapture(DeviceOwnedWindow devWnd)
     MTL::CommandBuffer *mtlCommandBuffer = m_mtlCommandQueue->commandBuffer();
     MTL::BlitCommandEncoder *mtlBlitEncoder = mtlCommandBuffer->blitCommandEncoder();
 
-    NS::UInteger sourceWidth = mtlBackBuffer->width();
-    NS::UInteger sourceHeight = mtlBackBuffer->height();
+    uint32_t sourceWidth = (uint32_t)mtlBackBuffer->width();
+    uint32_t sourceHeight = (uint32_t)mtlBackBuffer->height();
     MTL::Origin sourceOrigin(0, 0, 0);
     MTL::Size sourceSize(sourceWidth, sourceHeight, 1);
 


### PR DESCRIPTION
## Description

Enabling -Wshorten-64-to-32 PR overlapped with this code landing

Updated Mac CI to use macos-11 to fix Github warning about 10.15 being deprecated

Tweaked clang warning settings for Apple Clang version >= 13.1. 
Apple clang version 13 does not have the same warnings as standard clang version 13.
macos-11 includes Apple clang 13


