### PR TITLE
Capture and serialise `MTLBuffer` initial contents and in-frame CPU modifications

### DIFF
--- a/renderdoc/driver/metal/metal_buffer.h
+++ b/renderdoc/driver/metal/metal_buffer.h
@@ -36,6 +36,9 @@ public:
   void *contents();
 
   DECLARE_FUNCTION_SERIALISED(void, didModifyRange, NS::Range &range);
+  template <typename SerialiserType>
+  bool Serialise_InternalModifyCPUContents(SerialiserType &ser, uint64_t start, uint64_t end,
+                                           MetalBufferInfo *bufInfo);
 
   enum
   {

--- a/renderdoc/driver/metal/metal_device.cpp
+++ b/renderdoc/driver/metal/metal_device.cpp
@@ -632,6 +632,21 @@ WrappedMTLBuffer *WrappedMTLDevice::Common_NewBuffer(bool withBytes, const void 
 
     MetalResourceRecord *record = GetResourceManager()->AddResourceRecord(wrappedMTLBuffer);
     record->AddChunk(chunk);
+
+    MTL::StorageMode mode = realMTLBuffer->storageMode();
+    record->bufInfo = new MetalBufferInfo(mode);
+
+    // Create CPU side tracking info for CPU shared buffers
+    if(mode == MTL::StorageModeShared)
+    {
+      record->bufInfo->data = (byte *)realMTLBuffer->contents();
+      record->bufInfo->length = realMTLBuffer->length();
+    }
+    // Snapshot GPU only buffers
+    else if(mode == MTL::StorageModePrivate)
+    {
+      GetResourceManager()->MarkDirtyResource(id);
+    }
   }
   else
   {

--- a/renderdoc/driver/metal/metal_init_state.cpp
+++ b/renderdoc/driver/metal/metal_init_state.cpp
@@ -22,14 +22,88 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include "metal_buffer.h"
 #include "metal_common.h"
 #include "metal_device.h"
+
+static rdcliteral NameOfType(MetalResourceType type)
+{
+  switch(type)
+  {
+    case eResBuffer: return "MTLBuffer"_lit;
+    default: break;
+  }
+  return "MTLResource"_lit;
+}
 
 bool WrappedMTLDevice::Prepare_InitialState(WrappedMTLObject *res)
 {
   ResourceId id = GetResourceManager()->GetID(res);
 
   MetalResourceType type = res->m_Record->m_Type;
+
+  if(type == eResBuffer)
+  {
+    WrappedMTLBuffer *buffer = (WrappedMTLBuffer *)res;
+    MTL::Buffer *mtlBuffer = Unwrap(buffer);
+    MTL::Buffer *mtlSharedBuffer = NULL;
+    MTL::StorageMode storageMode = mtlBuffer->storageMode();
+    size_t len = mtlBuffer->length();
+    byte *data = NULL;
+    if(storageMode == MTL::StorageModeShared)
+    {
+      // MTLStorageModeShared buffers are automatically synchronized
+      data = (byte *)mtlBuffer->contents();
+    }
+    else if(storageMode == MTL::StorageModeManaged)
+    {
+      // MTLStorageModeManaged buffers need to call MTLBlitCommandEncoder::synchronizeResource
+      MTL::CommandBuffer *mtlCommandBuffer = m_mtlCommandQueue->commandBuffer();
+      MTL::BlitCommandEncoder *mtlBlitEncoder = mtlCommandBuffer->blitCommandEncoder();
+      mtlBlitEncoder->synchronizeResource(mtlBuffer);
+      mtlBlitEncoder->endEncoding();
+      mtlCommandBuffer->commit();
+      mtlCommandBuffer->waitUntilCompleted();
+      data = (byte *)mtlBuffer->contents();
+    }
+    else if(storageMode == MTL::StorageModePrivate)
+    {
+      // TODO: postpone readback until data is required
+      // TODO: batch readback for multiple resources to avoid sync per resource
+      // MTLStorageModePrivate buffer need to copy into a temporary MTLStorageModeShared buffer
+      mtlSharedBuffer = Unwrap(this)->newBuffer(len, MTL::ResourceStorageModeShared);
+      MTL::CommandBuffer *mtlCommandBuffer = m_mtlCommandQueue->commandBuffer();
+      MTL::BlitCommandEncoder *mtlBlitEncoder = mtlCommandBuffer->blitCommandEncoder();
+      mtlBlitEncoder->copyFromBuffer(mtlBuffer, 0, mtlSharedBuffer, 0, len);
+      mtlBlitEncoder->endEncoding();
+      mtlCommandBuffer->commit();
+      mtlCommandBuffer->waitUntilCompleted();
+      data = (byte *)mtlSharedBuffer->contents();
+    }
+    else
+    {
+      RDCERR("Unhandled buffer storage mode 0x%X", storageMode);
+    }
+
+    bytebuf bufferContents(data, len);
+    MetalInitialContents initialContents(type, bufferContents);
+    GetResourceManager()->SetInitialContents(id, initialContents);
+    if(mtlSharedBuffer)
+    {
+      mtlSharedBuffer->release();
+    }
+    if(storageMode == MTL::StorageModeShared)
+    {
+      // Set the base snapshot to match the initial contents
+      MetalBufferInfo *bufInfo = res->m_Record->bufInfo;
+      if(bufInfo->baseSnapshot.isEmpty())
+        bufInfo->baseSnapshot.resize(len);
+      RDCASSERTEQUAL(bufInfo->baseSnapshot.size(), len);
+      memcpy(bufInfo->baseSnapshot.data(), bufferContents.data(), len);
+    }
+    return true;
+  }
+  else
   {
     RDCERR("Unhandled resource type %d", type);
   }
@@ -39,8 +113,16 @@ bool WrappedMTLDevice::Prepare_InitialState(WrappedMTLObject *res)
 
 uint64_t WrappedMTLDevice::GetSize_InitialState(ResourceId id, const MetalInitialContents &initial)
 {
-  METAL_NOT_IMPLEMENTED();
-  return 128;
+  uint64_t ret = 128;
+
+  if(initial.type == eResBuffer)
+  {
+    ret += uint64_t(initial.resourceContents.size() + WriteSerialiser::GetChunkAlignment());
+    return ret;
+  }
+
+  RDCERR("Unhandled resource type %s", ToStr(initial.type).c_str());
+  return 0;
 }
 
 template <typename SerialiserType>
@@ -48,7 +130,29 @@ bool WrappedMTLDevice::Serialise_InitialState(SerialiserType &ser, ResourceId id
                                               MetalResourceRecord *record,
                                               const MetalInitialContents *initial)
 {
-  METAL_NOT_IMPLEMENTED();
+  SERIALISE_ELEMENT_LOCAL(type, initial->type);
+  SERIALISE_ELEMENT(id).TypedAs(NameOfType(type)).Important();
+  if(type == eResBuffer)
+  {
+    SERIALISE_CHECK_READ_ERRORS();
+
+    bytebuf contents;
+    if(ser.IsWriting())
+    {
+      ser.Serialise("Contents"_lit, initial->resourceContents);
+    }
+    else
+    {
+      ser.Serialise("Contents"_lit, contents);
+    }
+
+    if(IsReplayingAndReading())
+    {
+      // TODO: implement RD MTL replay
+    }
+    return true;
+  }
+  RDCERR("Unhandled resource type %d", type);
   return false;
 }
 

--- a/renderdoc/driver/metal/metal_manager.h
+++ b/renderdoc/driver/metal/metal_manager.h
@@ -42,6 +42,13 @@ struct MetalInitialContents
     type = t;
   }
 
+  MetalInitialContents(MetalResourceType t, bytebuf data)
+  {
+    memset(this, 0, sizeof(*this));
+    type = t;
+    resourceContents = data;
+  }
+
   template <typename Configuration>
   void Free(ResourceManager<Configuration> *rm)
   {

--- a/renderdoc/driver/metal/metal_resources.cpp
+++ b/renderdoc/driver/metal/metal_resources.cpp
@@ -56,4 +56,6 @@ MetalResourceRecord::~MetalResourceRecord()
 {
   if(m_Type == eResCommandBuffer)
     SAFE_DELETE(cmdInfo);
+  else if(m_Type == eResBuffer)
+    SAFE_DELETE(bufInfo);
 }

--- a/renderdoc/driver/metal/metal_resources.h
+++ b/renderdoc/driver/metal/metal_resources.h
@@ -148,6 +148,16 @@ struct MetalCmdBufferRecordingInfo
   bool presented = false;
 };
 
+struct MetalBufferInfo
+{
+  MetalBufferInfo() = delete;
+  MetalBufferInfo(MTL::StorageMode mode) : storageMode(mode), data(NULL), length(0) {}
+  MTL::StorageMode storageMode;
+  bytebuf baseSnapshot;
+  byte *data;
+  size_t length;
+};
+
 struct MetalResourceRecord : public ResourceRecord
 {
 public:
@@ -169,5 +179,6 @@ public:
   {
     void *ptrUnion;                          // for initialisation to NULL
     MetalCmdBufferRecordingInfo *cmdInfo;    // only for command buffers
+    MetalBufferInfo *bufInfo;                // only for buffers
   };
 };


### PR DESCRIPTION
## Description

`MTLBuffer` initial state chunks and in-frame CPU modification of `MTLBuffer` data.
Support for buffers created with the following modes`StorageModeShared`, `StorageModeManaged` & `StorageModePrivate`.
The initial contents are serialized for all 3 buffer storage modes.
`StorageModeShared` buffers: when submitting a command buffer for each referenced buffer serialize the difference in the buffer contents compared to the buffer base snapshot as a `MTLBuffer_InternalModifyCPUContents` chunk in the command buffer record.
`StorageModeManaged` buffers: serialise `didModifyRange` chunk in the command buffer record
`StorageModeManaged` buffers: no in-frame serialization rely on the snapshot in initial contents.

An example of replaying a capture made from this branch of a test program uses all 3 storage modes:
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/39392/180402214-13224006-d074-49de-88be-5e2ae4c766f4.png">
