### PR TITLE
Support dummy Wrapped Metal objects for replay

### DIFF
--- a/renderdoc/driver/metal/metal_blit_command_encoder.cpp
+++ b/renderdoc/driver/metal/metal_blit_command_encoder.cpp
@@ -31,7 +31,8 @@ WrappedMTLBlitCommandEncoder::WrappedMTLBlitCommandEncoder(
     : WrappedMTLObject(realMTLBlitCommandEncoder, objId, wrappedMTLDevice,
                        wrappedMTLDevice->GetStateRef())
 {
-  AllocateObjCBridge(this);
+  if(realMTLBlitCommandEncoder && objId != ResourceId())
+    AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_buffer.cpp
+++ b/renderdoc/driver/metal/metal_buffer.cpp
@@ -30,7 +30,8 @@ WrappedMTLBuffer::WrappedMTLBuffer(MTL::Buffer *realMTLBuffer, ResourceId objId,
                                    WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLBuffer, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  AllocateObjCBridge(this);
+  if(realMTLBuffer && objId != ResourceId())
+    AllocateObjCBridge(this);
 }
 
 void *WrappedMTLBuffer::contents()

--- a/renderdoc/driver/metal/metal_command_buffer.cpp
+++ b/renderdoc/driver/metal/metal_command_buffer.cpp
@@ -34,7 +34,8 @@ WrappedMTLCommandBuffer::WrappedMTLCommandBuffer(MTL::CommandBuffer *realMTLComm
                                                  ResourceId objId, WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLCommandBuffer, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  AllocateObjCBridge(this);
+  if(realMTLCommandBuffer && objId != ResourceId())
+    AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_command_queue.cpp
+++ b/renderdoc/driver/metal/metal_command_queue.cpp
@@ -30,7 +30,8 @@ WrappedMTLCommandQueue::WrappedMTLCommandQueue(MTL::CommandQueue *realMTLCommand
                                                ResourceId objId, WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLCommandQueue, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  AllocateObjCBridge(this);
+  if(realMTLCommandQueue && objId != ResourceId())
+    AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_library.cpp
+++ b/renderdoc/driver/metal/metal_library.cpp
@@ -30,7 +30,8 @@ WrappedMTLLibrary::WrappedMTLLibrary(MTL::Library *realMTLLibrary, ResourceId ob
                                      WrappedMTLDevice *wrappedMTLDevice)
     : WrappedMTLObject(realMTLLibrary, objId, wrappedMTLDevice, wrappedMTLDevice->GetStateRef())
 {
-  AllocateObjCBridge(this);
+  if(realMTLLibrary && objId != ResourceId())
+    AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/driver/metal/metal_render_command_encoder.cpp
+++ b/renderdoc/driver/metal/metal_render_command_encoder.cpp
@@ -35,7 +35,8 @@ WrappedMTLRenderCommandEncoder::WrappedMTLRenderCommandEncoder(
     : WrappedMTLObject(realMTLRenderCommandEncoder, objId, wrappedMTLDevice,
                        wrappedMTLDevice->GetStateRef())
 {
-  AllocateObjCBridge(this);
+  if(realMTLRenderCommandEncoder && objId != ResourceId())
+    AllocateObjCBridge(this);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
## Description

Metal replay serialization uses dummy wrapped metal objects ie.

```
case MetalChunk::MTLLibrary_newFunctionWithName:
  return m_DummyReplayLibrary->Serialise_newFunctionWithName(ser, NULL, NULL);
case MetalChunk::MTLRenderCommandEncoder_setRenderPipelineState:
  return m_DummyReplayRenderCommandEncoder->Serialise_setRenderPipelineState(ser, NULL);
case MetalChunk::MTLBlitCommandEncoder_endEncoding:
  return m_DummyReplayBlitCommandEncoder->Serialise_endEncoding(ser);

```
Reuse the same constructor with NULL real metal object instead of making a new constructor.
