### PR TITLE
Fix compilation warnings for ggp platform.

### DIFF
--- a/renderdoc/os/posix/ggp/ggp_callstack.cpp
+++ b/renderdoc/os/posix/ggp/ggp_callstack.cpp
@@ -47,11 +47,11 @@ public:
   void Set(uint64_t *calls, size_t num)
   {
     numLevels = num;
-    for(int i = 0; i < numLevels; i++)
+    for(size_t i = 0; i < numLevels; i++)
       addrs[i] = calls[i];
   }
 
-  size_t NumLevels() const { return size_t(numLevels); }
+  size_t NumLevels() const { return numLevels; }
   const uint64_t *GetAddrs() const { return addrs; }
 private:
   GgpCallstack(const Callstack::Stackwalk &other);
@@ -71,12 +71,12 @@ private:
       numLevels--;
     }
 
-    for(int i = 0; i < numLevels; i++)
+    for(size_t i = 0; i < numLevels; i++)
       addrs[i] = (uint64_t)addrs_ptr[i + offs];
   }
 
   uint64_t addrs[128];
-  int numLevels;
+  size_t numLevels;
 };
 
 namespace Callstack

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -46,6 +46,7 @@ elseif(ENABLE_GGP)
     find_library(GGP_LIBRARY ggp)
     list(APPEND libraries PRIVATE ${GGP_LIBRARY})
     set(LINKER_FLAGS "-Wl,--no-as-needed -Wl,--hash-style=gnu -Wl,--build-id=sha1")
+    set_property(SOURCE renderdoccmd_ggp.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-shadow")
 elseif(UNIX)
     list(APPEND sources renderdoccmd_linux.cpp)
 


### PR DESCRIPTION
This fix the warning about comparison of integers of different
signs and declaration shadows `desc` field.

