### PR TITLE
Fix -Wshorten-64-to-32 warnings in Android build

### DIFF
--- a/renderdoc/os/posix/android/android_callstack.cpp
+++ b/renderdoc/os/posix/android/android_callstack.cpp
@@ -38,7 +38,7 @@ public:
   void Set(uint64_t *calls, size_t num)
   {
     numLevels = num;
-    for(int i = 0; i < numLevels; i++)
+    for(size_t i = 0; i < numLevels; i++)
       addrs[i] = calls[i];
   }
 
@@ -48,7 +48,7 @@ private:
   AndroidCallstack(const Callstack::Stackwalk &other);
 
   uint64_t addrs[128];
-  int numLevels;
+  size_t numLevels;
 };
 
 namespace Callstack

--- a/renderdoc/os/posix/android/android_hook.cpp
+++ b/renderdoc/os/posix/android/android_hook.cpp
@@ -272,7 +272,7 @@ static int dl_iterate_callback(struct dl_phdr_info *info, size_t size, void *dat
       else if(dynamic->d_tag == DT_JMPREL)
         pltbase = (Elf_Rel *)(info->dlpi_addr + dynamic->d_un.d_ptr);
       else if(dynamic->d_tag == DT_PLTRELSZ)
-        pltcount = dynamic->d_un.d_val / sizeof(Elf_Rel);
+        pltcount = ElfW(Sword)(dynamic->d_un.d_val / sizeof(Elf_Rel));
 
       /*
       if(dynamic->d_tag == DT_NEEDED)
@@ -338,7 +338,7 @@ static int dl_iterate_callback(struct dl_phdr_info *info, size_t size, void *dat
       HOOK_DEBUG_PRINT("Got relro %p -> %p", relro_base, relro_end);
     HOOK_DEBUG_PRINT("Got %i PLT entries", pltcount);
 
-    int pagesize = sysconf(_SC_PAGE_SIZE);
+    size_t pagesize = sysconf(_SC_PAGE_SIZE);
 
     for(ElfW(Sword) i = 0; i < pltcount; i++)
     {


### PR DESCRIPTION
Adjusts some `int` types to `size_t` to match the other expressions around it.
One expression is cast to silence the warning.
