### PR TITLE
Fix event duplication for `vkQueueSubmit2` with no command buffers

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -259,6 +259,22 @@ void WrappedVulkan::ReplayQueueSubmit(VkQueue queue, VkSubmitInfo2 submitInfo, r
     // we're adding multiple events, need to increment ourselves
     m_RootEventID++;
 
+    if(submitInfo.commandBufferInfoCount == 0)
+    {
+      rdcstr name = StringFormat::Fmt("=> %s: No Command Buffers", basename.c_str());
+
+      ActionDescription action;
+      action.customName = name;
+      action.flags |= ActionFlags::CommandBufferBoundary | ActionFlags::PassBoundary;
+      AddEvent();
+
+      m_RootEvents.back().chunkIndex = APIEvent::NoChunk;
+      m_Events.back().chunkIndex = APIEvent::NoChunk;
+
+      AddAction(action);
+      m_RootEventID++;
+    }
+
     for(uint32_t c = 0; c < submitInfo.commandBufferInfoCount; c++)
     {
       ResourceId cmd = GetResourceManager()->GetOriginalID(
@@ -362,6 +378,13 @@ void WrappedVulkan::ReplayQueueSubmit(VkQueue queue, VkSubmitInfo2 submitInfo, r
   {
     // account for the queue submit event
     m_RootEventID++;
+
+    if(submitInfo.commandBufferInfoCount == 0)
+    {
+      // account for the "No Command Buffers" virtual label
+      m_RootEventID++;
+      m_RootActionID++;
+    }
 
     uint32_t startEID = m_RootEventID;
 


### PR DESCRIPTION
## Description

### Problem
A `vkQueueSubmit2` event was duplicated in the API inspector when it had no command buffers.

![renderdoc_api_inspector_duplicate_vkQueueSubmit2](https://user-images.githubusercontent.com/12509265/183441915-904c35f7-3925-4738-a508-e48f78e9b3c3.png)

The direct cause was `WrappedVulkan::ReplayQueueSubmit` not calling `AddAction` when `submitInfo.commandBufferInfoCount == 0`,
leaving `m_AddedAction == false` thus prompting `WrappedVulkan::ContextProcessChunk` to superfluously call `AddEvent`,
which had the effect of adding an event for the `vkQueueSubmit2` again, in addition to the one already added in `ReplayQueueSubmit`.

### Solution
This PR fixes this behavior by adding a "No Command Buffers" virtual label action when `commandBufferInfoCount == 0`, thus preventing `ContextProcessChunk` from making a superfluous call to `AddEvent`.

A quick-and-dirty solution would have been to just do `m_AddedAction = true` when `commandBufferInfoCount == 0`, but I figured it would be better solved by adding a virtual label action akin to those for `vkBeginCommandBuffer`/`vkEndCommandBuffer`

![renderdoc_api_inspector](https://user-images.githubusercontent.com/12509265/183443497-83bafe9e-c376-4f27-949c-44912eee8c7a.png)
![renderdoc_event_browser](https://user-images.githubusercontent.com/12509265/183443573-811ede5f-6f8e-4726-8f39-9b496293b6e6.png)

