### PR TITLE
Handle preloaders in GetExecutableFilename

### DIFF
--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -291,6 +291,7 @@ bool IsRelativePath(const rdcstr &path);
 rdcstr GetFullPathname(const rdcstr &filename);
 rdcstr FindFileInPath(const rdcstr &fileName);
 
+bool IsWineExecutable();
 void GetExecutableFilename(rdcstr &selfName);
 void GetLibraryFilename(rdcstr &selfName);
 

--- a/renderdoc/os/posix/android/android_stringio.cpp
+++ b/renderdoc/os/posix/android/android_stringio.cpp
@@ -85,6 +85,11 @@ rdcstr GetAppFolderFilename(const rdcstr &filename)
   return GetTempRootPath() + rdcstr("/") + filename;
 }
 
+bool IsWineExecutable()
+{
+  return false;
+}
+
 // For RenderDoc's apk, this returns our package name
 // For other APKs, we use it to get the writable temp directory.
 void GetExecutableFilename(rdcstr &selfName)

--- a/renderdoc/os/posix/apple/apple_stringio.cpp
+++ b/renderdoc/os/posix/apple/apple_stringio.cpp
@@ -159,6 +159,11 @@ rdcstr GetAppFolderFilename(const rdcstr &filename)
   return ret + filename;
 }
 
+bool IsWineExecutable()
+{
+  return false;
+}
+
 void GetExecutableFilename(rdcstr &selfName)
 {
   char path[512] = {0};

--- a/renderdoc/os/posix/ggp/ggp_stringio.cpp
+++ b/renderdoc/os/posix/ggp/ggp_stringio.cpp
@@ -92,6 +92,11 @@ rdcstr GetAppFolderFilename(const rdcstr &filename)
   return ret + filename;
 }
 
+bool IsWineExecutable()
+{
+  return false;
+}
+
 void GetExecutableFilename(rdcstr &selfName)
 {
   char path[512] = {0};

--- a/renderdoc/os/posix/linux/linux_stringio.cpp
+++ b/renderdoc/os/posix/linux/linux_stringio.cpp
@@ -605,6 +605,22 @@ rdcstr GetAppFolderFilename(const rdcstr &filename)
   return ret + filename;
 }
 
+bool IsWineExecutable()
+{
+  char path[512] = {0};
+  readlink("/proc/self/exe", path, 511);
+
+  const char *mod = strrchr(path, '/');
+  if(mod != NULL)
+    mod++;
+  else if(*path)
+    mod = path;
+  else
+    mod = "unknown";
+
+  return !strcmp(mod, "wine-preloader") || !strcmp(mod, "wine64-preloader");
+}
+
 void GetExecutableFilename(rdcstr &selfName)
 {
   char path[512] = {0};

--- a/renderdoc/os/posix/posix_stringio.cpp
+++ b/renderdoc/os/posix/posix_stringio.cpp
@@ -201,6 +201,14 @@ void GetDefaultFiles(const rdcstr &logBaseName, rdcstr &capture_filename, rdcstr
   else
     mod = "unknown";
 
+  // If this is a Wine preloader, strip trailing Windows slashes.
+  if(IsWineExecutable())
+  {
+    const char *winMod = strrchr(path.c_str(), '\\');
+    if(winMod != NULL)
+      mod = winMod + 1;
+  }
+
   target = rdcstr(mod);
 
   time_t t = time(NULL);

--- a/renderdoc/os/win32/win32_stringio.cpp
+++ b/renderdoc/os/win32/win32_stringio.cpp
@@ -162,6 +162,11 @@ bool GetKeyState(int key)
 
 namespace FileIO
 {
+bool IsWineExecutable()
+{
+  return false;
+}
+
 void GetExecutableFilename(rdcstr &selfName)
 {
   wchar_t curFile[512] = {0};


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Uses `/proc/self/cmdline` instead of `/proc/self/exe` for `GetExecutableFilename` to correctly handle preloaders, such as the Wine preloader.

Additionally handles removing leading directories with Windows style `\`s if it detects this is the Wine preloader.

This is intended to make things cleaner for developers using the new RenderDoc functionality in the SteamOS Devkit Client.