### PR TITLE
Fix OpDecoder::ForEachID OpEntryPoint name parsing

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_gen.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_gen.cpp
@@ -2055,7 +2055,15 @@ void OpDecoder::ForEachID(const ConstIter &it, const std::function<void(Id,bool)
       break;
     case rdcspv::Op::EntryPoint:
       callback(Id::fromWord(it.word(2)), false);
-      for(size_t i=0; i < size-4; i++) callback(Id::fromWord(it.word(4+i)), false);
+      {
+        size_t i;
+        for(i=3; i < size; i++)
+        {
+          uint32_t w = it.word(i);
+          if(!(w & 0xFF) || !(w & 0xFF00) || !(w & 0xFF0000) || !(w & 0xFF000000)) break;
+        }
+        for(i++; i < size; i++) callback(Id::fromWord(it.word(i)), false);
+      }
       break;
     case rdcspv::Op::ExecutionMode:
       callback(Id::fromWord(it.word(1)), false);


### PR DESCRIPTION
The issue I had is a crash in parsing of `OpEntryPoint` in `OpDecoder::ForEachID`. It seems the code does not account for entry point names longer than 1 word, and tries to interpret the string literal as IDs of entry point interface.

To reproduce the crash, have a shader module with long entry point name (I have "mainFragment") and try to debug a pixel.

This PR fixes the parsing in accordance with the SPIR-V spec, by skipping words until it finds a word with zero byte (end of UTF-8 string).