### PR TITLE
Export CSV/binaries with byte range provided by application.

### DIFF
--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -5315,15 +5315,19 @@ void BufferViewer::exportData(const BufferExport &params)
             // in memory.
             ResourceId buff = m_BufferID;
 
-            static const uint64_t chunkSize = 4 * 1024 * 1024;
-            for(uint64_t byteOffset = m_ByteOffset; byteOffset < m_ObjectByteSize;
-                byteOffset += chunkSize)
+            static const uint64_t maxChunkSize = 4 * 1024 * 1024;
+            const uint64_t byteEnd =
+                std::min(m_ObjectByteSize, m_ByteOffset + config.buffers[0]->size());
+
+            for(uint64_t byteOffset = m_ByteOffset; byteOffset < byteEnd;)
             {
+              const uint64_t chunkSize = std::min(byteEnd - byteOffset, maxChunkSize);
               // it's fine to block invoke, because this is on the export thread
-              m_Ctx.Replay().BlockInvoke([buff, f, byteOffset](IReplayController *r) {
+              m_Ctx.Replay().BlockInvoke([buff, f, byteOffset, chunkSize](IReplayController *r) {
                 bytebuf chunk = r->GetBufferData(buff, byteOffset, chunkSize);
                 f->write((const char *)chunk.data(), (qint64)chunk.size());
               });
+              byteOffset += chunkSize;
             }
           }
         }

--- a/qrenderdoc/Windows/BufferViewer.cpp
+++ b/qrenderdoc/Windows/BufferViewer.cpp
@@ -5416,13 +5416,17 @@ void BufferViewer::exportData(const BufferExport &params)
         {
           // write 64k rows at a time
           ResourceId buff = m_BufferID;
-          const uint64_t chunkSize = 64 * 1024 * config.buffers[0]->stride;
-          for(uint64_t byteOffset = m_ByteOffset; byteOffset < m_ObjectByteSize;
-              byteOffset += chunkSize)
+          const uint64_t byteEnd =
+              std::min(m_ObjectByteSize, m_ByteOffset + config.buffers[0]->size());
+          for(uint64_t byteOffset = m_ByteOffset; byteOffset < byteEnd;)
           {
+            const uint64_t chunkSize =
+                std::min<uint64_t>(byteEnd - byteOffset, 64 * 1024 * config.buffers[0]->stride);
+            const uint64_t localOffset = byteOffset - m_ByteOffset;
+
             // it's fine to block invoke, because this is on the export thread
             m_Ctx.Replay().BlockInvoke(
-                [buff, &s, &config, byteOffset, chunkSize](IReplayController *r) {
+                [buff, &s, &config, byteOffset, chunkSize, localOffset](IReplayController *r) {
                   // cache column data for the inner loop
                   QVector<CachedElData> cache;
 
@@ -5433,7 +5437,7 @@ void BufferViewer::exportData(const BufferExport &params)
 
                   size_t numRows =
                       (bufferData.storage.size() + bufferData.stride - 1) / bufferData.stride;
-                  size_t rowOffset = byteOffset / bufferData.stride;
+                  size_t rowOffset = localOffset / bufferData.stride;
 
                   CacheDataForIteration(cache, config.columns, config.props, {&bufferData}, 0);
 
@@ -5488,6 +5492,7 @@ void BufferViewer::exportData(const BufferExport &params)
                     s << "\n";
                   }
                 });
+            byteOffset += chunkSize;
           }
         }
       }


### PR DESCRIPTION
The length field of the resource viewer is currently ignored, meaning that we might end up exporting massive CSV/binaries. This PR takes the length field into account.