### PR TITLE
Fix for crash triggered by DepthStencil resolve inside D3D12 Renderpass

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list4_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list4_wrap.cpp
@@ -468,6 +468,20 @@ void WrappedID3D12GraphicsCommandList::BeginRenderPass(
   {
     unwrappedDSV = *pDepthStencil;
     unwrappedDSV.cpuDescriptor = Unwrap(unwrappedDSV.cpuDescriptor);
+    if(unwrappedDSV.DepthEndingAccess.Type == D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE)
+    {
+      unwrappedDSV.DepthEndingAccess.Resolve.pSrcResource =
+          Unwrap(unwrappedDSV.DepthEndingAccess.Resolve.pSrcResource);
+      unwrappedDSV.DepthEndingAccess.Resolve.pDstResource =
+          Unwrap(unwrappedDSV.DepthEndingAccess.Resolve.pDstResource);
+    }
+    if(unwrappedDSV.StencilEndingAccess.Type == D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE)
+    {
+      unwrappedDSV.StencilEndingAccess.Resolve.pSrcResource =
+          Unwrap(unwrappedDSV.StencilEndingAccess.Resolve.pSrcResource);
+      unwrappedDSV.StencilEndingAccess.Resolve.pDstResource =
+          Unwrap(unwrappedDSV.StencilEndingAccess.Resolve.pDstResource);
+    }
   }
 
   SERIALISE_TIME_CALL(m_pList4->BeginRenderPass(NumRenderTargets, unwrappedRTs,


### PR DESCRIPTION
Hi,

Follow up for this issue which did my problems with dx12 renderpass resolve, but the same crash started appearing after using depth resolve inside renderpass: https://github.com/baldurk/renderdoc/issues/2622

After adding the missing unwrapping, the crash no longer occurs. For test, here is an exe that will trigger the crash automatically without the fix (when running with RenderDoc attached). With the fix, the crash should no longer occur:
[Editor_Windows.zip](https://github.com/baldurk/renderdoc/files/9445323/Editor_Windows.zip)

Best regards,
Janos
