### PR TITLE
Enable AMD perf counter support for Samsung GPUs

### DIFF
--- a/renderdoc/api/replay/renderdoc_tostr.inl
+++ b/renderdoc/api/replay/renderdoc_tostr.inl
@@ -1001,6 +1001,7 @@ rdcstr DoStringise(const GPUVendor &el)
     STRINGISE_ENUM_CLASS(Qualcomm);
     STRINGISE_ENUM_CLASS(Verisilicon);
     STRINGISE_ENUM_CLASS(Software);
+    STRINGISE_ENUM_CLASS(Samsung);
   }
   END_ENUM_STRINGISE();
 }

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -1022,7 +1022,7 @@ to apply to multiple related things - see :data:`ClipDistance`, :data:`CullDista
 .. data:: StencilReference
 
   The stencil reference to be used for stenciling operations on this fragment.
-  
+
 .. data:: PointCoord
 
   The fragments co-ordinates within a point primitive being rasterized.
@@ -1701,6 +1701,10 @@ DOCUMENT(R"(Identifies a GPU vendor.
 .. data:: Software
 
   A software-rendering emulated GPU
+
+.. data:: Samsung
+
+  A Samsung GPU
 )");
 enum class GPUVendor : uint32_t
 {
@@ -1714,6 +1718,7 @@ enum class GPUVendor : uint32_t
   Qualcomm,
   Verisilicon,
   Software,
+  Samsung,
 };
 
 DECLARE_REFLECTION_ENUM(GPUVendor);
@@ -1737,6 +1742,7 @@ constexpr GPUVendor GPUVendorFromPCIVendor(uint32_t vendorID)
        : vendorID == 0x5143 ? GPUVendor::Qualcomm
        : vendorID == 0x1AE0 ? GPUVendor::Software   // Google Swiftshader
        : vendorID == 0x1414 ? GPUVendor::Software   // Microsoft WARP
+       : vendorID == 0x144D ? GPUVendor::Samsung    // Xclipse GPU
        : GPUVendor::Unknown;
   // clang-format on
 }

--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -2934,7 +2934,7 @@ bool WrappedID3D11Device::Serialise_SetShaderExtUAV(SerialiserType &ser, GPUVend
       }
       m_ReplayNVAPI->SetShaderExtUAV(~0U, reg, true);
     }
-    else if(vendor == GPUVendor::AMD)
+    else if(vendor == GPUVendor::AMD || vendor == GPUVendor::Samsung)
     {
       // do nothing, it was configured at device create time. This is purely informational
     }

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -3208,7 +3208,7 @@ bool WrappedID3D12Device::Serialise_SetShaderExtUAV(SerialiserType &ser, GPUVend
       }
       m_ReplayNVAPI->SetShaderExtUAV(space, reg, true);
     }
-    else if(vendor == GPUVendor::AMD)
+    else if(vendor == GPUVendor::AMD || vendor == GPUVendor::Samsung)
     {
       m_GlobalEXTUAVSpace = space;
       // do nothing, it was configured at device create time. This is purely informational

--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -153,7 +153,7 @@ void D3D12Replay::CreateResources()
     {
       AMDCounters *counters = NULL;
 
-      if(m_DriverInfo.vendor == GPUVendor::AMD)
+      if(m_DriverInfo.vendor == GPUVendor::AMD || m_DriverInfo.vendor == GPUVendor::Samsung)
       {
         RDCLOG("AMD GPU detected - trying to initialise AMD counters");
         counters = new AMDCounters(m_pDevice->IsDebugLayerEnabled());
@@ -271,7 +271,8 @@ APIProperties D3D12Replay::GetAPIProperties()
   ret.degraded = false;
   ret.shadersMutable = false;
   ret.rgpCapture =
-      m_DriverInfo.vendor == GPUVendor::AMD && m_RGP != NULL && m_RGP->DriverSupportsInterop();
+      (m_DriverInfo.vendor == GPUVendor::AMD || m_DriverInfo.vendor == GPUVendor::Samsung) &&
+      m_RGP != NULL && m_RGP->DriverSupportsInterop();
   ret.shaderDebugging = true;
 
   return ret;
@@ -4424,7 +4425,8 @@ RDResult D3D12_CreateReplayDevice(RDCFile *rdc, const ReplayOptions &opts, IRepl
           "Capture requires nvapi to replay, but it's not available or can't be initialised");
     }
   }
-  else if(initParams.VendorExtensions == GPUVendor::AMD)
+  else if(initParams.VendorExtensions == GPUVendor::AMD ||
+          initParams.VendorExtensions == GPUVendor::Samsung)
   {
     agsDev = InitialiseAGSReplay(initParams.VendorUAVSpace, initParams.VendorUAV);
 

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -308,9 +308,9 @@ void GLReplay::SetReplayData(GLWindowingData data)
         RDCLOG("Intel GPU detected - trying to initialise Intel GL counters");
         countersIntel = new IntelGlCounters();
       }
-      else if(m_DriverInfo.vendor == GPUVendor::AMD)
+      else if(m_DriverInfo.vendor == GPUVendor::AMD || m_DriverInfo.vendor == GPUVendor::Samsung)
       {
-        RDCLOG("AMD GPU detected - trying to initialise AMD counters");
+        RDCLOG("AMD or Samsung GPU detected - trying to initialise AMD counters");
         countersAMD = new AMDCounters();
       }
       else if(m_DriverInfo.vendor == GPUVendor::ARM)

--- a/renderdoc/driver/ihv/amd/amd_counters.cpp
+++ b/renderdoc/driver/ihv/amd/amd_counters.cpp
@@ -68,7 +68,7 @@ AMDCounters::AMDCounters(bool dx12DebugLayerEnabled)
 
 bool AMDCounters::Init(ApiType apiType, void *pContext)
 {
-#if DISABLED(RDOC_WIN32) && DISABLED(RDOC_LINUX) && DISABLED(RDOC_GGP)
+#if DISABLED(RDOC_WIN32) && DISABLED(RDOC_LINUX) && DISABLED(RDOC_GGP) && DISABLED(RDOC_ANDROID)
   (void)m_dx12DebugLayerEnabled;
   return false;
 #else

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -957,7 +957,7 @@ VkDriverInfo::VkDriverInfo(const VkPhysicalDeviceProperties &physProps, bool act
 // using the AMD official driver, but there's not a great other way to distinguish it from
 // the RADV open source driver.
 #if ENABLED(RDOC_WIN32)
-  if(m_Vendor == GPUVendor::AMD)
+  if(m_Vendor == GPUVendor::AMD || m_Vendor == GPUVendor::Samsung)
   {
     // for AMD the bugfix version isn't clear as version numbering wasn't strong for a while, but
     // any driver that reports a version of >= 1.0.0 is fine, as previous versions all reported

--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -2995,7 +2995,7 @@ void VulkanReplay::CreateResources()
 
     GPUVendor vendor = m_pDriver->GetDriverInfo().Vendor();
 
-    if(vendor == GPUVendor::AMD)
+    if(vendor == GPUVendor::AMD || vendor == GPUVendor::Samsung)
     {
       RDCLOG("AMD GPU detected - trying to initialise AMD counters");
       counters = new AMDCounters();

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -212,7 +212,8 @@ APIProperties VulkanReplay::GetAPIProperties()
   ret.degraded = false;
   ret.shadersMutable = false;
   ret.rgpCapture =
-      m_DriverInfo.vendor == GPUVendor::AMD && m_RGP != NULL && m_RGP->DriverSupportsInterop();
+      (m_DriverInfo.vendor == GPUVendor::AMD || m_DriverInfo.vendor == GPUVendor::Samsung) &&
+      m_RGP != NULL && m_RGP->DriverSupportsInterop();
   ret.shaderDebugging = true;
   ret.pixelHistory = true;
 


### PR DESCRIPTION
This change, along with changes in the GPA library, allows the user
to collect AMD counters from a Samsung Xclipse GPU. Previous to this,
the AMD counters could be collected only from GPUs with an AMD PCI
vendor ID.

Most of the changes are related to the fact that the Xclipse GPU has
a unique (Samsung) PCI vendor ID, but is ultimately an AMD
(RDNA2) derivative. So, we need the code to take the AMD path
while technically being its own (non-AMD) GPU.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
