### PR TITLE
Add "empty_map" unit tests for rdcflatmap

### DIFF
--- a/renderdoc/replay/basic_types_tests.cpp
+++ b/renderdoc/replay/basic_types_tests.cpp
@@ -2291,6 +2291,21 @@ TEST_CASE("Test flatmap type", "[basictypes][flatmap]")
     it = test.upper_bound(8);
     CHECK(it == test.end());
   };
+
+  SECTION("empty_map")
+  {
+    rdcflatmap<uint32_t, uint32_t> unsorted;
+    CHECK(unsorted.begin() == unsorted.end());
+    CHECK(unsorted.find(0) == unsorted.end());
+    CHECK(unsorted.lower_bound(1) == 0);
+    CHECK(unsorted.upper_bound(2) == 0);
+
+    rdcflatmap<uint32_t, uint32_t, 0> sorted;
+    CHECK(sorted.begin() == sorted.end());
+    CHECK(sorted.find(0) == sorted.end());
+    CHECK(sorted.lower_bound(1) == 0);
+    CHECK(sorted.upper_bound(2) == 0);
+  }
 };
 
 union foo


### PR DESCRIPTION
## Description

Validate expected behaviour on an empty sorted and unsorted `rdcflatmap` container

```
begin() == end()
find(*) == end()
lower_bound(*) == 0
upper_bound(*) == 0
```