### PR TITLE
Improve tracking of MTLDrawables (swapchains)

### DIFF
--- a/renderdoc/driver/metal/metal_command_buffer.h
+++ b/renderdoc/driver/metal/metal_command_buffer.h
@@ -41,7 +41,9 @@ public:
   DECLARE_FUNCTION_WITH_RETURN_SERIALISED(WrappedMTLRenderCommandEncoder *,
                                           renderCommandEncoderWithDescriptor,
                                           RDMTL::RenderPassDescriptor &descriptor);
-  DECLARE_FUNCTION_SERIALISED(void, presentDrawable, MTL::Drawable *drawable);
+  void presentDrawable(MTL::Drawable *drawable);
+  template <typename SerialiserType>
+  bool Serialise_presentDrawable(SerialiserType &ser, WrappedMTLTexture *presentedImage);
   DECLARE_FUNCTION_SERIALISED(void, commit);
   DECLARE_FUNCTION_SERIALISED(void, enqueue);
   DECLARE_FUNCTION_SERIALISED(void, waitUntilCompleted);

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -31,6 +31,12 @@
 class WrappedMTLDevice;
 class MetalReplay;
 
+struct MetalDrawableInfo
+{
+  CA::MetalLayer *mtlLayer;
+  WrappedMTLTexture *texture;
+};
+
 class MetalCapturer : public IFrameCapturer
 {
 public:
@@ -131,6 +137,9 @@ public:
   void RegisterMetalLayer(CA::MetalLayer *mtlLayer);
   void UnregisterMetalLayer(CA::MetalLayer *mtlLayer);
 
+  void RegisterDrawableInfo(CA::MetalDrawable *caMtlDrawable);
+  MetalDrawableInfo UnregisterDrawableInfo(MTL::Drawable *mtlDrawable);
+
   void AddEvent();
   void AddAction(const ActionDescription &a);
 
@@ -141,6 +150,11 @@ public:
   void DerivedResource(MetalType parent, ResourceId child)
   {
     DerivedResource(GetResID(parent), child);
+  }
+
+  void SetLastPresentedIamge(ResourceId lastPresentedImage)
+  {
+    m_LastPresentedImage = lastPresentedImage;
   }
 
   enum
@@ -177,6 +191,7 @@ private:
                                      MTL::ResourceOptions options);
 
   MetalResourceManager *m_ResourceManager = NULL;
+  ResourceId m_LastPresentedImage;
 
   // Dummy objects used for serialisation replay
   WrappedMTLBuffer *m_DummyBuffer = NULL;
@@ -194,6 +209,8 @@ private:
   Threading::CriticalSection m_CaptureOutputLayersLock;
   std::unordered_set<CA::MetalLayer *> m_CaptureOutputLayers;
   WrappedMTLTexture *m_CapturedBackbuffer = NULL;
+  Threading::CriticalSection m_CaptureDrawablesLock;
+  rdcflatmap<MTL::Drawable *, MetalDrawableInfo> m_CaptureDrawableInfos;
 
   CaptureState m_State;
   bool m_AppControlledCapture = false;


### PR DESCRIPTION
## Description

Serialize the presented texture (`presentedImage`) as part of `presentDrawable` serialization.
Use the presented texture resource ID in the action name ie. `presentDrawable(Texture 23219)`
Track the most recently presented image and use that in `SystemChunk::CaptureEnd` if the `PresentedImage` serialized data is an empty resource.
Track the `CAMetalDrawable`'s created via the hooked `CAMetalLayer::nextDrawable()` method.

Implements `TODO` in `WrappedMTLCommandBuffer::presentDrawable`
`remove the (CA::MetalDrawable*) cast. Associate created texture and layer in hooked nextDrawable with MTL::Drawable*
`
