### PR TITLE
Add the GL_OVR_* extensions to the list of OpenGL extensions too (not just GLES)

### DIFF
--- a/renderdoc/driver/gl/gl_driver.cpp
+++ b/renderdoc/driver/gl/gl_driver.cpp
@@ -259,6 +259,9 @@ void WrappedOpenGL::BuildGLExtensions()
   m_GLExtensions.push_back("GL_KHR_parallel_shader_compile");
   m_GLExtensions.push_back("GL_KHR_robustness");
   m_GLExtensions.push_back("GL_KHR_robust_buffer_access_behavior");
+  m_GLExtensions.push_back("GL_OVR_multiview");
+  m_GLExtensions.push_back("GL_OVR_multiview2");
+  m_GLExtensions.push_back("GL_OVR_multiview_multisampled_render_to_texture");
 
   // this WGL extension is advertised in the gl ext string instead of via the wgl ext string,
   // return it just in case anyone is checking for it via this place. On non-windows platforms


### PR DESCRIPTION
The `GL_OVR_multiview`, `GL_OVR_multiview2` and `GL_OVR_multiview_multisampled_render_to_texture` extensions exist for OpenGL too, not just GLES. (They are already on the list of GLES extensions that RenderDoc supports.)

See:

- https://registry.khronos.org/OpenGL/extensions/OVR/OVR_multiview.txt
- https://registry.khronos.org/OpenGL/extensions/OVR/OVR_multiview2.txt
- https://registry.khronos.org/OpenGL/extensions/OVR/OVR_multiview_multisampled_render_to_texture.txt

This little code change allowed me to debug my app that uses them!