### PR TITLE
Fix uv input declaration for new OpenGL custom texture viewer shaders

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -4512,8 +4512,16 @@ void TextureViewer::on_customCreate_clicked()
   {
     src =
         lit("#version 420 core\n\n"
-            "layout (location = 0) in vec2 uv;\n\n"
-            "layout (location = 0) out vec4 color_out;\n\n"
+            "#ifdef VULKAN\n"
+            "layout (location = 0) in vec2 uv;\n"
+            "#else\n"
+            "in vec2 uv;\n"
+            "#endif\n\n"
+            "#ifdef VULKAN\n"
+            "layout (location = 0) out vec4 color_out;\n"
+            "#else\n"
+            "out vec4 color_out;\n"
+            "#endif\n\n"
             "void main()\n"
             "{\n"
             "    color_out = vec4(0,0,0,1);\n"


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

When the TextureViewer window generates a new GLSL custom textuer viewer shader it creates a declaration for the uv vector with a layout specifier.  This does not work when using OpenGL rather than Vulkan. Any reference to uv causes the shader not to be used.

This change affects the declaration of the uv input variable, depending on the presence or absence of the VULKAN macro.
