### PR TITLE
Silence VVL best-practices warning

### DIFF
--- a/renderdoc/driver/vulkan/vk_next_chains.cpp
+++ b/renderdoc/driver/vulkan/vk_next_chains.cpp
@@ -1561,8 +1561,8 @@ void UnwrapNextChain(CaptureState state, const char *structName, byte *&tempMem,
 
         *out = *in;
 
-        out->pWaitSemaphores = outWaitSemaphores;
-        out->pSignalSemaphores = outSignalSemaphores;
+        out->pWaitSemaphores = in->waitSemaphoreCount == 0 ? NULL : outWaitSemaphores;
+        out->pSignalSemaphores = in->signalSemaphoreCount == 0 ? NULL : outSignalSemaphores;
         out->pBufferBinds = outBufferBinds;
         out->pImageOpaqueBinds = outImageOpaqueBinds;
         out->pImageBinds = outImageBinds;
@@ -2161,7 +2161,7 @@ void UnwrapNextChain(CaptureState state, const char *structName, byte *&tempMem,
 
         *out = *in;
         out->pSwapchains = outSwapchains;
-        out->pWaitSemaphores = outWaitSemaphores;
+        out->pWaitSemaphores = in->waitSemaphoreCount == 0 ? NULL : outWaitSemaphores;
 
         for(uint32_t i = 0; i < in->swapchainCount; i++)
           outSwapchains[i] = Unwrap(in->pSwapchains[i]);
@@ -2316,9 +2316,9 @@ void UnwrapNextChain(CaptureState state, const char *structName, byte *&tempMem,
         tempMem += sizeof(VkSemaphore) * in->signalSemaphoreCount;
 
         *out = *in;
-        out->pWaitSemaphores = outWaitSemaphores;
+        out->pWaitSemaphores = in->waitSemaphoreCount == 0 ? NULL : outWaitSemaphores;
         out->pCommandBuffers = outCmdBuffers;
-        out->pSignalSemaphores = outSignalSemaphores;
+        out->pSignalSemaphores = in->signalSemaphoreCount == 0 ? NULL : outSignalSemaphores;
 
         for(uint32_t i = 0; i < in->waitSemaphoreCount; i++)
           outWaitSemaphores[i] = Unwrap(in->pWaitSemaphores[i]);

--- a/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_wsi_funcs.cpp
@@ -864,7 +864,7 @@ VkResult WrappedVulkan::vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR 
     }
   }
 
-  unwrappedInfo.pWaitSemaphores = unwrappedWaitSems.data();
+  unwrappedInfo.pWaitSemaphores = unwrappedWaitSems.empty() ? NULL : unwrappedWaitSems.data();
   unwrappedInfo.waitSemaphoreCount = (uint32_t)unwrappedWaitSems.size();
 
   VkResult vkr;
@@ -1001,7 +1001,7 @@ void WrappedVulkan::HandlePresent(VkQueue queue, const VkPresentInfoKHR *pPresen
 
       // wait on the present's semaphores
       submitInfo.pWaitDstStageMask = waitStage.data();
-      submitInfo.pWaitSemaphores = unwrappedWaitSems.data();
+      submitInfo.pWaitSemaphores = unwrappedWaitSems.empty() ? NULL : unwrappedWaitSems.data();
       submitInfo.waitSemaphoreCount = (uint32_t)unwrappedWaitSems.size();
 
       // and signal overlaydone
@@ -1050,7 +1050,7 @@ void WrappedVulkan::HandlePresent(VkQueue queue, const VkPresentInfoKHR *pPresen
         waitStage.resize(1);
 
         submitInfo.pWaitDstStageMask = waitStage.data();
-        submitInfo.pWaitSemaphores = unwrappedWaitSems.data();
+        submitInfo.pWaitSemaphores = unwrappedWaitSems.empty() ? NULL : unwrappedWaitSems.data();
         submitInfo.waitSemaphoreCount = (uint32_t)unwrappedWaitSems.size();
 
         // and signal toext
@@ -1106,7 +1106,7 @@ void WrappedVulkan::HandlePresent(VkQueue queue, const VkPresentInfoKHR *pPresen
         waitStage.resize(1);
 
         submitInfo.pWaitDstStageMask = waitStage.data();
-        submitInfo.pWaitSemaphores = unwrappedWaitSems.data();
+        submitInfo.pWaitSemaphores = unwrappedWaitSems.empty() ? NULL : unwrappedWaitSems.data();
         submitInfo.waitSemaphoreCount = (uint32_t)unwrappedWaitSems.size();
 
         // release to the external queue


### PR DESCRIPTION
VVL's best-practices complains that pWaitSemaphores and pSignalSemaphores are non-NULL but count is 0.  This change silences that to avoid spamming the error log in the UI.