### PR TITLE
source home directory from ${HOME} when getpwuid() is not supported

### DIFF
--- a/renderdoc/os/posix/linux/linux_stringio.cpp
+++ b/renderdoc/os/posix/linux/linux_stringio.cpp
@@ -596,7 +596,16 @@ rdcstr GetTempRootPath()
 rdcstr GetAppFolderFilename(const rdcstr &filename)
 {
   passwd *pw = getpwuid(getuid());
-  const char *homedir = pw->pw_dir;
+  const char *homedir = pw ? pw->pw_dir : NULL;
+
+  if(!homedir)
+    homedir = getenv("HOME");
+
+  if(!homedir)
+  {
+    RDCERR("Can't get HOME directory, defaulting to '/' instead");
+    homedir = "";
+  }
 
   rdcstr ret = rdcstr(homedir) + "/.renderdoc/";
 


### PR DESCRIPTION
Source home directory from HOME environment variable

Source the user's home directory from the HOME envoironment variable if set.
If this is not set, fall back to the existing logic and call getpwuid().

## Description

I am working on a project where getpwuid() is not supportedin a Linux-based environmen, 
but the HOME variable is guaranteed to be populated.

Also the getpwuid man page (https://linux.die.net/man/3/getpwuid) notes that the value
of the HOME environment variable should be preferred over getpwuid(getuid())->pw_dir
if it is available.
Longer paragraph that details the change and any logic behind needing
to make the change, other impacts, future work etc. Keeping the title
to 72 characters means it will display fully in git log and github logs.

