### PR TITLE
vkEnumeratePhysicalDevices: Handle when count is too small

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -1502,14 +1502,22 @@ VkResult WrappedVulkan::vkEnumeratePhysicalDevices(VkInstance instance,
     }
   }
 
-  if(pPhysicalDeviceCount)
-    *pPhysicalDeviceCount = count;
+  VkResult result = VK_SUCCESS;
+
   if(pPhysicalDevices)
+  {
+    if(count > *pPhysicalDeviceCount)
+    {
+      count = *pPhysicalDeviceCount;
+      result = VK_INCOMPLETE;
+    }
     memcpy(pPhysicalDevices, devices, count * sizeof(VkPhysicalDevice));
+  }
+  *pPhysicalDeviceCount = count;
 
   SAFE_DELETE_ARRAY(devices);
 
-  return VK_SUCCESS;
+  return result;
 }
 
 bool WrappedVulkan::SelectGraphicsComputeQueue(const rdcarray<VkQueueFamilyProperties> &queueProps,


### PR DESCRIPTION
Per the Vulkan Spec: "If pPhysicalDeviceCount is less than the number of physical devices available, at most pPhysicalDeviceCount structures will be written, and VK_INCOMPLETE will be returned instead of VK_SUCCESS, to indicate that not all the available physical devices were returned."