### PR TITLE
MiniQtHelper: add ProgressBar widget

### DIFF
--- a/qrenderdoc/Code/Interface/Extensions.h
+++ b/qrenderdoc/Code/Interface/Extensions.h
@@ -941,7 +941,9 @@ By default the progress bar has minimum and maximum values of 0 and 100. These c
 
   DOCUMENT(R"(Reset a progress bar widget.
 
-The progress bar "rewinds" and shows no progress. The minimum and maximum values are not changed.
+Rewinds the progress bar's indicator and hides the indicator's label (theme dependent). If you want
+to keep the label visible, call :meth:`SetProgressBarValue(0)` instead. The minimum and maximum values
+are not changed.
 
 :param QWidget pbar: the progress bar.
 )")
@@ -976,7 +978,7 @@ the current value.
 
 If maximum is smaller than minimum, minimum is set as the maximum, too. If the current value falls
 outside the new range, the progress bar is reset. Use range (0, 0) to set the progress bar to
-undetermined state.
+indeterminated state (the progress cannot be estimated or is not being calculated).
 
 :param QWidget pbar: the progress bar.
 :param int minimum: the minimum value.

--- a/qrenderdoc/Code/Interface/Extensions.h
+++ b/qrenderdoc/Code/Interface/Extensions.h
@@ -927,6 +927,79 @@ an unknown option is passed, nothing will happen.
 )")
   virtual void SelectComboOption(QWidget *combo, const rdcstr &option) = 0;
 
+  DOCUMENT(R"(Create a progress bar widget.
+
+By default the progress bar has minimum and maximum values of 0 and 100. These can be changed with
+:meth:`SetProgressBarRange`.
+
+:param bool horizontal: the progress bar orientation, true for horizontal otherwise vertical.
+:return: The handle to the newly created widget.
+:rtype: QWidget
+
+)")
+  virtual QWidget *CreateProgressBar(bool horizontal) = 0;
+
+  DOCUMENT(R"(Reset a progress bar widget.
+
+The progress bar "rewinds" and shows no progress. The minimum and maximum values are not changed.
+
+:param QWidget pbar: the progress bar.
+)")
+  virtual void ResetProgressBar(QWidget *pbar) = 0;
+
+  DOCUMENT(R"(Set the progress bar's current value.
+
+Attempting to change the current value outside the minimum and maximum range does not affect
+the current value.
+
+:param QWidget pbar: the progress bar.
+:param int value: the new current value.
+)")
+  virtual void SetProgressBarValue(QWidget *pbar, int32_t value) = 0;
+
+  DOCUMENT(R"(Set the progress bar's current value relative to the existing value.
+
+:param QWidget pbar: the progress bar.
+:param int delta: the relative value to update the current value.
+)")
+  virtual void UpdateProgressBarValue(QWidget *pbar, int32_t delta) = 0;
+
+  DOCUMENT(R"(Get the progress bar's current value.
+
+:param QWidget pbar: the progress bar.
+:return: The current value of the progress bar.
+:rtype: int
+)")
+  virtual int32_t GetProgressBarValue(QWidget *pbar) = 0;
+
+  DOCUMENT(R"(Set a progress bar's minimum and maximum values.
+
+If maximum is smaller than minimum, minimum is set as the maximum, too. If the current value falls
+outside the new range, the progress bar is reset. Use range (0, 0) to set the progress bar to
+undetermined state.
+
+:param QWidget pbar: the progress bar.
+:param int minimum: the minimum value.
+:param int maximum: the maximum value.
+)")
+  virtual void SetProgressBarRange(QWidget *pbar, int32_t minimum, int32_t maximum) = 0;
+
+  DOCUMENT(R"(Get the minimum value of the progress bar's range.
+
+:param QWidget pbar: the progress bar.
+:return: The minimum value of the range.
+:rtype: int
+)")
+  virtual int32_t GetProgressBarMinimum(QWidget *pbar) = 0;
+
+  DOCUMENT(R"(Get the maximum value of the progress bar's range.
+
+:param QWidget pbar: the progress bar.
+:return: The maximum value of the range.
+:rtype: int
+)")
+  virtual int32_t GetProgressBarMaximum(QWidget *pbar) = 0;
+
 protected:
   DOCUMENT("");
   IMiniQtHelper() = default;

--- a/qrenderdoc/Code/MiniQtHelper.cpp
+++ b/qrenderdoc/Code/MiniQtHelper.cpp
@@ -29,6 +29,7 @@
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QProgressBar>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QVBoxLayout>
@@ -724,4 +725,96 @@ void MiniQtHelper::SelectComboOption(QWidget *combo, const rdcstr &option)
 
   if(comb)
     comb->setCurrentText(option);
+}
+
+QWidget *MiniQtHelper::CreateProgressBar(bool horizontal)
+{
+  QProgressBar *w = new QProgressBar();
+
+  w->setOrientation(horizontal ? Qt::Horizontal : Qt::Vertical);
+
+  return w;
+}
+
+void MiniQtHelper::ResetProgressBar(QWidget *pbar)
+{
+  if(!pbar)
+    return;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pb)
+    pb->reset();
+}
+
+void MiniQtHelper::SetProgressBarValue(QWidget *pbar, int32_t value)
+{
+  if(!pbar)
+    return;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pb)
+    pb->setValue(value);
+}
+
+void MiniQtHelper::UpdateProgressBarValue(QWidget *pbar, int32_t delta)
+{
+  if(!pbar)
+    return;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pb)
+    pb->setValue(pb->value() + delta);
+}
+
+int32_t MiniQtHelper::GetProgressBarValue(QWidget *pbar)
+{
+  if(!pbar)
+    return 0;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pb)
+    return pb->value();
+
+  return 0;
+}
+
+void MiniQtHelper::SetProgressBarRange(QWidget *pbar, int32_t minimum, int32_t maximum)
+{
+  if(!pbar)
+    return;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pb)
+    pb->setRange(minimum, maximum);
+}
+
+int32_t MiniQtHelper::GetProgressBarMinimum(QWidget *pbar)
+{
+  if(!pbar)
+    return 0;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pb)
+    return pb->minimum();
+
+  return 0;
+}
+
+int32_t MiniQtHelper::GetProgressBarMaximum(QWidget *pbar)
+{
+  if(!pbar)
+    return 0;
+
+  QProgressBar *pb = qobject_cast<QProgressBar *>(pbar);
+
+  if(pbar)
+    return pb->maximum();
+
+  return 0;
 }

--- a/qrenderdoc/Code/MiniQtHelper.h
+++ b/qrenderdoc/Code/MiniQtHelper.h
@@ -119,6 +119,16 @@ public:
   size_t GetComboCount(QWidget *combo) override;
   void SelectComboOption(QWidget *combo, const rdcstr &option) override;
 
+  QWidget *CreateProgressBar(bool horizontal) override;
+
+  void ResetProgressBar(QWidget *pbar) override;
+  void SetProgressBarValue(QWidget *pbar, int32_t value) override;
+  void UpdateProgressBarValue(QWidget *pbar, int32_t delta) override;
+  int32_t GetProgressBarValue(QWidget *pbar) override;
+  void SetProgressBarRange(QWidget *pbar, int32_t minimum, int32_t maximum) override;
+  int32_t GetProgressBarMinimum(QWidget *pbar) override;
+  int32_t GetProgressBarMaximum(QWidget *pbar) override;
+
 private:
   ICaptureContext &m_Ctx;
 

--- a/qrenderdoc/Windows/PythonShell.cpp
+++ b/qrenderdoc/Windows/PythonShell.cpp
@@ -312,6 +312,46 @@ struct MiniQtInvoker : ObjectForwarder<IMiniQtHelper>
   {
     InvokeVoidFunction(&IMiniQtHelper::SelectComboOption, combo, option);
   }
+
+  QWidget *CreateProgressBar(bool horizontal)
+  {
+    return InvokeRetFunction<QWidget *>(&IMiniQtHelper::CreateProgressBar, horizontal);
+  }
+
+  void ResetProgressBar(QWidget *pbar)
+  {
+    InvokeVoidFunction(&IMiniQtHelper::ResetProgressBar, pbar);
+  }
+
+  void SetProgressBarValue(QWidget *pbar, int32_t value)
+  {
+    InvokeVoidFunction(&IMiniQtHelper::SetProgressBarValue, pbar, value);
+  }
+
+  void UpdateProgressBarValue(QWidget *pbar, int32_t delta)
+  {
+    InvokeVoidFunction(&IMiniQtHelper::UpdateProgressBarValue, pbar, delta);
+  }
+
+  int32_t GetProgressBarValue(QWidget *pbar)
+  {
+    return InvokeRetFunction<int>(&IMiniQtHelper::GetProgressBarValue, pbar);
+  }
+
+  void SetProgressBarRange(QWidget *pbar, int32_t minimum, int32_t maximum)
+  {
+    InvokeVoidFunction(&IMiniQtHelper::SetProgressBarRange, pbar, minimum, maximum);
+  }
+
+  int32_t GetProgressBarMinimum(QWidget *pbar)
+  {
+    return InvokeRetFunction<int>(&IMiniQtHelper::GetProgressBarMinimum, pbar);
+  }
+
+  int32_t GetProgressBarMaximum(QWidget *pbar)
+  {
+    return InvokeRetFunction<int>(&IMiniQtHelper::GetProgressBarMaximum, pbar);
+  }
 };
 
 struct ExtensionInvoker : ObjectForwarder<IExtensionManager>


### PR DESCRIPTION
Added interface function to:
- create a progress bar widget,
- reset the progress shown,
- set the minimum and maximum values,
- set the current value arbitrarily,
- update relatively the current value,
- get the current value,
- get the minimum and maximum values