### PR TITLE
Fixed uninitialized local variable

### DIFF
--- a/util/test/demos/vk/vk_mesh_zoo.cpp
+++ b/util/test/demos/vk/vk_mesh_zoo.cpp
@@ -336,7 +336,7 @@ void main()
 
     VkPipeline stride0pipe = createGraphicsPipeline(pipeCreateInfo);
 
-    VkPipeline xfbpipe;
+    VkPipeline xfbpipe = NULL;
 
     VkPipelineRasterizationStateStreamCreateInfoEXT rastInfo = {
         VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT, NULL, 0, 2,

--- a/util/test/demos/vk/vk_mesh_zoo.cpp
+++ b/util/test/demos/vk/vk_mesh_zoo.cpp
@@ -336,7 +336,7 @@ void main()
 
     VkPipeline stride0pipe = createGraphicsPipeline(pipeCreateInfo);
 
-    VkPipeline xfbpipe = NULL;
+    VkPipeline xfbpipe = VK_NULL_HANDLE;
 
     VkPipelineRasterizationStateStreamCreateInfoEXT rastInfo = {
         VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT, NULL, 0, 2,


### PR DESCRIPTION
## Description
This patch solves the following Visual C compiler error when attempting to build the "util/tests/demos.sln" VS project from the command-line w/ MSBUILD:

`error C2220: the following warning is treated as an error`
`warning C4701: potentially uninitialized local variable 'xfbpipe' used`