### PR TITLE
Switch to MacOS 12 for CI and minimum SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,18 +307,9 @@ jobs:
     - name: Install Homebrew dependencies
       run: |
         brew update || true
-        sudo rm /usr/local/bin/2to3-3.11 || true
-        sudo rm /usr/local/bin/idle3.11 || true
-        sudo rm /usr/local/bin/pydoc3.11 || true
-        sudo rm /usr/local/bin/python3.11 || true
-        sudo rm /usr/local/bin/python3.11-config || true
-        sudo rm /usr/local/bin/2to3 || true
-        sudo rm /usr/local/bin/idle3 || true
-        sudo rm /usr/local/bin/pydoc3 || true
-        sudo rm /usr/local/bin/python3 || true
-        sudo rm /usr/local/bin/python3-config || true
-        brew install qt5 lftp automake pcre
-        brew link qt5 --force
+        brew install lftp automake pcre
+        brew install --overwrite qt5
+        brew link --overwrite --force qt5
     - name: Build
       run: |
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
   macOS:
     name: Mac
     needs: [commit-msg, clang-format]
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(APPLE)
   # Building for Apple requires at least CMake 3.20.0
   cmake_minimum_required(VERSION 3.20.0)
 
-  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum SDK for Mac OS X")
+  SET(CMAKE_OSX_DEPLOYMENT_TARGET "12.00" CACHE STRING "Minimum SDK for Mac OS X")
   SET(CMAKE_XCODE_GENERATE_SCHEME ON)
 endif()
 


### PR DESCRIPTION
## Description

- Use MacOS 12 image for CI.
- Add `--overwrite` for brew install line for qt5 which replaces the need for the `sudo rm` lines.
- Removed the `sudo rm` lines which are not required now `--overwrite` is being used.
- Set the minimum Mac SDK to 12.00