### PR TITLE
Fix Vulkan-only build

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -565,7 +565,7 @@ if(ENABLE_GL OR ENABLE_GLES)
 endif()
 
 # pull in the NVIDIA folder
-if(NOT ANDROID AND NOT APPLE AND (ENABLE_GL OR ENABLE_GLES))
+if(NOT ANDROID AND NOT APPLE AND (ENABLE_GL OR ENABLE_GLES OR ENABLE_VULKAN))
     add_subdirectory(driver/ihv/nv)
     list(APPEND renderdoc_objects $<TARGET_OBJECTS:rdoc_nv>)
 endif()

--- a/renderdoc/driver/ihv/nv/CMakeLists.txt
+++ b/renderdoc/driver/ihv/nv/CMakeLists.txt
@@ -1,16 +1,22 @@
 set(sources
     nv_counter_enumerator.cpp
     nv_counter_enumerator.h
-    nv_gl_counters.cpp
     nv_gl_counters.h
-    nv_vk_counters.cpp
     nv_vk_counters.h)
+
+if(ENABLE_GL OR ENABLE_GLES)
+    set(sources_gl nv_gl_counters.cpp)
+endif()
+
+if(ENABLE_VULKAN)
+    set(sources_vulkan nv_vk_counters.cpp)
+endif()
 
 set(include_dirs
     ${RDOC_INCLUDES}
     "${CMAKE_CURRENT_SOURCE_DIR}/official/PerfSDK/redist/include"
     "${CMAKE_CURRENT_SOURCE_DIR}/official/PerfSDK/redist/NvPerfUtility/include")
 
-add_library(rdoc_nv OBJECT ${sources})
+add_library(rdoc_nv OBJECT ${sources} ${sources_gl} ${sources_vulkan})
 target_compile_definitions(rdoc_nv ${RDOC_DEFINITIONS})
 target_include_directories(rdoc_nv ${include_dirs})


### PR DESCRIPTION
NVIDIA counters build assumed Vulkan build implies GL build.  This is not necessarily the case.