### PR TITLE
Allow multiple depth targets to be viewable in the TextureViewer

### DIFF
--- a/qrenderdoc/Code/Interface/QRDInterface.h
+++ b/qrenderdoc/Code/Interface/QRDInterface.h
@@ -597,13 +597,18 @@ DOCUMENT(R"(Specifies a type of followed resource for the :class:`TextureViewer`
   The index specifies a resource within the given shader's
   :data:`read-only resources <~renderdoc.ShaderReflection.readOnlyResources>`. The array element
   then specifies the index within that resource's array, if applicable.
+
+.. data:: OutputDepthResolve
+
+  The resource followed is the depth/stencil resolve output target. All other parameters are ignored.
 )");
 enum class FollowType : int
 {
   OutputColor,
   OutputDepth,
   ReadWrite,
-  ReadOnly
+  ReadOnly,
+  OutputDepthResolve
 };
 
 DOCUMENT("The texture viewer window.");

--- a/qrenderdoc/Windows/ShaderMessageViewer.cpp
+++ b/qrenderdoc/Windows/ShaderMessageViewer.cpp
@@ -185,6 +185,7 @@ ShaderMessageViewer::ShaderMessageViewer(ICaptureContext &ctx, ShaderStageMask s
   m_Multisampled = false;
   rdcarray<BoundResource> outs = pipe.GetOutputTargets();
   outs.push_back(pipe.GetDepthTarget());
+  outs.push_back(pipe.GetDepthResolveTarget());
   for(const BoundResource &o : outs)
   {
     if(o.resourceId == ResourceId())

--- a/qrenderdoc/Windows/TextureViewer.h
+++ b/qrenderdoc/Windows/TextureViewer.h
@@ -72,6 +72,7 @@ struct Following
   static rdcarray<BoundResource> GetOutputTargets(ICaptureContext &ctx);
 
   static BoundResource GetDepthTarget(ICaptureContext &ctx);
+  static BoundResource GetDepthResolveTarget(ICaptureContext &ctx);
   static rdcarray<BoundResourceArray> GetReadWriteResources(ICaptureContext &ctx, ShaderStage stage,
                                                             bool onlyUsed);
   static rdcarray<BoundResourceArray> GetReadOnlyResources(ICaptureContext &ctx, ShaderStage stage,

--- a/renderdoc/api/replay/pipestate.h
+++ b/renderdoc/api/replay/pipestate.h
@@ -388,6 +388,13 @@ For some APIs that don't distinguish by entry point, this may be empty.
 )");
   BoundResource GetDepthTarget() const;
 
+  DOCUMENT(R"(Retrieves the read/write resources bound to the depth-stencil resolve output.
+
+:return: The currently bound depth-stencil resolve resource.
+:rtype: BoundResource
+)");
+  BoundResource GetDepthResolveTarget() const;
+
   DOCUMENT(R"(Retrieves the resources bound to the color outputs.
 
 :return: The currently bound output targets.

--- a/renderdoc/api/replay/pipestate.inl
+++ b/renderdoc/api/replay/pipestate.inl
@@ -1760,6 +1760,32 @@ BoundResource PipeState::GetDepthTarget() const
   return BoundResource();
 }
 
+BoundResource PipeState::GetDepthResolveTarget() const
+{
+  if(IsCaptureLoaded())
+  {
+    if(IsCaptureVK())
+    {
+      const VKPipe::RenderPass &rp = m_Vulkan->currentPass.renderpass;
+      const VKPipe::Framebuffer &fb = m_Vulkan->currentPass.framebuffer;
+
+      if(rp.depthstencilResolveAttachment >= 0 &&
+         rp.depthstencilResolveAttachment < fb.attachments.count())
+      {
+        BoundResource ret;
+        ret.resourceId = fb.attachments[rp.depthstencilResolveAttachment].imageResourceId;
+        ret.firstMip = (int)fb.attachments[rp.depthstencilResolveAttachment].firstMip;
+        ret.firstSlice = (int)fb.attachments[rp.depthstencilResolveAttachment].firstSlice;
+        ret.typeCast = fb.attachments[rp.depthstencilResolveAttachment].viewFormat.compType;
+        return ret;
+      }
+
+      return BoundResource();
+    }
+  }
+  return BoundResource();
+}
+
 rdcarray<BoundResource> PipeState::GetOutputTargets() const
 {
   rdcarray<BoundResource> ret;


### PR DESCRIPTION
## Description

Last year I added a change that supported VK_KHR_depth_stencil_resolve in RenderDoc. I had forgotten to update the TextureViewer so that you can see the depth resolve output there. This change updates the TextureViewer so that it get grab multiple depth targets and show them.
![image](https://user-images.githubusercontent.com/122318233/211898197-7f377666-e6e6-4829-9a13-b03def477048.png)
