### PR TITLE
Fix brew python upgrade errors in Mac CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,8 +307,13 @@ jobs:
     - name: Install Homebrew dependencies
       run: |
         brew update || true
-        brew install lftp automake pcre
-        brew install --overwrite qt5
+        brew unlink python
+        brew link --overwrite --force python
+        brew unlink python@3.10
+        brew link --overwrite --force python@3.10
+        brew unlink python@3.11
+        brew link --overwrite --force python@3.11
+        brew install --overwrite lftp automake pcre qt5
         brew link --overwrite --force qt5
     - name: Build
       run: |


### PR DESCRIPTION
## Description

brew unlink python then brew force link python 3.10 & 3.11

This is similar in behaviour to `sudo rm` lines but brew handles which files to remove instead of a hand curated list.

The python dependency and upgrade was being triggered by installing the dependencies before `qt5` i.e.  `lftp`, `automake`, `pcre`