### PR TITLE
 Show errors from NvPerfUtility in the RenderDoc UI

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -176,7 +176,7 @@ void D3D12Replay::CreateResources()
         NVD3D12Counters *countersNV = new NVD3D12Counters();
 
         bool initSuccess = false;
-        if(countersNV && countersNV->Init(m_pDevice->GetReal()))
+        if(countersNV && countersNV->Init(*m_pDevice))
         {
           m_pNVCounters = countersNV;
           initSuccess = true;

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -370,7 +370,7 @@ void GLReplay::SetReplayData(GLWindowingData data)
     }
 
 #if DISABLED(RDOC_ANDROID) && DISABLED(RDOC_APPLE)
-    if(countersNV && countersNV->Init())
+    if(countersNV && countersNV->Init(m_pDriver))
     {
       m_pNVCounters = countersNV;
     }

--- a/renderdoc/driver/ihv/nv/nv_d3d12_counters.h
+++ b/renderdoc/driver/ihv/nv/nv_d3d12_counters.h
@@ -28,7 +28,6 @@
 #include "api/replay/rdcarray.h"
 #include "api/replay/replay_enums.h"
 
-struct ID3D12Device;
 class WrappedID3D12Device;
 
 class NVD3D12Counters final
@@ -37,7 +36,7 @@ public:
   NVD3D12Counters();
   ~NVD3D12Counters();
 
-  bool Init(ID3D12Device *device);
+  bool Init(WrappedID3D12Device &device);
 
   rdcarray<GPUCounter> EnumerateCounters() const;
   bool HasCounter(GPUCounter counterID) const;

--- a/renderdoc/driver/ihv/nv/nv_gl_counters.h
+++ b/renderdoc/driver/ihv/nv/nv_gl_counters.h
@@ -36,7 +36,7 @@ public:
   NVGLCounters();
   ~NVGLCounters();
 
-  bool Init();
+  bool Init(WrappedOpenGL *driver);
 
   rdcarray<GPUCounter> EnumerateCounters() const;
   bool HasCounter(GPUCounter counterID) const;


### PR DESCRIPTION
## Description
Errors related to collecting NVIDIA hardware counters are now shown in the "Errors and Warnings" window of the Renderdoc UI. Previously, these errors were only visible in stderr. This includes errors for device compatibility, resource availability, and insufficient privileges.

![renderdoc_nvperf_error](https://user-images.githubusercontent.com/68713353/213002814-605ba609-31b7-48c1-8469-73684d27e1ae.png)
