### PR TITLE
Fix errors from NvPerfUtility displayed when no library present

### DIFF
--- a/renderdoc/driver/ihv/nv/nv_d3d11_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_d3d11_counters.cpp
@@ -76,6 +76,9 @@ struct NVD3D11Counters::Impl
       return true;
     }
 
+    nv::perf::UserLogEnableCustom(NVD3D11Counters::Impl::LogNvPerfAsDebugMessage, (void *)device);
+    auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
+
     if(!nv::perf::D3D11LoadDriver())
     {
       Impl::LogDebugMessage("NVD3D11Counters::Impl::TryInitializePerfSDK",
@@ -201,9 +204,6 @@ bool NVD3D11Counters::Init(WrappedID3D11Device *device)
   m_Impl = new Impl;
   if(!m_Impl)
     return false;
-
-  nv::perf::UserLogEnableCustom(NVD3D11Counters::Impl::LogNvPerfAsDebugMessage, (void *)device);
-  auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
 
   const bool initSuccess = m_Impl->TryInitializePerfSDK(device);
   if(!initSuccess)

--- a/renderdoc/driver/ihv/nv/nv_d3d12_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_d3d12_counters.cpp
@@ -79,6 +79,9 @@ struct NVD3D12Counters::Impl
       return true;
     }
 
+    nv::perf::UserLogEnableCustom(NVD3D12Counters::Impl::LogNvPerfAsDebugMessage, (void *)&device);
+    auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
+
     if(!nv::perf::D3D12LoadDriver())
     {
       Impl::LogDebugMessage("NVD3D12Counters::Impl::TryInitializePerfSDK",
@@ -181,9 +184,6 @@ bool NVD3D12Counters::Init(WrappedID3D12Device &device)
 
   if(!m_Impl)
     return false;
-
-  nv::perf::UserLogEnableCustom(NVD3D12Counters::Impl::LogNvPerfAsDebugMessage, (void *)&device);
-  auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
 
   bool initSuccess = m_Impl->TryInitializePerfSDK(device);
   if(!initSuccess)

--- a/renderdoc/driver/ihv/nv/nv_gl_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_gl_counters.cpp
@@ -73,6 +73,9 @@ struct NVGLCounters::Impl
       return true;
     }
 
+    nv::perf::UserLogEnableCustom(NVGLCounters::Impl::LogNvPerfAsDebugMessage, (void *)driver);
+    auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
+
     if(!nv::perf::OpenGLLoadDriver())
     {
       Impl::LogDebugMessage("NVGLCounters::Impl::TryInitializePerfSDK",
@@ -197,9 +200,6 @@ bool NVGLCounters::Init(WrappedOpenGL *driver)
   m_Impl = new Impl;
   if(!m_Impl)
     return false;
-
-  nv::perf::UserLogEnableCustom(NVGLCounters::Impl::LogNvPerfAsDebugMessage, (void *)driver);
-  auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
 
   const bool initSuccess = m_Impl->TryInitializePerfSDK(driver);
   if(!initSuccess)

--- a/renderdoc/driver/ihv/nv/nv_vk_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_vk_counters.cpp
@@ -75,6 +75,9 @@ struct NVVulkanCounters::Impl
       return true;
     }
 
+    nv::perf::UserLogEnableCustom(NVVulkanCounters::Impl::LogNvPerfAsDebugMessage, (void *)driver);
+    auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
+
     if(!nv::perf::VulkanLoadDriver(Unwrap(driver->GetInstance())))
     {
       Impl::LogDebugMessage("NVVulkanCounters::Impl::TryInitializePerfSDK",
@@ -181,9 +184,6 @@ bool NVVulkanCounters::Init(WrappedVulkan *driver)
   m_Impl = new Impl;
   if(!m_Impl)
     return false;
-
-  nv::perf::UserLogEnableCustom(NVVulkanCounters::Impl::LogNvPerfAsDebugMessage, (void *)driver);
-  auto logGuard = nv::perf::ScopeExitGuard([]() { nv::perf::UserLogDisableCustom(); });
 
   const bool initSuccess = m_Impl->TryInitializePerfSDK(driver);
   if(!initSuccess)


### PR DESCRIPTION
## Description

Errors from NvPerfUtility do not need to be displayed if the Nsight Perf SDK library is not installed.

This is a fix for the problem identified in https://github.com/baldurk/renderdoc/pull/2824#issuecomment-1396910592
