### PR TITLE
Specify shader version when fetching texture image

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -2987,6 +2987,7 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
       if(bindTarget == eGL_TEXTURE_CUBE_MAP)
       {
         vssource =
+            "#version 100\n"
             "attribute vec2 pos;\n"
             "void main() { gl_Position = vec4(pos, 0.5, 0.5); }";
 
@@ -3008,6 +3009,7 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
         cubecoord += "\nreturn coord;\n}\n";
 
         fssource = rdcstr(
+                       "#version 100\n"
                        "precision highp float;\n"
                        "uniform vec3 res;\n"
                        "uniform samplerCube srcTex;\n") +
@@ -3019,11 +3021,13 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
       else if(target == eGL_TEXTURE_2D)
       {
         vssource =
+            "#version 100\n"
             "attribute vec2 pos;\n"
             "void main() { gl_Position = vec4(pos, 0.5, 0.5); }";
 
         fssource =
             rdcstr(
+                "#version 100\n"
                 "precision highp float;\n"
                 "uniform vec3 res;\n"
                 "uniform sampler2D srcTex;\n"


### PR DESCRIPTION
Without this patch I get the following log:
```
RDOC 024435: [13:44:31]      gl_emulated.cpp(2882) - Debug   - Doing manual blit from GL_ALPHA to GL_R8 with format GL_ALPHA and type GL_UNSIGNED_BYTE to allow readback
RDOC 024435: [13:44:31]      gl_emulated.cpp(3080) - Error   - Shader error: 0:1(1): error: syntax error, unexpected NEW_IDENTIFIER
```
It seems that the precision keyword is not recognized.
Prefixing with `#version 100` makes it work.
This has been tested in GLES context only.