### PR TITLE
Fix immutable samplers in vulkan shader debugging

### DIFF
--- a/renderdoc/driver/vulkan/vk_shaderdebug.cpp
+++ b/renderdoc/driver/vulkan/vk_shaderdebug.cpp
@@ -254,7 +254,14 @@ public:
             {
               const DescriptorSetSlot &slot = curSlots[i];
 
-              switch(slot.type)
+              // When bind layout contains immutable samplers, sampler-only slots always have type
+              // DescriptorSlotType::Unwritten. Treat them as sampler slots in that case.
+              DescriptorSlotType slotType = slot.type;
+              if(bindLayout.immutableSampler &&
+                 bindLayout.layoutDescType == VK_DESCRIPTOR_TYPE_SAMPLER)
+                slotType = DescriptorSlotType::Sampler;
+
+              switch(slotType)
               {
                 case DescriptorSlotType::Sampler:
                 case DescriptorSlotType::CombinedImageSampler:


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Immutable samplers are displayed correctly in pipeline state window, but are not available in shader debugging. Using them results in warning messages "descriptor set x binding y is not bound".

![2](https://user-images.githubusercontent.com/19588296/215317714-222c08eb-e219-49b0-9e69-df4265a4cff0.png)

![1](https://user-images.githubusercontent.com/19588296/215317737-519b7e42-e47a-4ef0-a024-e6fad89366d5.png)

This patch binds immutable samplers to binding storage when creating a new bindings array, to enable immutable samplers in shader debugging. Another related change is ignoring sampler-only descriptors with immutable samplers when creating `VkWriteDescriptorSet` for vulkan descriptor set initialization.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
