### PR TITLE
MiniQtHelper: Add getter and setter for CollapseGroupBox;

### DIFF
--- a/qrenderdoc/Code/Interface/Extensions.h
+++ b/qrenderdoc/Code/Interface/Extensions.h
@@ -819,7 +819,7 @@ If you want a default radio box to be checked, you should use :meth:`SetWidgetCh
   virtual QWidget *CreateRadiobox(WidgetCallback changed) = 0;
 
   DOCUMENT(R"(Set whether the widget is checked or not. This only affects checkboxes and radio
-boxes. If another type of widget is passed nothing will happen.
+boxes and group box. If another type of widget is passed nothing will happen.
 
 :param QWidget checkableWidget: The widget to check or uncheck.
 :param bool checked: ``True`` if the widget should be checked.
@@ -827,7 +827,7 @@ boxes. If another type of widget is passed nothing will happen.
   virtual void SetWidgetChecked(QWidget *checkableWidget, bool checked) = 0;
 
   DOCUMENT(R"(Return the current checked-state of a widget. See :meth:`SetWidgetChecked`. If another
-type of widget is passed other than a checkbox or radio box ``False`` will be returned.
+type of widget is passed other than a checkbox or radio box or group box ``False`` will be returned.
 
 :param QWidget checkableWidget: The widget to query.
 :return: ``True`` if the widget is currently checked.

--- a/qrenderdoc/Code/MiniQtHelper.cpp
+++ b/qrenderdoc/Code/MiniQtHelper.cpp
@@ -590,11 +590,14 @@ void MiniQtHelper::SetWidgetChecked(QWidget *checkableWidget, bool checked)
 
   QCheckBox *check = qobject_cast<QCheckBox *>(checkableWidget);
   QRadioButton *radio = qobject_cast<QRadioButton *>(checkableWidget);
+  CollapseGroupBox *group = qobject_cast<CollapseGroupBox *>(checkableWidget);
 
   if(check)
     check->setChecked(checked);
   else if(radio)
     radio->setChecked(checked);
+  else if(group)
+    group->setCollapsed(checked);
 }
 
 bool MiniQtHelper::IsWidgetChecked(QWidget *checkableWidget)
@@ -604,11 +607,14 @@ bool MiniQtHelper::IsWidgetChecked(QWidget *checkableWidget)
 
   QCheckBox *check = qobject_cast<QCheckBox *>(checkableWidget);
   QRadioButton *radio = qobject_cast<QRadioButton *>(checkableWidget);
+  CollapseGroupBox *group = qobject_cast<CollapseGroupBox *>(checkableWidget);
 
   if(check)
     return check->isChecked();
   else if(radio)
     return radio->isChecked();
+  else if(group)
+    return group->collapsed();
 
   return false;
 }


### PR DESCRIPTION
A CollapseGroupBox is basically a checkable widget, but there is not support to get the collapsed state for this type of widget.

Here adds the support to get or set a CollapseGroupBox collapsed status in MiniQtHelper, for better extension writting experience.