### PR TITLE
Avoid successful Windows build with no GITTAG

### DIFF
--- a/renderdoc/renderdoc_version.vcxproj
+++ b/renderdoc/renderdoc_version.vcxproj
@@ -138,11 +138,19 @@ namespace GitIntrospection {
 
         if(HEADref.StartsWith("ref: ")) {
           string refpath = Repository + ".git\\" + HEADref.Substring(5).Replace('/', '\\');
-          if(File.Exists(refpath))
+          if(File.Exists(refpath)) {
             Sha1 = File.ReadAllText(refpath).Trim();
+          }
+          else {
+            Log.LogError("File not found: " + refpath);
+            Log.LogError("Looks like this is a shallow git clone; do a full clone instead.");
+          }
         } else {
           Sha1 = HEADref;
         }
+      }
+      else {
+        Log.LogError("File not found: " + HEADpath);
       }
     }
 
@@ -170,7 +178,7 @@ namespace GitIntrospection {
   </Target>
   <!-- Similarly, only run this task if we didn't locate the assembly (or thought we couldn't use it) -->
   <Target Name="RunTaskManual" BeforeTargets="PrepareForBuild" Condition="!exists('$(LibGit2SharpPath)')">
-    <GetGitCommitManual Repository="$(SolutionDir)" ContinueOnError="WarnAndContinue">
+    <GetGitCommitManual Repository="$(SolutionDir)" ContinueOnError="false">
       <Output TaskParameter="Sha1" PropertyName="CommitId" />
     </GetGitCommitManual>
     <Message Importance="high" Text="Read Git commit: '$(CommitId)'" Condition="$(CommitId.Length) &gt; 0" />


### PR DESCRIPTION
## Description
For RenderDoc to work properly, the build must be able to determine the git HEAD SHA. In the case where LibGit2Sharp isn't available and the user (or CI system) has done a shallow git clone, the build system is unable to get that SHA. While it generates a warning, the build keeps trucking. You end up with what looks like a successful build but the result is effectively unusable. You get an error at runtime because the Qt app can't determine if the replay server and it were built from the same sources (which is mandatory). The likelihood of noticing that warning message among thousands of lines of build output and associating that back to the runtime problem is extremely unlikely.

This commit does two things. First it treats the inability to get the git SHA manually as an error instead of a warning. That causes the build to fail. It also adds error logging that will make it clear that the problem is the shallow git clone. This would have samed me quite a few hours, and hopefully will help others.

