### PR TITLE
cmake: fix installation to non-root prefix

### DIFF
--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -72,7 +72,7 @@ set(sources
 
 set(definitions ${RDOC_DEFINITIONS})
 
-set(VULKAN_LAYER_FOLDER_DEFAULT /etc/vulkan/implicit_layer.d)
+set(VULKAN_LAYER_FOLDER_DEFAULT etc/vulkan/implicit_layer.d)
 
 if(NOT ANDROID AND NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND NOT DEFINED VULKAN_LAYER_FOLDER)
     message(WARNING "*** CMAKE_INSTALL_PREFIX has been customised to ${CMAKE_INSTALL_PREFIX}, but VULKAN_LAYER_FOLDER is not customised and defaults to ${VULKAN_LAYER_FOLDER_DEFAULT}. This may not do what you expect, e.g. installing to a non-root location ***")


### PR DESCRIPTION
## Description

Installation of renderdoc to a non-root directory prefix failed when being non-root because it attempts to write renderdoc_capture.json to /etc/vulkan/implicit_layer.d. This is a path an ordinary user has no write access to.

Fix this by making the installation path relative to the installation prefix.

The error is:
```
CMake Error at build/renderdoc/driver/vulkan/cmake_install.cmake:54 (file):
  file INSTALL cannot copy file
  "/tmp/renderdoc-1.25/build/lib/renderdoc_capture.json" to
  "/etc/vulkan/implicit_layer.d/renderdoc_capture.json": Permission denied.
Call Stack (most recent call first):
  build/renderdoc/cmake_install.cmake:71 (include)
  build/cmake_install.cmake:55 (include)
```
For an already existing build folder, this can be fixed by configuring cmake with -DVULKAN_LAYER_FOLDER=etc/vulkan/implicit_layer.d
