### PR TITLE
Fix crash when XCB fails to return window geometry

### DIFF
--- a/renderdoc/driver/vulkan/vk_linux.cpp
+++ b/renderdoc/driver/vulkan/vk_linux.cpp
@@ -293,7 +293,8 @@ void VulkanReplay::GetOutputWindowDimensions(uint64_t id, int32_t &w, int32_t &h
     xcb_get_geometry_cookie_t geomCookie =
         xcb_get_geometry(outw.xcb.connection, outw.xcb.window);    // window is a xcb_drawable_t
     xcb_get_geometry_reply_t *geom = xcb_get_geometry_reply(outw.xcb.connection, geomCookie, NULL);
-    if (geom == NULL) {
+    if(geom == NULL)
+    {
       w = 0;
       h = 0;
       return;

--- a/renderdoc/driver/vulkan/vk_linux.cpp
+++ b/renderdoc/driver/vulkan/vk_linux.cpp
@@ -293,6 +293,11 @@ void VulkanReplay::GetOutputWindowDimensions(uint64_t id, int32_t &w, int32_t &h
     xcb_get_geometry_cookie_t geomCookie =
         xcb_get_geometry(outw.xcb.connection, outw.xcb.window);    // window is a xcb_drawable_t
     xcb_get_geometry_reply_t *geom = xcb_get_geometry_reply(outw.xcb.connection, geomCookie, NULL);
+    if (geom == NULL) {
+      w = 0;
+      h = 0;
+      return;
+    }
 
     w = (int32_t)geom->width;
     h = (int32_t)geom->height;


### PR DESCRIPTION
For some reasons, looking at a texture in my pipeline caused a crash in Renderdoc. libXCB fails to return the geometry, leading to a null pointer deref.

I am not familiar at all with libXCB, so not sure if there is a better way to handle this failure, but at least this prevents a crash. Was able to display the texture in the UI with this fix.

An alternative would be to return a boolean when we fail to gather window output dimensions. This would require a change across all drivers, and I am not sure of the side effects this could cause. (As for now, if the window is not found, we silently return). For this reason, I decided to go with a simple band-aid patch.

Fixes #2863