### PR TITLE
Fix a few OpenGL Pixel History Bugs

### DIFF
--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -1243,7 +1243,7 @@ void QueryPrimitiveIdPerFragment(WrappedOpenGL *driver, GLReplay *replay,
 
     // we expect this value to be overwritten by the primitive id shader. if not
     // it will cause an assertion that all color values are the same to fail
-    driver->glClearColor(0.0f, 0.17f, 0.2f, 0.49f);
+    driver->glClearColor(0.84f, 0.17f, 0.2f, 0.49f);
     driver->glClear(eGL_COLOR_BUFFER_BIT);
 
     driver->glGetIntegerv(eGL_CURRENT_PROGRAM, &currentProgram);
@@ -1278,15 +1278,23 @@ void QueryPrimitiveIdPerFragment(WrappedOpenGL *driver, GLReplay *replay,
                             eGL_NEAREST);
         CopyMSSample(driver, resources, copyFramebuffer, sampleIndex, 0, 0, primitiveIds);
       }
-      RDCASSERT(primitiveIds[0] == primitiveIds[1] && primitiveIds[0] == primitiveIds[2] &&
-                primitiveIds[0] == primitiveIds[3]);
-      if(usingFloatForPrimitiveId)
+
+      if(primitiveIds[0] == primitiveIds[1] && primitiveIds[0] == primitiveIds[2] &&
+         primitiveIds[0] == primitiveIds[3])
       {
-        historyIndex->primitiveID = int(primitiveIds[0]);
+        if(usingFloatForPrimitiveId)
+        {
+          historyIndex->primitiveID = int(primitiveIds[0]);
+        }
+        else
+        {
+          historyIndex->primitiveID = *(int *)primitiveIds;
+        }
       }
       else
       {
-        historyIndex->primitiveID = *(int *)primitiveIds;
+        historyIndex->primitiveID = ~0u;
+        RDCERR("Primitive ID was not written correctly");
       }
 
       ++historyIndex;


### PR DESCRIPTION


<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
- Filter out events that affect a mip layer that is not selected
- Fix an off by one replay error causing weird behaviour
- Fix framebuffer blitting when attached textures change during frame
<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
