### PR TITLE
Update RGP Interop Integration

### DIFF
--- a/renderdoc/driver/ihv/amd/official/RGP/DevDriverAPI.h
+++ b/renderdoc/driver/ihv/amd/official/RGP/DevDriverAPI.h
@@ -1,183 +1,329 @@
 //=============================================================================
-/// Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
-/// \author AMD Developer Tools Team
-/// \file
-/// \brief  An API for the developer mode driver to initialize driver protocols.
-///  Can be used by applications to take RGP profiles of themselves
+// Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+/// @author AMD Developer Tools Team
+/// @file
+/// @brief  An API for the developer mode driver to initialize driver protocols.
+///
+/// Can be used by applications to write RGP profiles/RMV traces of themselves.
 //=============================================================================
-#ifndef DEV_DRIVER_API_H_
-#define DEV_DRIVER_API_H_
+
+#ifndef RDP_SOURCE_API_DEV_DRIVER_API_H_
+#define RDP_SOURCE_API_DEV_DRIVER_API_H_
 
 #include <stdint.h>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-  /// The API calling convention on windows.
-  #define DEV_DRIVER_API_CALL __cdecl
-  #ifdef BUILD_DLL
-    #define DEV_DRIVER_API_EXPORT __declspec(dllexport)
-  #elif defined(IMPORT_DLL)
-    #define DEV_DRIVER_API_EXPORT __declspec(dllimport)
-  #else
-    #define DEV_DRIVER_API_EXPORT
-  #endif // BUILD_DLL
+// The API calling convention on Windows.
+#define DEV_DRIVER_API_CALL __cdecl
+#ifdef BUILD_DLL
+#define DEV_DRIVER_API_EXPORT __declspec(dllexport)
+#elif defined(IMPORT_DLL)
+#define DEV_DRIVER_API_EXPORT __declspec(dllimport)
 #else
-  /// The API calling convention on linux.
-  #define DEV_DRIVER_API_CALL
-  #define DEV_DRIVER_API_EXPORT
+#define DEV_DRIVER_API_EXPORT
+#endif  // BUILD_DLL
+#else
+// The API calling convention on Linux.
+#define DEV_DRIVER_API_CALL
+#define DEV_DRIVER_API_EXPORT
 #endif
-
-#define DEV_DRIVER_API_MAJOR_VERSION 1
-#define DEV_DRIVER_API_MINOR_VERSION (sizeof(DevDriverAPI))
 
 #ifdef __cplusplus
 extern "C" {
-#endif // #ifdef __cplusplus
+#endif  // #ifdef __cplusplus
 
+/// @brief Handle to a dev driver context.
 typedef void* DevDriverAPIContext;
 
-// An enum of status codes returned from the API
+/// @brief An enum of status codes returned from the API.
 typedef enum
 {
-    DEV_DRIVER_STATUS_SUCCESS               = 0,
-    DEV_DRIVER_STATUS_ERROR                 = -1,
-    DEV_DRIVER_STATUS_FAILED                = -2,
-    DEV_DRIVER_STATUS_NULL_POINTER          = -3,
-    DEV_DRIVER_STATUS_BAD_ALLOC             = -4,
-    DEV_DRIVER_STATUS_CAPTURE_FAILED        = -5,
-    DEV_DRIVER_STATUS_NOT_CAPTURED          = -6,
-    DEV_DRIVER_STATUS_INVALID_MAJOR_VERSION = -7,
-    DEV_DRIVER_STATUS_INVALID_PARAMETERS    = -8,
+    kDevDriverStatusSuccess             = 0,
+    kDevDriverStatusError               = -1,
+    kDevDriverStatusFailed              = -2,
+    kDevDriverStatusNullPointer         = -3,
+    kDevDriverStatusBadAlloc            = -4,
+    kDevDriverStatusCaptureFailed       = -5,
+    kDevDriverStatusNotCaptured         = -6,
+    kDevDriverStatusInvalidMajorVersion = -7,
+    kDevDriverStatusInvalidParameters   = -8,
+    kDevDriverStatusAlreadyCaptured     = -9,
+    kDevDriverStatusCaptureInProgress   = -10,
+    kDevDriverStatusNotAvailable        = -11,
+    kDevDriverStatusParsingFailure      = -12,
 } DevDriverStatus;
 
-// An enum of options to pass into the DevDriverAPI
+/// @brief An enum of options to pass into the DevDriverAPI.
 typedef enum
 {
-    DEV_DRIVER_FEATURE_ENABLE_RGP           = 1,
+    kDevDriverFeatureEnableRgp = 1,
+    kDevDriverFeatureEnableRmv = 2,
+    kDevDriverFeatureEnableRra = 3
 } DevDriverFeature;
 
-// structure containing any features relating to RGP
+/// @brief Structure containing any features relating to RGP.
 typedef struct DevDriverFeatureRGP
 {
-    // presently nothing needed for RGP initialization
-    uint32_t                    reserved;       ///< ensure a specific size struct for C/C++
-} DevDriverFeatureRGP;
-
-// structure containing a developer driver feature. Specific
-// feature structures can be added to the union as needed
-typedef struct DevDriverFeatures
-{
-    DevDriverFeature            m_option;
-    uint32_t                    m_size;
     union
     {
-        DevDriverFeatureRGP     m_featureRGP;
+        struct
+        {
+            uint32_t disable_etw : 1;               ///< Disable Etw protocol when creating listener.
+            uint32_t enable_instruction_trace : 1;  ///< Enable instruction tracing.
+            uint32_t reserved : 30;                 ///< Reserved for future use.
+        } flags;                                    ///< The configuration flags.
+
+        uint32_t u32_all;  ///< Representation of all of the flags.
+    };
+    union
+    {
+        struct
+        {
+            uint32_t start;  ///< OpenCL/HIP dispatch range start index.
+            uint32_t end;    ///< OpenCL/HIP dispatch range end index.
+        } dispatch_indices;  ///< OpenCL/HIP dispatch range indices.
+
+        uint32_t frame_number;  ///< DX/VK frame number to capture.
+    };
+
+    uint32_t shader_engine_mask;  ///< The SE mask used when collecting instruction trace data.
+
+} DevDriverFeatureRGP;
+
+/// @brief The API PSO version for RGP features.
+#define s_FEATURE_RGP_API_PSO_VERSION 24
+
+/// @brief Structure containing any features relating to RMV.
+typedef struct DevDriverFeatureRMV
+{
+    // Presently nothing needed for RMV initialization.
+    uint32_t reserved;  ///< Ensure a specific size struct for C/C++.
+} DevDriverFeatureRMV;
+
+/// @brief Structure containing any features relating to RRA capture.
+typedef struct DevDriverFeatureRRA
+{
+    uint32_t reserved;
+} DevDriverFeatureRRA;
+
+/// @brief Structure containing enabled developer driver feature options.
+///
+/// Specific feature structures can be added to the union as needed.
+typedef struct DevDriverFeatures
+{
+    DevDriverFeature option;  ///< Which feature this describes.
+
+    /// @brief The size of the actual data contained in this struct.
+    ///
+    /// If option is kDevDriverFeatureEnableRgp then this should be sizeof(DevDriverFeatureRGP),
+    /// otherwise it should be sizeof(DevDriverFeatureRMV) since this will be a description of
+    /// an RMV feature.
+    uint32_t size;
+
+    union
+    {
+        DevDriverFeatureRGP feature_rgp;  ///< The data describing the RGP features.
+        DevDriverFeatureRMV feature_rmv;  ///< The data describing the RMV features.
+        DevDriverFeatureRRA feature_rra;  ///< The data describing the RRA features.
     };
 } DevDriverFeatures;
 
-// structure containing any options required for taking an RGP profile
+/// @brief Structure containing any options required for taking an RGP profile.
 typedef struct RGPProfileOptions
 {
-    const char* m_pProfileFilePath;             ///< The file (and path) used to save the captured profile to. If the
-                                                ///< path is omitted, the file will be saved to the default folder.
-                                                ///< If nullptr is specified, then a filename will be generated based
-                                                ///< on the process name and a date/time timestamp
+    /// @brief The file (and path) used to save the captured profile to.
+    ///
+    /// If the path is omitted, the file will be saved to the default folder.
+    /// If nullptr is specified, then a filename will be generated based on the process
+    /// name and a date/time timestamp.
+    const char* profile_file_path;
 
-    // frame terminator values
-    uint64_t    m_beginFrameTerminatorTag;      ///< frame terminator begin tag (vulkan). Should be non-zero if being used
-    uint64_t    m_endFrameTerminatorTag;        ///< frame terminator end tag (vulkan). Should be non-zero if being used
-    const char* m_pBeginFrameTerminatorString;  ///< frame terminator begin string (D3D12). Should be non-null/non-empty if being used
-    const char* m_pEndFrameTerminatorString;    ///< frame terminator end string (D3D12). Should be non-null/non-empty if being used
+    // Frame terminator values.
+
+    /// @brief Frame terminator begin tag (Vulkan).
+    ///
+    /// Should be non-zero if being used.
+    uint64_t begin_frame_terminator_tag;
+
+    /// @brief Frame terminator end tag (Vulkan).
+    ///
+    /// Should be non-zero if being used.
+    uint64_t end_frame_terminator_tag;
+
+    /// @brief Frame terminator begin string (D3D12).
+    ///
+    /// Should be non-null/non-empty if being used.
+    const char* begin_frame_terminator_string;
+
+    /// @brief Frame terminator end string (D3D12).
+    ///
+    /// Should be non-null/non-empty if being used.
+    const char* end_frame_terminator_string;
 } RGPProfileOptions;
+
+/// @brief Structure containing any options required for taking an RMV trace.
+typedef struct RMVTraceOptions
+{
+    /// @brief The file (and path) used to save the captured trace to.
+    ///
+    /// If the path is omitted, the file will be saved to the default folder.
+    /// If nullptr is specified, then a filename will be generated based on the process
+    /// name and a date/time timestamp.
+    const char* trace_file_path;
+} RMVTraceOptions;
+
+typedef struct RRACaptureOptions
+{
+    /// @brief The file (and path) used to save the captured scene to.
+    ///
+    /// If this path component is omitted, then file will be saved to default working directory.
+    /// If nullptr is specified, then a filename will be generated based on the process name
+    /// and a date timestamp.
+    const char* capture_file_path;
+} RRACaptureOptions;
 
 // function typedefs
 
-/// Initialization function. To be called before initializing the device.
-/// \param featureList An array of DevDriverFeatures structures containing
-///  a list of features to be enabled
-/// \param featureCount The number of features in the list
-/// \param pOutHandle A returned handle to the DevDriverAPI context.
-/// \return DEV_DRIVER_STATUS_SUCCESS if successful, or a DevDriverStatus error
-///  code if not. If this function fails, pOutHandle will be unchanged.
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnInit)(const DevDriverFeatures featureList[], uint32_t featureCount, DevDriverAPIContext* pOutHandle);
+/// @brief Initialization function.
+///
+/// To be called before initializing the device.
+///
+/// @param feature_list An array of DevDriverFeatures structures containing
+///                     a list of features to be enabled.
+/// @param feature_count The number of features in the list.
+/// @param out_handle A returned handle to the DevDriverAPI context.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error
+///         code if not. If this function fails, out_handle will be unchanged.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnInit)(const DevDriverFeatures feature_list[], uint32_t feature_count, DevDriverAPIContext* out_handle);
 
-/// Cleanup function. To be called at application shutdown.
-/// \param context The DevDriverAPI context
-/// \return DEV_DRIVER_STATUS_SUCCESS if successful, or a DevDriverStatus error
-///  code if not.
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnFinish)(DevDriverAPIContext context);
+/// @brief Cleanup function to be called at application shutdown.
+/// @param context The DevDriverAPI context.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnFinish)(DevDriverAPIContext context);
 
-/// Start triggering a profile. The actual profiling is done in a separate thread.
+/// @brief Start triggering a profile.
+///
+/// The actual profiling is done in a separate thread.
 /// The calling function will need to call IsRGPProfileCaptured() to determine
 /// if the profile has finished.
-/// \param context The DevDriverAPI context
-/// \param profileOptions A structure of type RGPProfileOptions containing the
-///  profile options
-/// \return DEV_DRIVER_STATUS_SUCCESS if a capture was successfully started, or
-///  a DevDriverStatus error code if not.
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnTriggerRGPProfile)(DevDriverAPIContext context, const RGPProfileOptions* const profileOptions);
+///
+/// @param context The DevDriverAPI context.
+/// @param profile_options A structure of type RGPProfileOptions containing the
+///                        profile options.
+/// @return kDevDriverStatusSuccess if a capture was successfully started, or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnTriggerRGPProfile)(DevDriverAPIContext context, const RGPProfileOptions* const profile_options);
 
-/// Has an RGP profile been taken?
-/// \param context The DevDriverAPI context
-/// \return DEV_DRIVER_STATUS_SUCCESS if successful, or a DevDriverStatus error
-///  code if not.
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnIsRGPProfileCaptured)(DevDriverAPIContext context);
+/// @brief Has an RGP profile been taken?
+/// @param context The DevDriverAPI context.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnIsRGPProfileCaptured)(DevDriverAPIContext context);
 
-/// Get the name of the last captured RGP profile. Call this after taking a
-/// profile.
-/// \param context The DevDriverAPI context
-/// \return DEV_DRIVER_STATUS_SUCCESS if successful, or a DevDriverStatus error
-///  code if not.
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnGetRGPProfileName)(DevDriverAPIContext context, const char** ppOutProfileName);
+/// @brief Get the name of the last captured RGP profile.
+///
+/// Call this after taking a profile.
+///
+/// @param context [in] The DevDriverAPI context.
+/// @param out_profile_name [out] The name of the last captured RGP profile.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnGetRGPProfileName)(DevDriverAPIContext context, const char** out_profile_name);
 
-/// Get the video driver version number.
-/// indirectly returns the major and minor version numbers in the parameters
-/// \param outMajorVersion The major version number returned
-/// \param outMinorVersion The minor version number returned
-/// \return DEV_DRIVER_STATUS_SUCCESS if successful, or a DevDriverStatus error
-///  code if not. If an error is returned, the version nunbers passed in are
-///  unmodified.
-/// \warning This function is deprecated
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnGetDriverVersion)(DevDriverAPIContext context, unsigned int& outMajorVersion, unsigned int& outMinorVersion);
+/// @brief Get the video driver version number, including the subminor version.
+///
+/// Indirectly returns the major, minor and subminor version numbers in the parameters.
+///
+/// @param major_version The major version number returned.
+/// @param minor_version The minor version number returned.
+/// @param subminor_version The minor version number returned.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error
+///         code if not. If an error is returned, the version numbers passed in are
+///         unmodified.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnGetFullDriverVersion)(DevDriverAPIContext context,
+                                                                              unsigned int*       major_version,
+                                                                              unsigned int*       minor_version,
+                                                                              unsigned int*       subminor_version);
 
-/// Get the video driver version number, including the subminor version.
-/// indirectly returns the major, minor and subminor version numbers in the parameters
-/// \param pMajorVersion The major version number returned
-/// \param pMinorVersion The minor version number returned
-/// \param pSubminorVersion The minor version number returned
-/// \return DEV_DRIVER_STATUS_SUCCESS if successful, or a DevDriverStatus error
-///  code if not. If an error is returned, the version nunbers passed in are
-///  unmodified.
-typedef DevDriverStatus(DEV_DRIVER_API_CALL*
-    DevDriverFnGetFullDriverVersion)(DevDriverAPIContext context, unsigned int* pMajorVersion, unsigned int* pMinorVersion, unsigned int* ptSubminorVersion);
+/// @brief Insert a snapshot string into the RMV event stream.
+/// @param context The DevDriverAPI context.
+/// @param snapshot_name A null-terminated string to be inserted into the RMV event stream.
+/// @return kDevDriverStatusSuccess if the snapshot string was inserted successfully,
+///         or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnInsertRMVSnapshot)(DevDriverAPIContext context, const char* snapshot_name);
 
-// structure containing the list of functions supported by this version of the API.
-// Also contains major and minor version numbers
+/// @brief Trigger collection of an RMV trace.
+///
+/// The file writing is done in a separate thread.
+/// The calling function will need to call IsRMVTraceCaptured() to determine
+/// if the trace has finished.
+///
+/// @param context The DevDriverAPI context.
+/// @param trace_options A structure of type RMVTraceOptions containing the trace options.
+/// @return kDevDriverStatusSuccess if a capture was successfully started, or
+///         a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnTriggerRMVTrace)(DevDriverAPIContext context, const RMVTraceOptions* const trace_options);
+
+/// @brief Has an RMV trace been taken?
+/// @param context The DevDriverAPI context.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnIsRMVTraceCaptured)(DevDriverAPIContext context);
+
+/// @brief Get the name of the last captured RMV trace.
+///
+/// Call this after taking a trace.
+///
+/// @param [in] context The DevDriverAPI context.
+/// @param [out] out_trace_name The name of the last captured RMV trace.
+/// @return kDevDriverStatusSuccess if successful, or a DevDriverStatus error code if not.
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnGetRMVTraceName)(DevDriverAPIContext context, const char** out_trace_name);
+
+/// @brief Get RRA capture file name
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnGetRRACaptureName)(DevDriverAPIContext context, const char** out_capture_name);
+
+/// @brief Request an RRA capture
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnRequestRRACapture)(DevDriverAPIContext context);
+
+/// @brief Collect an RRA capture
+typedef DevDriverStatus(DEV_DRIVER_API_CALL* DevDriverFnCollectRRACapture)(DevDriverAPIContext context, const RRACaptureOptions* const capture_options);
+
+/// @brief Structure containing the list of functions supported by this version of the API.
+///
+/// Also contains major and minor version numbers.
 typedef struct DevDriverAPI
 {
-    uint32_t                        majorVersion;
-    uint32_t                        minorVersion;
+    uint32_t major_version;  ///< The major version of the API.
+    uint32_t minor_version;  ///< The minor version of the API.
 
-    DevDriverFnInit                 DevDriverInit;
-    DevDriverFnFinish               DevDriverFinish;
+    DevDriverFnInit   devdriver_init;    ///< Called before initializing the device.
+    DevDriverFnFinish devdriver_finish;  ///< Cleanup function to be called at application shutdown.
 
-    DevDriverFnTriggerRGPProfile    TriggerRgpProfile;
-    DevDriverFnIsRGPProfileCaptured IsRgpProfileCaptured;
-    DevDriverFnGetRGPProfileName    GetRgpProfileName;
-    DevDriverFnGetDriverVersion     GetDriverVersion;
-    DevDriverFnGetFullDriverVersion GetFullDriverVersion;
+    DevDriverFnTriggerRGPProfile    trigger_rgp_profile;      ///< Trigger a new RGP profile.
+    DevDriverFnIsRGPProfileCaptured is_rgp_profile_captured;  ///< Returns whether or not an RGP profile has been captured.
+    DevDriverFnGetRGPProfileName    get_rgp_profile_name;     ///< Provides the name of the last RGP profile captured.
+    void* reserved_entry_point;  ///< Removed entrypoint -- this is a placeholder to maintain backwards compatibility in the api table.
+    DevDriverFnGetFullDriverVersion get_full_driver_version;  ///< Provides the video driver version.
+
+    DevDriverFnInsertRMVSnapshot  insert_rmv_snapshot;    ///< Insert a snapshot string into the RMV event stream.
+    DevDriverFnTriggerRMVTrace    trigger_rmv_trace;      ///< Triggers an RMV trace.
+    DevDriverFnIsRMVTraceCaptured is_rmv_trace_captured;  ///< Returns whether or not an RMV trace has been captured.
+    DevDriverFnGetRMVTraceName    get_rmv_trace_name;     ///< Provides the name of the last RMV trace captured.
+
+    DevDriverFnGetRRACaptureName get_rra_capture_name;  ///< Provides the name of the last RRA capture.
+    DevDriverFnRequestRRACapture request_rra_capture;   ///< Requests RRA capture should be started.
+    DevDriverFnCollectRRACapture collect_rra_capture;   ///< Collects the RRA capture data and writes to disk.
 } DevDriverAPI;
 
-/// Get the function table
-DEV_DRIVER_API_EXPORT DevDriverStatus DEV_DRIVER_API_CALL DevDriverGetFuncTable(void* pApiTableOut);
+// Version constants
+///@brief The major version of the API.
+static const uint32_t kDevDriverApiMajorVersion = 2;
+
+/// @brief The minor version of the API.
+static const uint32_t kDevDriverApiMinorVersion = (sizeof(DevDriverAPI));
+
+/// @brief Get the function table.
+/// @param [out] api_table_out Where to write the API table to.
+DEV_DRIVER_API_EXPORT DevDriverStatus DEV_DRIVER_API_CALL DevDriverGetFuncTable(void* api_table_out);
 
 #ifdef __cplusplus
 }
-#endif // #ifdef __cplusplus
+#endif  // #ifdef __cplusplus
 
-#endif // DEV_DRIVER_API_H_
+#endif


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
This change is to update the RGP Interop integration to use the v2.x version of DevDriverAPI. v2.x changes are backward incompatible, and v2.x binaries of DevDriver API would be required. 

Latest DevDriver v2.8 release binaries can be found at
* Windows: https://github.com/GPUOpen-Tools/radeon_developer_panel/releases/download/v2.8.1/DevDriverAPI_2.8.1.6.zip
* Linux: https://github.com/GPUOpen-Tools/radeon_developer_panel/releases/download/v2.8.1/DevDriverAPI_2.8.1.6.tgz

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
