### PR TITLE
APIProperties serialization missing field

### DIFF
--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -494,6 +494,7 @@ void DoSerialise(SerialiserType &ser, APIProperties &el)
 
   SERIALISE_MEMBER(shaderDebugging);
   SERIALISE_MEMBER(pixelHistory);
+  SERIALISE_MEMBER(rgpCapture);
 
   SERIALISE_MEMBER(ShaderLinkage);
   SERIALISE_MEMBER(YUVTextures);


### PR DESCRIPTION
## Description

The field APIProperties::rgpCapture was added years ago but renderdoc_serialize.inl wasn't updated. One of those edge cases where the size check failed due to flag the oversight due to the field appearing prior to other subsequent (conditional) fields. End result is that the RGP Capture menu option is always disabled, even when the target supports it.
