### PR TITLE
Improve robustness of fbconfig selection for cloned GL context (glX)

### DIFF
--- a/renderdoc/driver/gl/glx_platform.cpp
+++ b/renderdoc/driver/gl/glx_platform.cpp
@@ -81,6 +81,10 @@ class GLXPlatform : public GLPlatform
     {
       int fbcfgID = -1;
       GLX.glXGetConfig(share.dpy, share.cfg, GLX_FBCONFIG_ID, &fbcfgID);
+
+      if(fbcfgID == -1)
+        GLX.glXQueryContext(share.dpy, share.ctx, GLX_FBCONFIG_ID, &fbcfgID);
+
       if(fbcfgID != -1)
       {
         visAttribs[i++] = GLX_FBCONFIG_ID;


### PR DESCRIPTION

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

The `glXGetConfig(..., GLX_FBCONFIG_ID, &fbcfgID)` call does not work reliably on many implementations. In this case, all available fbconfigs are queried and the first one is chosen, but this might be incompatible to the visual of the window, resulting in a failure when the cloned context is made current for the first time (issue: #2898).

This adds a fallback to query the fbconfig ID from the GL context if querying it from the VisualInfo failed.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
