### PR TITLE
Default Xcode option GPU Frame Capture to Disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 if(APPLE)
-  # Building for Apple requires at least CMake 3.20.0
-  cmake_minimum_required(VERSION 3.20.0)
+  # Building for Apple requires at least CMake 3.23.0
+  cmake_minimum_required(VERSION 3.23.0)
 
   SET(CMAKE_OSX_DEPLOYMENT_TARGET "12.00" CACHE STRING "Minimum SDK for Mac OS X")
   SET(CMAKE_XCODE_GENERATE_SCHEME ON)
+  SET(CMAKE_XCODE_SCHEME_ENABLE_GPU_FRAME_CAPTURE_MODE "Disabled")
 endif()
 
 # Configure some stuff that needs to be set really early


### PR DESCRIPTION
The `CMake` option `CMAKE_XCODE_SCHEME_ENABLE_GPU_FRAME_CAPTURE_MODE` is available starting from `CMake` version 3.23.0.

Increase the minimum `CMake` version for building Apple to 3.23.0 from 3.20.0

## Before
<img width="1447" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/39392/231205984-06fa38a9-1df9-45bc-a561-f51ccf515137.png">

## After
<img width="1447" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/39392/231206041-536035f5-1f5e-48d0-9ea4-3d2fbceb4131.png">
