### PR TITLE
Support spaces in clang-format path

### DIFF
--- a/util/clang_format_all.sh
+++ b/util/clang_format_all.sh
@@ -15,8 +15,8 @@ CLANG_FORMAT_VERSION=$CLANG_MAJOR.$CLANG_MINOR
 
 # define a function to check the current $CLANG_FORMAT
 valid_clang_format() {
-	if which $CLANG_FORMAT > /dev/null 2>&1; then
-		if $CLANG_FORMAT --version | grep -q $CLANG_FORMAT_VERSION; then
+	if which "$CLANG_FORMAT" > /dev/null 2>&1; then
+		if "$CLANG_FORMAT" --version | grep -q $CLANG_FORMAT_VERSION; then
 			echo "Located $CLANG_FORMAT";
 			return 0;
 		fi
@@ -27,7 +27,7 @@ valid_clang_format() {
 
 if ! valid_clang_format; then
 	# if not valid yet, first try the command line parameter
-	CLANG_FORMAT=$1
+	CLANG_FORMAT="$1"
 fi;
 
 if ! valid_clang_format; then
@@ -57,4 +57,4 @@ if ! valid_clang_format; then
 fi;
 
 # Search through the code that should be formatted, exclude any non-renderdoc code.
-find qrenderdoc/ renderdoc/ renderdoccmd/ renderdocshim/ util/test/demos/ -name "3rdparty" -prune -o -name "official" -prune -o -print | grep -E ".*\.(h|c|cpp|m|mm|inl|geom|frag|vert|comp|hlsl)$" | grep -E -v "resource.h$" | awk '{printf("%s%c",$0,0)}' | xargs -0 -n1 $CLANG_FORMAT -i -style=file
+find qrenderdoc/ renderdoc/ renderdoccmd/ renderdocshim/ util/test/demos/ -name "3rdparty" -prune -o -name "official" -prune -o -print | grep -E ".*\.(h|c|cpp|m|mm|inl|geom|frag|vert|comp|hlsl)$" | grep -E -v "resource.h$" | awk '{printf("%s%c",$0,0)}' | xargs -0 -n1 "$CLANG_FORMAT" -i -style=file


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

This allows setting the `CLANG_FORMAT` environment variable to (e.g.) `C:/Program Files/LLVM3.8.1/bin/clang-format.exe` and then using the script from Git Bash on Windows. Before, it would break if there were spaces in the path. (If a suitable clang-format were in the `PATH` environment variable, though, I don't think spaces caused problems.)

As a side note, the [clang-format wiki page](https://github.com/baldurk/renderdoc/wiki/Code-formatting-(using-clang-format)) is out of date. [Visual Studio 2017](https://devblogs.microsoft.com/cppblog/clangformat-support-in-visual-studio-2017-15-7-preview-1/) has a built-in integration, without needing an extension. That built-in version allows you to change the location of the clang-format executable without replacing files (at least in Visual Studio 2019):

![image](https://user-images.githubusercontent.com/127789813/231307632-680a990c-6efb-45cd-b4bd-19b55b4f04bf.png)

Additionally, the pre-commit hook at [renderdoc.org/pre-commit](https://renderdoc.org/pre-commit) already has the variable quoted so no changes are needed there.