### PR TITLE
Shader viewer buttons fixes

### DIFF
--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -622,6 +622,7 @@ QSize RDStyle::sizeFromContents(ContentsType type, const QStyleOption *opt, cons
   if(type == CT_PushButton || type == CT_ToolButton)
   {
     const QStyleOptionButton *button = qstyleoption_cast<const QStyleOptionButton *>(opt);
+    const QStyleOptionToolButton *toolbutton = qstyleoption_cast<const QStyleOptionToolButton *>(opt);
 
     QSize ret = size;
 
@@ -630,6 +631,10 @@ QSize RDStyle::sizeFromContents(ContentsType type, const QStyleOption *opt, cons
     {
       ret.setWidth(qMax(50, ret.width()));
       ret.setHeight(qMax(15, ret.height()));
+    }
+    else if(type == CT_ToolButton && toolbutton)
+    {
+      ret = adjustToolButtonSize(toolbutton, size, widget);
     }
 
     // add margin and border
@@ -897,17 +902,16 @@ void RDStyle::drawComplexControl(ComplexControl control, const QStyleOptionCompl
     const QStyleOptionToolButton *toolbutton = qstyleoption_cast<const QStyleOptionToolButton *>(opt);
 
     QStyleOptionToolButton labelTextIcon = *toolbutton;
-    labelTextIcon.rect = proxy()->subControlRect(control, opt, SC_ToolButton, widget);
+    labelTextIcon.rect = subControlRect(control, opt, SC_ToolButton, widget);
 
     // draw the label text/icon
     proxy()->drawControl(CE_ToolButtonLabel, &labelTextIcon, p, widget);
 
     // draw the menu arrow, if there is one
-    if((toolbutton->subControls & SC_ToolButtonMenu) ||
-       (toolbutton->features & QStyleOptionToolButton::HasMenu))
+    if(shouldDrawToolButtonMenuArrow(toolbutton))
     {
       QStyleOptionToolButton menu = *toolbutton;
-      menu.rect = proxy()->subControlRect(control, opt, SC_ToolButtonMenu, widget);
+      menu.rect = subControlRect(control, opt, SC_ToolButtonMenu, widget);
       proxy()->drawPrimitive(PE_IndicatorArrowDown, &menu, p, widget);
     }
 

--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -317,33 +317,7 @@ bool RDStyle::eventFilter(QObject *watched, QEvent *event)
 QRect RDStyle::subControlRect(ComplexControl cc, const QStyleOptionComplex *opt, SubControl sc,
                               const QWidget *widget) const
 {
-  if(cc == QStyle::CC_ToolButton)
-  {
-    int indicatorWidth = proxy()->pixelMetric(PM_MenuButtonIndicator, opt, widget);
-
-    QRect ret = opt->rect;
-
-    const QStyleOptionToolButton *toolbutton = qstyleoption_cast<const QStyleOptionToolButton *>(opt);
-
-    // return the normal rect if there's no menu
-    if(!(toolbutton->subControls & SC_ToolButtonMenu) &&
-       !(toolbutton->features & QStyleOptionToolButton::MenuButtonPopup))
-    {
-      return ret;
-    }
-
-    if(sc == QStyle::SC_ToolButton)
-    {
-      ret.setRight(ret.right() - indicatorWidth);
-    }
-    else if(sc == QStyle::SC_ToolButtonMenu)
-    {
-      ret.setLeft(ret.right() - indicatorWidth);
-    }
-
-    return ret;
-  }
-  else if(cc == QStyle::CC_GroupBox)
+  if(cc == QStyle::CC_GroupBox)
   {
     QRect ret = opt->rect;
 

--- a/qrenderdoc/Styles/RDTweakedNativeStyle/RDTweakedNativeStyle.cpp
+++ b/qrenderdoc/Styles/RDTweakedNativeStyle/RDTweakedNativeStyle.cpp
@@ -51,6 +51,39 @@ RDTweakedNativeStyle::~RDTweakedNativeStyle()
 {
 }
 
+QRect RDTweakedNativeStyle::subControlRect(ComplexControl cc, const QStyleOptionComplex *opt,
+                                           SubControl sc, const QWidget *widget) const
+{
+  if(cc == QStyle::CC_ToolButton)
+  {
+    int indicatorWidth = proxy()->pixelMetric(PM_MenuButtonIndicator, opt, widget);
+
+    QRect ret = opt->rect;
+
+    const QStyleOptionToolButton *toolbutton = qstyleoption_cast<const QStyleOptionToolButton *>(opt);
+
+    // return the normal rect if there's no menu
+    if(!(toolbutton->subControls & SC_ToolButtonMenu) &&
+       !(toolbutton->features & QStyleOptionToolButton::MenuButtonPopup))
+    {
+      return ret;
+    }
+
+    if(sc == QStyle::SC_ToolButton)
+    {
+      ret.setRight(ret.right() - indicatorWidth);
+    }
+    else if(sc == QStyle::SC_ToolButtonMenu)
+    {
+      ret.setLeft(ret.right() - indicatorWidth);
+    }
+
+    return ret;
+  }
+
+  return QProxyStyle::subControlRect(cc, opt, sc, widget);
+}
+
 QRect RDTweakedNativeStyle::subElementRect(SubElement element, const QStyleOption *opt,
                                            const QWidget *widget) const
 {

--- a/qrenderdoc/Styles/RDTweakedNativeStyle/RDTweakedNativeStyle.h
+++ b/qrenderdoc/Styles/RDTweakedNativeStyle/RDTweakedNativeStyle.h
@@ -27,6 +27,8 @@
 #include <QPalette>
 #include <QProxyStyle>
 
+class QStyleOptionToolButton;
+
 class RDTweakedNativeStyle : public QProxyStyle
 {
 private:
@@ -56,4 +58,7 @@ public:
                            const QWidget *widget = NULL) const override;
 
 protected:
+  bool shouldDrawToolButtonMenuArrow(const QStyleOptionToolButton *toolbutton) const;
+  QSize adjustToolButtonSize(const QStyleOptionToolButton *toolbutton, const QSize &size,
+                             const QWidget *widget) const;
 };

--- a/qrenderdoc/Styles/RDTweakedNativeStyle/RDTweakedNativeStyle.h
+++ b/qrenderdoc/Styles/RDTweakedNativeStyle/RDTweakedNativeStyle.h
@@ -35,6 +35,8 @@ public:
   RDTweakedNativeStyle(QStyle *parent);
   ~RDTweakedNativeStyle();
 
+  virtual QRect subControlRect(ComplexControl cc, const QStyleOptionComplex *opt, SubControl sc,
+                               const QWidget *widget = Q_NULLPTR) const override;
   virtual QRect subElementRect(SubElement element, const QStyleOption *option,
                                const QWidget *widget) const override;
   virtual QSize sizeFromContents(ContentsType type, const QStyleOption *option, const QSize &size,

--- a/qrenderdoc/Windows/PythonShell.ui
+++ b/qrenderdoc/Windows/PythonShell.ui
@@ -181,9 +181,6 @@
              <iconset resource="../Resources/resources.qrc">
               <normaloff>:/folder_page_white.png</normaloff>:/folder_page_white.png</iconset>
             </property>
-            <property name="popupMode">
-             <enum>QToolButton::InstantPopup</enum>
-            </property>
             <property name="toolButtonStyle">
              <enum>Qt::ToolButtonTextBesideIcon</enum>
             </property>

--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -705,6 +705,7 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
 
     {
       QMenu *backwardsMenu = new QMenu(this);
+      backwardsMenu->setToolTipsVisible(true);
       QAction *act;
 
       act = MakeExecuteAction(tr("&Run backwards"), Icons::control_start_blue(),
@@ -770,6 +771,7 @@ void ShaderViewer::debugShader(const ShaderBindpointMapping *bind, const ShaderR
 
     {
       QMenu *forwardsMenu = new QMenu(this);
+      forwardsMenu->setToolTipsVisible(true);
       QAction *act;
 
       act = MakeExecuteAction(tr("&Run forwards"), Icons::control_end_blue(),

--- a/qrenderdoc/Windows/ShaderViewer.ui
+++ b/qrenderdoc/Windows/ShaderViewer.ui
@@ -439,7 +439,7 @@
         <normaloff>:/control_reverse_blue@2x.png</normaloff>:/control_reverse_blue@2x.png</iconset>
       </property>
       <property name="popupMode">
-       <enum>QToolButton::MenuButtonPopup</enum>
+       <enum>QToolButton::InstantPopup</enum>
       </property>
       <property name="toolButtonStyle">
        <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -462,7 +462,7 @@
         <normaloff>:/control_play_blue.png</normaloff>:/control_play_blue.png</iconset>
       </property>
       <property name="popupMode">
-       <enum>QToolButton::MenuButtonPopup</enum>
+       <enum>QToolButton::InstantPopup</enum>
       </property>
       <property name="toolButtonStyle">
        <enum>Qt::ToolButtonTextBesideIcon</enum>

--- a/qrenderdoc/Windows/TextureViewer.ui
+++ b/qrenderdoc/Windows/TextureViewer.ui
@@ -761,9 +761,6 @@
       <property name="checked">
        <bool>true</bool>
       </property>
-      <property name="popupMode">
-       <enum>QToolButton::DelayedPopup</enum>
-      </property>
       <property name="autoRaise">
        <bool>true</bool>
       </property>


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
This PR consists of three small improvements to the shader viewer/debugger and its buttons.

In the second commit, I changed the popup mode for the execute forwards/backwards buttons. The old mode has an arrow that's used to access the menu while the button itself performs the default action. However, the execute forwards/backwards buttons have no default action, so clicking them does nothing, meaning the tiny arrow needs to be clicked instead. That's highly inconvenient. Now, clicking the button always opens the menu. (Theoretically, a default action could be set, but in my opinion always opening the menu is better.)

<table role="presentation">
<tr>
<th align="right">Before</td>
<td align="left"><a href="https://user-images.githubusercontent.com/127789813/231314002-d2aba119-27a1-4e92-aa66-248eed542a57.png"><img src="https://user-images.githubusercontent.com/127789813/231314002-d2aba119-27a1-4e92-aa66-248eed542a57.png" alt="image" style="max-width: 100%;"></a></td>
</tr>
<tr>
<th align="right">After</td>
<td align="left"><a href="https://user-images.githubusercontent.com/127789813/231314010-c2388d2c-8ac6-44f4-b015-f5816493ddde.png"><img src="https://user-images.githubusercontent.com/127789813/231314010-c2388d2c-8ac6-44f4-b015-f5816493ddde.png" alt="image" style="max-width: 100%;"></a></td>
</tr>
</table>

The third commit enables tooltips on the menus for execute forwards/execute backwards. `MakeExecuteAction` already set tooltips, but Qt does not show them unless [`toolTipsVisible`](https://doc.qt.io/qt-5/qmenu.html#toolTipsVisible-prop) is true.

The first commit actually is cleanup that does not change behavior at all. It removes two cases where [`popupMode`](https://doc.qt.io/qt-5/qtoolbutton.html#ToolButtonPopupMode-enum) is set despite the corresponding `QToolButton` not having a menu. I checked all uses of `popupMode` throughout renderdoc while working on the second commit and found that `MenuButtonPopup` is otherwise only used for export and save buttons where there is a default action, but did find these cases where `popupMode` appears to have been set by accident.
