### PR TITLE
Apple: Added drawableID to MetalDrawableInfo

### DIFF
--- a/renderdoc/driver/metal/metal_core.cpp
+++ b/renderdoc/driver/metal/metal_core.cpp
@@ -1034,6 +1034,7 @@ void WrappedMTLDevice::RegisterDrawableInfo(CA::MetalDrawable *caMtlDrawable)
   MetalDrawableInfo drawableInfo;
   drawableInfo.mtlLayer = caMtlDrawable->layer();
   drawableInfo.texture = GetWrapped(caMtlDrawable->texture());
+  drawableInfo.drawableID = caMtlDrawable->drawableID();
   SCOPED_LOCK(m_CaptureDrawablesLock);
   RDCASSERTEQUAL(m_CaptureDrawableInfos.find(caMtlDrawable), m_CaptureDrawableInfos.end());
   m_CaptureDrawableInfos[caMtlDrawable] = drawableInfo;
@@ -1048,6 +1049,17 @@ MetalDrawableInfo WrappedMTLDevice::UnregisterDrawableInfo(MTL::Drawable *mtlDra
     if(it != m_CaptureDrawableInfos.end())
     {
       drawableInfo = it->second;
+      m_CaptureDrawableInfos.erase(it);
+      return drawableInfo;
+    }
+  }
+  // Not found by pointer fall back and check by drawableID
+  NS::UInteger drawableID = mtlDrawable->drawableID();
+  for(auto it = m_CaptureDrawableInfos.begin(); it != m_CaptureDrawableInfos.end(); ++it)
+  {
+    drawableInfo = it->second;
+    if(drawableInfo.drawableID == drawableID)
+    {
       m_CaptureDrawableInfos.erase(it);
       return drawableInfo;
     }

--- a/renderdoc/driver/metal/metal_device.h
+++ b/renderdoc/driver/metal/metal_device.h
@@ -35,6 +35,7 @@ struct MetalDrawableInfo
 {
   CA::MetalLayer *mtlLayer;
   WrappedMTLTexture *texture;
+  NS::UInteger drawableID;
 };
 
 class MetalCapturer : public IFrameCapturer


### PR DESCRIPTION
## Description

If `MTL:Drawable` is not found by pointer, fallback and search for it by `drawableID` (which should be unique and monotonically increasing).

This fixes a problem preventing frame capture when launching RenderDoc UI from Xcode with `GPU Frame Capture` enabled.

The data flow is:
- `CA::MetalDrawable` is created in the RenderDoc hook of `CAMetalLayer::nextDrawable`, this object is then tracked in `m_CaptureDrawableInfos` (`CA::MetalDrawable` inherits from `MTL::Drawable`)
- The application `present` call passes `MTL:Drawable` which is used to look up the tracked `CA::MetalDrawable` in `m_CaptureDrawableInfos` (to find the corresponding layer and texture being presented).
- In normal application usage the RenderDoc created `CA::MetalLDrawable` corresponds directly to the `MTL::Drawable` passed to `present`.
  - When Xcode GPU frame capture is enabled it wraps the `CA::MetalDrawable` object and the wrapped object is ultimately passed to `present`.

The goal is be able to obtain the layer and texture being presented. That information is part of the `CA::MetalDrawable` protocol but it is not part of the `MTL::Drawable` protocol.

## Discussion
- `MTL::Drawable` and `CA:: MetalDrawable` are protocols which means they could be wrapped by RenderDoc.
  - I don't think that would help in this precise scenario as the problem is Xcode GPU frame capture has wrapped the object and RenderDoc can't unwrap that.
- Another potential option is to use the `objc_setAssociatedObject` system to attach RenderDoc tracking data (a unique handle) to the `CA::MetalDrawable` object and then use `objc_getAssociatedObject` to get the RenderDoc tracking handle.
  - This option has not been tested and might not work as data would be associated with the Xcode unwrapped object but the Xcode wrapped object is passed to `present`

