### PR TITLE
[D3D12] Don't create D3D12DebugManager when not in replay mode.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -136,10 +136,10 @@ IReplayDriver *D3D12Replay::MakeDummyDriver()
 
 void D3D12Replay::CreateResources()
 {
-  m_DebugManager = new D3D12DebugManager(m_pDevice);
-
   if(RenderDoc::Inst().IsReplayApp())
   {
+    m_DebugManager = new D3D12DebugManager(m_pDevice);
+
     CreateSOBuffers();
 
     if(m_pDevice->UsedDXIL())


### PR DESCRIPTION
The debug manager creates a bunch of resources such as debug shaders used to inspect data in buffers and textures.

It's possible that these shaders' creation fails and prevent the app from properly initializing D3D12.

This happened to me on the project I'm working on after updating the Agility SDK we're using from 1.602.0 to 1.606.4. In my specific case, calling ID3D12Device::CreateCommandQueue failed because D3D12DebugManager::CreateShaderDebugResources would return E_OUTOFMEMORY from trying to create the compute PSO for RENDERDOC_DebugMathOp.

Note that I tried also to reproduce in Microsoft's HelloWorld Triangle sample by loading RenderDoc 1.26 library before creating the device, and using Agility SDK 1.606.4's D3D12 DLL, but couldn't reproduce there.

However, on my project, disabling the use of the Agility SDK (as well as using 1.602.0 like we were before) works fine.