### PR TITLE
fix dynamic rendering stencilAttachmentFormat being set to the depthFormat instead of stencilFormat

### DIFF
--- a/renderdoc/driver/vulkan/vk_shader_cache.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_cache.cpp
@@ -952,7 +952,7 @@ void VulkanShaderCache::MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &p
   if(pipeInfo.renderpass == ResourceId())
   {
     dynRenderCreate.depthAttachmentFormat = pipeInfo.depthFormat;
-    dynRenderCreate.stencilAttachmentFormat = pipeInfo.depthFormat;
+    dynRenderCreate.stencilAttachmentFormat = pipeInfo.stencilFormat;
     dynRenderCreate.colorAttachmentCount = (uint32_t)pipeInfo.colorFormats.size();
     memcpy(colFormats, pipeInfo.colorFormats.data(), pipeInfo.colorFormats.byteSize());
 


### PR DESCRIPTION

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

dynamic rendering stencilAttachmentFormat is being setup with depthFormat instead of stencilFormat, probably just a copy paste bug

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
