### PR TITLE
Avoid hooking into a library if it's already been loaded on Win32

### DIFF
--- a/renderdoc/os/win32/win32_hook.cpp
+++ b/renderdoc/os/win32/win32_hook.cpp
@@ -267,12 +267,13 @@ struct CachedHookData
     if(!_stricmp(modName, "kernel32.dll") || !_stricmp(modName, "powrprof.dll") ||
        !_stricmp(modName, "CoreMessaging.dll") || !_stricmp(modName, "opengl32.dll") ||
        !_stricmp(modName, "gdi32.dll") || !_stricmp(modName, "gdi32full.dll") ||
-       !_stricmp(modName, "nvoglv32.dll") || !_stricmp(modName, "nvoglv64.dll") ||
-       !_stricmp(modName, "vulkan-1.dll") || !_stricmp(modName, "nvcuda.dll") ||
-       strstr(lowername, "cudart") == lowername || strstr(lowername, "msvcr") == lowername ||
-       strstr(lowername, "msvcp") == lowername || strstr(lowername, "nv-vk") == lowername ||
-       strstr(lowername, "amdvlk") == lowername || strstr(lowername, "igvk") == lowername ||
-       strstr(lowername, "nvopencl") == lowername || strstr(lowername, "nvapi") == lowername)
+       !_stricmp(modName, "windows.storage.dll") || !_stricmp(modName, "nvoglv32.dll") ||
+       !_stricmp(modName, "nvoglv64.dll") || !_stricmp(modName, "vulkan-1.dll") ||
+       !_stricmp(modName, "nvcuda.dll") || strstr(lowername, "cudart") == lowername ||
+       strstr(lowername, "msvcr") == lowername || strstr(lowername, "msvcp") == lowername ||
+       strstr(lowername, "nv-vk") == lowername || strstr(lowername, "amdvlk") == lowername ||
+       strstr(lowername, "igvk") == lowername || strstr(lowername, "nvopencl") == lowername ||
+       strstr(lowername, "nvapi") == lowername)
       return;
 
     if(ignores.find(lowername) != ignores.end())


### PR DESCRIPTION
## Description

This is a fix for a performance issue we've been having with the Renderdoc plugin in Unreal and the native Windows Explorer dialogs (for instance the "Import Asset" dialog). On Windows 10 at least (build 19045.2846), it seems like the code in `comdlg32.dll` is doing repeated calls to `LoadLibraryExW` for `shell32.dll` with the `LOAD_LIBRARY_SEARCH_USER_DIRS` flag set. This plays poorly with the existing check in `Hooked_LoadLibraryExW` that only skips re-hooking into the library if is already loaded (`GetModuleHandleW` returns a non-null pointer) if `LoadLibraryExW` was called without any flags, so in this case Renderdoc repeatedly tries to hook into the loaded module leading to a heavy degradations in the performances of the Explorer.

The fix I've implemented relies on comparing the previously loaded module handle returned by `GetModuleHandleW` with the module handle returned by `LoadLibraryExW` with the proper flags applied, and setting `dohook` to `false` if the modules are the same in order to avoid re-hooking into a module that's already been loaded anyway. This seems to fix the performance issue in the Unreal Editor on local builds, but of course since I'm not too familiar with the Renderdoc codebase (or the potential quirks of the Win32 API) this change may raise some additional complications for other use-cases.