### PR TITLE
Metal misc tidyups

### DIFF
--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1126,6 +1126,17 @@ rdcstr DoStringise(const MTL::CullMode &el)
 };
 
 template <>
+rdcstr DoStringise(const MTL::IndexType &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::IndexType)
+  {
+    MTL_STRINGISE_ENUM(IndexTypeUInt16);
+    MTL_STRINGISE_ENUM(IndexTypeUInt32);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
 rdcstr DoStringise(const MetalResourceType &el)
 {
   RDCCOMPILE_ASSERT((uint32_t)MetalResourceType::eResMax == 11, "MetalResourceType changed");

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -248,7 +248,7 @@ struct VertexBufferLayoutDescriptor
   NS::UInteger stepRate = 1;
 };
 
-// MTLVertexBufferLayoutDescriptor : based on the interface defined in
+// MTLVertexDescriptor : based on the interface defined in
 // Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLVertexDescriptor.h
 struct VertexDescriptor
 {
@@ -259,6 +259,8 @@ struct VertexDescriptor
   rdcarray<VertexAttributeDescriptor> attributes;
 };
 
+// Helper struct for holding MTLLinkedFunctions::groups data
+// NSDictionary<NSString*, NSArray<id<MTLFunction>>*> *groups;
 struct FunctionGroup
 {
   rdcstr callsite;
@@ -404,6 +406,8 @@ struct RenderPassSampleBufferAttachmentDescriptor
   NS::UInteger endOfFragmentSampleIndex = MTLCounterDontSample;
 };
 
+// MTLRenderPassDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLRenderPass.h
 struct RenderPassDescriptor
 {
   RenderPassDescriptor() = default;

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -159,6 +159,7 @@ MTL_DECLARE_REFLECTION_TYPE(ArgumentBuffersTier);
 MTL_DECLARE_REFLECTION_TYPE(DepthClipMode);
 MTL_DECLARE_REFLECTION_TYPE(TriangleFillMode);
 MTL_DECLARE_REFLECTION_TYPE(CullMode);
+MTL_DECLARE_REFLECTION_TYPE(IndexType);
 
 template <>
 inline rdcliteral TypeName<NS::Range>()

--- a/util/test/demos/apple/apple_window.cpp
+++ b/util/test/demos/apple/apple_window.cpp
@@ -132,7 +132,7 @@ void MyAppDelegate::CreateWindow(int width, int height, const char *title)
   view->setLayer((CA::Layer *)CA::MetalLayer::layer());
 
   _pWindow->setTitle(NS::String::string(title, NS::StringEncoding::UTF8StringEncoding));
-  _pWindow->makeKeyAndOrderFront(nullptr);
+  _pWindow->makeKeyAndOrderFront(NULL);
 }
 
 NS::View *MyAppDelegate::GetContentView()
@@ -147,7 +147,7 @@ NS::Window *MyAppDelegate::GetWindow()
 
 AppleWindow::~AppleWindow()
 {
-  pAppDelegate = nullptr;
+  pAppDelegate = NULL;
 }
 
 AppleWindow::AppleWindow(int width, int height, const char *title) : GraphicsWindow(title)


### PR DESCRIPTION
## Description

A few small updates to existing Metal code.
- Add serialisation for `MTL::IndexType`
- Remove some accidental use of `nullptr`
- Correct and update some comments for the helper structs in the `RDMTL` namespace