### PR TITLE
Fix CMake cross-compiling from Windows

### DIFF
--- a/renderdoc/3rdparty/include-bin/CMakeLists.txt
+++ b/renderdoc/3rdparty/include-bin/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Added for RenderDoc's use (particularly when cross-compiling RenderDoc, as a separate project
+# makes it easier to always compile include-bin for the host)
+cmake_minimum_required(VERSION 2.8.12)
+project(include-bin CXX)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+
+add_executable(include-bin main.cpp)

--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -460,21 +460,36 @@ set(data
 set(data_objects)
 
 # If we're cross-compiling, include-bin will get built for the target and we
-# then can't execute it. Instead, we force calling c++ (which we can safely
-# assume is present) directly to build the binary
+# then can't execute it. Instead, we invoke a new CMake instance and use that
+# to build it.
 
 if(CMAKE_CROSSCOMPILING)
-    set(HOST_NATIVE_CPP_COMPILER c++ CACHE STRING "Command to run to compile a .cpp into an executable. Default is just c++")
+    set(INCLUDE_BIN_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+        set(HOST_NATIVE_CMAKE_ARGS "" CACHE STRING "Arguments to pass to CMake when configuring for a host-native executable.")
+        set(HOST_NATIVE_CMAKE_BUILD_ARGS --config Release CACHE STRING "Arguments to pass to CMake when building a host-native executable.")
+        # Although Windows will happily execute include-bin.exe if include-bin is specified due to
+        # the PATHEXT environment variable, CMake only looks for include-bin when checking if tasks
+        # are up to date (and won't find include-bin.exe). Cygwin and derivatives (e.g. MSYS2) have
+        # magic to make such checks work but standalone CMake does not use those and we need to give
+        # special default arguments on Windows anyways.
+        set(INCLUDE_BIN_EXE "${INCLUDE_BIN_DIRECTORY}/include-bin.exe")
+    else()
+        set(HOST_NATIVE_CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release CACHE STRING "Arguments to pass to CMake when configuring for a host-native executable.")
+        set(HOST_NATIVE_CMAKE_BUILD_ARGS "" CACHE STRING "Arguments to pass to CMake when building a host-native executable.")
+        set(INCLUDE_BIN_EXE "${INCLUDE_BIN_DIRECTORY}/include-bin")
+    endif()
+    set(INCLUDE_BIN_DEP "${INCLUDE_BIN_EXE}")
 
-    add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        COMMAND ${HOST_NATIVE_CPP_COMPILER} 3rdparty/include-bin/main.cpp -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
-        DEPENDS 3rdparty/include-bin/main.cpp)
-    set(INCLUDE_BIN_EXE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
-    set(INCLUDE_BIN_DEP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
+    add_custom_command(OUTPUT ${INCLUDE_BIN_DEP}
+        COMMAND ${CMAKE_COMMAND} -E remove_directory "${INCLUDE_BIN_DIRECTORY}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${INCLUDE_BIN_DIRECTORY}"
+        COMMAND ${CMAKE_COMMAND} -E chdir "${INCLUDE_BIN_DIRECTORY}" ${CMAKE_COMMAND} "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/include-bin/" ${HOST_NATIVE_CMAKE_ARGS}
+        COMMAND ${CMAKE_COMMAND} --build "${INCLUDE_BIN_DIRECTORY}" ${HOST_NATIVE_CMAKE_BUILD_ARGS}
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/include-bin/CMakeLists.txt"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/include-bin/main.cpp")
 else()
-    add_executable(include-bin 3rdparty/include-bin/main.cpp)
+    add_subdirectory(3rdparty/include-bin)
     set(INCLUDE_BIN_EXE $<TARGET_FILE:include-bin>)
     set(INCLUDE_BIN_DEP include-bin)
 endif()

--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -459,43 +459,41 @@ set(data
 
 set(data_objects)
 
-if(UNIX)
-    # If we're cross-compiling, include-bin will get built for the target and we
-    # then can't execute it. Instead, we force calling c++ (which we can safely
-    # assume is present) directly to build the binary
+# If we're cross-compiling, include-bin will get built for the target and we
+# then can't execute it. Instead, we force calling c++ (which we can safely
+# assume is present) directly to build the binary
 
-    if(CMAKE_CROSSCOMPILING)
-        set(HOST_NATIVE_CPP_COMPILER c++ CACHE STRING "Command to run to compile a .cpp into an executable. Default is just c++")
+if(CMAKE_CROSSCOMPILING)
+    set(HOST_NATIVE_CPP_COMPILER c++ CACHE STRING "Command to run to compile a .cpp into an executable. Default is just c++")
 
-        add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            COMMAND ${HOST_NATIVE_CPP_COMPILER} 3rdparty/include-bin/main.cpp -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
-            DEPENDS 3rdparty/include-bin/main.cpp)
-        set(INCLUDE_BIN_EXE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
-        set(INCLUDE_BIN_DEP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
-    else()
-        add_executable(include-bin 3rdparty/include-bin/main.cpp)
-        set(INCLUDE_BIN_EXE $<TARGET_FILE:include-bin>)
-        set(INCLUDE_BIN_DEP include-bin)
-    endif()
-
-    foreach(res ${data})
-        set(in ${res})
-        set(working_dir ${CMAKE_CURRENT_SOURCE_DIR})
-        set(out_src ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/data.src/${in}.c)
-        get_filename_component(out_src_dir ${out_src} DIRECTORY)
-
-        add_custom_command(OUTPUT ${out_src}
-            WORKING_DIRECTORY ${working_dir}
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${out_src_dir}
-            COMMAND ${INCLUDE_BIN_EXE} ${in} ${out_src}
-            DEPENDS ${INCLUDE_BIN_DEP}
-            DEPENDS ${res})
-
-        list(APPEND data_objects ${out_src})
-    endforeach()
+    add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        COMMAND ${HOST_NATIVE_CPP_COMPILER} 3rdparty/include-bin/main.cpp -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin
+        DEPENDS 3rdparty/include-bin/main.cpp)
+    set(INCLUDE_BIN_EXE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
+    set(INCLUDE_BIN_DEP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/include-bin")
+else()
+    add_executable(include-bin 3rdparty/include-bin/main.cpp)
+    set(INCLUDE_BIN_EXE $<TARGET_FILE:include-bin>)
+    set(INCLUDE_BIN_DEP include-bin)
 endif()
+
+foreach(res ${data})
+    set(in ${res})
+    set(working_dir ${CMAKE_CURRENT_SOURCE_DIR})
+    set(out_src ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/data.src/${in}.c)
+    get_filename_component(out_src_dir ${out_src} DIRECTORY)
+
+    add_custom_command(OUTPUT ${out_src}
+        WORKING_DIRECTORY ${working_dir}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${out_src_dir}
+        COMMAND ${INCLUDE_BIN_EXE} ${in} ${out_src}
+        DEPENDS ${INCLUDE_BIN_DEP}
+        DEPENDS ${res})
+
+    list(APPEND data_objects ${out_src})
+endforeach()
 
 set(renderdoc_objects)
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
This PR fixes cross-compiling (to Android) using CMake from Windows. See the two (long!) commit messages for details, but the gist is that instead of trying to run `c++ 3rdparty/include-bin/main.cpp -o bin/include-bin`, it runs `cmake 3rdparty/include-bin/` and then `cmake --build bin/include-bin/`, letting CMake take care of identifying a working host compiler. As far as I can tell, invoking a new CMake instance like this is the only way to build something for the host machine while cross compiling everything else.

The first commit is mostly whitespace changes; see https://github.com/baldurk/renderdoc/commit/1486499068068323785c3db83e676c73833d0c73?w=1 for it without them.
<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
