### PR TITLE
Support launching .app files without NSBundle

### DIFF
--- a/renderdoc/os/posix/apple/apple_helpers.mm
+++ b/renderdoc/os/posix/apple/apple_helpers.mm
@@ -67,8 +67,8 @@ rdcstr apple_GetExecutablePathFromAppBundle(const char *appBundlePath)
   NSBundle *nsBundle = [NSBundle bundleWithPath:path];
   if(!nsBundle)
   {
-    RDCERR("Failed to open application '%s' as an NSBundle", appBundlePath);
-    return rdcstr();
+    RDCWARN("Failed to open application '%s' as an NSBundle", appBundlePath);
+    return rdcstr(appBundlePath);
   }
 
   NSString *executablePath = nsBundle.executablePath;


### PR DESCRIPTION
## Description

Before this change RenderDoc would not launch a Mac executable that had the `.app` extension and did not contain a valid `NSBundle` ie. the file was a plain executable with `.app` extension.

For `*.app` files, if a valid `NSBundle` can't be found, emit a warning (instead of an error) and return the `.app` file path as the executable path to launch.

Tested locally by renaming a plain executable to end with `.app` extension
