### PR TITLE
Fix mapping GL_INT_2_10_10_10_REV and GL_UNSIGNED_INT_2_10_10_10_REV

### DIFF
--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -964,12 +964,12 @@ void GLReplay::SavePipelineState(uint32_t eventId)
       case eGL_INT_2_10_10_10_REV:
         fmt.type = ResourceFormatType::R10G10B10A2;
         fmt.compCount = 4;
-        fmt.compType = CompType::UInt;
+        fmt.compType = CompType::SInt;
         break;
       case eGL_UNSIGNED_INT_2_10_10_10_REV:
         fmt.type = ResourceFormatType::R10G10B10A2;
         fmt.compCount = 4;
-        fmt.compType = CompType::SInt;
+        fmt.compType = CompType::UInt;
         break;
       case eGL_UNSIGNED_INT_10F_11F_11F_REV:
         fmt.type = ResourceFormatType::R11G11B10;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

When capturing an OpenGL application, the signedness of R10G10B10A2 vertex attributes is swapped, i.e. RenderDoc captures a GL_INT_2_10_10_10_REV attribute as R10G10B10A2_UNORM and a GL_UNSIGNED_INT_2_10_10_10_REV as R10G10B10A2_SNORM.

This PR fixes this mapping.
