### PR TITLE
Added sampler type in GL pipeline viewer

### DIFF
--- a/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
@@ -237,8 +237,8 @@ GLPipelineStateViewer::GLPipelineStateViewer(ICaptureContext &ctx, PipelineState
     samp->setHeader(header);
 
     samp->setColumns(
-        {tr("Slot"), tr("Object"), tr("Wrap Mode"), tr("Filter"), tr("LOD Clamp"), tr("LOD Bias")});
-    header->setColumnStretchHints({1, 2, 2, 2, 2, 2});
+        {tr("Slot"), tr("Object"), tr("Type"), tr("Wrap Mode"), tr("Filter"), tr("LOD Clamp"), tr("LOD Bias")});
+    header->setColumnStretchHints({1, 2, 2, 2, 2, 2, 2});
 
     samp->setClearSelectionOnFocusLoss(true);
     samp->setInstantTooltips(true);
@@ -948,7 +948,7 @@ void GLPipelineStateViewer::setShaderState(const GLPipe::Shader &stage, RDLabel 
           filter += QFormatStr(" (%1)").arg(ToQStr(s.filter.filter));
 
         RDTreeWidgetItem *node = new RDTreeWidgetItem({
-            slotname, s.resourceId != ResourceId() ? s.resourceId : r.resourceId, addressing,
+            slotname, s.resourceId != ResourceId() ? s.resourceId : r.resourceId, ToQStr(s.type), addressing,
             filter, QFormatStr("%1 - %2")
                         .arg(s.minLOD == -FLT_MAX ? lit("0") : QString::number(s.minLOD))
                         .arg(s.maxLOD == FLT_MAX ? lit("FLT_MAX") : QString::number(s.maxLOD)),

--- a/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
@@ -236,8 +236,8 @@ GLPipelineStateViewer::GLPipelineStateViewer(ICaptureContext &ctx, PipelineState
     RDHeaderView *header = new RDHeaderView(Qt::Horizontal, this);
     samp->setHeader(header);
 
-    samp->setColumns(
-        {tr("Slot"), tr("Object"), tr("Type"), tr("Wrap Mode"), tr("Filter"), tr("LOD Clamp"), tr("LOD Bias")});
+    samp->setColumns({tr("Slot"), tr("Object"), tr("Type"), tr("Wrap Mode"), tr("Filter"),
+                      tr("LOD Clamp"), tr("LOD Bias")});
     header->setColumnStretchHints({1, 2, 2, 2, 2, 2, 2});
 
     samp->setClearSelectionOnFocusLoss(true);
@@ -293,8 +293,7 @@ GLPipelineStateViewer::GLPipelineStateViewer(ICaptureContext &ctx, PipelineState
     RDHeaderView *header = new RDHeaderView(Qt::Horizontal, this);
     ui->xfbBuffers->setHeader(header);
 
-    ui->xfbBuffers->setColumns(
-        {tr("Slot"), tr("Buffer"), tr("Byte Length"), tr("Offset"), tr("Go")});
+    ui->xfbBuffers->setColumns({tr("Slot"), tr("Buffer"), tr("Byte Length"), tr("Offset"), tr("Go")});
     header->setColumnStretchHints({1, 4, 3, 2, -1});
 
     header->setMinimumSectionSize(40);
@@ -323,8 +322,7 @@ GLPipelineStateViewer::GLPipelineStateViewer(ICaptureContext &ctx, PipelineState
     RDHeaderView *header = new RDHeaderView(Qt::Horizontal, this);
     ui->scissors->setHeader(header);
 
-    ui->scissors->setColumns(
-        {tr("Slot"), tr("X"), tr("Y"), tr("Width"), tr("Height"), tr("Enabled")});
+    ui->scissors->setColumns({tr("Slot"), tr("X"), tr("Y"), tr("Width"), tr("Height"), tr("Enabled")});
     header->setColumnStretchHints({-1, -1, -1, -1, -1, 1});
     header->setMinimumSectionSize(40);
 
@@ -378,13 +376,26 @@ GLPipelineStateViewer::GLPipelineStateViewer(ICaptureContext &ctx, PipelineState
 
   ui->pipeFlow->setStages(
       {
-          lit("VTX"), lit("VS"), lit("TCS"), lit("TES"), lit("GS"), lit("RS"), lit("FS"), lit("FB"),
+          lit("VTX"),
+          lit("VS"),
+          lit("TCS"),
+          lit("TES"),
+          lit("GS"),
+          lit("RS"),
+          lit("FS"),
+          lit("FB"),
           lit("CS"),
       },
       {
-          tr("Vertex Input"), tr("Vertex Shader"), tr("Tess. Control Shader"),
-          tr("Tess. Eval. Shader"), tr("Geometry Shader"), tr("Rasterizer"), tr("Fragment Shader"),
-          tr("Framebuffer Output"), tr("Compute Shader"),
+          tr("Vertex Input"),
+          tr("Vertex Shader"),
+          tr("Tess. Control Shader"),
+          tr("Tess. Eval. Shader"),
+          tr("Geometry Shader"),
+          tr("Rasterizer"),
+          tr("Fragment Shader"),
+          tr("Framebuffer Output"),
+          tr("Compute Shader"),
       });
 
   ui->pipeFlow->setIsolatedStage(8);    // compute shader isolated
@@ -948,10 +959,14 @@ void GLPipelineStateViewer::setShaderState(const GLPipe::Shader &stage, RDLabel 
           filter += QFormatStr(" (%1)").arg(ToQStr(s.filter.filter));
 
         RDTreeWidgetItem *node = new RDTreeWidgetItem({
-            slotname, s.resourceId != ResourceId() ? s.resourceId : r.resourceId, ToQStr(s.type), addressing,
-            filter, QFormatStr("%1 - %2")
-                        .arg(s.minLOD == -FLT_MAX ? lit("0") : QString::number(s.minLOD))
-                        .arg(s.maxLOD == FLT_MAX ? lit("FLT_MAX") : QString::number(s.maxLOD)),
+            slotname,
+            s.resourceId != ResourceId() ? s.resourceId : r.resourceId,
+            ToQStr(s.type),
+            addressing,
+            filter,
+            QFormatStr("%1 - %2")
+                .arg(s.minLOD == -FLT_MAX ? lit("0") : QString::number(s.minLOD))
+                .arg(s.maxLOD == FLT_MAX ? lit("FLT_MAX") : QString::number(s.maxLOD)),
             s.mipLODBias,
         });
 
@@ -1175,12 +1190,10 @@ void GLPipelineStateViewer::setShaderState(const GLPipe::Shader &stage, RDLabel 
 
     if(showNode(usedSlot, filledSlot))
     {
-      QString binding =
-          readWriteType == GLReadWriteType::Image
-              ? tr("Image")
-              : readWriteType == GLReadWriteType::Atomic
-                    ? tr("Atomic")
-                    : readWriteType == GLReadWriteType::SSBO ? tr("SSBO") : tr("Unknown");
+      QString binding = readWriteType == GLReadWriteType::Image    ? tr("Image")
+                        : readWriteType == GLReadWriteType::Atomic ? tr("Atomic")
+                        : readWriteType == GLReadWriteType::SSBO   ? tr("SSBO")
+                                                                   : tr("Unknown");
 
       QString slotname = QFormatStr("%1: %2").arg(bindPoint).arg(res.name);
       QString dimensions;
@@ -1758,8 +1771,8 @@ void GLPipelineStateViewer::setState()
           else
             indexstring = QString::number(prev);
 
-          RDTreeWidgetItem *node = new RDTreeWidgetItem({indexstring, s1.x, s1.y, s1.width, s1.height,
-                                                         s1.enabled ? tr("True") : tr("False")});
+          RDTreeWidgetItem *node = new RDTreeWidgetItem(
+              {indexstring, s1.x, s1.y, s1.width, s1.height, s1.enabled ? tr("True") : tr("False")});
 
           if(s1.width == 0 || s1.height == 0)
             setEmptyRow(node);
@@ -2242,10 +2255,14 @@ void GLPipelineStateViewer::setState()
   if(state.stencilState.stencilEnable)
   {
     ui->stencils->addTopLevelItem(new RDTreeWidgetItem({
-        tr("Front"), ToQStr(state.stencilState.frontFace.function),
+        tr("Front"),
+        ToQStr(state.stencilState.frontFace.function),
         ToQStr(state.stencilState.frontFace.failOperation),
         ToQStr(state.stencilState.frontFace.depthFailOperation),
-        ToQStr(state.stencilState.frontFace.passOperation), QVariant(), QVariant(), QVariant(),
+        ToQStr(state.stencilState.frontFace.passOperation),
+        QVariant(),
+        QVariant(),
+        QVariant(),
     }));
 
     m_Common.SetStencilTreeItemValue(ui->stencils->topLevelItem(0), 5,
@@ -2595,8 +2612,9 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Vert
       i++;
     }
 
-    m_Common.exportHTMLTable(xml, {tr("Slot"), tr("Enabled"), tr("Vertex Buffer Slot"),
-                                   tr("Format"), tr("Relative Offset"), tr("Generic Value")},
+    m_Common.exportHTMLTable(xml,
+                             {tr("Slot"), tr("Enabled"), tr("Vertex Buffer Slot"), tr("Format"),
+                              tr("Relative Offset"), tr("Generic Value")},
                              rows);
   }
 
@@ -2629,8 +2647,9 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Vert
       i++;
     }
 
-    m_Common.exportHTMLTable(xml, {tr("Slot"), tr("Buffer"), tr("Stride"), tr("Offset"),
-                                   tr("Instance Divisor"), tr("Byte Length")},
+    m_Common.exportHTMLTable(xml,
+                             {tr("Slot"), tr("Buffer"), tr("Stride"), tr("Offset"),
+                              tr("Instance Divisor"), tr("Byte Length")},
                              rows);
   }
 
@@ -2703,29 +2722,30 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Vert
 
     m_Common.exportHTMLTable(xml,
                              {
-                                 tr("User Clip Plane"), tr("Enabled"),
+                                 tr("User Clip Plane"),
+                                 tr("Enabled"),
                              },
                              clipPlaneRows);
 
     xml.writeStartElement(tr("p"));
     xml.writeEndElement();
 
-    m_Common.exportHTMLTable(
-        xml,
-        {
-            tr("Default Inner Tessellation Level"), tr("Default Outer Tessellation level"),
-        },
-        {
-            QFormatStr("%1, %2")
-                .arg(pipe.vertexProcessing.defaultInnerLevel[0])
-                .arg(pipe.vertexProcessing.defaultInnerLevel[1]),
+    m_Common.exportHTMLTable(xml,
+                             {
+                                 tr("Default Inner Tessellation Level"),
+                                 tr("Default Outer Tessellation level"),
+                             },
+                             {
+                                 QFormatStr("%1, %2")
+                                     .arg(pipe.vertexProcessing.defaultInnerLevel[0])
+                                     .arg(pipe.vertexProcessing.defaultInnerLevel[1]),
 
-            QFormatStr("%1, %2, %3, %4")
-                .arg(pipe.vertexProcessing.defaultOuterLevel[0])
-                .arg(pipe.vertexProcessing.defaultOuterLevel[1])
-                .arg(pipe.vertexProcessing.defaultOuterLevel[2])
-                .arg(pipe.vertexProcessing.defaultOuterLevel[3]),
-        });
+                                 QFormatStr("%1, %2, %3, %4")
+                                     .arg(pipe.vertexProcessing.defaultOuterLevel[0])
+                                     .arg(pipe.vertexProcessing.defaultOuterLevel[1])
+                                     .arg(pipe.vertexProcessing.defaultOuterLevel[2])
+                                     .arg(pipe.vertexProcessing.defaultOuterLevel[3]),
+                             });
   }
 }
 
@@ -3046,12 +3066,10 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Shad
 
       // show if
       {
-        QString binding =
-            readWriteType == GLReadWriteType::Image
-                ? tr("Image")
-                : readWriteType == GLReadWriteType::Atomic
-                      ? tr("Atomic")
-                      : readWriteType == GLReadWriteType::SSBO ? tr("SSBO") : tr("Unknown");
+        QString binding = readWriteType == GLReadWriteType::Image    ? tr("Image")
+                          : readWriteType == GLReadWriteType::Atomic ? tr("Atomic")
+                          : readWriteType == GLReadWriteType::SSBO   ? tr("SSBO")
+                                                                     : tr("Unknown");
 
         QString slotname = QFormatStr("%1: %2").arg(bindPoint).arg(res.name);
         QString name = m_Ctx.GetResourceName(id);
@@ -3129,8 +3147,9 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Shad
     xml.writeEndElement();
 
     m_Common.exportHTMLTable(
-        xml, {tr("Slot"), tr("Name"), tr("Type"), tr("Width"), tr("Height"), tr("Depth"),
-              tr("Array Size"), tr("Format"), tr("First Mip"), tr("Num Mips")},
+        xml,
+        {tr("Slot"), tr("Name"), tr("Type"), tr("Width"), tr("Height"), tr("Depth"),
+         tr("Array Size"), tr("Format"), tr("First Mip"), tr("Num Mips")},
         textureRows);
   }
 
@@ -3166,12 +3185,16 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Shad
     xml.writeCharacters(tr("Read-write resources"));
     xml.writeEndElement();
 
-    m_Common.exportHTMLTable(
-        xml,
-        {
-            tr("Binding"), tr("Resource"), tr("Name"), tr("Dimensions"), tr("Format"), tr("Access"),
-        },
-        readwriteRows);
+    m_Common.exportHTMLTable(xml,
+                             {
+                                 tr("Binding"),
+                                 tr("Resource"),
+                                 tr("Name"),
+                                 tr("Dimensions"),
+                                 tr("Format"),
+                                 tr("Access"),
+                             },
+                             readwriteRows);
   }
 }
 
@@ -3183,9 +3206,8 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Feed
     xml.writeCharacters(tr("States"));
     xml.writeEndElement();
 
-    m_Common.exportHTMLTable(
-        xml, {tr("Active"), tr("Paused")},
-        {xfb.active ? tr("Yes") : tr("No"), xfb.paused ? tr("Yes") : tr("No")});
+    m_Common.exportHTMLTable(xml, {tr("Active"), tr("Paused")},
+                             {xfb.active ? tr("Yes") : tr("No"), xfb.paused ? tr("Yes") : tr("No")});
   }
 
   {
@@ -3241,9 +3263,10 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Rast
     xml.writeEndElement();
 
     m_Common.exportHTMLTable(
-        xml, {tr("Multisample Enable"), tr("Sample Shading"), tr("Sample Mask"),
-              tr("Sample Coverage"), tr("Sample Coverage Invert"), tr("Alpha to Coverage"),
-              tr("Alpha to One"), tr("Min Sample Shading Rate")},
+        xml,
+        {tr("Multisample Enable"), tr("Sample Shading"), tr("Sample Mask"), tr("Sample Coverage"),
+         tr("Sample Coverage Invert"), tr("Alpha to Coverage"), tr("Alpha to One"),
+         tr("Min Sample Shading Rate")},
         {
             rs.state.multisampleEnable ? tr("Yes") : tr("No"),
             rs.state.sampleShading ? tr("Yes") : tr("No"),
@@ -3258,18 +3281,21 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Rast
     xml.writeStartElement(tr("p"));
     xml.writeEndElement();
 
-    m_Common.exportHTMLTable(
-        xml,
-        {
-            tr("Programmable Point Size"), tr("Fixed Point Size"), tr("Line Width"),
-            tr("Point Fade Threshold"), tr("Point Origin Upper Left"),
-        },
-        {
-            rs.state.programmablePointSize ? tr("Yes") : tr("No"),
-            Formatter::Format(rs.state.pointSize), Formatter::Format(rs.state.lineWidth),
-            Formatter::Format(rs.state.pointFadeThreshold),
-            rs.state.pointOriginUpperLeft ? tr("Yes") : tr("No"),
-        });
+    m_Common.exportHTMLTable(xml,
+                             {
+                                 tr("Programmable Point Size"),
+                                 tr("Fixed Point Size"),
+                                 tr("Line Width"),
+                                 tr("Point Fade Threshold"),
+                                 tr("Point Origin Upper Left"),
+                             },
+                             {
+                                 rs.state.programmablePointSize ? tr("Yes") : tr("No"),
+                                 Formatter::Format(rs.state.pointSize),
+                                 Formatter::Format(rs.state.lineWidth),
+                                 Formatter::Format(rs.state.pointFadeThreshold),
+                                 rs.state.pointOriginUpperLeft ? tr("Yes") : tr("No"),
+                             });
 
     xml.writeStartElement(tr("p"));
     xml.writeEndElement();
@@ -3288,7 +3314,10 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Rast
     m_Common.exportHTMLTable(
         xml,
         {
-            tr("Derivatives"), tr("Line Smooth"), tr("Poly Smooth"), tr("Tex Compression"),
+            tr("Derivatives"),
+            tr("Line Smooth"),
+            tr("Poly Smooth"),
+            tr("Tex Compression"),
         },
         {
             ToQStr(pipe.hints.derivatives),
@@ -3313,9 +3342,10 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Rast
       i++;
     }
 
-    m_Common.exportHTMLTable(xml, {tr("Slot"), tr("X"), tr("Y"), tr("Width"), tr("Height"),
-                                   tr("Min Depth"), tr("Max Depth")},
-                             rows);
+    m_Common.exportHTMLTable(
+        xml,
+        {tr("Slot"), tr("X"), tr("Y"), tr("Width"), tr("Height"), tr("Min Depth"), tr("Max Depth")},
+        rows);
   }
 
   {
@@ -3354,7 +3384,8 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Fram
 
     m_Common.exportHTMLTable(xml, {tr("Framebuffer SRGB"), tr("Blend Factor")},
                              {
-                                 fb.framebufferSRGB ? tr("Yes") : tr("No"), blendFactor,
+                                 fb.framebufferSRGB ? tr("Yes") : tr("No"),
+                                 blendFactor,
                              });
 
     xml.writeStartElement(tr("h3"));
@@ -3382,15 +3413,21 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Fram
       i++;
     }
 
-    m_Common.exportHTMLTable(
-        xml,
-        {
-            tr("Slot"), tr("Blend Enable"), tr("Blend Source"), tr("Blend Destination"),
-            tr("Blend Operation"), tr("Alpha Blend Source"), tr("Alpha Blend Destination"),
-            tr("Alpha Blend Operation"), tr("Logic Operation Enabled"), tr("Logic Operation"),
-            tr("Write Mask"),
-        },
-        rows);
+    m_Common.exportHTMLTable(xml,
+                             {
+                                 tr("Slot"),
+                                 tr("Blend Enable"),
+                                 tr("Blend Source"),
+                                 tr("Blend Destination"),
+                                 tr("Blend Operation"),
+                                 tr("Alpha Blend Source"),
+                                 tr("Alpha Blend Destination"),
+                                 tr("Alpha Blend Operation"),
+                                 tr("Logic Operation Enabled"),
+                                 tr("Logic Operation"),
+                                 tr("Write Mask"),
+                             },
+                             rows);
   }
 
   {
@@ -3398,18 +3435,18 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Fram
     xml.writeCharacters(tr("Depth State"));
     xml.writeEndElement();
 
-    m_Common.exportHTMLTable(xml, {tr("Depth Test Enable"), tr("Depth Writes Enable"),
-                                   tr("Depth Function"), tr("Depth Bounds")},
-                             {
-                                 pipe.depthState.depthEnable ? tr("Yes") : tr("No"),
-                                 pipe.depthState.depthWrites ? tr("Yes") : tr("No"),
-                                 ToQStr(pipe.depthState.depthFunction),
-                                 pipe.depthState.depthEnable
-                                     ? QFormatStr("%1 - %2")
-                                           .arg(Formatter::Format(pipe.depthState.nearBound))
-                                           .arg(Formatter::Format(pipe.depthState.farBound))
-                                     : tr("Disabled"),
-                             });
+    m_Common.exportHTMLTable(
+        xml,
+        {tr("Depth Test Enable"), tr("Depth Writes Enable"), tr("Depth Function"), tr("Depth Bounds")},
+        {
+            pipe.depthState.depthEnable ? tr("Yes") : tr("No"),
+            pipe.depthState.depthWrites ? tr("Yes") : tr("No"),
+            ToQStr(pipe.depthState.depthFunction),
+            pipe.depthState.depthEnable ? QFormatStr("%1 - %2")
+                                              .arg(Formatter::Format(pipe.depthState.nearBound))
+                                              .arg(Formatter::Format(pipe.depthState.farBound))
+                                        : tr("Disabled"),
+        });
   }
 
   {
@@ -3424,8 +3461,9 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Fram
     xml.writeEndElement();
 
     m_Common.exportHTMLTable(
-        xml, {tr("Face"), tr("Reference"), tr("Value Mask"), tr("Write Mask"), tr("Function"),
-              tr("Pass Operation"), tr("Fail Operation"), tr("Depth Fail Operation")},
+        xml,
+        {tr("Face"), tr("Reference"), tr("Value Mask"), tr("Write Mask"), tr("Function"),
+         tr("Pass Operation"), tr("Fail Operation"), tr("Depth Fail Operation")},
         {
             {tr("Front"), Formatter::Format(pipe.stencilState.frontFace.reference, true),
              Formatter::Format(pipe.stencilState.frontFace.compareMask, true),
@@ -3484,7 +3522,10 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Fram
 
     m_Common.exportHTMLTable(xml,
                              {
-                                 tr("Slot"), tr("Image"), tr("First mip"), tr("First array slice"),
+                                 tr("Slot"),
+                                 tr("Image"),
+                                 tr("First mip"),
+                                 tr("First array slice"),
                              },
                              rows);
 
@@ -3542,7 +3583,10 @@ void GLPipelineStateViewer::exportHTML(QXmlStreamWriter &xml, const GLPipe::Fram
 
     m_Common.exportHTMLTable(xml,
                              {
-                                 tr("Slot"), tr("Image"), tr("First mip"), tr("First array slice"),
+                                 tr("Slot"),
+                                 tr("Image"),
+                                 tr("First mip"),
+                                 tr("First array slice"),
                              },
                              rows);
 

--- a/renderdoc/api/replay/gl_pipestate.h
+++ b/renderdoc/api/replay/gl_pipestate.h
@@ -339,8 +339,8 @@ struct Sampler
 
   bool operator==(const Sampler &o) const
   {
-    return resourceId == o.resourceId && type == o.type && addressS == o.addressS && addressT == o.addressT &&
-           addressR == o.addressR && borderColor == o.borderColor &&
+    return resourceId == o.resourceId && type == o.type && addressS == o.addressS &&
+           addressT == o.addressT && addressR == o.addressR && borderColor == o.borderColor &&
            compareFunction == o.compareFunction && filter == o.filter &&
            seamlessCubeMap == o.seamlessCubeMap && maxAnisotropy == o.maxAnisotropy &&
            maxLOD == o.maxLOD && minLOD == o.minLOD && mipLODBias == o.mipLODBias;

--- a/renderdoc/api/replay/gl_pipestate.h
+++ b/renderdoc/api/replay/gl_pipestate.h
@@ -339,7 +339,7 @@ struct Sampler
 
   bool operator==(const Sampler &o) const
   {
-    return resourceId == o.resourceId && addressS == o.addressS && addressT == o.addressT &&
+    return resourceId == o.resourceId && type == o.type && addressS == o.addressS && addressT == o.addressT &&
            addressR == o.addressR && borderColor == o.borderColor &&
            compareFunction == o.compareFunction && filter == o.filter &&
            seamlessCubeMap == o.seamlessCubeMap && maxAnisotropy == o.maxAnisotropy &&
@@ -349,6 +349,8 @@ struct Sampler
   {
     if(!(resourceId == o.resourceId))
       return resourceId < o.resourceId;
+    if(!(type == o.type))
+      return type < o.type;
     if(!(addressS == o.addressS))
       return addressS < o.addressS;
     if(!(addressT == o.addressT))
@@ -375,6 +377,8 @@ struct Sampler
   }
   DOCUMENT("The :class:`ResourceId` of the sampler object, if a separate one is set.");
   ResourceId resourceId;
+  DOCUMENT("The :class:`Type` of the sampler object.");
+  SamplerType type;
   DOCUMENT("The :class:`AddressMode` in the S direction.");
   AddressMode addressS = AddressMode::Wrap;
   DOCUMENT("The :class:`AddressMode` in the T direction.");

--- a/renderdoc/api/replay/renderdoc_tostr.inl
+++ b/renderdoc/api/replay/renderdoc_tostr.inl
@@ -635,6 +635,34 @@ rdcstr DoStringise(const TextureType &el)
 }
 
 template <>
+rdcstr DoStringise(const SamplerType &el)
+{
+  BEGIN_ENUM_STRINGISE(SamplerType)
+  {
+    STRINGISE_ENUM_CLASS_NAMED(Unknown, "Unknown");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler1D, "Sampler 1D");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler2D, "Sampler 2D");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler3D, "Sampler 3D");
+    STRINGISE_ENUM_CLASS_NAMED(GSamplerCube, "Sampler Cube");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler2DRect, "Sampler 2D Rect");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler1DArray, "Sampler 1D Array");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler2DArray, "Sampler 2D Array");
+    STRINGISE_ENUM_CLASS_NAMED(GSamplerCubeArray, "Sampler Cube Array");
+    STRINGISE_ENUM_CLASS_NAMED(GSamplerBuffer, "Sampler Buffer");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler2DMS, "Sampler 2D MS");
+    STRINGISE_ENUM_CLASS_NAMED(GSampler2DMSArray, "Sampler 2D MS Array");
+    STRINGISE_ENUM_CLASS_NAMED(Sampler1DShadow, "Sampler 1D Shadow");
+    STRINGISE_ENUM_CLASS_NAMED(Sampler2DShadow, "Sampler 2D Shadow");
+    STRINGISE_ENUM_CLASS_NAMED(SamplerCubeShadow, "Sampler Cube Shadow");
+    STRINGISE_ENUM_CLASS_NAMED(Sampler2DRectShadow, "Sampler 2D Rect Shadow");
+    STRINGISE_ENUM_CLASS_NAMED(Sampler1DArrayShadow, "Sampler 1D Array Shadow");
+    STRINGISE_ENUM_CLASS_NAMED(Sampler2DArrayShadow, "Sampler 2D Array Shadow");
+    STRINGISE_ENUM_CLASS_NAMED(SamplerCubeArrayShadow, "Sampler Cube Array Shadow");
+  }
+  END_ENUM_STRINGISE();
+}
+
+template <>
 rdcstr DoStringise(const ShaderBuiltin &el)
 {
   BEGIN_ENUM_STRINGISE(ShaderBuiltin)

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -755,6 +755,43 @@ enum class TextureType : uint16_t
 ITERABLE_OPERATORS(TextureType);
 DECLARE_REFLECTION_ENUM(TextureType);
 
+DOCUMENT(R"(The type of the sampler in the shader.
+
+.. data:: Unknown
+
+  An unknown type of texture.
+
+.. data:: Buffer
+
+  A texel buffer.
+)");
+enum class SamplerType : uint16_t
+{
+  Unknown,
+  GSampler1D,
+  GSampler2D,
+  GSampler3D,
+  GSamplerCube,
+  GSampler2DRect,
+  GSampler1DArray,
+  GSampler2DArray,
+  GSamplerCubeArray,
+  GSamplerBuffer,
+  GSampler2DMS,
+  GSampler2DMSArray,
+  Sampler1DShadow,
+  Sampler2DShadow,
+  SamplerCubeShadow,
+  Sampler2DRectShadow,
+  Sampler1DArrayShadow,
+  Sampler2DArrayShadow,
+  SamplerCubeArrayShadow,
+  Count,
+};
+
+ITERABLE_OPERATORS(SamplerType);
+DECLARE_REFLECTION_ENUM(SamplerType);
+
 DOCUMENT(R"(The type of a shader resource bind.
 
 .. data:: Unknown

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -1401,6 +1401,36 @@ void GLReplay::SavePipelineState(uint32_t eventId)
 
         pipe.samplers[unit].resourceId = rm->GetOriginalID(rm->GetResID(SamplerRes(ctx, samp)));
 
+        std::map<std::string, SamplerType> samplerTypesFromString = { 
+            {"sampler1D", SamplerType::GSampler1D},
+            {"sampler2D", SamplerType::GSampler2D},
+            {"sampler3D", SamplerType::GSampler3D},
+            {"samplerCube", SamplerType::GSamplerCube},
+            {"sampler2DRect", SamplerType::GSampler2DRect},
+            {"sampler1DArray", SamplerType::GSampler1DArray},
+            {"sampler2DArray", SamplerType::GSampler2DArray},
+            {"samplerCubeArray", SamplerType::GSamplerCubeArray},
+            {"samplerBuffer", SamplerType::GSamplerBuffer},
+            {"sampler2DMS", SamplerType::GSampler2DMS},
+            {"sampler2DMSArray", SamplerType::GSampler2DMSArray},
+            {"sampler1DShadow", SamplerType::Sampler1DShadow},
+            {"sampler2DShadow", SamplerType::Sampler2DShadow},
+            {"samplerCubeShadow", SamplerType::SamplerCubeShadow},
+            {"sampler2DRectShadow", SamplerType::Sampler2DRectShadow},
+            {"sampler1DArrayShadow", SamplerType::Sampler1DArrayShadow},
+            {"sampler2DArrayShadow", SamplerType::Sampler2DArrayShadow},
+            {"samplerCubeArrayShadow", SamplerType::SamplerCubeArrayShadow},
+        };
+        ShaderConstantType samplerType = pipe.fragmentShader.reflection->readOnlyResources[unit].variableType;
+        std::string samplerName = samplerType.name.c_str();
+        if(samplerTypesFromString.count(samplerName))
+        {
+            pipe.samplers[unit].type = samplerTypesFromString[samplerName];
+        }
+        else {
+            pipe.samplers[unit].type = SamplerType::Unknown;
+        }
+
         // checking texture completeness is a pretty expensive operation since it requires a lot of
         // queries against the driver's texture properties.
         // We assume that if a texture and sampler are complete at any point, even if their

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -1401,7 +1401,7 @@ void GLReplay::SavePipelineState(uint32_t eventId)
 
         pipe.samplers[unit].resourceId = rm->GetOriginalID(rm->GetResID(SamplerRes(ctx, samp)));
 
-        std::map<std::string, SamplerType> samplerTypesFromString = { 
+        std::map<std::string, SamplerType> samplerTypesFromString = {
             {"sampler1D", SamplerType::GSampler1D},
             {"sampler2D", SamplerType::GSampler2D},
             {"sampler3D", SamplerType::GSampler3D},
@@ -1421,14 +1421,16 @@ void GLReplay::SavePipelineState(uint32_t eventId)
             {"sampler2DArrayShadow", SamplerType::Sampler2DArrayShadow},
             {"samplerCubeArrayShadow", SamplerType::SamplerCubeArrayShadow},
         };
-        ShaderConstantType samplerType = pipe.fragmentShader.reflection->readOnlyResources[unit].variableType;
+        ShaderConstantType samplerType =
+            pipe.fragmentShader.reflection->readOnlyResources[unit].variableType;
         std::string samplerName = samplerType.name.c_str();
         if(samplerTypesFromString.count(samplerName))
         {
-            pipe.samplers[unit].type = samplerTypesFromString[samplerName];
+          pipe.samplers[unit].type = samplerTypesFromString[samplerName];
         }
-        else {
-            pipe.samplers[unit].type = SamplerType::Unknown;
+        else
+        {
+          pipe.samplers[unit].type = SamplerType::Unknown;
         }
 
         // checking texture completeness is a pretty expensive operation since it requires a lot of
@@ -3059,7 +3061,7 @@ void GLReplay::GetTextureData(ResourceId tex, const Subresource &sub,
           dst = data.data() + d * sliceSize;
           src = dst + (height - 1) * rowSize;
 
-          for(GLsizei i = 0; i<height>> 1; i++)
+          for(GLsizei i = 0; i < height >> 1; i++)
           {
             memcpy(row, src, rowSize);
             memcpy(src, dst, rowSize);
@@ -3083,9 +3085,7 @@ void GLReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     drv.glDeleteTextures(1, &tempTex);
 }
 
-void GLReplay::SetCustomShaderIncludes(const rdcarray<rdcstr> &directories)
-{
-}
+void GLReplay::SetCustomShaderIncludes(const rdcarray<rdcstr> &directories) {}
 
 void GLReplay::BuildCustomShader(ShaderEncoding sourceEncoding, const bytebuf &source,
                                  const rdcstr &entry, const ShaderCompileFlags &compileFlags,
@@ -3219,8 +3219,7 @@ void GLReplay::BuildTargetShader(ShaderEncoding sourceEncoding, const bytebuf &s
     case ShaderStage::Geometry: shtype = eGL_GEOMETRY_SHADER; break;
     case ShaderStage::Fragment: shtype = eGL_FRAGMENT_SHADER; break;
     case ShaderStage::Compute: shtype = eGL_COMPUTE_SHADER; break;
-    default:
-    {
+    default: {
       RDCERR("Unknown shader type %u", type);
       id = ResourceId();
       return;
@@ -3998,7 +3997,9 @@ rdcarray<GLVersion> GetReplayVersions(RDCDriver api)
   if(api == RDCDriver::OpenGLES)
   {
     return {
-        {3, 2}, {3, 1}, {3, 0},
+        {3, 2},
+        {3, 1},
+        {3, 0},
     };
   }
   else


### PR DESCRIPTION
## Description

![image](https://github.com/baldurk/renderdoc/assets/42851709/9cee8e29-1a07-4096-8ec5-f18fc7c22675)

Added a column to the samplers table in the pipeline state viewer for OpenGL.
I put this PR together quickly, I'm not sure if it's the correct way to do it.