### PR TITLE
D3D12 Replay loading GPU sync for ExecuteIndirect. Closes #2970

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_queue_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_queue_wrap.cpp
@@ -492,7 +492,7 @@ bool WrappedID3D12CommandQueue::Serialise_ExecuteCommandLists(SerialiserType &se
           ID3D12CommandList *list = Unwrap(ppCommandLists[i]);
           real->ExecuteCommandLists(1, &list);
           if(D3D12_Debug_SingleSubmitFlushing())
-            m_pDevice->GPUSyncAllQueues();
+            m_pDevice->GPUSync();
         }
         else
         {
@@ -504,8 +504,8 @@ bool WrappedID3D12CommandQueue::Serialise_ExecuteCommandLists(SerialiserType &se
 
           for(size_t c = 1; c < info.crackedLists.size(); c++)
           {
-            // ensure all work on all queues has finished
-            m_pDevice->GPUSyncAllQueues();
+            // ensure all GPU work has finished
+            m_pDevice->GPUSync();
 
             if(m_pDevice->HasFatalError())
               return false;
@@ -525,7 +525,7 @@ bool WrappedID3D12CommandQueue::Serialise_ExecuteCommandLists(SerialiserType &se
           }
 
           if(D3D12_Debug_SingleSubmitFlushing())
-            m_pDevice->GPUSyncAllQueues();
+            m_pDevice->GPUSync();
         }
       }
 
@@ -714,7 +714,7 @@ bool WrappedID3D12CommandQueue::Serialise_ExecuteCommandLists(SerialiserType &se
           for(size_t i = 0; i < rerecordedCmds.size(); i++)
           {
             real->ExecuteCommandLists(1, &rerecordedCmds[i]);
-            m_pDevice->GPUSyncAllQueues();
+            m_pDevice->GPUSync();
           }
         }
         else

--- a/util/test/demos/d3d12/d3d12_execute_indirect.cpp
+++ b/util/test/demos/d3d12/d3d12_execute_indirect.cpp
@@ -81,20 +81,23 @@ RD_TEST(D3D12_Execute_Indirect, D3D12GraphicsTest)
       D3D12_CPU_DESCRIPTOR_HANDLE rtv =
           MakeRTV(bb).Format(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB).CreateCPU(0);
 
-      ClearRenderTargetView(cmd, rtv, {1.0f, 0.0f, 0.0f, 1.0f});
+      for(int i = 0; i < 8; ++i)
+      {
+        ClearRenderTargetView(cmd, rtv, {1.0f, 0.0f, 0.0f, 1.0f});
 
-      cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
-      IASetVertexBuffer(cmd, vb, sizeof(DefaultA2V), 0);
-      cmd->SetPipelineState(pso);
-      cmd->SetGraphicsRootSignature(sig);
+        IASetVertexBuffer(cmd, vb, sizeof(DefaultA2V), 0);
+        cmd->SetPipelineState(pso);
+        cmd->SetGraphicsRootSignature(sig);
 
-      RSSetViewport(cmd, {0.0f, 0.0f, (float)screenWidth, (float)screenHeight, 0.0f, 1.0f});
-      RSSetScissorRect(cmd, {0, 0, screenWidth, screenHeight});
+        RSSetViewport(cmd, {0.0f, 0.0f, (float)screenWidth, (float)screenHeight, 0.0f, 1.0f});
+        RSSetScissorRect(cmd, {0, 0, screenWidth, screenHeight});
 
-      OMSetRenderTargets(cmd, {rtv}, {});
+        OMSetRenderTargets(cmd, {rtv}, {});
 
-      cmd->ExecuteIndirect(cmdsig, 1, argBuf, 0, NULL, 0);
+        cmd->ExecuteIndirect(cmdsig, 1, argBuf, 0, NULL, 0);
+      }
 
       FinishUsingBackbuffer(cmd, D3D12_RESOURCE_STATE_RENDER_TARGET);
 

--- a/util/test/tests/D3D12/D3D12_Execute_Indirect.py
+++ b/util/test/tests/D3D12/D3D12_Execute_Indirect.py
@@ -6,9 +6,37 @@ class D3D12_Execute_Indirect(rdtest.TestCase):
     demos_test_name = 'D3D12_Execute_Indirect'
 
     def check_capture(self):
-        action = self.find_action("IndirectDraw")
+        from_eid = 0
+        for i in range(8):
+            action = self.find_action("IndirectDraw", from_eid)
+            self.controller.SetFrameEvent(action.eventId, False)
+            # Should be a green triangle in the centre of the screen on a red background
+            self.check_triangle(back=[1.0, 0.0, 0.0, 1.0])
+            postvs_data = self.get_postvs(action, rd.MeshDataStage.VSOut, 0, action.numIndices)
 
-        self.controller.SetFrameEvent(action.eventId, False)
+            postvs_ref = {
+            0: {
+            'vtx': 0,
+            'idx': 0,
+            'SV_POSITION': [-0.5, -0.5, 0.0, 1.0],
+            'COLOR': [0.0, 1.0, 0.0, 1.0],
+            'TEXCOORD': [0.0, 0.0],
+            },
+            1: {
+            'vtx': 1,
+            'idx': 1,
+            'SV_POSITION': [0.0, 0.5, 0.0, 1.0],
+            'COLOR': [0.0, 1.0, 0.0, 1.0],
+            'TEXCOORD': [0.0, 1.0],
+            },
+            2: {
+            'vtx': 2,
+            'idx': 2,
+            'SV_POSITION': [0.5, -0.5, 0.0, 1.0],
+            'COLOR': [0.0, 1.0, 0.0, 1.0],
+            'TEXCOORD': [1.0, 0.0],
+            },
+            }
 
-        # Should be a green triangle in the centre of the screen on a red background
-        self.check_triangle(back=[1.0, 0.0, 0.0, 1.0])
+            self.check_mesh_data(postvs_ref, postvs_data)
+            from_eid = action.eventId + 1


### PR DESCRIPTION
## Description

GPUSyncAllQueues() changed behaviour in e33629ca which meant the GPU was not guaranteed to be synchronized when patching the execute indirect arguments when loading a capture (specifically if there were multiple ExecuteIndirect calls inside the same command buffer).

This led to a race between CPU & GPU and incorrect argument data being read back from the GPU to the CPU and then used for the ExecuteIndirect replay.

In addition to fixing the bug changed other calls from `GPUSyncAllQueues()` to `GPUSync()` where appropriate ie. single flush validate debug mode.

Extended the D3D12_Execute_Indirect test to act as a regression test for this case but also to cover the case of multiple ExecuteIndirect calls within the same command buffer. Changed the test to do 8 indirect draws with a clear in between and then check the pixel and mesh data for each draw is correct (simple triangle). 