### PR TITLE
Test null DSV in D3D12::GetRenderOutputSubresource

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -956,7 +956,7 @@ RenderOutputSubresource D3D12Replay::GetRenderOutputSubresource(ResourceId id)
     }
   }
 
-  if(id == rs.dsv.GetResResourceId())
+  if(id == rs.dsv.GetResResourceId() && rs.dsv.GetResResourceId() != ResourceId())
   {
     FillResourceView(view, &rs.dsv);
     return RenderOutputSubresource(view.firstMip, view.firstSlice, view.numSlices);

--- a/renderdoc/replay/replay_output.cpp
+++ b/renderdoc/replay/replay_output.cpp
@@ -288,7 +288,7 @@ void ReplayOutput::RefreshOverlay()
   {
     ResourceId id = m_pDevice->GetLiveID(m_RenderData.texDisplay.resourceId);
 
-    if(action && m_pDevice->IsRenderOutput(id))
+    if(id != ResourceId() && action && m_pDevice->IsRenderOutput(id))
     {
       FloatVector f = m_RenderData.texDisplay.backgroundColor;
 


### PR DESCRIPTION
## Description

Prevents a crash when refreshing the overlay for a null Texture resource and the pipeline state does not have a bound DSV.

Related to 742e3de2 which changed the internal behaviour of FillResourceView().

