### PR TITLE
Add missing ")" R11G11B10 GetBufferFormatString()

### DIFF
--- a/qrenderdoc/Code/BufferFormatter.cpp
+++ b/qrenderdoc/Code/BufferFormatter.cpp
@@ -2442,7 +2442,7 @@ QString BufferFormatter::GetBufferFormatString(Packing::Rules pack, ResourceId s
       }
       else if(viewFormat.type == ResourceFormatType::R11G11B10)
       {
-        format = lit("[[packed(r11g11b10]] float3");
+        format = lit("[[packed(r11g11b10)]] float3");
       }
       else
       {


### PR DESCRIPTION
## Description

When viewing a data buffer typed with R11G11B10F the pre-generated format string was incorrect
`[[packed(r11g11b10]] float3`
but it should have been
`[[packed(r11g11b10)]] float3`

There was a missing `)`