### PR TITLE
Hide invalid shader resources in pipeline state viewer since 1.24

### DIFF
--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
@@ -1154,6 +1154,10 @@ void D3D12PipelineStateViewer::setShaderState(
           if(bind == NULL ||
              (bind->arraySize != ~0U && bind->bind + (int)bind->arraySize <= shaderReg))
           {
+            // reset the bind if we don't have any match
+            bind = NULL;
+            shaderInput = NULL;
+
             for(int k = 0; k < binds.count(); k++)
             {
               const Bindpoint &b = binds[k];


### PR DESCRIPTION
## Description

Since v1.24 after this commit 61fc2f82f20c966287173d561bffdd1711158e84.

The D3D12 pipeline state viewer keep showing useless shader resource which are not defined in shader source：

![Snipaste_2023-07-19_17-02-49](https://github.com/baldurk/renderdoc/assets/8079836/2ea92b57-e94b-4b6b-92c7-01bf8ae1bb42)
【 This is a capture of Unreal Engine. But the problem is showing on every d3d12 captuers.】

This problem is not showing in v1.23. This PR should fix this problem:
![Snipaste_2023-07-19_17-04-37](https://github.com/baldurk/renderdoc/assets/8079836/ec70b33e-1c4f-4a5a-890a-263d5337d269)


