### PR TITLE
Use innertype id to look up image type. Closes #2975

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
@@ -1257,10 +1257,12 @@ ShaderDebugTrace *Debugger::BeginDebug(DebugAPIWrapper *api, const ShaderStage s
         // sampler, so accessing the original type might be non-trivial at point of access
         uint32_t texType = DebugAPIWrapper::Float_Texture;
 
-        Id imgid = type.InnerType();
+        Id imgid = innertype->id;
 
         if(innertype->type == DataType::SampledImageType)
           imgid = sampledImageTypes[imgid].baseId;
+
+        RDCASSERT(imageTypes[imgid].dim != Dim::Max);
 
         if(imageTypes[imgid].dim == Dim::Buffer)
           texType |= DebugAPIWrapper::Buffer_Texture;

--- a/util/test/demos/vk/vk_test.cpp
+++ b/util/test/demos/vk/vk_test.cpp
@@ -751,6 +751,7 @@ bool VulkanGraphicsTest::Init()
 
   headlessCmds = new VulkanCommands(this);
 
+  if(!headless)
   {
     VkPipelineLayout layout = createPipelineLayout(vkh::PipelineLayoutCreateInfo());
 


### PR DESCRIPTION
## Description

Fix incorrect shader debugging for `ImageFetch` operation on arrays on buffers (and certain scenarios of arrays of textures).

Fix crash trying to launch `VK_Compute_Only`
