### PR TITLE
Fix ResourcePreview crash on specific version of Qt Closes #2971

### DIFF
--- a/qrenderdoc/Windows/PipelineState/PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/PipelineStateViewer.cpp
@@ -90,7 +90,7 @@ RDPreviewTooltip::RDPreviewTooltip(PipelineStateViewer *parent, CustomPaintWidge
 
   pipe = parent;
 
-  setWindowFlags(Qt::ToolTip);
+  setWindowFlags(Qt::ToolTip | Qt::WindowStaysOnTopHint);
   setAttribute(Qt::WA_TransparentForMouseEvents);
   setForegroundRole(QPalette::ToolTipText);
   setBackgroundRole(QPalette::ToolTipBase);


### PR DESCRIPTION
## Description

Qt on Ubuntu 23.04 includes [f9e4402ffe](https://github.com/qt/qtbase/commit/f9e4402ffe), which during `show()` under certain scenarios (for example `Qt::ToolTip` windows) would destroy and recreate the xcb window. This caused ResourcePreview tooltips to crash when replay tried to reference the destroyed xcb window handle.

Adding `Qt:WindowStaysOnTopHint` to the window flags for ToolTip windows prevents the xcb window from being destroyed and recreated during `show()`.

## Testing

Ran official 1.27 builds side by side with locally compiled version (on Windows and Linux) to compare resource preview behaviour, could not see any difference in behaviour.