### PR TITLE
fix renderdoc__replay__marker not present in Mac client

### DIFF
--- a/renderdoc/api/replay/apidefs.h
+++ b/renderdoc/api/replay/apidefs.h
@@ -85,7 +85,7 @@
     defined(RENDERDOC_PLATFORM_ANDROID) || defined(RENDERDOC_PLATFORM_GGP) ||   \
     defined(RENDERDOC_PLATFORM_SWITCH)
 
-#define RENDERDOC_EXPORT_API __attribute__((visibility("default")))
+#define RENDERDOC_EXPORT_API __attribute__((visibility("default"), used, noinline))
 #define RENDERDOC_IMPORT_API
 
 #define RENDERDOC_CC


### PR DESCRIPTION
Mac build was crashing for me with Qt5.15.12 because the replay marker got stripped