### PR TITLE
Workaround nVidia crash in SetGraphicsRoot32BitConstants during replay

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -1943,12 +1943,15 @@ bool WrappedID3D12GraphicsCommandList::Serialise_SetComputeRoot32BitConstants(
 
     bool stateUpdate = false;
 
+    UINT dummyData;
+    // nVidia driver crashes if pSrcData is NULL even with Num32BitValuesToSet = 0
+    const UINT *pValidSrcData = (Num32BitValuesToSet > 0) ? pSrcData : &dummyData;
     if(IsActiveReplaying(m_State))
     {
       if(m_Cmd->InRerecordRange(m_Cmd->m_LastCmdListID))
       {
         Unwrap(m_Cmd->RerecordCmdList(m_Cmd->m_LastCmdListID))
-            ->SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData,
+            ->SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pValidSrcData,
                                            DestOffsetIn32BitValues);
 
         stateUpdate = true;
@@ -1961,10 +1964,10 @@ bool WrappedID3D12GraphicsCommandList::Serialise_SetComputeRoot32BitConstants(
     else
     {
       Unwrap(pCommandList)
-          ->SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData,
+          ->SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pValidSrcData,
                                          DestOffsetIn32BitValues);
       GetCrackedList()->SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet,
-                                                     pSrcData, DestOffsetIn32BitValues);
+                                                     pValidSrcData, DestOffsetIn32BitValues);
 
       stateUpdate = true;
     }
@@ -1974,7 +1977,7 @@ bool WrappedID3D12GraphicsCommandList::Serialise_SetComputeRoot32BitConstants(
       D3D12RenderState &state = m_Cmd->m_BakedCmdListInfo[m_Cmd->m_LastCmdListID].state;
 
       state.compute.sigelems.resize_for_index(RootParameterIndex);
-      state.compute.sigelems[RootParameterIndex].SetConstants(Num32BitValuesToSet, pSrcData,
+      state.compute.sigelems[RootParameterIndex].SetConstants(Num32BitValuesToSet, pValidSrcData,
                                                               DestOffsetIn32BitValues);
     }
   }


### PR DESCRIPTION
## Description

When `Num32BitValuesToSet = 0`, set valid dummy pointer for `pSrcData`. 
The nVidia driver was crashing if `pSrcData` is `NULL`.

Does not crash on AMD drivers. Reproduction capture came from AMD DX12 FSR2 sample.

At capture time  `pSrcData` was non-NULL, however with 0 elements that gets serialized as NULL.
