### PR TITLE
For Pixel History use GL_ANY_SAMPLES_PASSED instead of GL_SAMPLES_PASSED Closes #2972

### DIFF
--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -1374,14 +1374,14 @@ bool QueryTest(WrappedOpenGL *driver, GLPixelHistoryResources &resources, const 
   }
 
   driver->SetFetchCounters(true);
-  driver->glBeginQuery(eGL_SAMPLES_PASSED, samplesPassedQuery);
+  driver->glBeginQuery(eGL_ANY_SAMPLES_PASSED, samplesPassedQuery);
   driver->ReplayLog(event.eventId, event.eventId, eReplay_OnlyDraw);
-  driver->glEndQuery(eGL_SAMPLES_PASSED);
+  driver->glEndQuery(eGL_ANY_SAMPLES_PASSED);
   driver->SetFetchCounters(false);
-  int numSamplesPassed;
-  driver->glGetQueryObjectiv(samplesPassedQuery, eGL_QUERY_RESULT, &numSamplesPassed);
+  int anySamplesPassed = GL_FALSE;
+  driver->glGetQueryObjectiv(samplesPassedQuery, eGL_QUERY_RESULT, &anySamplesPassed);
   driver->glDeleteQueries(1, &samplesPassedQuery);
-  return numSamplesPassed == 0;
+  return anySamplesPassed == GL_FALSE;
 }
 
 void QueryFailedTests(WrappedOpenGL *driver, GLPixelHistoryResources &resources,


### PR DESCRIPTION
## Description

**GL_SAMPLES_PASSED** is not supported by GLES.
The pixel history test is already using a 1x1 scissor test, using **GL_ANY_SAMPLES_PASSED**
should be the same as **GL_SAMPLES_PASSED**. The pixel history logic is only testing for non-zero passing samples, the precise number of passing samples is not used.

Set **anySamplesPassed = GL_FALSE** by default, because the return parameter is not guaranteed to be set if **glGetQueryObjectiv** has an error.

## Testing

The reproduction capture on nVidia+Linux (where the problem can be recreated).
The automated GL tests run on nVidia+Linux and AMD+Windows.
A sample GL application comparing pixel history results on this branch against v1.27.