### PR TITLE
GL Pixel History improvements

### DIFF
--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -2165,6 +2165,12 @@ rdcarray<PixelModification> GLReplay::PixelHistory(rdcarray<EventUsage> events, 
   QueryPrimitiveIdPerFragment(m_pDriver, this, resources, modEvents, x, flippedY, history,
                               eventFragments, usingFloatForPrimitiveId, textureDesc.msSamp,
                               sampleIdx);
+  // copy the postMod depth to next history's preMod depth
+  // (preMode depth is to prime the depth buffer in QueryPostModPerFragment)
+  for(size_t i = 1; i < history.size(); ++i)
+  {
+    history[i].preMod.depth = history[i - 1].postMod.depth;
+  }
   QueryPostModPerFragment(m_pDriver, this, resources, modEvents, x, flippedY, history,
                           eventFragments, textureDesc.msSamp, sampleIdx, textureWidth, textureHeight);
 

--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -2035,6 +2035,11 @@ void CalculateFragmentDepthTests(WrappedOpenGL *driver, GLPixelHistoryResources 
       continue;
     }
 
+    GLboolean depthTestEnabled = driver->glIsEnabled(eGL_DEPTH_TEST);
+    // default for no depth test
+    int depthFunc = eGL_ALWAYS;
+    if(depthTestEnabled)
+      driver->glGetIntegerv(eGL_DEPTH_FUNC, &depthFunc);
     for(; historyIndex < history.size() && modEvents[i].eventId == history[historyIndex].eventId;
         ++historyIndex)
     {
@@ -2043,19 +2048,8 @@ void CalculateFragmentDepthTests(WrappedOpenGL *driver, GLPixelHistoryResources 
         continue;
       }
 
-      if(driver->glIsEnabled(eGL_DEPTH_TEST))
-      {
-        int depthFunc;
-        driver->glGetIntegerv(eGL_DEPTH_FUNC, &depthFunc);
-
-        history[historyIndex].depthTestFailed = !depthTestPassed(
-            depthFunc, history[historyIndex].shaderOut.depth, history[historyIndex].preMod.depth);
-      }
-      else
-      {
-        // since there is no depth test, there is no failure.
-        history[historyIndex].depthTestFailed = false;
-      }
+      history[historyIndex].depthTestFailed = !depthTestPassed(
+          depthFunc, history[historyIndex].shaderOut.depth, history[historyIndex].preMod.depth);
     }
 
     if(i < modEvents.size() - 1)


### PR DESCRIPTION
## Description

Fix a bug where the depth buffer had the wrong value when computing the history per fragment leading to incorrect pixel history analysis

Before the fix
![image](https://github.com/baldurk/renderdoc/assets/39392/a4de3c21-81c9-430a-b08f-6bca7b188715)

After the fix
![image](https://github.com/baldurk/renderdoc/assets/39392/dd50a98a-0d6c-4f0a-ad03-4321e8c1ce5b)

Minor code tidy up in `CalculateFragmentDepthTests()` to simplify the logic and move a constant out of the inner loop.

## Testing

Ran automated tests for GL_Pixel_* on WIndows+AMD and Linux+AMD.
Ran reproduction project on Windows & Linux