### PR TITLE
Fix Android Vulkan capturing

### DIFF
--- a/renderdoc/driver/vulkan/vk_layer.cpp
+++ b/renderdoc/driver/vulkan/vk_layer.cpp
@@ -44,7 +44,7 @@
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT extern "C" __declspec(dllexport)
 
-#elif ENABLED(RDOC_LINUX)
+#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID)
 
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))

--- a/renderdoc/driver/vulkan/vk_layer_android.cpp
+++ b/renderdoc/driver/vulkan/vk_layer_android.cpp
@@ -33,7 +33,7 @@
 #include "vk_resources.h"
 
 #undef VK_LAYER_EXPORT
-#define VK_LAYER_EXPORT
+#define VK_LAYER_EXPORT __attribute__((visibility("default")))
 
 // The android loader has limitations at present that require the enumerate functions
 // to be exported with the precise canonical names. We just forward them to the


### PR DESCRIPTION
## Description

Add `__attribute__((visibility("default")))` to `VK_LAYER_EXPORT` on Android. It used to be defined in the Vulkan headers and changed when the update to the latest Vulkan headers was integrated in 5118f08e2387

