### PR TITLE
Change RenderDoc style checkboxes to use checks for low contrast themes

### DIFF
--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -1425,7 +1425,89 @@ void RDStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *opt, Q
 
     if(opt->state & State_On)
     {
-      p->fillRect(rect, opt->palette.brush(QPalette::ButtonText));
+      QPainterPath checkpath;
+      QPolygonF poly;
+
+      // Left side:
+      //
+      //             X
+      //             | CheckCornerSize
+      //             X
+      //              \\   innerSize
+      //               \\  (width and height)
+      // CheckHeight    X
+      //               /
+      //              /
+      //             X
+      //             | CheckCornerSize
+      //             X
+
+      // Top side:
+      //
+      // X---X      X----X
+      //      \\   /
+      //       \\ /
+      //         X
+
+      Q_ASSERT(rect.height() == rect.width());
+
+      const float innerSize = float(rect.height() - Constants::CheckCornerSize * 2) / 2.0f;
+
+      const float totalSize = innerSize * 2 + Constants::CheckCornerSize * 2;
+      Q_ASSERT(totalSize == rect.height());
+
+      // left edge
+      QPointF pt = rect.topLeft();
+      poly << pt;
+      pt.setY(pt.y() + Constants::CheckCornerSize);
+      poly << pt;
+      pt.setY(pt.y() + innerSize);
+      pt.setX(pt.x() + innerSize);
+      poly << pt;
+      pt.setY(pt.y() + innerSize);
+      pt.setX(pt.x() - innerSize);
+      poly << pt;
+      pt.setY(pt.y() + Constants::CheckCornerSize);
+      poly << pt;
+
+      // bottom edge
+      pt.setX(pt.x() + Constants::CheckCornerSize);
+      poly << pt;
+      pt.setX(pt.x() + innerSize);
+      pt.setY(pt.y() - innerSize);
+      poly << pt;
+      pt.setX(pt.x() + innerSize);
+      pt.setY(pt.y() + innerSize);
+      poly << pt;
+      pt.setX(pt.x() + Constants::CheckCornerSize);
+      poly << pt;
+
+      // right edge
+      pt.setY(pt.y() - Constants::CheckCornerSize);
+      poly << pt;
+      pt.setX(pt.x() - innerSize);
+      pt.setY(pt.y() - innerSize);
+      poly << pt;
+      pt.setX(pt.x() + innerSize);
+      pt.setY(pt.y() - innerSize);
+      poly << pt;
+      pt.setY(pt.y() - Constants::CheckCornerSize);
+      poly << pt;
+
+      // top edge
+      pt.setX(pt.x() - Constants::CheckCornerSize);
+      poly << pt;
+      pt.setX(pt.x() - innerSize);
+      pt.setY(pt.y() + innerSize);
+      poly << pt;
+      pt.setX(pt.x() - innerSize);
+      pt.setY(pt.y() - innerSize);
+      poly << pt;
+      pt.setX(pt.x() - Constants::CheckCornerSize);
+      poly << pt;
+
+      checkpath.addPolygon(poly);
+      p->fillPath(checkpath, opt->palette.brush(QPalette::ButtonText));
     }
     else if(opt->state & State_NoChange)
     {
@@ -1637,7 +1719,7 @@ void RDStyle::drawControl(ControlElement control, const QStyleOption *opt, QPain
         pt.setY(pt.y() - Constants::CheckCornerSize);
         poly << pt;
 
-        // topt edge
+        // top edge
         pt.setX(pt.x() - Constants::CheckCornerSize);
         poly << pt;
         pt.setX(pt.x() - innerSize);


### PR DESCRIPTION
## Description

Include `InidicatorCheckBox` style to match style change in 7452e29ceca

### Before
![image](https://github.com/baldurk/renderdoc/assets/39392/537a7b02-cda2-4361-aaf2-0f745c40befc)

### After
![image](https://github.com/baldurk/renderdoc/assets/39392/9726145b-3681-4bc0-9f33-d464bb30695a)


