### PR TITLE
Support for drawing non-square checkboxes

### DIFF
--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -1291,6 +1291,93 @@ void RDStyle::drawComplexControl(ComplexControl control, const QStyleOptionCompl
   return RDTweakedNativeStyle::drawComplexControl(control, opt, p, widget);
 }
 
+static void drawX(const QStyleOption *opt, QPainter *p, const QRectF &rect)
+{
+  QPainterPath checkpath;
+  QPolygonF poly;
+
+  // Left side:
+  //
+  //             X
+  //             | CheckCornerSize
+  //             X
+  //              \\   innerSizeX, innerSizeY
+  //               \\  (width and height)
+  // CheckHeight    X
+  //               /
+  //              /
+  //             X
+  //             | CheckCornerSize
+  //             X
+
+  // Top side:
+  //
+  // X---X      X----X
+  //      \\   /
+  //       \\ /
+  //         X
+
+  Q_ASSERT(rect.height() == rect.width());
+
+  const float innerSize = float(rect.height() - Constants::CheckCornerSize * 2) / 2.0f;
+
+  const float totalSize = innerSize * 2 + Constants::CheckCornerSize * 2;
+  Q_ASSERT(totalSize == rect.height());
+
+  // left edge
+  QPointF pt = rect.topLeft();
+  poly << pt;
+  pt.setY(pt.y() + Constants::CheckCornerSize);
+  poly << pt;
+  pt.setY(pt.y() + innerSize);
+  pt.setX(pt.x() + innerSize);
+  poly << pt;
+  pt.setY(pt.y() + innerSize);
+  pt.setX(pt.x() - innerSize);
+  poly << pt;
+  pt.setY(pt.y() + Constants::CheckCornerSize);
+  poly << pt;
+
+  // bottom edge
+  pt.setX(pt.x() + Constants::CheckCornerSize);
+  poly << pt;
+  pt.setX(pt.x() + innerSize);
+  pt.setY(pt.y() - innerSize);
+  poly << pt;
+  pt.setX(pt.x() + innerSize);
+  pt.setY(pt.y() + innerSize);
+  poly << pt;
+  pt.setX(pt.x() + Constants::CheckCornerSize);
+  poly << pt;
+
+  // right edge
+  pt.setY(pt.y() - Constants::CheckCornerSize);
+  poly << pt;
+  pt.setX(pt.x() - innerSize);
+  pt.setY(pt.y() - innerSize);
+  poly << pt;
+  pt.setX(pt.x() + innerSize);
+  pt.setY(pt.y() - innerSize);
+  poly << pt;
+  pt.setY(pt.y() - Constants::CheckCornerSize);
+  poly << pt;
+
+  // top edge
+  pt.setX(pt.x() - Constants::CheckCornerSize);
+  poly << pt;
+  pt.setX(pt.x() - innerSize);
+  pt.setY(pt.y() + innerSize);
+  poly << pt;
+  pt.setX(pt.x() - innerSize);
+  pt.setY(pt.y() - innerSize);
+  poly << pt;
+  pt.setX(pt.x() - Constants::CheckCornerSize);
+  poly << pt;
+
+  checkpath.addPolygon(poly);
+  p->fillPath(checkpath, opt->palette.brush(QPalette::ButtonText));
+}
+
 void RDStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *opt, QPainter *p,
                             const QWidget *widget) const
 {
@@ -1406,6 +1493,20 @@ void RDStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *opt, Q
   else if(element == QStyle::PE_IndicatorViewItemCheck || element == QStyle::PE_IndicatorCheckBox)
   {
     QRect rect = opt->rect;
+    int w = rect.width();
+    int h = rect.height();
+    if(w < h)
+    {
+      int padding = (h - w) / 2;
+      rect.setHeight(w);
+      rect.adjust(0, padding, 0, padding);
+    }
+    else if(h < w)
+    {
+      int padding = (w - h) / 2;
+      rect.setWidth(h);
+      rect.adjust(padding, 0, padding, 0);
+    }
 
     QPen outlinePen(outlineBrush(opt->palette), 1.0);
 
@@ -1425,89 +1526,7 @@ void RDStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *opt, Q
 
     if(opt->state & State_On)
     {
-      QPainterPath checkpath;
-      QPolygonF poly;
-
-      // Left side:
-      //
-      //             X
-      //             | CheckCornerSize
-      //             X
-      //              \\   innerSize
-      //               \\  (width and height)
-      // CheckHeight    X
-      //               /
-      //              /
-      //             X
-      //             | CheckCornerSize
-      //             X
-
-      // Top side:
-      //
-      // X---X      X----X
-      //      \\   /
-      //       \\ /
-      //         X
-
-      Q_ASSERT(rect.height() == rect.width());
-
-      const float innerSize = float(rect.height() - Constants::CheckCornerSize * 2) / 2.0f;
-
-      const float totalSize = innerSize * 2 + Constants::CheckCornerSize * 2;
-      Q_ASSERT(totalSize == rect.height());
-
-      // left edge
-      QPointF pt = rect.topLeft();
-      poly << pt;
-      pt.setY(pt.y() + Constants::CheckCornerSize);
-      poly << pt;
-      pt.setY(pt.y() + innerSize);
-      pt.setX(pt.x() + innerSize);
-      poly << pt;
-      pt.setY(pt.y() + innerSize);
-      pt.setX(pt.x() - innerSize);
-      poly << pt;
-      pt.setY(pt.y() + Constants::CheckCornerSize);
-      poly << pt;
-
-      // bottom edge
-      pt.setX(pt.x() + Constants::CheckCornerSize);
-      poly << pt;
-      pt.setX(pt.x() + innerSize);
-      pt.setY(pt.y() - innerSize);
-      poly << pt;
-      pt.setX(pt.x() + innerSize);
-      pt.setY(pt.y() + innerSize);
-      poly << pt;
-      pt.setX(pt.x() + Constants::CheckCornerSize);
-      poly << pt;
-
-      // right edge
-      pt.setY(pt.y() - Constants::CheckCornerSize);
-      poly << pt;
-      pt.setX(pt.x() - innerSize);
-      pt.setY(pt.y() - innerSize);
-      poly << pt;
-      pt.setX(pt.x() + innerSize);
-      pt.setY(pt.y() - innerSize);
-      poly << pt;
-      pt.setY(pt.y() - Constants::CheckCornerSize);
-      poly << pt;
-
-      // top edge
-      pt.setX(pt.x() - Constants::CheckCornerSize);
-      poly << pt;
-      pt.setX(pt.x() - innerSize);
-      pt.setY(pt.y() + innerSize);
-      poly << pt;
-      pt.setX(pt.x() - innerSize);
-      pt.setY(pt.y() - innerSize);
-      poly << pt;
-      pt.setX(pt.x() - Constants::CheckCornerSize);
-      poly << pt;
-
-      checkpath.addPolygon(poly);
-      p->fillPath(checkpath, opt->palette.brush(QPalette::ButtonText));
+      drawX(opt, p, rect);
     }
     else if(opt->state & State_NoChange)
     {
@@ -1625,6 +1644,20 @@ void RDStyle::drawControl(ControlElement control, const QStyleOption *opt, QPain
     if(checkbox)
     {
       QRectF rect = proxy()->subElementRect(SE_CheckBoxIndicator, opt, widget).adjusted(1, 1, -1, -1);
+      float w = rect.width();
+      float h = rect.height();
+      if(w < h)
+      {
+        int padding = (h - w) * 0.5;
+        rect.setHeight(w);
+        rect.adjust(0, padding, 0, padding);
+      }
+      else if(h < w)
+      {
+        int padding = (w - h) * 0.5;
+        rect.setWidth(h);
+        rect.adjust(padding, 0, padding, 0);
+      }
 
       QPen outlinePen(outlineBrush(opt->palette), 1.0);
 
@@ -1650,89 +1683,7 @@ void RDStyle::drawControl(ControlElement control, const QStyleOption *opt, QPain
 
       if(opt->state & State_On)
       {
-        QPainterPath checkpath;
-        QPolygonF poly;
-
-        // Left side:
-        //
-        //             X
-        //             | CheckCornerSize
-        //             X
-        //              \\   innerSize
-        //               \\  (width and height)
-        // CheckHeight    X
-        //               /
-        //              /
-        //             X
-        //             | CheckCornerSize
-        //             X
-
-        // Top side:
-        //
-        // X---X      X----X
-        //      \\   /
-        //       \\ /
-        //         X
-
-        Q_ASSERT(rect.height() == rect.width());
-
-        const float innerSize = float(rect.height() - Constants::CheckCornerSize * 2) / 2.0f;
-
-        const float totalSize = innerSize * 2 + Constants::CheckCornerSize * 2;
-        Q_ASSERT(totalSize == rect.height());
-
-        // left edge
-        QPointF pt = rect.topLeft();
-        poly << pt;
-        pt.setY(pt.y() + Constants::CheckCornerSize);
-        poly << pt;
-        pt.setY(pt.y() + innerSize);
-        pt.setX(pt.x() + innerSize);
-        poly << pt;
-        pt.setY(pt.y() + innerSize);
-        pt.setX(pt.x() - innerSize);
-        poly << pt;
-        pt.setY(pt.y() + Constants::CheckCornerSize);
-        poly << pt;
-
-        // bottom edge
-        pt.setX(pt.x() + Constants::CheckCornerSize);
-        poly << pt;
-        pt.setX(pt.x() + innerSize);
-        pt.setY(pt.y() - innerSize);
-        poly << pt;
-        pt.setX(pt.x() + innerSize);
-        pt.setY(pt.y() + innerSize);
-        poly << pt;
-        pt.setX(pt.x() + Constants::CheckCornerSize);
-        poly << pt;
-
-        // right edge
-        pt.setY(pt.y() - Constants::CheckCornerSize);
-        poly << pt;
-        pt.setX(pt.x() - innerSize);
-        pt.setY(pt.y() - innerSize);
-        poly << pt;
-        pt.setX(pt.x() + innerSize);
-        pt.setY(pt.y() - innerSize);
-        poly << pt;
-        pt.setY(pt.y() - Constants::CheckCornerSize);
-        poly << pt;
-
-        // top edge
-        pt.setX(pt.x() - Constants::CheckCornerSize);
-        poly << pt;
-        pt.setX(pt.x() - innerSize);
-        pt.setY(pt.y() + innerSize);
-        poly << pt;
-        pt.setX(pt.x() - innerSize);
-        pt.setY(pt.y() - innerSize);
-        poly << pt;
-        pt.setX(pt.x() - Constants::CheckCornerSize);
-        poly << pt;
-
-        checkpath.addPolygon(poly);
-        p->fillPath(checkpath, opt->palette.brush(QPalette::ButtonText));
+        drawX(opt, p, rect);
       }
       else if(opt->state & State_NoChange)
       {


### PR DESCRIPTION
## Description

Some checkboxes are not square and triggered asserts. Examples were right-click context menu for the pixel history and shader debugger.

Force the checkbox to be square, extends 7452e29ceca  

### Before
![image](https://github.com/baldurk/renderdoc/assets/39392/dd2eee3a-571b-4620-a1a4-aa69ede5e6cd)
![image](https://github.com/baldurk/renderdoc/assets/39392/abda4890-6ced-40f1-8bb5-4df4393f07bf)

### After
![image](https://github.com/baldurk/renderdoc/assets/39392/59e2c534-6a38-4db3-9e1f-f8b9d208663b)
![image](https://github.com/baldurk/renderdoc/assets/39392/e9ba74b1-1393-4425-9b6b-708b34486d66)
