### PR TITLE
Add "used" attribute to prevent exported symbol dead-stripping

### DIFF
--- a/renderdoc/api/replay/apidefs.h
+++ b/renderdoc/api/replay/apidefs.h
@@ -85,7 +85,7 @@
     defined(RENDERDOC_PLATFORM_ANDROID) || defined(RENDERDOC_PLATFORM_GGP) ||   \
     defined(RENDERDOC_PLATFORM_SWITCH)
 
-#define RENDERDOC_EXPORT_API __attribute__((visibility("default")))
+#define RENDERDOC_EXPORT_API __attribute__((visibility("default"), used))
 #define RENDERDOC_IMPORT_API
 
 #define RENDERDOC_CC


### PR DESCRIPTION
## Description

Similar to https://github.com/baldurk/renderdoc/pull/2991

Ideally would use `retain` but that would require upgrading to recent compilers in CI and the project.

```
__attribute__((retain)) function/variable to prevent linker garbage
collection.
```

Tested by adding `set(QMAKE_LDFLAGS "-Wl,-dead_strip")` to the qrenderdoc CMakeLists.txt and looking for the export symbol ie. 
`nm -P build/bin/qrenderdoc.app/Contents/MacOS/qrenderdoc | grep replay`
Working:
`_renderdoc__replay__marker T 1006dae98 0`
Not Working then the symbol is not present.

Tested on Linux : no change to the symbol visibility and UI launched and was able to launch and capture and replay.
Tested on Android: compiled and checked the symbol visibility in `librenderdoccmd.so`

