### PR TITLE
Create pixel history variables for dual source output and blend src/dest

### DIFF
--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -2100,8 +2100,9 @@ struct PixelModification
   {
     return eventId == o.eventId && directShaderWrite == o.directShaderWrite &&
            unboundPS == o.unboundPS && fragIndex == o.fragIndex && primitiveID == o.primitiveID &&
-           preMod == o.preMod && shaderOut == o.shaderOut && shaderOutDualSrc == o.shaderOutDualSrc &&
-           postMod == o.postMod && sampleMasked == o.sampleMasked &&
+           preMod == o.preMod && shaderOut == o.shaderOut &&
+           shaderOutDualSrc == o.shaderOutDualSrc && blendSrc == o.blendSrc &&
+           blendDst == o.blendDst && postMod == o.postMod && sampleMasked == o.sampleMasked &&
            backfaceCulled == o.backfaceCulled && depthClipped == o.depthClipped &&
            depthBoundsFailed == o.depthBoundsFailed && viewClipped == o.viewClipped &&
            scissorClipped == o.scissorClipped && shaderDiscarded == o.shaderDiscarded &&
@@ -2125,6 +2126,10 @@ struct PixelModification
       return shaderOut < o.shaderOut;
     if(!(shaderOutDualSrc == o.shaderOutDualSrc))
       return shaderOutDualSrc < o.shaderOutDualSrc;
+    if(!(blendSrc == o.blendSrc))
+      return blendSrc < o.blendSrc;
+    if(!(blendDst == o.blendDst))
+      return blendDst < o.blendDst;
     if(!(postMod == o.postMod))
       return postMod < o.postMod;
     if(!(sampleMasked == o.sampleMasked))
@@ -2182,6 +2187,16 @@ pixel.
 :type: ModificationValue
 )");
   ModificationValue shaderOutDualSrc;
+  DOCUMENT(R"(The source component in the blend equation for this fragment.
+
+:type: ModificationValue
+)");
+  ModificationValue blendSrc;
+  DOCUMENT(R"(The destination component in the blend equation for this fragment.
+
+:type: ModificationValue
+)");
+  ModificationValue blendDst;
   DOCUMENT(R"(The value of the texture after this fragment ran.
 
 :type: ModificationValue

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -2100,12 +2100,12 @@ struct PixelModification
   {
     return eventId == o.eventId && directShaderWrite == o.directShaderWrite &&
            unboundPS == o.unboundPS && fragIndex == o.fragIndex && primitiveID == o.primitiveID &&
-           preMod == o.preMod && shaderOut == o.shaderOut && postMod == o.postMod &&
-           sampleMasked == o.sampleMasked && backfaceCulled == o.backfaceCulled &&
-           depthClipped == o.depthClipped && depthBoundsFailed == o.depthBoundsFailed &&
-           viewClipped == o.viewClipped && scissorClipped == o.scissorClipped &&
-           shaderDiscarded == o.shaderDiscarded && depthTestFailed == o.depthTestFailed &&
-           stencilTestFailed == o.stencilTestFailed;
+           preMod == o.preMod && shaderOut == o.shaderOut && shaderOutDualSrc == o.shaderOutDualSrc &&
+           postMod == o.postMod && sampleMasked == o.sampleMasked &&
+           backfaceCulled == o.backfaceCulled && depthClipped == o.depthClipped &&
+           depthBoundsFailed == o.depthBoundsFailed && viewClipped == o.viewClipped &&
+           scissorClipped == o.scissorClipped && shaderDiscarded == o.shaderDiscarded &&
+           depthTestFailed == o.depthTestFailed && stencilTestFailed == o.stencilTestFailed;
   }
   bool operator<(const PixelModification &o) const
   {
@@ -2123,6 +2123,8 @@ struct PixelModification
       return preMod < o.preMod;
     if(!(shaderOut == o.shaderOut))
       return shaderOut < o.shaderOut;
+    if(!(shaderOutDualSrc == o.shaderOutDualSrc))
+      return shaderOutDualSrc < o.shaderOutDualSrc;
     if(!(postMod == o.postMod))
       return postMod < o.postMod;
     if(!(sampleMasked == o.sampleMasked))
@@ -2175,6 +2177,11 @@ pixel.
 :type: ModificationValue
 )");
   ModificationValue shaderOut;
+  DOCUMENT(R"(The value that this fragment wrote from the pixel shader to the second output.
+
+:type: ModificationValue
+)");
+  ModificationValue shaderOutDualSrc;
   DOCUMENT(R"(The value of the texture after this fragment ran.
 
 :type: ModificationValue

--- a/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
+++ b/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
@@ -1941,6 +1941,8 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
       // fragments writing to the pixel in this event with original shader
       mod.shaderOut.col.intValue[1] = int32_t(data[3].y);
       mod.shaderOutDualSrc.SetInvalid();
+      mod.blendSrc.SetInvalid();
+      mod.blendDst.SetInvalid();
     }
   }
 
@@ -2318,6 +2320,8 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
 
         memcpy(&history[h].shaderOut.col.uintValue[0], data, 4 * sizeof(float));
         history[h].shaderOutDualSrc.SetInvalid();
+        history[h].blendSrc.SetInvalid();
+        history[h].blendDst.SetInvalid();
 
         // primitive ID is in the next slot after that
         memcpy(&history[h].primitiveID, data + sizeof(Vec4f), sizeof(uint32_t));

--- a/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
+++ b/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
@@ -1940,6 +1940,7 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
       // data[3].x (depth) unused
       // fragments writing to the pixel in this event with original shader
       mod.shaderOut.col.intValue[1] = int32_t(data[3].y);
+      mod.shaderOutDualSrc.SetInvalid();
     }
   }
 
@@ -2316,6 +2317,7 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
         byte *data = shadoutStoreData + sizeof(Vec4f) * pixstoreStride * offsettedSlot;
 
         memcpy(&history[h].shaderOut.col.uintValue[0], data, 4 * sizeof(float));
+        history[h].shaderOutDualSrc.SetInvalid();
 
         // primitive ID is in the next slot after that
         memcpy(&history[h].primitiveID, data + sizeof(Vec4f), sizeof(uint32_t));

--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -1304,6 +1304,8 @@ std::map<uint32_t, uint32_t> QueryNumFragmentsByEvent(
       history[i].shaderOut.stencil = history[i].postMod.stencil;
     }
     history[i].shaderOutDualSrc.SetInvalid();
+    history[i].blendSrc.SetInvalid();
+    history[i].blendDst.SetInvalid();
 
     eventFragments.emplace(modEvents[i].eventId, numFragments);
 
@@ -1589,6 +1591,8 @@ void QueryShaderOutPerFragment(WrappedOpenGL *driver, GLReplay *replay,
         historyIndex->shaderOut.stencil = oldStencil;
       }
       historyIndex->shaderOutDualSrc.SetInvalid();
+      historyIndex->blendSrc.SetInvalid();
+      historyIndex->blendDst.SetInvalid();
       historyIndex++;
     }
 

--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -1303,6 +1303,7 @@ std::map<uint32_t, uint32_t> QueryNumFragmentsByEvent(
       numFragments = history[i].shaderOut.stencil;
       history[i].shaderOut.stencil = history[i].postMod.stencil;
     }
+    history[i].shaderOutDualSrc.SetInvalid();
 
     eventFragments.emplace(modEvents[i].eventId, numFragments);
 
@@ -1587,6 +1588,7 @@ void QueryShaderOutPerFragment(WrappedOpenGL *driver, GLReplay *replay,
                         int(historyIndex - history.begin()));
         historyIndex->shaderOut.stencil = oldStencil;
       }
+      historyIndex->shaderOutDualSrc.SetInvalid();
       historyIndex++;
     }
 

--- a/renderdoc/driver/vulkan/vk_pixelhistory.cpp
+++ b/renderdoc/driver/vulkan/vk_pixelhistory.cpp
@@ -3973,6 +3973,8 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
       mod.postMod.SetInvalid();
       mod.shaderOut.SetInvalid();
       mod.shaderOutDualSrc.SetInvalid();
+      mod.blendSrc.SetInvalid();
+      mod.blendDst.SetInvalid();
       h++;
       continue;
     }
@@ -4001,6 +4003,8 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
     mod.shaderOut.col.intValue[0] = frags;
     mod.shaderOut.col.intValue[1] = fragsClipped;
     mod.shaderOutDualSrc.SetInvalid();
+    mod.blendSrc.SetInvalid();
+    mod.blendDst.SetInvalid();
     bool someFragsClipped = (fragsClipped < frags);
     mod.primitiveID = someFragsClipped;
     // Draws in secondary command buffers will fail this check,
@@ -4149,6 +4153,9 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
         }
 
         history[h].shaderOutDualSrc.SetInvalid();
+
+        history[h].blendSrc.SetInvalid();
+        history[h].blendDst.SetInvalid();
       }
 
       // check the depth value between premod/shaderout against the known test if we have valid

--- a/renderdoc/driver/vulkan/vk_pixelhistory.cpp
+++ b/renderdoc/driver/vulkan/vk_pixelhistory.cpp
@@ -3972,6 +3972,7 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
       mod.preMod.SetInvalid();
       mod.postMod.SetInvalid();
       mod.shaderOut.SetInvalid();
+      mod.shaderOutDualSrc.SetInvalid();
       h++;
       continue;
     }
@@ -3999,6 +4000,7 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
     int32_t fragsClipped = int32_t(ei.dsWithShaderDiscard[4]);
     mod.shaderOut.col.intValue[0] = frags;
     mod.shaderOut.col.intValue[1] = fragsClipped;
+    mod.shaderOutDualSrc.SetInvalid();
     bool someFragsClipped = (fragsClipped < frags);
     mod.primitiveID = someFragsClipped;
     // Draws in secondary command buffers will fail this check,
@@ -4145,6 +4147,8 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
         {
           history[h].preMod = history[h - 1].postMod;
         }
+
+        history[h].shaderOutDualSrc.SetInvalid();
       }
 
       // check the depth value between premod/shaderout against the known test if we have valid

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -894,6 +894,8 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
   SERIALISE_MEMBER(preMod);
   SERIALISE_MEMBER(shaderOut);
   SERIALISE_MEMBER(shaderOutDualSrc);
+  SERIALISE_MEMBER(blendSrc);
+  SERIALISE_MEMBER(blendDst);
   SERIALISE_MEMBER(postMod);
 
   SERIALISE_MEMBER(sampleMasked);
@@ -907,7 +909,7 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
   SERIALISE_MEMBER(stencilTestFailed);
   SERIALISE_MEMBER(predicationSkipped);
 
-  SIZE_CHECK(124);
+  SIZE_CHECK(172);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -893,6 +893,7 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
 
   SERIALISE_MEMBER(preMod);
   SERIALISE_MEMBER(shaderOut);
+  SERIALISE_MEMBER(shaderOutDualSrc);
   SERIALISE_MEMBER(postMod);
 
   SERIALISE_MEMBER(sampleMasked);
@@ -906,7 +907,7 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
   SERIALISE_MEMBER(stencilTestFailed);
   SERIALISE_MEMBER(predicationSkipped);
 
-  SIZE_CHECK(100);
+  SIZE_CHECK(124);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
This is split off from #3003. On its own, it does nothing, but it is a shared requirement for other changes that actually implement dual source output and blend src/dest for pixel history.
<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
