### PR TITLE
Add UI for pixel history for dual source output and blend src/dest

### DIFF
--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -1551,9 +1551,25 @@ void RDStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *opt, Q
       group = QPalette::Inactive;
 
     if(viewitem->state & QStyle::State_Selected)
-      p->fillRect(viewitem->rect, viewitem->palette.brush(group, QPalette::Highlight));
-    else if(viewitem->backgroundBrush.style() != Qt::NoBrush)
-      p->fillRect(viewitem->rect, viewitem->backgroundBrush);
+    {
+      if(viewitem->backgroundBrush.style() != Qt::NoBrush)
+      {
+        p->fillRect(viewitem->rect, viewitem->backgroundBrush);
+        // If we have a custom color, use the selection color at half opacity over the custom color
+        QColor col = viewitem->palette.color(group, QPalette::Highlight);
+        col.setAlphaF(0.5f);
+        p->fillRect(viewitem->rect, QBrush(col));
+      }
+      else
+      {
+        p->fillRect(viewitem->rect, viewitem->palette.brush(group, QPalette::Highlight));
+      }
+    }
+    else
+    {
+      if(viewitem->backgroundBrush.style() != Qt::NoBrush)
+        p->fillRect(viewitem->rect, viewitem->backgroundBrush);
+    }
 
     return;
   }

--- a/qrenderdoc/Widgets/Extended/RDTreeView.cpp
+++ b/qrenderdoc/Widgets/Extended/RDTreeView.cpp
@@ -771,17 +771,10 @@ void RDTreeView::drawBranches(QPainter *painter, const QRect &rect, const QModel
     idx = idx.parent();
   }
 
-  opt.rect = rect;
-  opt.rect.setWidth(depth * indentation());
+  opt.rect = allLinesRect;
   opt.showDecorationSelected = true;
+  opt.backgroundBrush = index.data(Qt::BackgroundRole).value<QBrush>();
   style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, this);
-
-  QBrush back = index.data(Qt::BackgroundRole).value<QBrush>();
-
-  if(!selectionModel()->isSelected(index) && back.style() != Qt::NoBrush)
-  {
-    painter->fillRect(allLinesRect, back);
-  }
 
   if(m_VisibleBranches)
   {
@@ -821,12 +814,12 @@ void RDTreeView::drawBranches(QPainter *painter, const QRect &rect, const QModel
   {
     parent = parents.pop();
 
-    back = parent.data(RDTreeView::TreeLineColorRole).value<QBrush>();
+    QBrush line = parent.data(RDTreeView::TreeLineColorRole).value<QBrush>();
 
-    if(back.style() != Qt::NoBrush)
+    if(line.style() != Qt::NoBrush)
     {
       // draw a centred pen vertically down the middle of branchRect
-      painter->setPen(QPen(QBrush(back), m_treeColorLineWidth));
+      painter->setPen(QPen(line, m_treeColorLineWidth));
 
       QPoint topCentre = QRect(branchRect).center();
       QPoint bottomCentre = topCentre;

--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -48,6 +48,10 @@ enum
   COL_SHADER_OUT_COLOR,
   COL_SHADER_OUT_2,
   COL_SHADER_OUT_2_COLOR,
+  COL_BLEND_SRC,
+  COL_BLEND_SRC_COLOR,
+  COL_BLEND_DST,
+  COL_BLEND_DST_COLOR,
   COL_TEX_AFTER,
   COL_TEX_AFTER_COLOR,
   COL_COUNT,
@@ -92,6 +96,8 @@ public:
       case COL_TEX_BEFORE_COLOR:
       case COL_SHADER_OUT_COLOR:
       case COL_SHADER_OUT_2_COLOR:
+      case COL_BLEND_SRC_COLOR:
+      case COL_BLEND_DST_COLOR:
       case COL_TEX_AFTER_COLOR: return true;
       default: return false;
     }
@@ -193,6 +199,10 @@ public:
         case COL_SHADER_OUT_COLOR: result = lit("Shader Out"); break;
         case COL_SHADER_OUT_2:
         case COL_SHADER_OUT_2_COLOR: result = lit("Shader Out 2"); break;
+        case COL_BLEND_SRC:
+        case COL_BLEND_SRC_COLOR: result = lit("Blend Source"); break;
+        case COL_BLEND_DST:
+        case COL_BLEND_DST_COLOR: result = lit("Blend Dest"); break;
         case COL_TEX_AFTER:
         case COL_TEX_AFTER_COLOR: result = lit("Tex After"); break;
       }
@@ -342,11 +352,12 @@ public:
         {
           // We can't provide meaningful shader out messages for events, only individual primitives.
           // So, use the Tex Before value for all of them.
-          if(col == COL_TEX_BEFORE || col == COL_SHADER_OUT || col == COL_SHADER_OUT_2)
+          if(col == COL_TEX_BEFORE || col == COL_SHADER_OUT || col == COL_SHADER_OUT_2 ||
+             col == COL_BLEND_SRC)
           {
             return tr("Tex Before\n\n") + modString(getMods(index).first().preMod);
           }
-          else if(col == COL_TEX_AFTER)
+          else if(col == COL_TEX_AFTER || col == COL_BLEND_DST)
           {
             return tr("Tex After\n\n") + modString(getMods(index).last().postMod);
           }
@@ -370,6 +381,14 @@ public:
             else
               return tr("Shader Out 2\n\n") + modString(mod.shaderOutDualSrc, 4);
           }
+          else if(col == COL_BLEND_SRC)
+          {
+            return tr("Blend Source\n\n") + modString(getMod(index).blendSrc);
+          }
+          else if(col == COL_BLEND_DST)
+          {
+            return tr("Blend Dest\n\n") + modString(getMod(index).blendDst);
+          }
           else if(col == COL_TEX_AFTER)
           {
             return tr("Tex After\n\n") + modString(getMod(index).postMod);
@@ -382,11 +401,11 @@ public:
         if(isEvent(index))
         {
           if(col == COL_TEX_BEFORE_COLOR || col == COL_SHADER_OUT_COLOR ||
-             col == COL_SHADER_OUT_2_COLOR)
+             col == COL_SHADER_OUT_2_COLOR || col == COL_BLEND_SRC_COLOR)
           {
             return backgroundBrush(getMods(index).first().preMod);
           }
-          else if(col == COL_TEX_AFTER_COLOR)
+          else if(col == COL_TEX_AFTER_COLOR || col == COL_BLEND_DST_COLOR)
           {
             return backgroundBrush(getMods(index).last().postMod);
           }
@@ -407,6 +426,14 @@ public:
               return backgroundBrush(mod.shaderOut);
             else
               return backgroundBrush(mod.shaderOutDualSrc);
+          }
+          else if(col == COL_BLEND_SRC_COLOR)
+          {
+            return backgroundBrush(getMod(index).blendSrc);
+          }
+          else if(col == COL_BLEND_DST_COLOR)
+          {
+            return backgroundBrush(getMod(index).blendDst);
           }
           else if(col == COL_TEX_AFTER_COLOR)
           {
@@ -716,6 +743,10 @@ PixelHistoryView::PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint p
   ui->events->header()->setSectionResizeMode(COL_SHADER_OUT_COLOR, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_SHADER_OUT_2, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_SHADER_OUT_2_COLOR, QHeaderView::ResizeToContents);
+  ui->events->header()->setSectionResizeMode(COL_BLEND_SRC, QHeaderView::ResizeToContents);
+  ui->events->header()->setSectionResizeMode(COL_BLEND_SRC_COLOR, QHeaderView::ResizeToContents);
+  ui->events->header()->setSectionResizeMode(COL_BLEND_DST, QHeaderView::ResizeToContents);
+  ui->events->header()->setSectionResizeMode(COL_BLEND_DST_COLOR, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_TEX_AFTER, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_TEX_AFTER_COLOR, QHeaderView::ResizeToContents);
 
@@ -724,6 +755,10 @@ PixelHistoryView::PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint p
   ui->events->header()->hideSection(COL_TEX_BEFORE_COLOR);
   ui->events->header()->hideSection(COL_SHADER_OUT_2);
   ui->events->header()->hideSection(COL_SHADER_OUT_2_COLOR);
+  ui->events->header()->hideSection(COL_BLEND_SRC);
+  ui->events->header()->hideSection(COL_BLEND_SRC_COLOR);
+  ui->events->header()->hideSection(COL_BLEND_DST);
+  ui->events->header()->hideSection(COL_BLEND_DST_COLOR);
 
   QObject::connect(ui->events, &RDTreeView::customContextMenuRequested, this,
                    &PixelHistoryView::events_contextMenu);

--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -46,6 +46,8 @@ enum
   COL_TEX_BEFORE_COLOR,
   COL_SHADER_OUT,
   COL_SHADER_OUT_COLOR,
+  COL_SHADER_OUT_2,
+  COL_SHADER_OUT_2_COLOR,
   COL_TEX_AFTER,
   COL_TEX_AFTER_COLOR,
   COL_COUNT,
@@ -89,6 +91,7 @@ public:
     {
       case COL_TEX_BEFORE_COLOR:
       case COL_SHADER_OUT_COLOR:
+      case COL_SHADER_OUT_2_COLOR:
       case COL_TEX_AFTER_COLOR: return true;
       default: return false;
     }
@@ -188,6 +191,8 @@ public:
         case COL_TEX_BEFORE_COLOR: result = lit("Tex Before"); break;
         case COL_SHADER_OUT:
         case COL_SHADER_OUT_COLOR: result = lit("Shader Out"); break;
+        case COL_SHADER_OUT_2:
+        case COL_SHADER_OUT_2_COLOR: result = lit("Shader Out 2"); break;
         case COL_TEX_AFTER:
         case COL_TEX_AFTER_COLOR: result = lit("Tex After"); break;
       }
@@ -337,7 +342,7 @@ public:
         {
           // We can't provide meaningful shader out messages for events, only individual primitives.
           // So, use the Tex Before value for all of them.
-          if(col == COL_TEX_BEFORE || col == COL_SHADER_OUT)
+          if(col == COL_TEX_BEFORE || col == COL_SHADER_OUT || col == COL_SHADER_OUT_2)
           {
             return tr("Tex Before\n\n") + modString(getMods(index).first().preMod);
           }
@@ -352,7 +357,7 @@ public:
           {
             return tr("Tex Before\n\n") + modString(getMod(index).preMod);
           }
-          else if(col == COL_SHADER_OUT)
+          else if(col == COL_SHADER_OUT || col == COL_SHADER_OUT_2)
           {
             const PixelModification &mod = getMod(index);
             if(mod.unboundPS)
@@ -360,7 +365,10 @@ public:
             if(mod.directShaderWrite)
               return tr("Tex Before\n\n") + modString(mod.preMod);
 
-            return tr("Shader Out\n\n") + modString(mod.shaderOut, 4);
+            if(col == COL_SHADER_OUT)
+              return tr("Shader Out\n\n") + modString(mod.shaderOut, 4);
+            else
+              return tr("Shader Out 2\n\n") + modString(mod.shaderOutDualSrc, 4);
           }
           else if(col == COL_TEX_AFTER)
           {
@@ -373,7 +381,8 @@ public:
       {
         if(isEvent(index))
         {
-          if(col == COL_TEX_BEFORE_COLOR || col == COL_SHADER_OUT_COLOR)
+          if(col == COL_TEX_BEFORE_COLOR || col == COL_SHADER_OUT_COLOR ||
+             col == COL_SHADER_OUT_2_COLOR)
           {
             return backgroundBrush(getMods(index).first().preMod);
           }
@@ -388,13 +397,16 @@ public:
           {
             return backgroundBrush(getMod(index).preMod);
           }
-          else if(col == COL_SHADER_OUT_COLOR)
+          else if(col == COL_SHADER_OUT_COLOR || col == COL_SHADER_OUT_2_COLOR)
           {
             const PixelModification &mod = getMod(index);
             if(mod.directShaderWrite)
               return backgroundBrush(mod.preMod);
 
-            return backgroundBrush(mod.shaderOut);
+            if(col == COL_SHADER_OUT_COLOR)
+              return backgroundBrush(mod.shaderOut);
+            else
+              return backgroundBrush(mod.shaderOutDualSrc);
           }
           else if(col == COL_TEX_AFTER_COLOR)
           {
@@ -702,12 +714,16 @@ PixelHistoryView::PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint p
   ui->events->header()->setSectionResizeMode(COL_TEX_BEFORE_COLOR, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_SHADER_OUT, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_SHADER_OUT_COLOR, QHeaderView::ResizeToContents);
+  ui->events->header()->setSectionResizeMode(COL_SHADER_OUT_2, QHeaderView::ResizeToContents);
+  ui->events->header()->setSectionResizeMode(COL_SHADER_OUT_2_COLOR, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_TEX_AFTER, QHeaderView::ResizeToContents);
   ui->events->header()->setSectionResizeMode(COL_TEX_AFTER_COLOR, QHeaderView::ResizeToContents);
 
   // Hide these by default; only shader out and tex after are visible by default
   ui->events->header()->hideSection(COL_TEX_BEFORE);
   ui->events->header()->hideSection(COL_TEX_BEFORE_COLOR);
+  ui->events->header()->hideSection(COL_SHADER_OUT_2);
+  ui->events->header()->hideSection(COL_SHADER_OUT_2_COLOR);
 
   QObject::connect(ui->events, &RDTreeView::customContextMenuRequested, this,
                    &PixelHistoryView::events_contextMenu);

--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -848,8 +848,8 @@ void PixelHistoryView::on_events_customContextMenuRequested(const QPoint &pos)
     debugText = tr("&Debug Pixel (%1, %2) primitive %3 at Event %4")
                     .arg(m_Pixel.x())
                     .arg(m_Pixel.y())
-                    .arg(tag.eventId)
-                    .arg(tag.primitive);
+                    .arg(tag.primitive)
+                    .arg(tag.eventId);
 
     contextMenu.addAction(&jumpAction);
   }

--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -442,6 +442,10 @@ public:
         }
       }
 
+      const QColor GRAY_BACKGROUND = QColor::fromRgb(235, 235, 235);
+      const QColor GREEN_BACKGROUND = QColor::fromRgb(235, 255, 235);
+      const QColor RED_BACKGROUND = QColor::fromRgb(255, 235, 235);
+
       // text backgrounds marking pass/fail
       if(role == Qt::BackgroundRole && !isColorColumn(col))
       {
@@ -456,15 +460,14 @@ public:
 
           if(mods[0].directShaderWrite &&
              mods[0].preMod.col.uintValue == mods[0].postMod.col.uintValue)
-            return QBrush(QColor::fromRgb(235, 235, 235));
+            return QBrush(GRAY_BACKGROUND);
 
-          return passed ? QBrush(QColor::fromRgb(235, 255, 235))
-                        : QBrush(QColor::fromRgb(255, 235, 235));
+          return passed ? QBrush(GREEN_BACKGROUND) : QBrush(RED_BACKGROUND);
         }
         else
         {
           if(!getMod(index).Passed())
-            return QBrush(QColor::fromRgb(255, 235, 235));
+            return QBrush(RED_BACKGROUND);
         }
       }
 
@@ -472,8 +475,7 @@ public:
       // ensure contrast with all UI themes
       if(role == Qt::ForegroundRole && !isColorColumn(col))
       {
-        QColor textColor =
-            contrastingColor(QColor::fromRgb(235, 235, 235), m_Palette.color(QPalette::Text));
+        QColor textColor = contrastingColor(GRAY_BACKGROUND, m_Palette.color(QPalette::Text));
         if(isEvent(index))
         {
           return QBrush(textColor);

--- a/qrenderdoc/Windows/PixelHistoryView.h
+++ b/qrenderdoc/Windows/PixelHistoryView.h
@@ -55,8 +55,11 @@ public:
   void OnEventChanged(uint32_t eventId) override;
 private slots:
   // automatic slots
-  void on_events_customContextMenuRequested(const QPoint &pos);
   void on_events_doubleClicked(const QModelIndex &index);
+
+  // manual slots
+  void colSelect_clicked();
+  void events_contextMenu(const QPoint &pos);
 
 protected:
   void enterEvent(QEvent *event) override;

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -2100,8 +2100,9 @@ struct PixelModification
   {
     return eventId == o.eventId && directShaderWrite == o.directShaderWrite &&
            unboundPS == o.unboundPS && fragIndex == o.fragIndex && primitiveID == o.primitiveID &&
-           preMod == o.preMod && shaderOut == o.shaderOut && shaderOutDualSrc == o.shaderOutDualSrc &&
-           postMod == o.postMod && sampleMasked == o.sampleMasked &&
+           preMod == o.preMod && shaderOut == o.shaderOut &&
+           shaderOutDualSrc == o.shaderOutDualSrc && blendSrc == o.blendSrc &&
+           blendDst == o.blendDst && postMod == o.postMod && sampleMasked == o.sampleMasked &&
            backfaceCulled == o.backfaceCulled && depthClipped == o.depthClipped &&
            depthBoundsFailed == o.depthBoundsFailed && viewClipped == o.viewClipped &&
            scissorClipped == o.scissorClipped && shaderDiscarded == o.shaderDiscarded &&
@@ -2125,6 +2126,10 @@ struct PixelModification
       return shaderOut < o.shaderOut;
     if(!(shaderOutDualSrc == o.shaderOutDualSrc))
       return shaderOutDualSrc < o.shaderOutDualSrc;
+    if(!(blendSrc == o.blendSrc))
+      return blendSrc < o.blendSrc;
+    if(!(blendDst == o.blendDst))
+      return blendDst < o.blendDst;
     if(!(postMod == o.postMod))
       return postMod < o.postMod;
     if(!(sampleMasked == o.sampleMasked))
@@ -2182,6 +2187,16 @@ pixel.
 :type: ModificationValue
 )");
   ModificationValue shaderOutDualSrc;
+  DOCUMENT(R"(The source component in the blend equation for this fragment.
+
+:type: ModificationValue
+)");
+  ModificationValue blendSrc;
+  DOCUMENT(R"(The destination component in the blend equation for this fragment.
+
+:type: ModificationValue
+)");
+  ModificationValue blendDst;
   DOCUMENT(R"(The value of the texture after this fragment ran.
 
 :type: ModificationValue

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -2100,12 +2100,12 @@ struct PixelModification
   {
     return eventId == o.eventId && directShaderWrite == o.directShaderWrite &&
            unboundPS == o.unboundPS && fragIndex == o.fragIndex && primitiveID == o.primitiveID &&
-           preMod == o.preMod && shaderOut == o.shaderOut && postMod == o.postMod &&
-           sampleMasked == o.sampleMasked && backfaceCulled == o.backfaceCulled &&
-           depthClipped == o.depthClipped && depthBoundsFailed == o.depthBoundsFailed &&
-           viewClipped == o.viewClipped && scissorClipped == o.scissorClipped &&
-           shaderDiscarded == o.shaderDiscarded && depthTestFailed == o.depthTestFailed &&
-           stencilTestFailed == o.stencilTestFailed;
+           preMod == o.preMod && shaderOut == o.shaderOut && shaderOutDualSrc == o.shaderOutDualSrc &&
+           postMod == o.postMod && sampleMasked == o.sampleMasked &&
+           backfaceCulled == o.backfaceCulled && depthClipped == o.depthClipped &&
+           depthBoundsFailed == o.depthBoundsFailed && viewClipped == o.viewClipped &&
+           scissorClipped == o.scissorClipped && shaderDiscarded == o.shaderDiscarded &&
+           depthTestFailed == o.depthTestFailed && stencilTestFailed == o.stencilTestFailed;
   }
   bool operator<(const PixelModification &o) const
   {
@@ -2123,6 +2123,8 @@ struct PixelModification
       return preMod < o.preMod;
     if(!(shaderOut == o.shaderOut))
       return shaderOut < o.shaderOut;
+    if(!(shaderOutDualSrc == o.shaderOutDualSrc))
+      return shaderOutDualSrc < o.shaderOutDualSrc;
     if(!(postMod == o.postMod))
       return postMod < o.postMod;
     if(!(sampleMasked == o.sampleMasked))
@@ -2175,6 +2177,11 @@ pixel.
 :type: ModificationValue
 )");
   ModificationValue shaderOut;
+  DOCUMENT(R"(The value that this fragment wrote from the pixel shader to the second output.
+
+:type: ModificationValue
+)");
+  ModificationValue shaderOutDualSrc;
   DOCUMENT(R"(The value of the texture after this fragment ran.
 
 :type: ModificationValue

--- a/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
+++ b/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
@@ -1941,6 +1941,8 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
       // fragments writing to the pixel in this event with original shader
       mod.shaderOut.col.intValue[1] = int32_t(data[3].y);
       mod.shaderOutDualSrc.SetInvalid();
+      mod.blendSrc.SetInvalid();
+      mod.blendDst.SetInvalid();
     }
   }
 
@@ -2318,6 +2320,8 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
 
         memcpy(&history[h].shaderOut.col.uintValue[0], data, 4 * sizeof(float));
         history[h].shaderOutDualSrc.SetInvalid();
+        history[h].blendSrc.SetInvalid();
+        history[h].blendDst.SetInvalid();
 
         // primitive ID is in the next slot after that
         memcpy(&history[h].primitiveID, data + sizeof(Vec4f), sizeof(uint32_t));

--- a/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
+++ b/renderdoc/driver/d3d11/d3d11_pixelhistory.cpp
@@ -1940,6 +1940,7 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
       // data[3].x (depth) unused
       // fragments writing to the pixel in this event with original shader
       mod.shaderOut.col.intValue[1] = int32_t(data[3].y);
+      mod.shaderOutDualSrc.SetInvalid();
     }
   }
 
@@ -2316,6 +2317,7 @@ rdcarray<PixelModification> D3D11Replay::PixelHistory(rdcarray<EventUsage> event
         byte *data = shadoutStoreData + sizeof(Vec4f) * pixstoreStride * offsettedSlot;
 
         memcpy(&history[h].shaderOut.col.uintValue[0], data, 4 * sizeof(float));
+        history[h].shaderOutDualSrc.SetInvalid();
 
         // primitive ID is in the next slot after that
         memcpy(&history[h].primitiveID, data + sizeof(Vec4f), sizeof(uint32_t));

--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -1304,6 +1304,8 @@ std::map<uint32_t, uint32_t> QueryNumFragmentsByEvent(
       history[i].shaderOut.stencil = history[i].postMod.stencil;
     }
     history[i].shaderOutDualSrc.SetInvalid();
+    history[i].blendSrc.SetInvalid();
+    history[i].blendDst.SetInvalid();
 
     eventFragments.emplace(modEvents[i].eventId, numFragments);
 
@@ -1589,6 +1591,8 @@ void QueryShaderOutPerFragment(WrappedOpenGL *driver, GLReplay *replay,
         historyIndex->shaderOut.stencil = oldStencil;
       }
       historyIndex->shaderOutDualSrc.SetInvalid();
+      historyIndex->blendSrc.SetInvalid();
+      historyIndex->blendDst.SetInvalid();
       historyIndex++;
     }
 

--- a/renderdoc/driver/gl/gl_pixelhistory.cpp
+++ b/renderdoc/driver/gl/gl_pixelhistory.cpp
@@ -1303,6 +1303,7 @@ std::map<uint32_t, uint32_t> QueryNumFragmentsByEvent(
       numFragments = history[i].shaderOut.stencil;
       history[i].shaderOut.stencil = history[i].postMod.stencil;
     }
+    history[i].shaderOutDualSrc.SetInvalid();
 
     eventFragments.emplace(modEvents[i].eventId, numFragments);
 
@@ -1587,6 +1588,7 @@ void QueryShaderOutPerFragment(WrappedOpenGL *driver, GLReplay *replay,
                         int(historyIndex - history.begin()));
         historyIndex->shaderOut.stencil = oldStencil;
       }
+      historyIndex->shaderOutDualSrc.SetInvalid();
       historyIndex++;
     }
 

--- a/renderdoc/driver/vulkan/vk_pixelhistory.cpp
+++ b/renderdoc/driver/vulkan/vk_pixelhistory.cpp
@@ -3973,6 +3973,8 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
       mod.postMod.SetInvalid();
       mod.shaderOut.SetInvalid();
       mod.shaderOutDualSrc.SetInvalid();
+      mod.blendSrc.SetInvalid();
+      mod.blendDst.SetInvalid();
       h++;
       continue;
     }
@@ -4001,6 +4003,8 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
     mod.shaderOut.col.intValue[0] = frags;
     mod.shaderOut.col.intValue[1] = fragsClipped;
     mod.shaderOutDualSrc.SetInvalid();
+    mod.blendSrc.SetInvalid();
+    mod.blendDst.SetInvalid();
     bool someFragsClipped = (fragsClipped < frags);
     mod.primitiveID = someFragsClipped;
     // Draws in secondary command buffers will fail this check,
@@ -4149,6 +4153,9 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
         }
 
         history[h].shaderOutDualSrc.SetInvalid();
+
+        history[h].blendSrc.SetInvalid();
+        history[h].blendDst.SetInvalid();
       }
 
       // check the depth value between premod/shaderout against the known test if we have valid

--- a/renderdoc/driver/vulkan/vk_pixelhistory.cpp
+++ b/renderdoc/driver/vulkan/vk_pixelhistory.cpp
@@ -3972,6 +3972,7 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
       mod.preMod.SetInvalid();
       mod.postMod.SetInvalid();
       mod.shaderOut.SetInvalid();
+      mod.shaderOutDualSrc.SetInvalid();
       h++;
       continue;
     }
@@ -3999,6 +4000,7 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
     int32_t fragsClipped = int32_t(ei.dsWithShaderDiscard[4]);
     mod.shaderOut.col.intValue[0] = frags;
     mod.shaderOut.col.intValue[1] = fragsClipped;
+    mod.shaderOutDualSrc.SetInvalid();
     bool someFragsClipped = (fragsClipped < frags);
     mod.primitiveID = someFragsClipped;
     // Draws in secondary command buffers will fail this check,
@@ -4145,6 +4147,8 @@ rdcarray<PixelModification> VulkanReplay::PixelHistory(rdcarray<EventUsage> even
         {
           history[h].preMod = history[h - 1].postMod;
         }
+
+        history[h].shaderOutDualSrc.SetInvalid();
       }
 
       // check the depth value between premod/shaderout against the known test if we have valid

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -894,6 +894,8 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
   SERIALISE_MEMBER(preMod);
   SERIALISE_MEMBER(shaderOut);
   SERIALISE_MEMBER(shaderOutDualSrc);
+  SERIALISE_MEMBER(blendSrc);
+  SERIALISE_MEMBER(blendDst);
   SERIALISE_MEMBER(postMod);
 
   SERIALISE_MEMBER(sampleMasked);
@@ -907,7 +909,7 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
   SERIALISE_MEMBER(stencilTestFailed);
   SERIALISE_MEMBER(predicationSkipped);
 
-  SIZE_CHECK(124);
+  SIZE_CHECK(172);
 }
 
 template <typename SerialiserType>

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -893,6 +893,7 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
 
   SERIALISE_MEMBER(preMod);
   SERIALISE_MEMBER(shaderOut);
+  SERIALISE_MEMBER(shaderOutDualSrc);
   SERIALISE_MEMBER(postMod);
 
   SERIALISE_MEMBER(sampleMasked);
@@ -906,7 +907,7 @@ void DoSerialise(SerialiserType &ser, PixelModification &el)
   SERIALISE_MEMBER(stencilTestFailed);
   SERIALISE_MEMBER(predicationSkipped);
 
-  SIZE_CHECK(100);
+  SIZE_CHECK(124);
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
Split from #3003; depends on (and includes a copy of) #3009.

This PR modifies the pixel history UI to add additional columns for dual source blend and the blend source/destination components. Currently, those are not implemented for any API. It also adds a column for the previous color, for which data was already obtained but not visible in the UI. All of these columns are hidden by default.

It also fixes a few minor UI issues: there was a mistake in the right-click message on pixel history where the message was "`Debug Pixel (<x>, <y>) primitive <event> at Event <primitive>`", and the color columns in the pixel history view were always shown in the same color if the column was selected (now, the actual color is blended with the selection color to make things a bit clearer).
<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
