### PR TITLE
Blend pixel history widget background color with selection color

### DIFF
--- a/qrenderdoc/Styles/RDStyle/RDStyle.cpp
+++ b/qrenderdoc/Styles/RDStyle/RDStyle.cpp
@@ -1551,9 +1551,25 @@ void RDStyle::drawPrimitive(PrimitiveElement element, const QStyleOption *opt, Q
       group = QPalette::Inactive;
 
     if(viewitem->state & QStyle::State_Selected)
-      p->fillRect(viewitem->rect, viewitem->palette.brush(group, QPalette::Highlight));
-    else if(viewitem->backgroundBrush.style() != Qt::NoBrush)
-      p->fillRect(viewitem->rect, viewitem->backgroundBrush);
+    {
+      if(viewitem->backgroundBrush.style() != Qt::NoBrush)
+      {
+        p->fillRect(viewitem->rect, viewitem->backgroundBrush);
+        // If we have a custom color, use the selection color at half opacity over the custom color
+        QColor col = viewitem->palette.color(group, QPalette::Highlight);
+        col.setAlphaF(0.5f);
+        p->fillRect(viewitem->rect, QBrush(col));
+      }
+      else
+      {
+        p->fillRect(viewitem->rect, viewitem->palette.brush(group, QPalette::Highlight));
+      }
+    }
+    else
+    {
+      if(viewitem->backgroundBrush.style() != Qt::NoBrush)
+        p->fillRect(viewitem->rect, viewitem->backgroundBrush);
+    }
 
     return;
   }

--- a/qrenderdoc/Widgets/Extended/RDTreeView.cpp
+++ b/qrenderdoc/Widgets/Extended/RDTreeView.cpp
@@ -771,17 +771,10 @@ void RDTreeView::drawBranches(QPainter *painter, const QRect &rect, const QModel
     idx = idx.parent();
   }
 
-  opt.rect = rect;
-  opt.rect.setWidth(depth * indentation());
+  opt.rect = allLinesRect;
   opt.showDecorationSelected = true;
+  opt.backgroundBrush = index.data(Qt::BackgroundRole).value<QBrush>();
   style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, this);
-
-  QBrush back = index.data(Qt::BackgroundRole).value<QBrush>();
-
-  if(!selectionModel()->isSelected(index) && back.style() != Qt::NoBrush)
-  {
-    painter->fillRect(allLinesRect, back);
-  }
 
   if(m_VisibleBranches)
   {
@@ -821,12 +814,12 @@ void RDTreeView::drawBranches(QPainter *painter, const QRect &rect, const QModel
   {
     parent = parents.pop();
 
-    back = parent.data(RDTreeView::TreeLineColorRole).value<QBrush>();
+    QBrush line = parent.data(RDTreeView::TreeLineColorRole).value<QBrush>();
 
-    if(back.style() != Qt::NoBrush)
+    if(line.style() != Qt::NoBrush)
     {
       // draw a centred pen vertically down the middle of branchRect
-      painter->setPen(QPen(QBrush(back), m_treeColorLineWidth));
+      painter->setPen(QPen(line, m_treeColorLineWidth));
 
       QPoint topCentre = QRect(branchRect).center();
       QPoint bottomCentre = topCentre;


### PR DESCRIPTION
Before, if a row was selected, the color was completely replaced, which makes the color preview column completely useless for that row.

This change also fixes some inconsistencies with how the selection hover works on tree widgets; previously part of the row was not highlighted.

Before:

![image](https://github.com/baldurk/renderdoc/assets/127789813/981d19e3-bd9b-41a3-bb12-535141cbdce4)
![image](https://github.com/baldurk/renderdoc/assets/127789813/ee88ec4c-7ac6-4e21-9ed8-956c491a007c)

After:

![image](https://github.com/baldurk/renderdoc/assets/127789813/cb3f0ab8-f6a6-4495-b40e-39cbbf5964cb)
![image](https://github.com/baldurk/renderdoc/assets/127789813/14bf9c92-7252-42cf-91ea-d1e6d7850924)


(Split off from #3003.)

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
