### PR TITLE
Fix debug pixel at primitive and event message mixing parameter order up

### DIFF
--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -848,8 +848,8 @@ void PixelHistoryView::on_events_customContextMenuRequested(const QPoint &pos)
     debugText = tr("&Debug Pixel (%1, %2) primitive %3 at Event %4")
                     .arg(m_Pixel.x())
                     .arg(m_Pixel.y())
-                    .arg(tag.eventId)
-                    .arg(tag.primitive);
+                    .arg(tag.primitive)
+                    .arg(tag.eventId);
 
     contextMenu.addAction(&jumpAction);
   }


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
The message when right-clicking on a specific primitive in pixel history had the primitive ID and EID reversed.

Before:
![image](https://github.com/baldurk/renderdoc/assets/127789813/1dfd7d14-a277-4bc0-a05a-ffa864163867)

After:
![image](https://github.com/baldurk/renderdoc/assets/127789813/2af26c16-966c-4cde-82aa-b82ccc5d6626)

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
(Split off from https://github.com/baldurk/renderdoc/pull/3003.)