### PR TITLE
Fix bug in y-flipping code in ResamplePixels()

### DIFF
--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -1320,7 +1320,7 @@ void RenderDoc::ResamplePixels(const FramePixels &in, RDCThumb &out)
 
   if(!in.is_y_flipped)
   {
-    for(uint16_t y = 0; y <= out.height / 2; y++)
+    for(uint16_t y = 0; y < out.height / 2; y++)
     {
       uint16_t flipY = (out.height - 1 - y);
       for(uint16_t x = 0; x < out.width; x++)


### PR DESCRIPTION
## Description

Issue #3025

In GL captures causes the generated thumbnail image to be incorrect for the middle two rows of the image.

Added basic unit tests to `ResamplePixels()`

Tests:
y-flipping: true/false
BGRA: true/false
Downsample from 4x4 to 2x2

Before
![image](https://github.com/baldurk/renderdoc/assets/39392/573df233-e5bf-4588-a921-9e9259c2c742)

After
![image](https://github.com/baldurk/renderdoc/assets/39392/520d2de7-0c61-4638-92e6-82542db8deee)


