### PR TITLE
Allow XDG base directory to be used to store application data on Linux

### DIFF
--- a/docs/getting_started/faq.rst
+++ b/docs/getting_started/faq.rst
@@ -261,3 +261,32 @@ What is an Action?
 RenderDoc uses 'action' as an umbrella term to cover events like draws, dispatches, copies, clears, resolves, and other calls that cause the GPU to do work or can affect memory and resources like textures and buffers. This is sometimes referred to as a drawcall, but the term action is used to be less ambiguous compared to actual rasterization drawing.
 
 This means that when browsing in the event browser by default only actions will be shown, meaning you can only see the list of actions and user-defined markers.
+
+How do I configure renderdoc to use XDG base directories?
+---------------------------------------------------------
+
+By default, renderdoc uses the ``~/.renderdoc`` directory to store its configuration files and data.
+
+If you want renderdoc to use the XDG config directory instead, you have to do the following
+
+Make sure that the directory ``~/.renderdoc`` does not exist. renderdoc will always use ``~/.renderdoc`` if it finds this path.
+
+Make sure that the ``XDG_CONFIG_HOME`` environment variable, which is typically ``~/.config``, points to your XDG config base directory. 
+
+.. highlight:: bash
+.. code:: bash
+
+    export XDG_CONFIG_HOME="$HOME/.config"
+
+Create or move ``~/.renderdoc`` to ``$XDG_CONFIG_HOME/renderdoc``
+
+For example
+
+.. highlight:: bash
+.. code:: bash
+
+    mkdir -p $XDG_CONFIG_HOME/renderdoc
+    # or
+    mv ~/.renderdoc $XDG_CONFIG_HOME/renderdoc
+
+Without ``~/.renderdoc`` and with XDG_CONFIG_HOME set to a config base directory containing a renderdoc subdirectory, renderdoc will now use ``$XDG_CONFIG_HOME/renderdoc`` instead of ``~/.renderdoc``.


### PR DESCRIPTION
## Description
If `~/.renderdoc` does not exist, `~/.config/renderdoc` will be used as the application directory. If `~/.renderdoc` exists and is a directory, then it will be used instead.

This means that a new user will probably have `~/.config/renderdoc` as their application directory by default. There is currently no automated migration from ~/.renderdoc to `~/.config/renderdoc`. If users wish to migrate to the new path, they shall do so manually.

## Motivations
This change is to partially support the XDG Base Directory Spec to reduce the amount of top level hidden files in the HOME directory.

`~/.config` is a well-known and widely used analogue of `/etc` for user-specific configuration on major Linux distributions, and sometimes, albeit mistakenly, used on Mac OS. This path likely to remain unchanged for the next few decades, as it has for the last two. Many existing, widely deployed, projects use `~/.config` by default. For example, `gtk`, `mesa`, `qtcreator`, `chromium` project, `visual studio code`, `pip`, `pipx`, `clangd`, `CUPS`, etc. Therefore, it might be logically reasonable and common for the users to assume that renderdoc will also use this path.

The implementation is simple and minimal, the new preferred application path is hard-coded and does NOT depend on any new environment variables.

Albeit the spec states that `$XDG_CONFIG_HOME` should be used instead of hard-coding, this practice shall be strongly discouraged as it introduces additional complexity, maintenance cost, and potential for bugs by inviting variability in system configuration, especially on Linux where systems vary wildly in unpredictable ways. Thus, with these factors in mind, **Under NO circumstances I will consider with any request to use environment variables to support the XDG Base Directory Specification in this PR**

For simplicity, the cache, config or any logs would not be correspondingly moved to ~/.cache or ~/.local/state. 
