### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ Release32/
 Release64/
 build/
 build-*/
+/compile_commands.json
+.cache/
 /dist/
 /package/
 util/buildscripts/support
@@ -25,6 +27,7 @@ obj/
 *.opensdf
 *.VC.*db
 .vs/
+.vscode/
 *.pdb
 *.sln.ide/
 *.so


### PR DESCRIPTION
## Description

- `.cache/`: symbols cache, generated by clangd
- `compile_commands.json`: usually generated by vscode or build system
- `.vsocde`: generated by vscode

`compile_commands.json` and `.vscode` are usually specific to a person's
environment, not configurable in any way, so there is no reason to put
them in the git repository. 
