### PR TITLE
Use replay ID to look up GL layered depth buffer texture

### DIFF
--- a/qrenderdoc/Windows/PipelineState/D3D11PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D11PipelineStateViewer.cpp
@@ -681,7 +681,7 @@ void D3D11PipelineStateViewer::setViewDetails(RDTreeWidgetItem *node, const D3D1
      (res.numElements * res.elementByteSize) < buf->length)
   {
     text += tr("The view covers bytes %1-%2 (%3 elements).\nThe buffer is %4 bytes in length (%5 "
-               "elements).")
+               "elements).\n")
                 .arg(res.firstElement * res.elementByteSize)
                 .arg((res.firstElement + res.numElements) * res.elementByteSize)
                 .arg(res.numElements)

--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
@@ -705,7 +705,7 @@ void D3D12PipelineStateViewer::setViewDetails(RDTreeWidgetItem *node, const D3D1
   if(res.firstElement > 0 || (res.numElements * res.elementByteSize) < buf->length)
   {
     text += tr("The view covers bytes %1-%2 (%3 elements).\nThe buffer is %4 bytes in length (%5 "
-               "elements).")
+               "elements).\n")
                 .arg(res.firstElement * res.elementByteSize)
                 .arg((res.firstElement + res.numElements) * res.elementByteSize)
                 .arg(res.numElements)

--- a/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/GLPipelineStateViewer.cpp
@@ -553,9 +553,9 @@ void GLPipelineStateViewer::setViewDetails(RDTreeWidgetItem *node, TextureDescri
     if((tex->mips > 1 && firstMip > 0) || numMips < tex->mips)
     {
       if(numMips == 1)
-        text += tr("The texture has %1 mips, the view covers mip %2.").arg(tex->mips).arg(firstMip);
+        text += tr("The texture has %1 mips, the view covers mip %2.\n").arg(tex->mips).arg(firstMip);
       else
-        text += tr("The texture has %1 mips, the view covers mips %2-%3.")
+        text += tr("The texture has %1 mips, the view covers mips %2-%3.\n")
                     .arg(tex->mips)
                     .arg(firstMip)
                     .arg(firstMip + numMips - 1);
@@ -564,10 +564,11 @@ void GLPipelineStateViewer::setViewDetails(RDTreeWidgetItem *node, TextureDescri
     if((tex->arraysize > 1 && firstSlice > 0) || numSlices < tex->arraysize)
     {
       if(numSlices == 1)
-        text +=
-            tr("The texture has %1 slices, the view covers slice %2.").arg(tex->arraysize).arg(firstSlice);
+        text += tr("The texture has %1 slices, the view covers slice %2.\n")
+                    .arg(tex->arraysize)
+                    .arg(firstSlice);
       else
-        text += tr("The texture has %1 slices, the view covers slices %2-%3.")
+        text += tr("The texture has %1 slices, the view covers slices %2-%3.\n")
                     .arg(tex->arraysize)
                     .arg(firstSlice)
                     .arg(firstSlice + numSlices - 1);

--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -775,7 +775,7 @@ bool VulkanPipelineStateViewer::setViewDetails(RDTreeWidgetItem *node, const bin
 
   if(view.byteOffset > 0 || view.byteSize < buf->length)
   {
-    text += tr("The view covers bytes %1-%2.\nThe buffer is %3 bytes in length.")
+    text += tr("The view covers bytes %1-%2.\nThe buffer is %3 bytes in length.\n")
                 .arg(view.byteOffset)
                 .arg(view.byteOffset + view.byteSize)
                 .arg(buf->length);

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -1883,8 +1883,9 @@ void GLReplay::SavePipelineState(uint32_t eventId)
       pipe.framebuffer.drawFBO.colorAttachments[i].swizzle.alpha = MakeSwizzle(swizzles[3]);
     }
 
-    pipe.framebuffer.drawFBO.depthAttachment.resourceId = rm->GetOriginalID(
-        rm->GetResID(rbDepth ? RenderbufferRes(ctx, curDepth) : TextureRes(ctx, curDepth)));
+    ResourceId id =
+        rm->GetResID(rbDepth ? RenderbufferRes(ctx, curDepth) : TextureRes(ctx, curDepth));
+    pipe.framebuffer.drawFBO.depthAttachment.resourceId = rm->GetOriginalID(id);
     pipe.framebuffer.drawFBO.stencilAttachment.resourceId = rm->GetOriginalID(
         rm->GetResID(rbStencil ? RenderbufferRes(ctx, curStencil) : TextureRes(ctx, curStencil)));
 
@@ -1901,7 +1902,6 @@ void GLReplay::SavePipelineState(uint32_t eventId)
     pipe.framebuffer.drawFBO.depthAttachment.numSlices = 1;
     pipe.framebuffer.drawFBO.stencilAttachment.numSlices = 1;
 
-    ResourceId id = pipe.framebuffer.drawFBO.depthAttachment.resourceId;
     if(!rbDepth && id != ResourceId())
     {
       // desktop GL allows layered attachments which attach all slices from 0 to N


### PR DESCRIPTION
## Description

Whilst replaying capture from https://github.com/baldurk/renderdoc/issues/2858 noticed the tooltip for the depth buffer on EID 245 looked like this (this includes the code fix to add the missing newline between mips & slices information).

![image](https://github.com/baldurk/renderdoc/assets/39392/6a1f6b03-9c68-46b6-a63f-638a0b294291)

This was because `numSlices = 0` for the depth buffer. Back tracking to find why `numSlices = 0` led to the code was using the original ID to look for the texture in `m_pDriver->m_Textures` which would create a default entry if the ID was not found leading to `numSlices = 0` and then the pipeline state resource tooltip would show `covers slices 0-4294967294`

After the fix the tool tip looks like this

![image](https://github.com/baldurk/renderdoc/assets/39392/04bbe3fc-2a60-43b9-a11e-36c4e2538ea2)

