### PR TITLE
Improve hlsl shader source stepping for an source file which is unnamed

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_spdb.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_spdb.cpp
@@ -167,7 +167,7 @@ SPDBChunk::SPDBChunk(byte *data, uint32_t spdblength)
       SPDBLOG("Found file '%s' from stream %u", filename, it->second);
 
       if(filename[0] == 0)
-        filename = "shader";
+        filename = "unnamed_shader";
 
       Files.push_back({filename, rdcstr((const char *)fileContents.Data(), s.byteLength)});
     }
@@ -1397,7 +1397,7 @@ SPDBChunk::SPDBChunk(byte *data, uint32_t spdblength)
           {
             name = Names[checksum->nameIndex];
             if(name.empty())
-              name = Names[checksum->nameIndex] = "shader";
+              name = Names[checksum->nameIndex] = "unnamed_shader";
           }
           else
           {

--- a/renderdoc/driver/shaders/dxbc/dxbc_spdb.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_spdb.cpp
@@ -1467,9 +1467,25 @@ SPDBChunk::SPDBChunk(byte *data, uint32_t spdblength)
             // source according to #line
             if(!name.empty())
             {
-              Files.push_back({name, ""});
+              int32_t fileIdx = -1;
+              if(name == "unnamed_shader")
+              {
+                for(int32_t i = 0; i < Files.count(); i++)
+                {
+                  if(!_stricmp(Files[i].filename.c_str(), name.c_str()))
+                  {
+                    fileIdx = i;
+                    break;
+                  }
+                }
+              }
+              if(fileIdx == -1)
+              {
+                Files.push_back({name, ""});
+                fileIdx = (int32_t)Files.size() - 1;
+              }
 
-              FileMapping[chunkOffs] = (int32_t)Files.size() - 1;
+              FileMapping[chunkOffs] = fileIdx;
             }
             else
             {

--- a/renderdoc/replay/replay_driver.cpp
+++ b/renderdoc/replay/replay_driver.cpp
@@ -699,7 +699,7 @@ void PreprocessLineDirectives(rdcarray<ShaderSourceFile> &sourceFiles)
 
           rdcstr fname = filename;
           if(fname.empty())
-            fname = "shader";
+            fname = "unnamed_shader";
 
           // find the new destination file
           bool found = false;


### PR DESCRIPTION
## Description

Rename the empty shader source file name from `shader` to `unnamed_shader`

Search the Files container and reuse the entry for empty shader source file `unnamed_shader`
This is similar to how a physical file would work.

This fixes shader source file stepping when the source shader uses constructs like

`#line XY ""`