### PR TITLE
Fix not being able to force replay to llvm_pipe when opening a capture

### DIFF
--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -137,8 +137,9 @@ rdcarray<GPUDevice> VulkanReplay::GetAvailableGPUs()
     VkPhysicalDeviceDriverProperties driverProps = {};
     GetPhysicalDeviceDriverProperties(ObjDisp(instance), devices[p], driverProps);
 
+    VkDriverInfo driverInfo(props, driverProps);
     GPUDevice dev;
-    dev.vendor = GPUVendorFromPCIVendor(props.vendorID);
+    dev.vendor = driverInfo.Vendor();
     dev.deviceID = props.deviceID;
     dev.name = props.deviceName;
     dev.apis = {GraphicsAPI::Vulkan};


### PR DESCRIPTION
## Description

Use VkDriverInfo to get the vendor ID instead of GPUVendorFromPCIVendor() which returns Unknown for the llvm_pipe driver.

This then prevents being able to force replay to run on llvm_pipe when opening a capture.

Before
![image](https://github.com/baldurk/renderdoc/assets/39392/781d86f6-e1e4-4d02-aa37-fad1b89ee18f)

After
![image](https://github.com/baldurk/renderdoc/assets/39392/6cfc62df-3c4b-49e4-b20e-d30ca3bfdb71)
