### PR TITLE
Zero initialize read_dds_data before loading DDS file

### DIFF
--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -493,7 +493,7 @@ RDResult IMG_CreateReplayDevice(RDCFile *rdc, IReplayDriver **driver)
   {
     FileIO::fseek64(f, 0, SEEK_SET);
     StreamReader reader(f);
-    read_dds_data read_data;
+    read_dds_data read_data = {};
     RDResult res = load_dds_from_file(&reader, read_data);
     f = NULL;
 

--- a/renderdoc/os/win32/win32_shellext.cpp
+++ b/renderdoc/os/win32/win32_shellext.cpp
@@ -138,6 +138,7 @@ struct RDCThumbnailProvider : public IThumbnailProvider, IInitializeWithStream
       }
 
       StreamReader reader(captureHeader.data(), (ULONG)size);
+      m_ddsData = {};
       RDResult res = load_dds_from_file(&reader, m_ddsData);
 
       if(res != ResultCode::Succeeded)


### PR DESCRIPTION
## Description

Discovered when loading multiple DDS files sometimes the DDS files would trigger a stream read error because the loading code thought the DDS file was a cubemap (but cubemap had never set to true or false).