### PR TITLE
Improve D3D11 pixel history handling of discarded fragments Closes #3040

### DIFF
--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -1221,7 +1221,7 @@ RDResult load_dds_from_file(StreamReader *reader, read_dds_data &ret)
      uint64_t(ret.depth) > fileSize || uint64_t(ret.slices) > fileSize ||
      uint64_t(ret.mips) > fileSize || uint64_t(ret.slices) * ret.mips > fileSize ||
      (uint64_t(ret.width) * uint64_t(ret.height) * uint64_t(ret.depth) *
-      RDCMAX(uint64_t(ret.slices), uint64_t(ret.depth))) /
+      RDCMAX(uint64_t(ret.slices), uint64_t(ret.mips))) /
              16 >
          fileSize)
   {

--- a/renderdoc/replay/replay_controller.cpp
+++ b/renderdoc/replay/replay_controller.cpp
@@ -908,7 +908,7 @@ ResultDetails ReplayController::SaveTexture(const TextureSave &saveData, const r
       {
         byte *depthslice = new byte[mipSlicePitch];
         byte *b = data.data() + mipSlicePitch * sliceOffset;
-        memcpy(depthslice, b, slicePitch);
+        memcpy(depthslice, b, mipSlicePitch);
         subdata.push_back(depthslice);
 
         continue;


### PR DESCRIPTION
## Description

### Improve D3D11 pixel history handling of discarded fragments
- Include the discarded offset when indexing to get the post mod data per fragment
- Do not include the discarded offset when indexing to get the primitive ID per fragment (primitive ID uses a replacement shader which is not affected by discards in the original shader)
- Store the post mod depth data in slot 1 of the depth output to make the indexing simpler to keep track of discarded fragments
- Set the post mod data for discarded fragments (excluding the final fragment) to be the known texture after (which starts as the pre mod data and is updated for non-discarded fragments).

### Small Fixes
- Fix error which stopped DDS file being loaded with depth 128 and mipcount of 6
- Fix memory overwrite when saving a single slice of texture