### PR TITLE
Fix handling of Op::LogicalNot for specialisation constants

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_processor.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_processor.cpp
@@ -1506,7 +1506,7 @@ ShaderVariable Processor::EvaluateConstant(Id constID, const rdcarray<SpecConsta
       {
         case Op::SNegate: a.s64v[0] = -a.s64v[0]; break;
         case Op::Not: a.u64v[0] = ~a.u64v[0]; break;
-        case Op::LogicalNot: a.u64v[0] = a.u64v[0] ? 1 : 0; break;
+        case Op::LogicalNot: a.u64v[0] = a.u64v[0] ? 0 : 1; break;
         case Op::IAdd:
           if(signedness)
             a.s64v[0] += b.s64v[0];

--- a/renderdoc/renderdoc_version.vcxproj
+++ b/renderdoc/renderdoc_version.vcxproj
@@ -132,12 +132,24 @@ namespace GitIntrospection {
       return !Log.HasLoggedErrors;
     }
     private void GetCommit() {
-      string HEADpath = Repository + ".git\\HEAD";
+      string dotGITpath = Repository + ".git";
+      string refGITpath = dotGITpath;
+      if(File.Exists(dotGITpath)) {
+        string gitData = File.ReadAllText(dotGITpath).Trim();
+        if(gitData.StartsWith("gitdir: ")) {
+          dotGITpath = Repository + gitData.Substring(8).Replace('/', '\\');
+          int index = dotGITpath.IndexOf(".git");
+          if (index >= 0) {
+            refGITpath = dotGITpath.Substring(0, index+4);
+          }
+        }
+      }
+      string HEADpath = dotGITpath + "\\HEAD";
       if(File.Exists(HEADpath)) {
         string HEADref = File.ReadAllText(HEADpath).Trim();
 
         if(HEADref.StartsWith("ref: ")) {
-          string refpath = Repository + ".git\\" + HEADref.Substring(5).Replace('/', '\\');
+          string refpath = refGITpath + "\\" + HEADref.Substring(5).Replace('/', '\\');
           if(File.Exists(refpath))
             Sha1 = File.ReadAllText(refpath).Trim();
         } else {


### PR DESCRIPTION
## Description

Using reproduction capture from issue #3046 identified the bug in processing of `Op::LogicalNot` instruction for specialisation constants.


