### PR TITLE
Fix brew install qt5 Mac CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,7 @@ jobs:
     - name: Install Homebrew dependencies
       run: |
         brew update || true
+        brew upgrade aom
         brew unlink python
         brew link --overwrite --force python
         brew unlink python@3.10


### PR DESCRIPTION
## Description

Update `aom` manually using brew to stop update failing when installing qt5 and its dependencies on CI.