### PR TITLE
Support to read GL uniform struct array of size 1

### DIFF
--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -2176,6 +2176,16 @@ void GLReplay::OpenGLFillCBufferVariables(ResourceId shader, GLuint prog, bool b
 
       GLuint idx = GL.glGetProgramResourceIndex(prog, eGL_UNIFORM, fullname.c_str());
 
+      // if this is an array of size 1 try looking for <array_variable_name>[0].<member_name>
+      if((idx == GL_INVALID_INDEX) && (desc.elements == 1))
+      {
+        rdcstr arrayZeroName = prefix;
+        if(!arrayZeroName.empty() && arrayZeroName.back() == '.')
+          arrayZeroName.pop_back();
+        arrayZeroName += "[0]." + var.name;
+
+        idx = GL.glGetProgramResourceIndex(prog, eGL_UNIFORM, arrayZeroName.c_str());
+      }
       if(idx == GL_INVALID_INDEX)
       {
         // this might not be an error, this might be the corresponding member in an array-of-structs

--- a/util/test/demos/gl/gl_cbuffer_zoo.cpp
+++ b/util/test/demos/gl/gl_cbuffer_zoo.cpp
@@ -342,6 +342,7 @@ uniform uvec2 I;
 uniform uvec3 J;
 uniform uvec4 K;
 uniform ivec4 L;
+uniform float2_struct M[1];
 
 void main()
 {
@@ -355,6 +356,7 @@ void main()
   blah *= vertIn.uv.z;
   if(H < 1 || I.x < 1 || J.x < 1 || K.x < 1) blah *= 0.1f;
   if(L.x > 1) blah *= 0.1f;
+  blah += M[0].x + M[0].y;
   Color = blah + test + vec4(0.1f, 0.0f, 0.0f, 0.0f);
 }
 
@@ -621,6 +623,13 @@ void main()
       location = glGetUniformLocation(program, "L");
       if(location != -1)
         glUniform4i(location, -24000, -25000, -26000, -27000);
+
+      location = glGetUniformLocation(program, "M[0].x");
+      if(location != -1)
+        glUniform1f(location, 28001.0);
+      location = glGetUniformLocation(program, "M[0].y");
+      if(location != -1)
+        glUniform1f(location, -28000.0);
 
       glViewport(0, 0, GLsizei(screenWidth), GLsizei(screenHeight));
 

--- a/util/test/tests/GL/GL_CBuffer_Zoo.py
+++ b/util/test/tests/GL/GL_CBuffer_Zoo.py
@@ -428,7 +428,7 @@ class GL_CBuffer_Zoo(rdtest.TestCase):
 
         rdtest.log.success("CBuffer variables are as expected")
 
-        self.check_pixel_value(pipe.GetOutputTargets()[0].resourceId, 0.5, 0.5, [536.1, 537.0, 538.0, 539.0])
+        self.check_pixel_value(pipe.GetOutputTargets()[0].resourceId, 0.5, 0.5, [537.1, 538.0, 539.0, 540.0])
 
         rdtest.log.success("Picked value is as expected")
 
@@ -577,6 +577,11 @@ class GL_CBuffer_Zoo(rdtest.TestCase):
         var_check.check('J').cols(3).rows(1).value([17000, 18000, 19000])
         var_check.check('K').cols(4).rows(1).value([20000, 21000, 22000, 23000])
         var_check.check('L').cols(4).rows(1).value([-24000, -25000, -26000, -27000])
+        # float2_struct M[1];
+        var_check.check('M').cols(0).rows(0).arraySize(2).members({
+            0: lambda x: x.cols(1).rows(1).value([28001.0]),
+            1: lambda x: x.cols(1).rows(1).value([-28000.0]),
+        })
 
         var_check.done()
 


### PR DESCRIPTION
## Description

Issue #3047

```
struct A {
		vec3 m1;
		vec3 m2;
		vec3 m2;
	};

uniform A a[1];
```

Previously it would look for `a.m1`, now if that is not found then it looks for `a[0].m1` etc.

## Testing

Extending `GL_CBuffer_Zoo` to include a test with a uniform array of size 1 ie.

`uniform float2_struct M[1];`
