### PR TITLE
Fix d3d12_common.cpp typo

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_common.cpp
+++ b/renderdoc/driver/d3d12/d3d12_common.cpp
@@ -1702,8 +1702,8 @@ D3D12_PACKED_PIPELINE_STATE_STREAM_DESC &D3D12_PACKED_PIPELINE_STATE_STREAM_DESC
     // one to ensure we don't fail when the new one isn't supported
     if(expanded.DepthStencilState.StencilEnable &&
        (expanded.DepthStencilState.FrontFace.StencilReadMask !=
-            expanded.DepthStencilState.FrontFace.StencilReadMask ||
-        expanded.DepthStencilState.BackFace.StencilWriteMask !=
+            expanded.DepthStencilState.BackFace.StencilReadMask ||
+        expanded.DepthStencilState.FrontFace.StencilWriteMask !=
             expanded.DepthStencilState.BackFace.StencilWriteMask))
     {
       WRITE_VERSIONED_SUBOJBECT(D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL2,

--- a/renderdoc/driver/d3d12/d3d12_common.h
+++ b/renderdoc/driver/d3d12/d3d12_common.h
@@ -687,7 +687,7 @@ private:
 #endif
     // since data must be tightly packed, the final structs that are versioned and may not be
     // supported are pushed in here
-    byte alignas(void *) VariableVersionedData[
+    alignas(void *) byte VariableVersionedData[
         // depth-stencil is versioned for separate stencil masks
         sizeof(D3D12_DEPTH_STENCIL_DESC2) + sizeof(void *) +
         // rasterization is versioned for line raster mode


### PR DESCRIPTION
I noticed what looks to be a typo, submitted [in this commit](https://github.com/baldurk/renderdoc/commit/7de3fb54eec905c4d93e6bd7f505209c246c0dc4), in `d3d12_common.cpp` -
```cpp
// do we have separate stencil masks? if so use the new type of D/S desc. Otherwise use the old
// one to ensure we don't fail when the new one isn't supported
if(expanded.DepthStencilState.StencilEnable &&
   (expanded.DepthStencilState.FrontFace.StencilReadMask !=
        expanded.DepthStencilState.FrontFace.StencilReadMask ||
    expanded.DepthStencilState.BackFace.StencilWriteMask !=
        expanded.DepthStencilState.BackFace.StencilWriteMask))
{
  WRITE_VERSIONED_SUBOJBECT(D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL2,
                            expanded.DepthStencilState);
}
```
The condition always evaluates to false since each  `!=` is comparing the same thing.  I believe it should be checking for differences between front vs back stencil read masks and front vs back stencil write mask, which is what I've done in one of the attached commits.

I found this issue as a result of putting together a clang-based build of all targets in this project.  It has identified a few other minor issues.  One of which is the other commit in this PR but I've just noticed you have guidance saying -
>commits for code formatting or compile fixes should be squashed into the relevant commits that they update, rather than left in the history

which I interpret to mean that you don't want to see the "Fix 'alignas' use" commit in here but instead added amongst a larger single commit later on that might, for example, fix up all clang-cl build issues for all build targets, is that right?
