### PR TITLE
Fix validation error in Vk_Overlay_Test

### DIFF
--- a/util/test/demos/vk/vk_overlay_test.cpp
+++ b/util/test/demos/vk/vk_overlay_test.cpp
@@ -363,6 +363,7 @@ void main()
     pipeCreateInfo.rasterizationState.rasterizerDiscardEnable = VK_TRUE;
     pipeCreateInfo.multisampleState.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipeCreateInfo.renderPass = renderPass;
+    pipeCreateInfo.stages.pop_back();
     VkPipeline discardPipe = createGraphicsPipeline(pipeCreateInfo);
 
     AllocatedImage subimg(


### PR DESCRIPTION
## Description

Found when running `VK_Overlay_Test` with `--debug` option

Can't have a fragment shader if `rasterizerDiscardEnable` is true