### PR TITLE
Cannot run functional tests using Python >= 3.10

### DIFF
--- a/renderdoc/replay/entry_points.cpp
+++ b/renderdoc/replay/entry_points.cpp
@@ -945,8 +945,13 @@ extern "C" RENDERDOC_API int RENDERDOC_CC RENDERDOC_RunFunctionalTests(int pytho
   for(rdcstr py : pythonlibs)
   {
     // patch up the python minor version
-    char *ver = strchr(&py[0], '?');
-    *ver = char('0' + pythonMinorVersion);
+    const int32_t idx = py.find('?');
+    if(idx == -1)
+    {
+      TestPrintMsg(StringFormat::Fmt("Python library pattern missing placeholder: %s\n", py.c_str()));
+      return 1;
+    }
+    py.replace(idx, 1, StringFormat::Fmt("%d", pythonMinorVersion));
 
     handle = Process::LoadModule(py);
     if(handle)


### PR DESCRIPTION
## Description
In replay/entry_points.cpp RENDERDOC_RunFunctionalTests(..), it uses a simple char-replacement algorithm for finding the Python modules depending on the Python minor version.

Unfortunately that mechanism relies on there being only a single character to replace which doesn't work once we reach double figures.
