### PR TITLE
RISC-V support

### DIFF
--- a/renderdoc/3rdparty/plthook/plthook_elf.c
+++ b/renderdoc/3rdparty/plthook/plthook_elf.c
@@ -95,6 +95,9 @@
 #elif defined __powerpc__
 #define R_JUMP_SLOT   R_PPC_JMP_SLOT
 #define Elf_Plt_Rel   Elf_Rela
+#elif defined __riscv
+#define R_JUMP_SLOT   R_RISCV_JUMP_SLOT
+#define Elf_Plt_Rel   Elf_Rela
 #elif 0 /* disabled because not tested */ && (defined __sparcv9 || defined __sparc_v9__)
 #define R_JUMP_SLOT   R_SPARC_JMP_SLOT
 #define Elf_Plt_Rel   Elf_Rela

--- a/renderdoc/common/globalconfig.h
+++ b/renderdoc/common/globalconfig.h
@@ -36,8 +36,9 @@
 
 /////////////////////////////////////////////////
 // Build/machine configuration
-#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || \
-    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) ||        \
+    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__) || \
+    (defined(__riscv64) && __riscv_xlen == 64)
 #define RDOC_X64 OPTION_ON
 #else
 #define RDOC_X64 OPTION_OFF

--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -227,6 +227,15 @@ static uint64_t get_nanotime()
 // the instruction pointer at all.
 #define BREAK_INST_INST_PTR_ADJUST 0
 
+#elif defined(__riscv)
+
+#define INST_PTR_REG pc
+
+// ebreak
+#define BREAK_INST 0x00100073ULL
+#define BREAK_INST_BYTES_SIZE 4
+#define BREAK_INST_INST_PTR_ADJUST 4
+
 #else
 
 #define BREAK_INST 0xccULL

--- a/util/test/demos/vk/vk_ext_buffer_address.cpp
+++ b/util/test/demos/vk/vk_ext_buffer_address.cpp
@@ -27,8 +27,9 @@
 // only support on 64-bit, just because it's easier to share CPU & GPU structs if pointer size is
 // identical
 
-#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || \
-    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) ||        \
+    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__) || \
+    (defined(__riscv) && __riscv_xlen == 64)
 
 RD_TEST(VK_EXT_Buffer_Address, VulkanGraphicsTest)
 {

--- a/util/test/demos/vk/vk_headers.h
+++ b/util/test/demos/vk/vk_headers.h
@@ -32,7 +32,7 @@
 
 #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || \
     defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) ||       \
-    defined(__powerpc64__)
+    defined(__powerpc64__) || (defined(__riscv) && __riscv_xlen == 64)
 
 #else
 

--- a/util/test/demos/vk/vk_khr_buffer_address.cpp
+++ b/util/test/demos/vk/vk_khr_buffer_address.cpp
@@ -27,8 +27,9 @@
 // only support on 64-bit, just because it's easier to share CPU & GPU structs if pointer size is
 // identical
 
-#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || \
-    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) ||        \
+    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__) || \
+    (defined(__riscv) && __riscv_xlen == 64)
 
 RD_TEST(VK_KHR_Buffer_Address, VulkanGraphicsTest)
 {

--- a/util/test/demos/vk/vk_mem_bench.cpp
+++ b/util/test/demos/vk/vk_mem_bench.cpp
@@ -78,8 +78,9 @@ bool Vec16NotEqual(void *a, void *b)
 	}
 	
 	return false;
-#elif defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || \
-    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#elif defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) ||      \
+    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__) || \
+    (defined(__riscv) && __riscv_xlen == 64)
   uint64_t *a64 = (uint64_t *)a;
   uint64_t *b64 = (uint64_t *)b;
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

With some addition to macros the project is able to build on riscv64 machine.

plthook has [added RISC-V support upstream](https://github.com/kubo/plthook/commit/a564738a4707fc5eb4d388b9e97eeab51b8c9d56). However upstream has changed their code quite a bit, so I just modified the current vendored version.