### PR TITLE
Don't hook into AMD driver

### DIFF
--- a/renderdoc/os/win32/win32_hook.cpp
+++ b/renderdoc/os/win32/win32_hook.cpp
@@ -269,11 +269,11 @@ struct CachedHookData
        !_stricmp(modName, "gdi32.dll") || !_stricmp(modName, "gdi32full.dll") ||
        !_stricmp(modName, "windows.storage.dll") || !_stricmp(modName, "nvoglv32.dll") ||
        !_stricmp(modName, "nvoglv64.dll") || !_stricmp(modName, "vulkan-1.dll") ||
-       !_stricmp(modName, "nvcuda.dll") || strstr(lowername, "cudart") == lowername ||
-       strstr(lowername, "msvcr") == lowername || strstr(lowername, "msvcp") == lowername ||
-       strstr(lowername, "nv-vk") == lowername || strstr(lowername, "amdvlk") == lowername ||
-       strstr(lowername, "igvk") == lowername || strstr(lowername, "nvopencl") == lowername ||
-       strstr(lowername, "nvapi") == lowername)
+       !_stricmp(modName, "atio6axx.dll") || !_stricmp(modName, "nvcuda.dll") ||
+       strstr(lowername, "cudart") == lowername || strstr(lowername, "msvcr") == lowername ||
+       strstr(lowername, "msvcp") == lowername || strstr(lowername, "nv-vk") == lowername ||
+       strstr(lowername, "amdvlk") == lowername || strstr(lowername, "igvk") == lowername ||
+       strstr(lowername, "nvopencl") == lowername || strstr(lowername, "nvapi") == lowername)
       return;
 
     if(ignores.find(lowername) != ignores.end())


### PR DESCRIPTION
## Description

AMD driver was creating and presenting a D3D12 swapchain when creating a GL context