### PR TITLE
Small fixes

### DIFF
--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -561,6 +561,7 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
 
     if(Vulkan_Debug_SingleSubmitFlushing())
     {
+      CloseInitStateCmd();
       SubmitCmds();
       FlushQ();
     }

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -1805,7 +1805,11 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
         if(overlay == DebugOverlay::Depth)
           ds->depthTestEnable = origDepthTest;
         else
+        {
+          ds->front.passOp = ds->front.failOp = ds->front.depthFailOp = VK_STENCIL_OP_KEEP;
+          ds->back.passOp = ds->back.failOp = ds->back.depthFailOp = VK_STENCIL_OP_KEEP;
           ds->stencilTestEnable = origStencilTest;
+        }
         pipeCreateInfo.renderPass = depthRP;
       }
       else

--- a/util/test/tests/Iter_Test.py
+++ b/util/test/tests/Iter_Test.py
@@ -182,6 +182,8 @@ class Iter_Test(rdtest.TestCase):
         # TODO, query for some pixel this action actually touched.
         x = int(random.random()*viewport.width + viewport.x)
         y = int(random.random()*viewport.height + viewport.y)
+        x = abs(x)
+        y = abs(y)
 
         target = rd.ResourceId.Null()
 


### PR DESCRIPTION
## Description

- Prevent exception about `uint32_t` overflow if negative x or y is used during call to `pixel_history` in `Iter_Test` python  script
- Disable stencil buffer writes for the Vulkan Stencil overlay (fixes rare problem of current draw not displaying when switching from Stencil overlay to None overlay and the current draw uses the stencil buffer contents, as demonstrated by `Vk_Overlay` test)
- Missing `CloseInitStateCmd()` in `SingleSubmitFlushing()` Vulkan debug mode