### PR TITLE
Changes to Android demos to support RenderDoc capture

### DIFF
--- a/util/test/demos/CMakeLists.txt
+++ b/util/test/demos/CMakeLists.txt
@@ -403,14 +403,14 @@ if(ANDROID)
         message(FATAL_ERROR "ABI ${ANDROID_ABI} is not supported.")
     endif()
 
-    set(RENDERDOC_ANDROID_PACKAGE_NAME "org.renderdoc.demos.${ABI_EXTENSION_NAME}")
+    set(RENDERDOC_ANDROID_PACKAGE_NAME "renderdoc.org.demos.${ABI_EXTENSION_NAME}")
 
     set(APK_FILE ${CMAKE_BINARY_DIR}/bin/${RENDERDOC_ANDROID_PACKAGE_NAME}.apk)
     add_custom_target(apk ALL
                       DEPENDS ${APK_FILE})
 
     # Copy in android package files, replacing the package name with the architecture-specific package name
-    configure_file(android/Loader.java ${CMAKE_CURRENT_BINARY_DIR}/src/org/renderdoc/demos/Loader.java)
+    configure_file(android/Loader.java ${CMAKE_CURRENT_BINARY_DIR}/src/renderdoc/org/demos/Loader.java)
     configure_file(android/AndroidManifest.xml ${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml)
     configure_file(android/icon.png ${CMAKE_CURRENT_BINARY_DIR}/res/drawable/icon.png COPYONLY)
 
@@ -428,12 +428,12 @@ if(ANDROID)
     if(NOT EXISTS ${D8_SCRIPT})
         set(DEX_COMMAND ${BUILD_TOOLS}/dx${TOOL_SCRIPT_EXTENSION} --dex --output=bin/classes.dex ./obj)
     else()
-        set(DEX_COMMAND ${D8_SCRIPT} --output ./bin/ ./obj/org/renderdoc/demos/${ABI_EXTENSION_NAME}/*.class)
+        set(DEX_COMMAND ${D8_SCRIPT} --output ./bin/ ./obj/renderdoc/org/demos/${ABI_EXTENSION_NAME}/*.class)
     endif()
 
     add_custom_command(OUTPUT ${APK_FILE} APPEND
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
-                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/org/renderdoc/demos/*.java
+                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/renderdoc/org/demos/*.java
                        COMMAND ${DEX_COMMAND}
                        COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml --version-code ${APK_VERSION_CODE} --version-name ${APK_VERSION_NAME} -S res -I ${ANDROID_JAR} -F demos-unaligned.apk bin libs
                        COMMAND ${BUILD_TOOLS}/zipalign -f 4 demos-unaligned.apk demos.apk

--- a/util/test/demos/android/AndroidManifest.xml
+++ b/util/test/demos/android/AndroidManifest.xml
@@ -12,6 +12,10 @@
   <application android:debuggable="true" android:label="demos" android:icon="@drawable/icon" android:hasCode="true">
     <activity android:name=".Loader" android:label="RenderDoc" android:exported="true" android:screenOrientation="landscape" android:configChanges="orientation|keyboardHidden">
       <meta-data android:name="android.app.lib_name" android:value="demos"/>
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.CATEGORY_ALTERNATIVE" />
+      </intent-filter>
     </activity>
 
   </application>


### PR DESCRIPTION
## Description

Change package name to `renderdoc.org.demos` instead of `org.renderdoc.demos` (RenderDoc filters out packages containing `org.renderdoc.`)

Added an `<intent-filter>` to the Android manifest.
This registers the activity with the android package system which means RenderDoc Launch Application knows the activity name to launch. Used category `CATEGORY_ALTERNATIVE` to prevent the activity from appearing on the launcher UI.

Example of Launch Application showing the RenderDoc demos test program
![image](https://github.com/baldurk/renderdoc/assets/39392/2d7d937e-09f4-4a95-98a2-8ceb4ca6ea9e)

Example Capture and Replay of `VK_Simple_Triangle` on Android
![image](https://github.com/baldurk/renderdoc/assets/39392/d27b1bef-4e2d-43bc-a777-ca5d57157456)
