### PR TITLE
Add generic D3D12 callback for pixel history

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_common.cpp
+++ b/renderdoc/driver/d3d12/d3d12_common.cpp
@@ -849,6 +849,12 @@ UINT GetNumSubresources(ID3D12Device *dev, const D3D12_RESOURCE_DESC *desc)
   return 1;
 }
 
+UINT D3D12CalcSubresource(UINT MipSlice, UINT ArraySlice, UINT PlaneSlice, UINT MipLevels,
+                          UINT ArraySize)
+{
+  return MipSlice + (ArraySlice * MipLevels) + (PlaneSlice * MipLevels * ArraySize);
+}
+
 ShaderStageMask ConvertVisibility(D3D12_SHADER_VISIBILITY ShaderVisibility)
 {
   switch(ShaderVisibility)

--- a/renderdoc/driver/d3d12/d3d12_common.h
+++ b/renderdoc/driver/d3d12/d3d12_common.h
@@ -240,6 +240,9 @@ inline UINT GetNumSubresources(ID3D12Device *dev, const D3D12_RESOURCE_DESC1 *de
   return GetNumSubresources(dev, &desc0);
 }
 
+UINT D3D12CalcSubresource(UINT MipSlice, UINT ArraySlice, UINT PlaneSlice, UINT MipLevels,
+                          UINT ArraySize);
+
 class WrappedID3D12Device;
 
 template <typename RealType>

--- a/renderdoc/driver/d3d12/d3d12_debug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_debug.cpp
@@ -2645,6 +2645,35 @@ void D3D12Replay::PixelPicking::Release()
   SAFE_RELEASE(Texture);
 }
 
+void D3D12Replay::PixelHistory::Init(WrappedID3D12Device *device, D3D12DebugManager *debug)
+{
+  D3D12ShaderCache *shaderCache = device->GetShaderCache();
+
+  shaderCache->SetCaching(true);
+
+  rdcstr hlsl = GetEmbeddedResource(d3d12_pixelhistory_hlsl);
+
+  shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PrimitiveIDPS",
+                             D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_5_0", &PrimitiveIDPS);
+  shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PrimitiveIDPS",
+                             D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_6_0", &PrimitiveIDPSDxil);
+
+  shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
+                             D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_5_0", &FixedColorPS);
+  shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
+                             D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_6_0", &FixedColorPSDxil);
+
+  shaderCache->SetCaching(false);
+}
+
+void D3D12Replay::PixelHistory::Release()
+{
+  SAFE_RELEASE(PrimitiveIDPS);
+  SAFE_RELEASE(PrimitiveIDPSDxil);
+  SAFE_RELEASE(FixedColorPS);
+  SAFE_RELEASE(FixedColorPSDxil);
+}
+
 void D3D12Replay::HistogramMinMax::Init(WrappedID3D12Device *device, D3D12DebugManager *debug)
 {
   HRESULT hr = S_OK;

--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -160,6 +160,7 @@ void D3D12Replay::CreateResources()
     m_Overlay.Init(m_pDevice, m_DebugManager);
     m_VertexPick.Init(m_pDevice, m_DebugManager);
     m_PixelPick.Init(m_pDevice, m_DebugManager);
+    m_PixelHistory.Init(m_pDevice, m_DebugManager);
     m_Histogram.Init(m_pDevice, m_DebugManager);
 
     if(!m_Proxy && D3D12_HardwareCounters())
@@ -214,6 +215,7 @@ void D3D12Replay::DestroyResources()
   m_Overlay.Release();
   m_VertexPick.Release();
   m_PixelPick.Release();
+  m_PixelHistory.Release();
   m_Histogram.Release();
 
   SAFE_RELEASE(m_BindlessFeedback.FeedbackBuffer);

--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -467,6 +467,18 @@ private:
     ID3D12Resource *Texture = NULL;
   } m_PixelPick;
 
+  struct PixelHistory
+  {
+    void Init(WrappedID3D12Device *device, D3D12DebugManager *debug);
+    void Release();
+
+    ID3DBlob *PrimitiveIDPS = NULL;
+    ID3DBlob *PrimitiveIDPSDxil = NULL;
+
+    ID3DBlob *FixedColorPS = NULL;
+    ID3DBlob *FixedColorPSDxil = NULL;
+  } m_PixelHistory;
+
   struct HistogramMinMax
   {
     void Init(WrappedID3D12Device *device, D3D12DebugManager *debug);


### PR DESCRIPTION
This adds the next step toward D3D12 pixel history, which is mostly the generic action callback that is used for other replays later (similar to how Vulkan pixel history operates). There are some potential edge cases identified with TODOs but nothing that causes the functional test (to be checked in later) to fail.