### PR TITLE
Minor changes to Android to improve functional test support

### DIFF
--- a/util/test/demos/CMakeLists.txt
+++ b/util/test/demos/CMakeLists.txt
@@ -432,6 +432,7 @@ if(ANDROID)
     endif()
 
     add_custom_command(OUTPUT ${APK_FILE} APPEND
+                       COMMAND ${CMAKE_COMMAND} -E remove ${APK_FILE} # Don't package any existing artifact into the new one
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
                        COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/renderdoc/org/demos/*.java
                        COMMAND ${DEX_COMMAND}

--- a/util/test/run_tests.py
+++ b/util/test/run_tests.py
@@ -16,7 +16,7 @@ parser.add_argument('-t', '--test_include', default=".*",
 parser.add_argument('-x', '--test_exclude', default="",
                     help="The tests to exclude, as a regexp filter", type=str)
 parser.add_argument('--in-process',
-                    help="Lists the tests available to run", action="store_true")
+                    help="Run test code in the same process as test runner", action="store_true")
 parser.add_argument('--slow-tests',
                     help="Run potentially slow tests", action="store_true")
 parser.add_argument('--data', default=os.path.join(script_dir, "data"),


### PR DESCRIPTION
## Description
* Change server upload routine so that as long as one of the supported ABIs is uploaded successfully, it is considered successful.  This is because the next-gen Arm CPUs will be dropping 32bit support
* FIxed issue where a previously built demo APK would be added into the APK archive upon next build
* Make demo available test and help output logcat friendly so that the test runner picks up the available tests properly
* Make demo init output DEBUG so that it doesn't interfere with functional tests
* Prevent Discard_Zoo 1D texture tests running pre-discard out of bounds tests
* Correct the functional test's --in-process help output
