### PR TITLE
Mention where to put android arm64 builds

### DIFF
--- a/docs/CONTRIBUTING/Compiling.md
+++ b/docs/CONTRIBUTING/Compiling.md
@@ -60,6 +60,17 @@ On windows cmake you need to specify the 'generator' type to the cmake invocatio
 cmake -DBUILD_ANDROID=On -DANDROID_ABI=armeabi-v7a -G "MSYS Makefiles" ..
 ```
 
+If using developing with multiple Android ABIs, naming your build folders as follows will allow renderdoc to find the right version to install automatically:
+
+| ABI         | Folder Name         |
+|-------------|---------------------|
+| armeabi-v7a | build-android-arm32 |
+| arm64-v8a   | build-android-arm64 |
+| x86\*       | build-android-x86   |
+| x86_64\*    | build-android-x64   |
+
+\* Not officially supported
+
 ### Note:
 
 With GLES programs on Android, the built-in hooking method doesn't always work. If you have trouble with crashes or problems capturing GLES programs, try enabling building with [interceptor-lib](../../renderdoc/3rdparty/interceptor-lib/README.md). **WARNING**: Building this requires a hefty dependency.


### PR DESCRIPTION
## Description

Renderdoc seems to automatically pick up android builds from 'build-android-arm32/64', but this isn't in the docs. This has bit me a few times when trying to get renderdoc to find its arm64 apks-- it specifically seems to only look for the arm32 builds in 'build-android'.

Make a quick table to tell what folder name should be used for each arch in Compiling.md.

A quick look through the issues show Android-x86/64 is not officially supported, but I wanted to put the folder names here for completeness since there is code to handle those.