### PR TITLE
Wait for GPU before destroying counter query pools

### DIFF
--- a/renderdoc/driver/vulkan/vk_counters.cpp
+++ b/renderdoc/driver/vulkan/vk_counters.cpp
@@ -690,6 +690,8 @@ rdcarray<CounterResult> VulkanReplay::FetchCountersKHR(const rdcarray<GPUCounter
       sizeof(VkPerformanceCounterResultKHR) * perfResults.size(), &perfResults[0],
       sizeof(VkPerformanceCounterResultKHR) * counters.size(), VK_QUERY_RESULT_WAIT_BIT);
   CheckVkResult(vkr);
+  m_pDriver->SubmitCmds();
+  m_pDriver->FlushQ();
 
   ObjDisp(dev)->DestroyQueryPool(Unwrap(dev), queryPool, NULL);
 
@@ -1021,6 +1023,8 @@ rdcarray<CounterResult> VulkanReplay::FetchCounters(const rdcarray<GPUCounter> &
       sizeof(uint64_t) * timeStampData.size(), &timeStampData[0], sizeof(uint64_t),
       VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
   CheckVkResult(vkr);
+  m_pDriver->SubmitCmds();
+  m_pDriver->FlushQ();
 
   ObjDisp(dev)->DestroyQueryPool(Unwrap(dev), timeStampPool, NULL);
 


### PR DESCRIPTION
## Description

The get query results uses `VK_QUERY_RESULT_WAIT_BIT` option which makes destroying the query pool safe (the validation layers must not handle this case or it isn't specified behaviour).

This change adds a GPU sync which removes the following validation error. The GPU has already been waited on by the queries using `VK_QUERY_RESULT_WAIT_BIT` options.

> Validation Error: [ VUID-vkDestroyQueryPool-queryPool-00793 ] | MessageID = 0x5ef3bf2b | Cannot call vkDestroyQueryPool on VkQueryPool 0xf49d4000000029b[] that is currently in use by a command buffer. The Vulkan spec states: All submitted commands that refer to queryPool must have completed execution (https://vulkan.lunarg.com/doc/view/1.3.261.1/windows/1.3-extensions/vkspec.html#VUID-vkDestroyQueryPool-queryPool-00793)
