### PR TITLE
Reset the `PixelUnpackState` for replay serialisation of `glTexImage*` APIs

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -2763,6 +2763,14 @@ bool WrappedOpenGL::Serialise_glTextureImage1DEXT(SerialiserType &ser, GLuint te
     GLint align = 1;
     GL.glGetIntegerv(eGL_UNPACK_ALIGNMENT, &align);
 
+    PixelUnpackState unpack;
+    if(pixels)
+    {
+      unpack.Fetch(true);
+      ResetPixelUnpackState(true, 1);
+      RDCASSERT(!unpackbuf);
+    }
+
     if(IsLoading(m_State) && m_CurEventID == 0)
     {
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, 0);
@@ -2775,6 +2783,8 @@ bool WrappedOpenGL::Serialise_glTextureImage1DEXT(SerialiserType &ser, GLuint te
     if(unpackbuf)
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, unpackbuf);
     GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, align);
+    if(pixels)
+      unpack.Apply(false);
 
     if(IsLoading(m_State) && m_CurEventID > 0)
       m_ResourceUses[GetResourceManager()->GetResID(texture)].push_back(
@@ -3004,6 +3014,14 @@ bool WrappedOpenGL::Serialise_glTextureImage2DEXT(SerialiserType &ser, GLuint te
     GLint align = 1;
     GL.glGetIntegerv(eGL_UNPACK_ALIGNMENT, &align);
 
+    PixelUnpackState unpack;
+    if(pixels)
+    {
+      unpack.Fetch(true);
+      ResetPixelUnpackState(true, 1);
+      RDCASSERT(!unpackbuf);
+    }
+
     if(IsLoading(m_State) && m_CurEventID == 0)
     {
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, 0);
@@ -3038,6 +3056,8 @@ bool WrappedOpenGL::Serialise_glTextureImage2DEXT(SerialiserType &ser, GLuint te
     if(unpackbuf)
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, unpackbuf);
     GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, align);
+    if(pixels)
+      unpack.Apply(false);
 
     if(IsLoading(m_State) && m_CurEventID > 0)
       m_ResourceUses[GetResourceManager()->GetResID(texture)].push_back(
@@ -3271,6 +3291,14 @@ bool WrappedOpenGL::Serialise_glTextureImage3DEXT(SerialiserType &ser, GLuint te
     GLint align = 1;
     GL.glGetIntegerv(eGL_UNPACK_ALIGNMENT, &align);
 
+    PixelUnpackState unpack;
+    if(pixels)
+    {
+      unpack.Fetch(true);
+      ResetPixelUnpackState(true, 1);
+      RDCASSERT(!unpackbuf);
+    }
+
     if(IsLoading(m_State) && m_CurEventID == 0)
     {
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, 0);
@@ -3283,6 +3311,8 @@ bool WrappedOpenGL::Serialise_glTextureImage3DEXT(SerialiserType &ser, GLuint te
     if(unpackbuf)
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, unpackbuf);
     GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, align);
+    if(pixels)
+      unpack.Apply(false);
 
     if(IsLoading(m_State) && m_CurEventID > 0)
       m_ResourceUses[GetResourceManager()->GetResID(texture)].push_back(
@@ -3526,12 +3556,22 @@ bool WrappedOpenGL::Serialise_glCompressedTextureImage1DEXT(SerialiserType &ser,
       GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, 1);
     }
 
+    PixelUnpackState unpack;
+    if(pixels)
+    {
+      unpack.Fetch(true);
+      ResetPixelUnpackState(true, 1);
+      RDCASSERT(!unpackbuf);
+    }
+
     GL.glCompressedTextureImage1DEXT(texture.name, target, level, internalformat, width, border,
                                      imageSize, databuf);
 
     if(unpackbuf)
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, unpackbuf);
     GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, align);
+    if(pixels)
+      unpack.Apply(false);
 
     if(IsLoading(m_State) && m_CurEventID > 0)
       m_ResourceUses[GetResourceManager()->GetResID(texture)].push_back(
@@ -3860,6 +3900,14 @@ bool WrappedOpenGL::Serialise_glCompressedTextureImage2DEXT(SerialiserType &ser,
     GLint align = 1;
     GL.glGetIntegerv(eGL_UNPACK_ALIGNMENT, &align);
 
+    PixelUnpackState unpack;
+    if(pixels)
+    {
+      unpack.Fetch(true);
+      ResetPixelUnpackState(true, 1);
+      RDCASSERT(!unpackbuf);
+    }
+
     if(IsLoading(m_State) && m_CurEventID == 0)
     {
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, 0);
@@ -3894,6 +3942,8 @@ bool WrappedOpenGL::Serialise_glCompressedTextureImage2DEXT(SerialiserType &ser,
     if(unpackbuf)
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, unpackbuf);
     GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, align);
+    if(pixels)
+      unpack.Apply(false);
 
     if(IsLoading(m_State) && m_CurEventID > 0)
       m_ResourceUses[GetResourceManager()->GetResID(texture)].push_back(
@@ -4132,6 +4182,14 @@ bool WrappedOpenGL::Serialise_glCompressedTextureImage3DEXT(SerialiserType &ser,
     GLint align = 1;
     GL.glGetIntegerv(eGL_UNPACK_ALIGNMENT, &align);
 
+    PixelUnpackState unpack;
+    if(pixels)
+    {
+      unpack.Fetch(true);
+      ResetPixelUnpackState(true, 1);
+      RDCASSERT(!unpackbuf);
+    }
+
     if(IsLoading(m_State) && m_CurEventID == 0)
     {
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, 0);
@@ -4144,6 +4202,8 @@ bool WrappedOpenGL::Serialise_glCompressedTextureImage3DEXT(SerialiserType &ser,
     if(unpackbuf)
       GL.glBindBuffer(eGL_PIXEL_UNPACK_BUFFER, unpackbuf);
     GL.glPixelStorei(eGL_UNPACK_ALIGNMENT, align);
+    if(pixels)
+      unpack.Apply(false);
 
     if(IsLoading(m_State) && m_CurEventID > 0)
       m_ResourceUses[GetResourceManager()->GetResID(texture)].push_back(


### PR DESCRIPTION
## Description

Reset the `PixelUnpackState` for replay serialisation of the following APIs:
- `glTexImage1D`
- `glTexImage2D`
- `glTexImage3D`
- `glCompressedTexImage1D`
- `glCompressedTexImage2D`
- `glCompressedTexImage3D`

Did **NOT** add support for non-zero `pixels` parameter being used as an offset to `GL_PIXEL_UNPACK_BUFFER`

## Notes

Could extend this work by:
1. support non-zero `pixels` parameter used as an offset to `GL_PIXEL_UNPACK_BUFFER` (it looks like it would need capture changes to serialize extra data)
2. Extend the testing to include more formats, mipmaps, more values of `UNPACK_ROW_LENGTH` and to cover the `glCompressedTexImage?D` APIs

## Testing

Added a basic test for to `gl_texture_zoo` for non-zero `UNPACK_ROW_LENGTH` for the following APIs:

- `glTexImage1D`
- `glTexImage2D`
- `glTexImage3D`

The test fails before the code change and passes afterwards.

## Background

Looking at GL APIs related to storing pixel data into textures discovered the following:

### GL APIs affected by `glPixelStore`
- `glTexImage1D`
- `glTexImage2D`
- `glTexImage3D`
- `glCompressedTexImage1D`
- `glCompressedTexImage2D`
- `glCompressedTexImage3D`
- `glTexSubImage1D`
- `glTexSubImage2D`
- `glTexSubImage3D`
- `glCompressedTexSubImage1D`
- `glCompressedTexSubImage2D`
- `glCompressedTexSubImage1D`

### APIs that handle `glPixelStore` parameters during RenderDoc replay
- `glTexSubImage1D`
- `glTexSubImage2D`
- `glTexSubImage3D`
- `glCompressedTexSubImage1D`
- `glCompressedTexSubImage2D`
- `glCompressedTexSubImage1D`

These APIs also **DO** support pixels being an offset into `GL_PIXEL_UNPACK_BUFFER`

### APIs that do not handle `glPixelStore` parameters during RenderDoc replay
- `glTexImage1D`
- `glTexImage2D`
- `glTexImage3D`
- `glCompressedTexImage1D`
- `glCompressedTexImage2D`
- `glCompressedTexImage3D`

These APIs also **DO NOT** support the `pixels` parameter being a non-zero offset into `GL_PIXEL_UNPACK_BUFFER` (which is supported by the replay serialisation of the other GL texture storage APIs).
