### PR TITLE
New 'multi wait before signal' pixel checking python test

### DIFF
--- a/util/test/demos/d3d12/d3d12_multi_wait_before_signal.cpp
+++ b/util/test/demos/d3d12/d3d12_multi_wait_before_signal.cpp
@@ -433,6 +433,7 @@ float4 mainPS(in float4 pos : SV_POSITION) : SV_Target0
         rootConstants[0] = 1;    // myBufferIdx
         cmd->SetGraphicsRoot32BitConstants(0, 1, &rootConstants[0], 0);
         cmd->DrawInstanced(3, 1, 3, 0);
+        setMarker(cmd, "Last draw");    // Help locate this draw through 'find_action' in python test
 
         ResourceBarrier(cmd, bbTex[texIdx], D3D12_RESOURCE_STATE_RENDER_TARGET,
                         D3D12_RESOURCE_STATE_PRESENT);

--- a/util/test/demos/demos.vcxproj.filters
+++ b/util/test/demos/demos.vcxproj.filters
@@ -959,7 +959,4 @@
       <Filter>Android</Filter>
     </ClInclude>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\..\.clang-format" />
-  </ItemGroup>
 </Project>

--- a/util/test/tests/D3D12/D3D12_Multi_Wait_Before_Signal.py
+++ b/util/test/tests/D3D12/D3D12_Multi_Wait_Before_Signal.py
@@ -1,0 +1,23 @@
+import renderdoc as rd
+import rdtest
+
+class D3D12_Multi_Wait_Before_Signal(rdtest.TestCase):
+    demos_test_name = 'D3D12_Multi_Wait_Before_Signal'
+
+    def check_support(self):
+        # TODO: Enable this if/when rdoc can reorder from the original submission
+        # order, which blocks multiple queues with waits that get signalled by
+        # later submissions to other queues.
+        return False, 'Renderdoc does not yet adequately reorder capture replay'
+
+    def check_capture(self):
+        draw_marker: rd.ActionDescription = self.find_action("Last draw")
+        self.controller.SetFrameEvent(draw_marker.eventId, False)
+
+        pipe: rd.PipeState = self.controller.GetPipelineState()
+
+        tex = pipe.GetOutputTargets()[0].resourceId
+        self.check_pixel_value(tex, 270, 194, [0.20117, 0.20117, 0.20117, 0.0])
+        self.check_pixel_value(tex, 180, 170, [0.5031, 0.25, 1.0, 1.0])
+        self.check_pixel_value(tex, 180, 194, [0.25, 0.75391, 1.0, 1.0])
+


### PR DESCRIPTION
## Description

Following on from the new interleaved multi-queue d3d12 test [here](https://github.com/baldurk/renderdoc/pull/3096), I've done as discussed and added a matching new python test that checks for expected pixel colours.

The test is currently disabled because of how the replay is known to run in original submission order, which produces pure blue triangles instead of the green and purple the test should ultimately expect if/when the 'wait before signal' serialisation ordering is respected.

Also, I obviously made a mistake in that earlier PR and neglected to remove a stray reference to the `.clang-format` file. Not sure how I missed that after I said I'd removed it, but have removed in this PR.