### PR TITLE
Update Android SDK/JDK setting tooltips to match RDOC_CONFIG

### DIFF
--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -1231,7 +1231,7 @@ Only happens if the capture is not in the recent files list.</string>
           <item row="0" column="0">
            <widget class="QLabel" name="label_24">
             <property name="toolTip">
-             <string>The location of the Android SDK, used to locate tools for controlling Android devices.</string>
+             <string>The location of the root of the Android SDK. This path should contain folders such as build-tools and platform-tools.</string>
             </property>
             <property name="text">
              <string>Android SDK root path</string>
@@ -1241,14 +1241,14 @@ Only happens if the capture is not in the recent files list.</string>
           <item row="1" column="0">
            <widget class="QLineEdit" name="Android_SDKPath">
             <property name="toolTip">
-             <string>The location of adb.exe, used to control Android devices.</string>
+             <string>The location of the root of the Android SDK. This path should contain folders such as build-tools and platform-tools.</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
            <widget class="QPushButton" name="browseAndroidSDKPath">
             <property name="toolTip">
-             <string>The location of adb.exe, used to control Android devices.</string>
+             <string>The location of the root of the Android SDK. This path should contain folders such as build-tools and platform-tools.</string>
             </property>
             <property name="text">
              <string>Browse</string>
@@ -1257,16 +1257,26 @@ Only happens if the capture is not in the recent files list.</string>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_7">
+            <property name="toolTip">
+             <string>The location of the root of the Java JDK. This path should contain folders such as bin and lib.</string>
+            </property>
             <property name="text">
              <string>Java JDK path</string>
             </property>
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLineEdit" name="Android_JDKPath"/>
+           <widget class="QLineEdit" name="Android_JDKPath">
+            <property name="toolTip">
+             <string>The location of the root of the Java JDK. This path should contain folders such as bin and lib.</string>
+            </property>
+           </widget>
           </item>
           <item row="3" column="1">
            <widget class="QPushButton" name="browseJDKPath">
+            <property name="toolTip">
+             <string>The location of the root of the Java JDK. This path should contain folders such as bin and lib.</string>
+            </property>
             <property name="text">
              <string>Browse</string>
             </property>


### PR DESCRIPTION
Previously, the SDK tooltip was inconsistent between the label and the text field/button, with the latter incorrectly saying the location of adb.exe should be used. There also was no description at all for the JDK option.

![image](https://github.com/baldurk/renderdoc/assets/127789813/5be93744-9b8c-4caa-88a9-c098ee566b7d)
![image](https://github.com/baldurk/renderdoc/assets/127789813/3472f438-5731-4418-bb2b-2de10da453b9)

I've copied the descriptions from the `RDOC_CONFIG` macros in `android_tools.cpp`, which should make it easier to set these correctly.

https://github.com/baldurk/renderdoc/blob/0ff1c66ca7c53f1b36dec45a113dd8e32318c5d8/renderdoc/android/android_tools.cpp#L31-L37

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->
