### PR TITLE
Fix links in buffer format help widget and brackets in documentation

### DIFF
--- a/docs/how/how_buffer_format.rst
+++ b/docs/how/how_buffer_format.rst
@@ -162,13 +162,13 @@ The buffer format supports annotations on declarations to specify special proper
 Struct definitions support the following annotations:
 
 * ``[[size(number)]]`` or ``[[byte_size(number)]]`` - Forces the struct to be padded up to a given size even if the contents don't require it.
-* ``[[single]]`` or ``[fixed]]`` - Forces the struct to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See the below section for more details. Structs with this annotation **may not** be declared as a variable, and should instead be the implicit final struct in a definition.
+* ``[[single]]`` or ``[[fixed]]`` - Forces the struct to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See the below section for more details. Structs with this annotation **may not** be declared as a variable, and should instead be the implicit final struct in a definition.
 
 Variable declarations support the following annotations:
 
 * ``[[offset(number)]]`` or ``[[byte_offset(number)]]`` - Forces this member to be at a given offset **relative to its parent**. This cannot place the member any earlier than it would have according to tight packing with the current packing rules.
 * ``[[pad]]`` or ``[[padding]]`` - Mark this member as padding, such that structure layout is calculated accounting for it but it is not displayed visibly.
-* ``[[single]]`` or ``[fixed]]`` - Forces this variable to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See :ref:`the below section <aos-soa>` for more details. This must be a global variable, and it must be the only global variable in the format definition.
+* ``[[single]]`` or ``[[fixed]]`` - Forces this variable to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See :ref:`the below section <aos-soa>` for more details. This must be a global variable, and it must be the only global variable in the format definition.
 * ``[[row_major]]`` or ``[[col_major]]`` - Declares the memory order for a matrix.
 * ``[[rgb]]`` - Will color the background of any repeated data by interpreting its contents as RGB color.
 * ``[[hex]]`` or ``[[hexadecimal]]`` - Will show integer data as hexadecimal.
@@ -209,7 +209,7 @@ In the opposite direction, normally a loose collection of variables without any 
     float c;
   };
 
-However if the desire is to display this as a single fixed element where the fixed tree view is more appropriate, the structure or an variable of it can be annotated as ``[single]]`` or ``[[fixed]]``.
+However if the desire is to display this as a single fixed element where the fixed tree view is more appropriate, the structure or an variable of it can be annotated as ``[[single]]`` or ``[[fixed]]``.
 
 .. code:: c++
 

--- a/qrenderdoc/Widgets/BufferFormatSpecifier.ui
+++ b/qrenderdoc/Widgets/BufferFormatSpecifier.ui
@@ -57,7 +57,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QTextEdit" name="helpText">
+       <widget class="QTextBrowser" name="helpText">
         <property name="html">
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
@@ -78,7 +78,10 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Annotations are supported for explicit layout, bitpacked types like R10G10B10A2, or alternate displays of values including RGB/hexadecimal/octal display. For a complete list see &lt;/span&gt;&lt;a href=&quot;https://renderdoc.org/docs/how/how_buffer_format.html&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#0000ff;&quot;&gt;the documentation linked above&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse|Qt::LinksAccessibleByMouse|Qt::LinksAccessibleByKeyboard</set>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

The first change fixes a set of typos in the [buffer format documentation](https://renderdoc.org/docs/how/how_buffer_format.html); there were missing brackets on `[[fixed]]` and `[[single]]`.

The second change fixes the in-app link - before, all said "Exhaustive documentation can be found in the online docs" with something that renders as a link but wasn't clickable (even right-clicking it didn't give the link destination). That required changing the text interaction flags, converting the help message to a `QTextBrowser`, and setting the `openExternalLinks` property.

I verified that other uses of links work properly via checking all of them found via `git grep href`:
* CaptureContext: Uses `QMessageBox` which defers to the style's `SH_MessageBox_TextInteractionFlags` which in practice has at least `Qt::LinksAccessibleByMouse`:
  * https://github.com/qt/qtbase/blob/v5.15.11-lts-lgpl/src/plugins/styles/mac/qmacstyle_mac.mm#L2850-L2852
  * https://github.com/qt/qtbase/blob/v5.15.11-lts-lgpl/src/widgets/styles/qcommonstyle.cpp#L5303-L5305
  * https://github.com/qt/qtbase/blob/v5.15.11-lts-lgpl/src/widgets/styles/qfusionstyle.cpp#L3702-L3703
* AboutDialog: sets `openExternalLinks` to true on the `version` and `contact` labels in the ui file
* AnalyticsConfirmDialog and AnalyticsPromptDialog: uses `on_label_linkActivated` as an automatic slot (as it needs custom handling for opening the documented analytics report)
* SettingsDialog: uses `on_analyticsDescribeLabel_linkActivated` as an automatic slot (and only has an internal link for opening the documented analytics report)
* CrashDialog: several different ones:
  * captureFilename works via `on_captureFilename_linkActivated` as an automatic slot (and opens a file in explorer)
  * reportText has `openExternalLinks` in the ui file
  * on_send_clicked uses `RDDialog::information` with an email address, which uses `QMessageBox` (see CaptureContext)
  * finishedText has `openExternalLinks` in the ui file
* ExtensionManager: sets `openExternalLinks` to true on the `URL` and `author` labels in the ui file
* TipsDialog: sets `openExternalLinks` to true on the `tipUrlLabel` label in the ui file
* nv_counter_enumerator.cpp: sets `openExternalLinks` to true on the `counterDescription` label in PerformanceCounterSelection.ui