### PR TITLE
Small tweaks to GL and HLSL shaders used to copy depth for Depth overlay

### DIFF
--- a/renderdoc/data/glsl/depth_copy.frag
+++ b/renderdoc/data/glsl/depth_copy.frag
@@ -36,6 +36,6 @@ uniform PRECISION sampler2D srcDepth;
 
 void main()
 {
-  ivec2 srcCoord = ivec2(int(gl_FragCoord.x), int(gl_FragCoord.y));
+  ivec2 srcCoord = ivec2(gl_FragCoord.xy);
   gl_FragDepth = texelFetch(srcDepth, srcCoord, 0).x;
 }

--- a/renderdoc/data/glsl/depth_copyms.frag
+++ b/renderdoc/data/glsl/depth_copyms.frag
@@ -42,6 +42,6 @@ uniform PRECISION sampler2DMS srcDepth;
 
 void main()
 {
-  ivec2 srcCoord = ivec2(int(gl_FragCoord.x), int(gl_FragCoord.y));
+  ivec2 srcCoord = ivec2(gl_FragCoord.xy);
   gl_FragDepth = texelFetch(srcDepth, srcCoord, gl_SampleID).x;
 }

--- a/renderdoc/data/hlsl/depth_copy.hlsl
+++ b/renderdoc/data/hlsl/depth_copy.hlsl
@@ -26,7 +26,7 @@ Texture2D<float2> srcDepth : register(t0);
 
 void RENDERDOC_DepthCopyPS(float4 pos : SV_Position, out float depth : SV_Depth)
 {
-  int2 srcCoord = int2(int(pos.x), int(pos.y));
+  int2 srcCoord = int2(pos.xy);
   depth = srcDepth.Load(int3(srcCoord, 0)).r;
 }
 
@@ -37,6 +37,6 @@ void RENDERDOC_DepthCopyMSPS(float4 pos
                              : SV_SampleIndex, out float depth
                              : SV_Depth)
 {
-  int2 srcCoord = int2(int(pos.x), int(pos.y));
+  int2 srcCoord = int2(pos.xy);
   depth = srcDepthMS.Load(srcCoord, sample).r;
 }


### PR DESCRIPTION
## Description

Minor tidy up of depth copy shaders.

## Testing
- D3D11 & GL automated tests for Overlay
- Online Mali shader compiler to double check GLES version of the glsl shader