### PR TITLE
Couple of small fixes: add a link to the buffer view documents, change the buffer viewer error style for dark mode

### DIFF
--- a/docs/how/how_buffer_format.rst
+++ b/docs/how/how_buffer_format.rst
@@ -162,7 +162,7 @@ The buffer format supports annotations on declarations to specify special proper
 Struct definitions support the following annotations:
 
 * ``[[size(number)]]`` or ``[[byte_size(number)]]`` - Forces the struct to be padded up to a given size even if the contents don't require it.
-* ``[[single]]`` or ``[[fixed]]`` - Forces the struct to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See the below section for more details. Structs with this annotation **may not** be declared as a variable, and should instead be the implicit final struct in a definition.
+* ``[[single]]`` or ``[[fixed]]`` - Forces the struct to be considered as a fixed SoA definition, even if in context the buffer viewer may default to AoS. See :ref:`the below section <aos-soa>` for more details. Structs with this annotation **may not** be declared as a variable, and should instead be the implicit final struct in a definition.
 
 Variable declarations support the following annotations:
 

--- a/qrenderdoc/Widgets/BufferFormatSpecifier.cpp
+++ b/qrenderdoc/Widgets/BufferFormatSpecifier.cpp
@@ -86,9 +86,13 @@ BufferFormatSpecifier::BufferFormatSpecifier(QWidget *parent)
 
   QColor base = formatText->palette().color(QPalette::Base);
 
-  QColor col = QColor::fromHslF(0.0f, 1.0f, qBound(0.1, base.lightnessF(), 0.9));
+  QColor backCol = QColor::fromHslF(0.0f, 1.0f, qBound(0.1, base.lightnessF(), 0.9));
+  QColor foreCol = contrastingColor(backCol, QColor(0, 0, 0));
 
-  formatText->styleSetBack(ERROR_STYLE, SCINTILLA_COLOUR(col.red(), col.green(), col.blue()));
+  formatText->styleSetBack(ERROR_STYLE,
+                           SCINTILLA_COLOUR(backCol.red(), backCol.green(), backCol.blue()));
+  formatText->styleSetFore(ERROR_STYLE,
+                           SCINTILLA_COLOUR(foreCol.red(), foreCol.green(), foreCol.blue()));
 
   ConfigureSyntax(formatText, SCLEX_BUFFER);
 


### PR DESCRIPTION
## Description

- Added a link to "below section" to the buffer viewer struct docs
  - verified by making a documentation build and checking the new link works locally
- In dark mode invert the lightness for the buffer format error style
  - Welcome advice on a different or better way to change the style for Dark Mode 

- Before Buffer Format Error
Dark Mode
![image](https://github.com/Zorro666/renderdoc/assets/39392/98abc6f1-235b-4f9a-bfa3-83f14ce72e47)

- After Buffer Format Error
Dark Mode
![image](https://github.com/baldurk/renderdoc/assets/39392/06482bdb-e845-4994-840a-0a7c85bc0379)
Light Mode
![image](https://github.com/baldurk/renderdoc/assets/39392/3a7ef019-9f22-475e-8ef4-2de2ac230574)

