### PR TITLE
Extend Vulkan Depth Test Overlay

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -195,6 +195,14 @@ static void create(WrappedVulkan *driver, const char *objName, const int line,
     RDCERR("Failed creating object %s at line %i, vkr was %s", objName, line, ToStr(vkr).c_str());
 }
 
+enum class StencilMode
+{
+  KEEP,
+  KEEP_TEST_EQUAL_ONE,
+  REPLACE,
+  WRITE_ZERO,
+};
+
 // a simpler one-shot descriptor containing anything we might want to vary in a graphics pipeline
 struct ConciseGraphicsPipeline
 {
@@ -214,7 +222,7 @@ struct ConciseGraphicsPipeline
   // depth stencil
   bool depthEnable;
   bool stencilEnable;
-  VkStencilOp stencilOp;
+  StencilMode stencilOperations;
 
   // color blend
   bool colourOutput;
@@ -260,6 +268,34 @@ static void create(WrappedVulkan *driver, const char *objName, const int line, V
     msaa.sampleShadingEnable = true;
   }
 
+  VkCompareOp stencilTest = VK_COMPARE_OP_ALWAYS;
+  VkStencilOp stencilOp = VK_STENCIL_OP_KEEP;
+  uint8_t stencilReference = 0;
+
+  switch(info.stencilOperations)
+  {
+    case StencilMode::KEEP:
+    {
+      break;
+    }
+    case StencilMode::KEEP_TEST_EQUAL_ONE:
+    {
+      stencilTest = VK_COMPARE_OP_EQUAL;
+      stencilReference = 1;
+      break;
+    }
+    case StencilMode::REPLACE:
+    {
+      stencilOp = VK_STENCIL_OP_REPLACE;
+      break;
+    }
+    case StencilMode::WRITE_ZERO:
+    {
+      stencilOp = VK_STENCIL_OP_ZERO;
+      break;
+    }
+  };
+
   const VkPipelineDepthStencilStateCreateInfo depthStencil = {
       VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
       NULL,
@@ -269,8 +305,8 @@ static void create(WrappedVulkan *driver, const char *objName, const int line, V
       VK_COMPARE_OP_ALWAYS,
       false,
       info.stencilEnable,
-      {info.stencilOp, info.stencilOp, info.stencilOp, VK_COMPARE_OP_ALWAYS, 0xff, 0xff, 0},
-      {info.stencilOp, info.stencilOp, info.stencilOp, VK_COMPARE_OP_ALWAYS, 0xff, 0xff, 0},
+      {stencilOp, stencilOp, stencilOp, stencilTest, 0xff, 0xff, stencilReference},
+      {stencilOp, stencilOp, stencilOp, stencilTest, 0xff, 0xff, stencilReference},
       0.0f,
       1.0f,
   };
@@ -686,7 +722,7 @@ VulkanDebugManager::VulkanDebugManager(WrappedVulkan *driver)
         true,    // sampleRateShading
         true,    // depthEnable
         true,    // stencilEnable
-        VK_STENCIL_OP_REPLACE,
+        StencilMode::REPLACE,
         false,    // colourOutput
         false,    // blendEnable
         VK_BLEND_FACTOR_ONE,
@@ -738,7 +774,7 @@ VulkanDebugManager::VulkanDebugManager(WrappedVulkan *driver)
         false,    // sampleRateShading
         false,    // depthEnable
         false,    // stencilEnable
-        VK_STENCIL_OP_REPLACE,
+        StencilMode::REPLACE,
         true,     // colourOutput
         false,    // blendEnable
         VK_BLEND_FACTOR_ONE,
@@ -1079,7 +1115,7 @@ void VulkanDebugManager::CreateCustomShaderPipeline(ResourceId shader, VkPipelin
       false,    // sampleRateShading
       false,    // depthEnable
       false,    // stencilEnable
-      VK_STENCIL_OP_KEEP,
+      StencilMode::KEEP,
       true,     // colourOutput
       false,    // blendEnable
       VK_BLEND_FACTOR_ONE,
@@ -2094,7 +2130,7 @@ void VulkanDebugManager::FillWithDiscardPattern(VkCommandBuffer cmd, DiscardType
           false,    // sampleRateShading
           true,     // depthEnable
           true,     // stencilEnable
-          VK_STENCIL_OP_REPLACE,
+          StencilMode::REPLACE,
           true,     // colourOutput
           false,    // blendEnable
           VK_BLEND_FACTOR_ONE,
@@ -3378,7 +3414,7 @@ void VulkanReplay::TextureRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
         false,    // sampleRateShading
         false,    // depthEnable
         false,    // stencilEnable
-        VK_STENCIL_OP_KEEP,
+        StencilMode::KEEP,
         true,     // colourOutput
         false,    // blendEnable
         VK_BLEND_FACTOR_ONE,
@@ -3825,6 +3861,8 @@ void VulkanReplay::OverlayRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
   CREATE_OBJECT(SRGBA8RP, VK_FORMAT_R8G8B8A8_SRGB);
   CREATE_OBJECT(SRGBA8MSRP, VK_FORMAT_R8G8B8A8_SRGB, VULKAN_MESH_VIEW_SAMPLES);
 
+  CREATE_OBJECT(m_PointSampler, VK_FILTER_NEAREST);
+
   CREATE_OBJECT(m_CheckerDescSetLayout,
                 {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_ALL, NULL}});
 
@@ -3839,12 +3877,24 @@ void VulkanReplay::OverlayRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
                     {2, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_ALL, NULL},
                 });
 
+  CREATE_OBJECT(m_DepthCopyDescSetLayout, {
+                                              {
+                                                  0,
+                                                  VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                                  1,
+                                                  VK_SHADER_STAGE_ALL,
+                                                  &m_PointSampler,
+                                              },
+                                          });
+
   CREATE_OBJECT(m_CheckerPipeLayout, m_CheckerDescSetLayout, 0);
   CREATE_OBJECT(m_QuadResolvePipeLayout, m_QuadDescSetLayout, 0);
   CREATE_OBJECT(m_TriSizePipeLayout, m_TriSizeDescSetLayout, 0);
+  CREATE_OBJECT(m_DepthCopyPipeLayout, m_DepthCopyDescSetLayout, 0);
   CREATE_OBJECT(m_QuadDescSet, descriptorPool, m_QuadDescSetLayout);
   CREATE_OBJECT(m_TriSizeDescSet, descriptorPool, m_TriSizeDescSetLayout);
   CREATE_OBJECT(m_CheckerDescSet, descriptorPool, m_CheckerDescSetLayout);
+  CREATE_OBJECT(m_DepthCopyDescSet, descriptorPool, m_DepthCopyDescSetLayout);
 
   m_CheckerUBO.Create(driver, driver->GetDev(), 128, 10, 0);
   RDCCOMPILE_ASSERT(sizeof(CheckerboardUBOData) <= 128, "checkerboard UBO size");
@@ -3861,7 +3911,7 @@ void VulkanReplay::OverlayRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
       false,    // sampleRateShading
       false,    // depthEnable
       false,    // stencilEnable
-      VK_STENCIL_OP_KEEP,
+      StencilMode::KEEP,
       true,     // colourOutput
       false,    // blendEnable
       VK_BLEND_FACTOR_SRC_ALPHA,
@@ -3899,7 +3949,7 @@ void VulkanReplay::OverlayRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
     else
       continue;
 
-    // if we this sample count is supported then create a pipeline
+    // if we know this sample count is supported then create a pipeline
     pipeInfo.renderPass = RGBA16MSRP;
     pipeInfo.sampleCount = VkSampleCountFlagBits(1 << i);
 
@@ -3924,8 +3974,259 @@ void VulkanReplay::OverlayRendering::Init(WrappedVulkan *driver, VkDescriptorPoo
     driver->vkDestroyRenderPass(driver->GetDev(), RGBA16MSRP, NULL);
   }
 
+  samplesHandled = 0;
+  {
+    ConciseGraphicsPipeline DepthCopyPipeInfo = {
+        SRGBA8RP,
+        m_DepthCopyPipeLayout,
+        shaderCache->GetBuiltinModule(BuiltinShader::BlitVS),
+        shaderCache->GetBuiltinModule(BuiltinShader::DepthCopyFS),
+        {VK_DYNAMIC_STATE_VIEWPORT},
+        VK_SAMPLE_COUNT_1_BIT,
+        false,    // sampleRateShading
+        true,     // depthEnable
+        true,     // stencilEnable
+        StencilMode::WRITE_ZERO,
+        true,     // colourOutput
+        false,    // blendEnable
+        VK_BLEND_FACTOR_DST_ALPHA,
+        VK_BLEND_FACTOR_ONE,
+        0x0,    // writeMask
+    };
+
+    VkAttachmentReference colRef = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    VkAttachmentReference dsRef = {1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
+
+    VkAttachmentDescription attDescs[] = {
+        {
+            0,
+            VK_FORMAT_R16G16B16A16_SFLOAT,
+            VK_SAMPLE_COUNT_1_BIT,
+            VK_ATTACHMENT_LOAD_OP_LOAD,
+            VK_ATTACHMENT_STORE_OP_STORE,
+            VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+            VK_ATTACHMENT_STORE_OP_DONT_CARE,
+            colRef.layout,
+            colRef.layout,
+        },
+        {
+            0,
+            VK_FORMAT_D24_UNORM_S8_UINT,
+            VK_SAMPLE_COUNT_1_BIT,    // will patch this just below
+            VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+            VK_ATTACHMENT_STORE_OP_STORE,
+            VK_ATTACHMENT_LOAD_OP_CLEAR,
+            VK_ATTACHMENT_STORE_OP_STORE,
+            dsRef.layout,
+            dsRef.layout,
+        },
+    };
+
+    VkSubpassDescription subp = {
+        0,      VK_PIPELINE_BIND_POINT_GRAPHICS,
+        0,      NULL,       // inputs
+        1,      &colRef,    // color
+        NULL,               // resolve
+        &dsRef,             // depth-stencil
+        0,      NULL,       // preserve
+    };
+
+    VkRenderPassCreateInfo rpinfo = {
+        VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+        NULL,
+        0,
+        2,
+        attDescs,
+        1,
+        &subp,
+        0,
+        NULL,    // dependencies
+    };
+
+    RDCCOMPILE_ASSERT(ARRAY_COUNT(m_DepthResolvePipeline) == ARRAY_COUNT(m_DepthResolvePipeline),
+                      "m_DepthCopyPipeline size must match m_DepthResolvePipeline");
+
+    if(DepthCopyPipeInfo.fragment != VK_NULL_HANDLE)
+    {
+      for(size_t f = 0; f < ARRAY_COUNT(m_DepthCopyPipeline); ++f)
+      {
+        VkFormat fmt = (f == 0) ? VK_FORMAT_D24_UNORM_S8_UINT : VK_FORMAT_D32_SFLOAT_S8_UINT;
+        attDescs[1].format = fmt;
+        for(size_t i = 0; i < ARRAY_COUNT(m_DepthCopyPipeline[f]); ++i)
+        {
+          m_DepthCopyPipeline[f][i] = VK_NULL_HANDLE;
+          VkSampleCountFlagBits samples = VkSampleCountFlagBits(1 << i);
+
+          if((supportedSampleCounts & (uint32_t)samples) == 0)
+            continue;
+
+          VkRenderPass depthMSRP = VK_NULL_HANDLE;
+          attDescs[0].samples = samples;
+          attDescs[1].samples = samples;
+          VkResult vkr = driver->vkCreateRenderPass(driver->GetDev(), &rpinfo, NULL, &depthMSRP);
+          if(vkr != VK_SUCCESS)
+            RDCERR("Failed to create depth overlay resolve render pass: %s", ToStr(vkr).c_str());
+
+          if(depthMSRP != VK_NULL_HANDLE)
+            samplesHandled |= (uint32_t)samples;
+          else
+            continue;
+
+          // if we know this sample count is supported then create a pipeline
+          DepthCopyPipeInfo.renderPass = depthMSRP;
+          DepthCopyPipeInfo.sampleCount = VkSampleCountFlagBits(1 << i);
+
+          if(i == 0)
+            DepthCopyPipeInfo.fragment = shaderCache->GetBuiltinModule(BuiltinShader::DepthCopyFS);
+          else
+            DepthCopyPipeInfo.fragment = shaderCache->GetBuiltinModule(BuiltinShader::DepthCopyMSFS);
+
+          CREATE_OBJECT(m_DepthCopyPipeline[f][i], DepthCopyPipeInfo);
+
+          driver->vkDestroyRenderPass(driver->GetDev(), depthMSRP, NULL);
+        }
+      }
+    }
+  }
   RDCASSERTEQUAL((uint32_t)driver->GetDeviceProps().limits.framebufferColorSampleCounts,
                  samplesHandled);
+
+  samplesHandled = 0;
+  {
+    // make patched shader
+    VkShaderModule greenFSmod = VK_NULL_HANDLE;
+    float green[] = {0.0f, 1.0f, 0.0f, 1.0f};
+    driver->GetDebugManager()->PatchFixedColShader(greenFSmod, green);
+
+    CREATE_OBJECT(m_DepthResolvePipeLayout, VK_NULL_HANDLE, 0);
+
+    ConciseGraphicsPipeline DepthResolvePipeInfo = {
+        SRGBA8RP,
+        m_DepthResolvePipeLayout,
+        shaderCache->GetBuiltinModule(BuiltinShader::BlitVS),
+        greenFSmod,
+        {VK_DYNAMIC_STATE_VIEWPORT},
+        VK_SAMPLE_COUNT_1_BIT,
+        false,    // sampleRateShading
+        false,    // depthEnable
+        true,     // stencilEnable
+        StencilMode::KEEP_TEST_EQUAL_ONE,
+        true,     // colourOutput
+        false,    // blendEnable
+        VK_BLEND_FACTOR_DST_ALPHA,
+        VK_BLEND_FACTOR_ONE,
+        0xf,    // writeMask
+    };
+
+    VkAttachmentReference colRef = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    VkAttachmentReference dsRef = {1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
+
+    VkAttachmentDescription attDescs[] = {
+        {
+            0,
+            VK_FORMAT_R16G16B16A16_SFLOAT,
+            VK_SAMPLE_COUNT_1_BIT,
+            VK_ATTACHMENT_LOAD_OP_LOAD,
+            VK_ATTACHMENT_STORE_OP_STORE,
+            VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+            VK_ATTACHMENT_STORE_OP_DONT_CARE,
+            colRef.layout,
+            colRef.layout,
+        },
+        {
+            0,
+            VK_FORMAT_D24_UNORM_S8_UINT,
+            VK_SAMPLE_COUNT_1_BIT,    // will patch this just below
+            VK_ATTACHMENT_LOAD_OP_LOAD,
+            VK_ATTACHMENT_STORE_OP_STORE,
+            VK_ATTACHMENT_LOAD_OP_LOAD,
+            VK_ATTACHMENT_STORE_OP_STORE,
+            dsRef.layout,
+            dsRef.layout,
+        },
+    };
+
+    VkSubpassDescription subp = {
+        0,      VK_PIPELINE_BIND_POINT_GRAPHICS,
+        0,      NULL,       // inputs
+        1,      &colRef,    // color
+        NULL,               // resolve
+        &dsRef,             // depth-stencil
+        0,      NULL,       // preserve
+    };
+
+    VkRenderPassCreateInfo rpinfo = {
+        VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+        NULL,
+        0,
+        2,
+        attDescs,
+        1,
+        &subp,
+        0,
+        NULL,    // dependencies
+    };
+
+    if(DepthResolvePipeInfo.fragment != VK_NULL_HANDLE)
+    {
+      for(size_t f = 0; f < ARRAY_COUNT(m_DepthResolvePipeline); ++f)
+      {
+        VkFormat fmt = (f == 0) ? VK_FORMAT_D24_UNORM_S8_UINT : VK_FORMAT_D32_SFLOAT_S8_UINT;
+        attDescs[1].format = fmt;
+        for(size_t i = 0; i < ARRAY_COUNT(m_DepthResolvePipeline[f]); ++i)
+        {
+          m_DepthResolvePipeline[f][i] = VK_NULL_HANDLE;
+          VkSampleCountFlagBits samples = VkSampleCountFlagBits(1 << i);
+
+          if((supportedSampleCounts & (uint32_t)samples) == 0)
+            continue;
+
+          VkRenderPass rgba16MSRP = VK_NULL_HANDLE;
+          attDescs[0].samples = samples;
+          attDescs[1].samples = samples;
+          VkResult vkr = driver->vkCreateRenderPass(driver->GetDev(), &rpinfo, NULL, &rgba16MSRP);
+          if(vkr != VK_SUCCESS)
+            RDCERR("Failed to create depth overlay resolve render pass: %s", ToStr(vkr).c_str());
+
+          if(rgba16MSRP != VK_NULL_HANDLE)
+            samplesHandled |= (uint32_t)samples;
+          else
+            continue;
+
+          // if we know this sample count is supported then create a pipeline
+          DepthResolvePipeInfo.renderPass = rgba16MSRP;
+          DepthResolvePipeInfo.sampleCount = VkSampleCountFlagBits(1 << i);
+
+          CREATE_OBJECT(m_DepthResolvePipeline[f][i], DepthResolvePipeInfo);
+
+          driver->vkDestroyRenderPass(driver->GetDev(), rgba16MSRP, NULL);
+        }
+      }
+    }
+  }
+
+  RDCASSERTEQUAL((uint32_t)driver->GetDeviceProps().limits.framebufferColorSampleCounts,
+                 samplesHandled);
+
+  m_DefaultDepthStencilFormat = VK_FORMAT_UNDEFINED;
+  {
+    for(VkFormat fmt : {VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT})
+    {
+      VkImageFormatProperties imgprops = {};
+      VkResult vkr = driver->vkGetPhysicalDeviceImageFormatProperties(
+          driver->GetPhysDev(), fmt, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, 0, &imgprops);
+      if(vkr == VK_SUCCESS)
+      {
+        m_DefaultDepthStencilFormat = fmt;
+        break;
+      }
+    }
+  }
+  if(m_DefaultDepthStencilFormat == VK_FORMAT_UNDEFINED)
+  {
+    RDCERR("Overlay failed to find default depth stencil format");
+  }
 
   VkDescriptorBufferInfo checkerboard = {};
   m_CheckerUBO.FillDescriptor(checkerboard);
@@ -3959,6 +4260,19 @@ void VulkanReplay::OverlayRendering::Destroy(WrappedVulkan *driver)
   for(size_t i = 0; i < ARRAY_COUNT(m_QuadResolvePipeline); i++)
     driver->vkDestroyPipeline(driver->GetDev(), m_QuadResolvePipeline[i], NULL);
 
+  driver->vkDestroyPipelineLayout(driver->GetDev(), m_DepthResolvePipeLayout, NULL);
+  driver->vkDestroyDescriptorSetLayout(driver->GetDev(), m_DepthCopyDescSetLayout, NULL);
+  driver->vkDestroyPipelineLayout(driver->GetDev(), m_DepthCopyPipeLayout, NULL);
+
+  for(size_t f = 0; f < ARRAY_COUNT(m_DepthResolvePipeline); ++f)
+  {
+    for(size_t i = 0; i < ARRAY_COUNT(m_DepthResolvePipeline[f]); ++i)
+    {
+      driver->vkDestroyPipeline(driver->GetDev(), m_DepthResolvePipeline[f][i], NULL);
+      driver->vkDestroyPipeline(driver->GetDev(), m_DepthCopyPipeline[f][i], NULL);
+    }
+  }
+
   driver->vkDestroyDescriptorSetLayout(driver->GetDev(), m_CheckerDescSetLayout, NULL);
   driver->vkDestroyPipelineLayout(driver->GetDev(), m_CheckerPipeLayout, NULL);
   for(size_t i = 0; i < ARRAY_COUNT(m_CheckerF16Pipeline); i++)
@@ -3971,6 +4285,8 @@ void VulkanReplay::OverlayRendering::Destroy(WrappedVulkan *driver)
   m_TriSizeUBO.Destroy();
   driver->vkDestroyDescriptorSetLayout(driver->GetDev(), m_TriSizeDescSetLayout, NULL);
   driver->vkDestroyPipelineLayout(driver->GetDev(), m_TriSizePipeLayout, NULL);
+
+  driver->vkDestroySampler(driver->GetDev(), m_PointSampler, NULL);
 }
 
 void VulkanReplay::MeshRendering::Init(WrappedVulkan *driver, VkDescriptorPool descriptorPool)

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -646,10 +646,21 @@ private:
     VkPipelineLayout m_QuadResolvePipeLayout = VK_NULL_HANDLE;
     VkPipeline m_QuadResolvePipeline[8] = {VK_NULL_HANDLE};
 
+    VkDescriptorSetLayout m_DepthCopyDescSetLayout = VK_NULL_HANDLE;
+    VkDescriptorSet m_DepthCopyDescSet = VK_NULL_HANDLE;
+    VkPipelineLayout m_DepthCopyPipeLayout = VK_NULL_HANDLE;
+    VkPipeline m_DepthCopyPipeline[2][5];
+
+    VkPipelineLayout m_DepthResolvePipeLayout = VK_NULL_HANDLE;
+    VkPipeline m_DepthResolvePipeline[2][5];
+
     GPUBuffer m_TriSizeUBO;
     VkDescriptorSetLayout m_TriSizeDescSetLayout = VK_NULL_HANDLE;
     VkDescriptorSet m_TriSizeDescSet = VK_NULL_HANDLE;
     VkPipelineLayout m_TriSizePipeLayout = VK_NULL_HANDLE;
+
+    VkSampler m_PointSampler = VK_NULL_HANDLE;
+    VkFormat m_DefaultDepthStencilFormat;
   } m_Overlay;
 
   struct MeshRendering

--- a/renderdoc/driver/vulkan/vk_shader_cache.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_cache.cpp
@@ -131,6 +131,10 @@ static const BuiltinShaderConfig builtinShaders[] = {
     BuiltinShaderConfig(BuiltinShader::DepthBuf2MSFS, EmbeddedResource(glsl_vk_depthbuf2ms_frag),
                         rdcspv::ShaderStage::Fragment,
                         FeatureCheck::SampleShading | FeatureCheck::NonMetalBackend),
+    BuiltinShaderConfig(BuiltinShader::DepthCopyFS, EmbeddedResource(glsl_depth_copy_frag),
+                        rdcspv::ShaderStage::Fragment, FeatureCheck::FragmentStores),
+    BuiltinShaderConfig(BuiltinShader::DepthCopyMSFS, EmbeddedResource(glsl_depth_copyms_frag),
+                        rdcspv::ShaderStage::Fragment, FeatureCheck::FragmentStores),
 };
 
 RDCCOMPILE_ASSERT(ARRAY_COUNT(builtinShaders) == arraydim<BuiltinShader>(),

--- a/renderdoc/driver/vulkan/vk_shader_cache.h
+++ b/renderdoc/driver/vulkan/vk_shader_cache.h
@@ -60,6 +60,8 @@ enum class BuiltinShader
   DepthMS2BufferCS,
   Buffer2MSCS,
   DepthBuf2MSFS,
+  DepthCopyFS,
+  DepthCopyMSFS,
   Count,
 };
 


### PR DESCRIPTION
## Description

Vulkan Replay support for Issue [#2858](https://github.com/baldurk/renderdoc/issues/2858)

This is a PR in a sequence of PRs which all together complete the implementation of the feature.
The next PR will extend the automated overlay tests `GL_Overlay_Test`, `D3D11_Overlay_Test`, `D3D12_Overlay_Test`, `VK_Overlay_Test`.

The feature enables supporting shader exported depth for the Depth Test overlay by replaying the draw using the pixel shader from the capture instead of a replacement shader. Depth test passing pixels are identified by using the stencil buffer to generate a stencil mask.

If the depth buffer used for the draw does not have a stencil buffer then a new depth buffer is created with a depth+stencil format and a fullscreen pass is used to copy depth from the original depth buffer to the newly created depth+stencil buffer.
 
## Tested on Windows using changes to `Vk_Overlay_Test`
**The change makes the pixel shader write out depth 0.0 for a small rectangle just bottom-left of the centre**

#### Before (using v1.29) : the rectangle of output depth 0.0 is shown as failing the depth test
Depth Buffer format `D24_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/0871ffd3-2df2-4a6d-b7c4-6cd214c314ab)

Depth Buffer format `D32F_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/0dc7a0d9-ce12-492f-91b8-bc1c8b94a9ec)

Depth Buffer format `D16` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/293dac3d-4681-4f42-b207-561ed94a154d)

Depth Buffer format `D24` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/4c8035e3-3c29-4c56-a5e9-9ba92c2a68d2)

Depth Buffer format `D32F` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/288533af-0584-46cc-84bd-c6457a296687)

#### After  : the rectangle of output depth 0.0 is shown as passing the depth test
Depth Buffer format `D24_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/59d586f5-d678-46dc-8b44-754541b967f6)

Depth Buffer format `D32F_S8`
![image](https://github.com/Zorro666/renderdoc/assets/39392/b2d3c510-7309-438b-9d5f-008c4b3bdffa)

Depth Buffer format `D16` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/3190abeb-c567-4436-983e-e227b99f0722)

Depth Buffer format `D24` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/9823795a-3525-49fc-b42c-9da60c0670b6)

Buffer format `D32F` MSAA
![image](https://github.com/Zorro666/renderdoc/assets/39392/ef3934fc-ee04-401f-a90a-1cb5bc6ff5cf)
