### PR TITLE
Fix abi name for android x86

### DIFF
--- a/renderdoc/android/android_utils.cpp
+++ b/renderdoc/android/android_utils.cpp
@@ -100,7 +100,7 @@ ABI GetABI(const rdcstr &abiName)
     return ABI::armeabi_v7a;
   else if(abiName == "arm64-v8a")
     return ABI::arm64_v8a;
-  else if(abiName == "x86-v7a")
+  else if(abiName == "x86")
     return ABI::x86;
   else if(abiName == "x86_64")
     return ABI::x86_64;


### PR DESCRIPTION
## Description

Fix abi name check for x86 for android.

