### PR TITLE
Stop compute shader usage being computed for Drawcalls

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -4997,7 +4997,7 @@ void WrappedVulkan::AddUsage(VulkanActionTreeNode &actionNode, rdcarray<DebugMes
   }
   else if(action.flags & ActionFlags::Drawcall)
   {
-    shaderStages = {0, 1, 2, 3, 4, 5};
+    shaderStages = {0, 1, 2, 3, 4};
   }
   else if(action.flags & ActionFlags::MeshDispatch)
   {


### PR DESCRIPTION
## Description

Crash found whilst running pixel history tests on a large Vulkan capture 