### PR TITLE
Depth Overlay improvements

### DIFF
--- a/renderdoc/data/hlsl/depth_copy.hlsl
+++ b/renderdoc/data/hlsl/depth_copy.hlsl
@@ -23,11 +23,23 @@
  ******************************************************************************/
 
 Texture2D<float2> srcDepth : register(t0);
+cbuffer ViewInput : register(b0)
+{
+  uint4 viewData;    // viewIndex, ???, ???, ???
+};
 
 void RENDERDOC_DepthCopyPS(float4 pos : SV_Position, out float depth : SV_Depth)
 {
   int2 srcCoord = int2(pos.xy);
   depth = srcDepth.Load(int3(srcCoord, 0)).r;
+}
+
+Texture2DArray<float2> srcDepthArray : register(t0);
+
+void RENDERDOC_DepthCopyArrayPS(float4 pos : SV_Position, out float depth : SV_Depth)
+{
+  int2 srcCoord = int2(pos.xy);
+  depth = srcDepthArray.Load(int4(srcCoord, viewData.x, 0)).r;
 }
 
 Texture2DMS<float2> srcDepthMS : register(t0);
@@ -39,4 +51,15 @@ void RENDERDOC_DepthCopyMSPS(float4 pos
 {
   int2 srcCoord = int2(pos.xy);
   depth = srcDepthMS.Load(srcCoord, sample).r;
+}
+
+Texture2DMSArray<float2> srcDepthMSArray : register(t0);
+
+void RENDERDOC_DepthCopyMSArrayPS(float4 pos
+                                  : SV_Position, uint sample
+                                  : SV_SampleIndex, out float depth
+                                  : SV_Depth)
+{
+  int2 srcCoord = int2(pos.xy);
+  depth = srcDepthMSArray.Load(int3(srcCoord, viewData.x), sample).r;
 }

--- a/renderdoc/driver/d3d11/d3d11_debug.cpp
+++ b/renderdoc/driver/d3d11/d3d11_debug.cpp
@@ -1139,7 +1139,11 @@ void D3D11Replay::OverlayRendering::Init(WrappedID3D11Device *device)
     rdcstr hlsl = GetEmbeddedResource(depth_copy_hlsl);
 
     DepthCopyPS = shaderCache->MakePShader(hlsl.c_str(), "RENDERDOC_DepthCopyPS", "ps_5_0");
+    DepthCopyArrayPS =
+        shaderCache->MakePShader(hlsl.c_str(), "RENDERDOC_DepthCopyArrayPS", "ps_5_0");
     DepthCopyMSPS = shaderCache->MakePShader(hlsl.c_str(), "RENDERDOC_DepthCopyMSPS", "ps_5_0");
+    DepthCopyMSArrayPS =
+        shaderCache->MakePShader(hlsl.c_str(), "RENDERDOC_DepthCopyMSArrayPS", "ps_5_0");
   }
   {
     D3D11_BLEND_DESC blendDesc = {};
@@ -1179,7 +1183,9 @@ void D3D11Replay::OverlayRendering::Release()
   SAFE_RELEASE(TriangleSizeGS);
   SAFE_RELEASE(TriangleSizePS);
   SAFE_RELEASE(DepthCopyPS);
+  SAFE_RELEASE(DepthCopyArrayPS);
   SAFE_RELEASE(DepthCopyMSPS);
+  SAFE_RELEASE(DepthCopyMSArrayPS);
 
   SAFE_RELEASE(DepthResolveDS);
   SAFE_RELEASE(DepthBlendRTMaskZero);

--- a/renderdoc/driver/d3d11/d3d11_replay.h
+++ b/renderdoc/driver/d3d11/d3d11_replay.h
@@ -426,7 +426,9 @@ private:
     ID3D11PixelShader *QOResolvePS = NULL;
     ID3D11PixelShader *TriangleSizePS = NULL;
     ID3D11PixelShader *DepthCopyPS = NULL;
+    ID3D11PixelShader *DepthCopyArrayPS = NULL;
     ID3D11PixelShader *DepthCopyMSPS = NULL;
+    ID3D11PixelShader *DepthCopyMSArrayPS = NULL;
     ID3D11GeometryShader *TriangleSizeGS = NULL;
     ID3D11BlendState *DepthBlendRTMaskZero = NULL;
     ID3D11DepthStencilState *DepthResolveDS = NULL;

--- a/renderdoc/driver/gl/gl_overlay.cpp
+++ b/renderdoc/driver/gl/gl_overlay.cpp
@@ -1012,6 +1012,7 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, Debug
 
     GLuint depthCopy = 0, stencilCopy = 0;
     bool useBlitFramebuffer = true;
+    bool useDepthStencilMask = (overlay == DebugOverlay::Depth) && (curDepth != 0);
 
     // create matching depth for existing FBO
     if(curDepth != 0)
@@ -1062,8 +1063,16 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, Debug
 
         if(oldFmt != fmt)
         {
-          useBlitFramebuffer = false;
-          curStencil = curDepth;
+          if(DebugData.overlayTexSlices > 1)
+          {
+            useDepthStencilMask = false;
+            RDCWARN("Depth overlay using fallback method instead of stencil mask");
+          }
+          else
+          {
+            useBlitFramebuffer = false;
+            curStencil = curDepth;
+          }
         }
       }
 
@@ -1331,7 +1340,6 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, Debug
     if(!IsGLES && !rs.Enabled[GLRenderState::eEnabled_DepthClamp])
       drv.glDisable(eGL_DEPTH_CLAMP);
 
-    bool useDepthStencilMask = (overlay == DebugOverlay::Depth) && (curDepth != 0);
     if(useDepthStencilMask)
     {
       drv.glStencilMask(0xff);

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -2122,9 +2122,22 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
       m_pDriver->ReplayLog(0, eventId, eReplay_OnlyDraw);
 
       if(useDepthWriteStencilPass)
+      {
+        // override stencil dynamic state
+        state.front.compare = 0xff;
+        state.front.write = 0xff;
+        state.front.ref = 0x1;
+        state.front.failOp = VK_STENCIL_OP_KEEP;
+        state.front.passOp = VK_STENCIL_OP_REPLACE;
+        state.front.depthFailOp = VK_STENCIL_OP_KEEP;
+        state.front.compare = VK_COMPARE_OP_ALWAYS;
+        state.back = state.front;
         state.graphics.pipeline = GetResID(depthWriteStencilPipe);
+      }
       else
+      {
         state.graphics.pipeline = GetResID(passpipe);
+      }
 
       if(depthRP != VK_NULL_HANDLE)
       {

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -1676,7 +1676,7 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
           if(m_Overlay.m_DepthResolvePipeline[fmtIndex][sampleIndex] == 0)
           {
             RDCERR("Unhandled depth resolve format : %s", ToStr(dsNewFmt).c_str());
-            return ResourceId();
+            useDepthWriteStencilPass = false;
           }
           if(dsNewFmt != dsFmt)
           {
@@ -1684,8 +1684,20 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
             if(m_Overlay.m_DepthCopyPipeline[fmtIndex][sampleIndex] == 0)
             {
               RDCERR("Unhandled depth copy format : %s", ToStr(dsNewFmt).c_str());
-              return ResourceId();
+              useDepthWriteStencilPass = false;
+              needDepthCopyToDepthStencil = false;
             }
+          }
+          // Currently depth-copy is only supported for Texture2D and Texture2DMS
+          if(dsFmt != dsNewFmt)
+          {
+            if(depthImageInfo.type != VK_IMAGE_TYPE_2D)
+              useDepthWriteStencilPass = false;
+          }
+          if(!useDepthWriteStencilPass)
+          {
+            RDCWARN("Depth overlay using fallback method instead of stencil mask");
+            dsNewFmt = dsFmt;
           }
         }
 


### PR DESCRIPTION
## Description

- Handle depth copying with a texture array source
- Clear stencil to zero during the depth copy to match the other implementations
- Specify the bind flags when creating the new depth-stencil texture
- Use fallback if the depth copy does not handle the depth texture configuration
- Vulkan Depth Overlay specify stencil dynamic state
