### PR TITLE
D3D12 Depth overlay fix for unset stencil mask

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -2323,6 +2323,8 @@ ResourceId D3D12Replay::RenderOverlay(ResourceId texid, FloatVector clearCol, De
         psoDesc.DepthStencilState.FrontFace.StencilFailOp = D3D12_STENCIL_OP_KEEP;
         psoDesc.DepthStencilState.FrontFace.StencilDepthFailOp = D3D12_STENCIL_OP_KEEP;
         psoDesc.DepthStencilState.FrontFace.StencilPassOp = D3D12_STENCIL_OP_REPLACE;
+        psoDesc.DepthStencilState.FrontFace.StencilReadMask = 0xff;
+        psoDesc.DepthStencilState.FrontFace.StencilWriteMask = 0xff;
         psoDesc.DepthStencilState.BackFace = psoDesc.DepthStencilState.FrontFace;
       }
       else


### PR DESCRIPTION
## Description

- D3D12 depth overlay resolve pass was not setting the stencil mask values