### PR TITLE
Support for 64-bit selectors in SPIR-V Disassembly and Shader Debugger

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_common.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_common.cpp
@@ -192,3 +192,22 @@ ShaderBuiltin MakeShaderBuiltin(ShaderStage stage, const rdcspv::BuiltIn el)
 
   return ShaderBuiltin::Undefined;
 }
+
+namespace rdcspv
+{
+
+bool ManualForEachID(const ConstIter &it, const std::function<void(Id, bool)> &callback)
+{
+  switch(it.opcode())
+  {
+    case rdcspv::Op::Switch:
+      // Include just the selector
+      callback(Id::fromWord(it.word(1)), false);
+      return true;
+    default:
+      // unhandled
+      return false;
+  }
+}
+
+};    // namespace rdcspv

--- a/renderdoc/driver/shaders/spirv/spirv_debug.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug.cpp
@@ -3011,6 +3011,9 @@ void ThreadState::StepNext(ShaderDebugState *state, const rdcarray<ThreadState> 
       break;
     }
 
+    case Op::Unreachable:
+      RDCERR("Op::Unreachable reached, terminating debugging!");
+      DELIBERATE_FALLTHROUGH();
     case Op::TerminateInvocation:
     case Op::Kill:
     {
@@ -3806,7 +3809,6 @@ void ThreadState::StepNext(ShaderDebugState *state, const rdcarray<ThreadState> 
     case Op::DecorationGroup:
     case Op::GroupDecorate:
     case Op::GroupMemberDecorate:
-    case Op::Unreachable:
     case Op::DecorateString:
     case Op::MemberDecorateString:
     case Op::DecorateId:

--- a/renderdoc/driver/shaders/spirv/spirv_gen.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_gen.cpp
@@ -1809,12 +1809,6 @@ rdcstr ParamToStr(const std::function<rdcstr(rdcspv::Id)> &idName, const rdcstr 
 }
 
 template<>
-rdcstr ParamToStr(const std::function<rdcstr(rdcspv::Id)> &idName, const PairLiteralIntegerIdRef &el)
-{
-  return StringFormat::Fmt("[%u, %s]", el.first, idName(el.second).c_str());
-}
-
-template<>
 rdcstr ParamToStr(const std::function<rdcstr(rdcspv::Id)> &idName, const PairIdRefLiteralInteger &el)
 {
   return StringFormat::Fmt("[%s, %u]", idName(el.first).c_str(), el.second);
@@ -2151,6 +2145,8 @@ rdcstr ParamToStr(const std::function<rdcstr(rdcspv::Id)> &idName, const rdcspv:
 
 void OpDecoder::ForEachID(const ConstIter &it, const std::function<void(Id,bool)> &callback)
 {
+  if (rdcspv::ManualForEachID(it, callback))
+    return;
   size_t size = it.size();
   uint32_t word = 0;
   (void)word;
@@ -3338,8 +3334,6 @@ void OpDecoder::ForEachID(const ConstIter &it, const std::function<void(Id,bool)
       callback(Id::fromWord(it.word(3)), false);
       break;
     case rdcspv::Op::Switch:
-      callback(Id::fromWord(it.word(1)), false);
-      callback(Id::fromWord(it.word(2)), false);
       break;
     case rdcspv::Op::Kill:
       break;
@@ -7518,14 +7512,8 @@ rdcstr OpDecoder::Disassemble(const ConstIter &it, const std::function<rdcstr(Id
     }
     case rdcspv::Op::Switch:
     {
-      OpSwitch decoded(it);
-      ret += rdcstr("Switch("_lit)
-           + ParamToStr(idName, decoded.selector)
-           + ", "
-           + ParamToStr(idName, decoded.def)
-           + ", "
-           + ParamsToStr(idName, decoded.target)
-           + ")";
+      OpDecoder decoded(it);
+      ret += "Switch(...)";
       break;
     }
     case rdcspv::Op::Kill:

--- a/renderdoc/driver/vulkan/vk_shaderdebug.cpp
+++ b/renderdoc/driver/vulkan/vk_shaderdebug.cpp
@@ -2103,7 +2103,7 @@ private:
     rdcspv::Id breakLabel = editor.MakeId();
     rdcspv::Id defaultLabel = editor.MakeId();
 
-    rdcarray<rdcspv::PairLiteralIntegerIdRef> targets;
+    rdcarray<rdcspv::SwitchPairU32LiteralId> targets;
 
     rdcspv::OperationList cases;
 
@@ -2209,7 +2209,7 @@ private:
     }
 
     func.add(rdcspv::OpSelectionMerge(breakLabel, rdcspv::SelectionControl::None));
-    func.add(rdcspv::OpSwitch(opParam, defaultLabel, targets));
+    func.add(rdcspv::OpSwitch32(opParam, defaultLabel, targets));
 
     func.append(cases);
 
@@ -2544,7 +2544,7 @@ private:
     switchVal = func.add(rdcspv::OpIAdd(u32, editor.MakeId(), switchVal, dim));
 
     // switch on the combined operation and image type value
-    rdcarray<rdcspv::PairLiteralIntegerIdRef> targets;
+    rdcarray<rdcspv::SwitchPairU32LiteralId> targets;
 
     rdcspv::OperationList cases;
 
@@ -2925,7 +2925,7 @@ private:
     }
 
     func.add(rdcspv::OpSelectionMerge(breakLabel, rdcspv::SelectionControl::None));
-    func.add(rdcspv::OpSwitch(switchVal, defaultLabel, targets));
+    func.add(rdcspv::OpSwitch32(switchVal, defaultLabel, targets));
 
     func.append(cases);
 

--- a/util/test/tests/Vulkan/VK_Shader_Debug_Zoo.py
+++ b/util/test/tests/Vulkan/VK_Shader_Debug_Zoo.py
@@ -57,6 +57,28 @@ class VK_Shader_Debug_Zoo(rdtest.TestCase):
                     rdtest.log.success("Test {} in sub-section {} matched as expected".format(test, child))
             rdtest.log.end_section(test_name)
 
+            test_name = "Disassembly Tests"
+            rdtest.log.begin_section(test_name)
+
+            action = self.find_action("ASM tests")
+            self.controller.SetFrameEvent(action.children[0].eventId, False)
+            pipe: rd.PipeState = self.controller.GetPipelineState()
+            refl: rd.ShaderReflection = pipe.GetShaderReflection(rd.ShaderStage.Pixel)
+            disasm = self.controller.DisassembleShader(pipe.GetGraphicsPipelineObject(), refl, "")
+            # Test for some expected strings in the disassembly
+            expectedStrings = []
+            # OpSwitch disassembly of 32-bit and 64-bit literals
+            expectedStrings.append("case 305419896:")
+            expectedStrings.append("case 4063516280:")
+            expectedStrings.append("case 1311768465173141112:")
+            expectedStrings.append("case 17452669529668998776:")
+            for exp in expectedStrings:
+                if exp not in disasm:
+                    failed = True
+                    rdtest.log.error("Failed to find `{}` in disassembly".format(exp))
+
+            rdtest.log.end_section(test_name)
+
         if failed:
             raise rdtest.TestFailureException("Some tests were not as expected")
 


### PR DESCRIPTION
## Description

Issue #3140 

GLSL and HLSL only support 32-bit types for switch selection, SPIR-V supports longer types.
Added support for 64-bit selectors.
Removed Op::Switch handling in SPIR-V helper generator code.
Replaced with hand coded OpSwitch32 in vk_shaderdebug.cpp.
Hand coded support for 64-bit selectors in SPIR-V disassembly and debugger code.

Changed shader debugger handling for `Op::Unreachable` to terminate the debug session.

## Testing
- Extended `VK_Shader_Debug_Zoo` test to include a switch statement using `int`, `uint`, `i64`, `u64` to cover the shader debugger.
- Extended python test to disassemble the ASM test fragment shader and check for hardcoded `case XXXX` strings to validate the disassembly switch case formatting code to ensure it can handle 64-bit literals.
- Reproduction project in the issue
`Before`
```
void generated_store_Generic_u8(ulong _150, ubyte _151) {
  ulong rshift_logical_88 = _150 >> 62;
  
  switch(rshift_logical_88) {
      Unreachable();
    case 0:
      Unreachable();
      Unreachable();
    case 0:
      ulong rshift_logical_89 = _150 >> 61;
      ulong and_90 = rshift_logical_89 & 1;
      bool eq_91 = and_90 == 1;
      ulong select_92 = Select(eq_91, 13835058055282163712, 0);
      ulong and_93 = _150 & 4611686018427387903;
      ulong or_94 = and_93 | select_92;
      generated_store_PrivatePhysical_varying_u8(or_94, _151);
      break;
    default:
      Unreachable();
  }

  return;
}
```
`After`
```
void generated_store_Generic_u8(ulong _150, ubyte _151) {
  ulong rshift_logical_88 = _150 >> 62;
  
  switch(rshift_logical_88) {
    case 0:
      Unreachable();
    case 1:
      Unreachable();
    case 2:
      Unreachable();
    case 3:
      ulong rshift_logical_89 = _150 >> 61;
      ulong and_90 = rshift_logical_89 & 1;
      bool eq_91 = and_90 == 1;
      ulong select_92 = Select(eq_91, 13835058055282163712, 0);
      ulong and_93 = _150 & 4611686018427387903;
      ulong or_94 = and_93 | select_92;
      generated_store_PrivatePhysical_varying_u8(or_94, _151);
      break;
    default:
      Unreachable();
  }

  return;
}
```