### PR TITLE
Mostly updates to depth overlay

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_overlay.cpp
+++ b/renderdoc/driver/d3d11/d3d11_overlay.cpp
@@ -1313,8 +1313,8 @@ ResourceId D3D11Replay::RenderOverlay(ResourceId texid, FloatVector clearCol, De
       float clearColour[] = {0.0f, 0.0f, 0.0f, 0.0f};
       m_pImmediateContext->ClearRenderTargetView(rtv, clearColour);
 
-      ID3D11Buffer *prevCB[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT] = {0};
-      m_pImmediateContext->PSGetConstantBuffers(0, 1, prevCB);
+      ID3D11Buffer *prevCB = NULL;
+      m_pImmediateContext->PSGetConstantBuffers(0, 1, &prevCB);
       ID3D11PixelShader *prevPS = NULL;
       ID3D11ClassInstance *prevClassInstances[D3D11_SHADER_MAX_INTERFACES] = {0};
       UINT prevNumClassInstances = 0;
@@ -1526,9 +1526,10 @@ ResourceId D3D11Replay::RenderOverlay(ResourceId texid, FloatVector clearCol, De
         }
       }
 
-      m_pImmediateContext->PSSetConstantBuffers(0, 1, prevCB);
+      m_pImmediateContext->PSSetConstantBuffers(0, 1, &prevCB);
       m_pImmediateContext->PSSetShader(prevPS, prevClassInstances, prevNumClassInstances);
       m_pImmediateContext->RSSetState(prevrs);
+      SAFE_RELEASE(prevCB);
 
       d = dsDesc;
       d.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;

--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -1175,20 +1175,6 @@ ResourceId D3D12Replay::RenderOverlay(ResourceId texid, FloatVector clearCol, De
         renderDepth, dsViewDesc.Format == DXGI_FORMAT_UNKNOWN ? NULL : &dsViewDesc, dsv);
   }
 
-  D3D12_DEPTH_STENCIL_DESC dsDesc;
-
-  dsDesc.BackFace.StencilFailOp = dsDesc.BackFace.StencilPassOp =
-      dsDesc.BackFace.StencilDepthFailOp = D3D12_STENCIL_OP_KEEP;
-  dsDesc.BackFace.StencilFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-  dsDesc.FrontFace.StencilFailOp = dsDesc.FrontFace.StencilPassOp =
-      dsDesc.FrontFace.StencilDepthFailOp = D3D12_STENCIL_OP_KEEP;
-  dsDesc.FrontFace.StencilFunc = D3D12_COMPARISON_FUNC_ALWAYS;
-  dsDesc.DepthEnable = TRUE;
-  dsDesc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
-  dsDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
-  dsDesc.StencilEnable = FALSE;
-  dsDesc.StencilReadMask = dsDesc.StencilWriteMask = 0xff;
-
   WrappedID3D12PipelineState *pipe = NULL;
 
   if(rs.pipe != ResourceId())

--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -2459,6 +2459,16 @@ ResourceId D3D12Replay::RenderOverlay(ResourceId texid, FloatVector clearCol, De
         rs.pipe = GetResID(greenPSO);
       }
 
+      if(useDepthWriteStencilPass)
+      {
+        list = m_pDevice->GetNewList();
+        if(!list)
+          return ResourceId();
+        list->ClearDepthStencilView(dsv, D3D12_CLEAR_FLAG_STENCIL, 0.0f, 0, 0, NULL);
+        list->Close();
+        list = NULL;
+      }
+
       m_pDevice->ReplayLog(0, eventId, eReplay_OnlyDraw);
 
       rs = prev;

--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -48,7 +48,7 @@
 RDOC_CONFIG(bool, D3D12_HardwareCounters, true,
             "Enable support for IHV-specific hardware counters on D3D12.");
 
-RDOC_CONFIG(bool, D3D12_PixelHistory, false, "BETA: Enable D3D12 pixel history support.");
+RDOC_DEBUG_CONFIG(bool, D3D12_PixelHistory, false, "BETA: Enable D3D12 pixel history support.");
 
 // this is global so we can free it even after D3D12Replay is destroyed
 static HMODULE D3D12Lib = NULL;

--- a/util/test/demos/d3d11/d3d11_overlay_test.cpp
+++ b/util/test/demos/d3d11/d3d11_overlay_test.cpp
@@ -150,6 +150,20 @@ PixOut main(v2f IN)
         {Vec3f(-1.3f, -1.3f, 0.95f), Vec4f(0.1f, 0.1f, 0.5f, 1.0f), Vec2f(0.0f, 0.0f)},
         {Vec3f(0.0f, 1.3f, 0.95f), Vec4f(0.1f, 0.1f, 0.5f, 1.0f), Vec2f(0.0f, 1.0f)},
         {Vec3f(1.3f, -1.3f, 0.95f), Vec4f(0.1f, 0.1f, 0.5f, 1.0f), Vec2f(1.0f, 0.0f)},
+
+        // fullscreen quad used with scissor to set stencil
+        // -1,-1 - +1,-1
+        //   |     /
+        // -1,+1
+        {Vec3f(-1.0f, -1.0f, 0.99f), Vec4f(0.2f, 0.2f, 0.2f, 1.0f), Vec2f(0.0f, 0.0f)},
+        {Vec3f(-1.0f, +1.0f, 0.99f), Vec4f(0.2f, 0.2f, 0.2f, 1.0f), Vec2f(0.0f, 0.0f)},
+        {Vec3f(+1.0f, -1.0f, 0.99f), Vec4f(0.2f, 0.2f, 0.2f, 1.0f), Vec2f(0.0f, 0.0f)},
+        //      +1,-1
+        //    /    |
+        // -1,+1 - +1,+1
+        {Vec3f(+1.0f, -1.0f, 0.99f), Vec4f(0.2f, 0.2f, 0.2f, 1.0f), Vec2f(0.0f, 0.0f)},
+        {Vec3f(-1.0f, +1.0f, 0.99f), Vec4f(0.2f, 0.2f, 0.2f, 1.0f), Vec2f(0.0f, 0.0f)},
+        {Vec3f(+1.0f, +1.0f, 0.99f), Vec4f(0.2f, 0.2f, 0.2f, 1.0f), Vec2f(0.0f, 0.0f)},
     };
 
     ID3D11BufferPtr vb = MakeBuffer().Vertex().Data(VBData);
@@ -241,6 +255,18 @@ PixOut main(v2f IN)
 
           ClearRenderTargetView(rtv, {0.2f, 0.2f, 0.2f, 1.0f});
           ctx->ClearDepthStencilView(curDSV, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+
+          if(hasStencil)
+          {
+            SetStencilRef(0x1);
+            depth.StencilEnable = TRUE;
+            SetDepthState(depth);
+            RSSetScissor({32, 32, 38, 38});
+            ctx->Draw(6, 36);
+            RSSetScissor({0, 0, screenWidth, screenHeight});
+            SetStencilRef(0x55);
+            depth.StencilEnable = FALSE;
+          }
 
           // draw the setup triangles
 

--- a/util/test/demos/d3d12/d3d12_overlay_test.cpp
+++ b/util/test/demos/d3d12/d3d12_overlay_test.cpp
@@ -416,6 +416,14 @@ PixOut main(v2f IN)
             ClearDepthStencilView(cmd, is_msaa ? msaadsvs[f] : dsvs[f],
                                   D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL, 1.0f, 0);
 
+            D3D12_RECT stencilClearRect;
+            stencilClearRect.left = 32;
+            stencilClearRect.right = 38;
+            stencilClearRect.top = 32;
+            stencilClearRect.bottom = 38;
+            cmd->ClearDepthStencilView(m_DSV->GetCPUDescriptorHandleForHeapStart(),
+                                       D3D12_CLEAR_FLAG_STENCIL, 0.0f, 1, 1, &stencilClearRect);
+
             cmd->OMSetStencilRef(0x55);
 
             // draw the setup triangles

--- a/util/test/demos/gl/gl_overlay_test.cpp
+++ b/util/test/demos/gl/gl_overlay_test.cpp
@@ -319,6 +319,14 @@ void main()
           float col[] = {0.2f, 0.2f, 0.2f, 1.0f};
           glClearBufferfv(GL_COLOR, 0, col);
           glClearBufferfi(GL_DEPTH_STENCIL, 0, 1.0f, 0);
+
+          if(hasStencil)
+          {
+            glScissor(32, GLsizei(screenHeight) - 32, 6, 6);
+            glClearBufferfi(GL_DEPTH_STENCIL, 0, 1.0f, 1);
+            glScissor(0, 0, screenWidth, screenHeight);
+          }
+
           glUseProgram(program);
 
           // 1: write depth

--- a/util/test/rdtest/shared/Overlay_Test.py
+++ b/util/test/rdtest/shared/Overlay_Test.py
@@ -49,6 +49,7 @@ class Overlay_Test(rdtest.TestCase):
 
                 # Background around the outside
                 self.check_pixel_value(col_tex, 0.1, 0.1, [0.2, 0.2, 0.2, 1.0])
+                self.check_pixel_value(col_tex, 0.15, 0.2, [0.2, 0.2, 0.2, 1.0])
                 self.check_pixel_value(col_tex, 0.8, 0.1, [0.2, 0.2, 0.2, 1.0])
                 self.check_pixel_value(col_tex, 0.5, 0.95, [0.2, 0.2, 0.2, 1.0])
 
@@ -167,6 +168,13 @@ class Overlay_Test(rdtest.TestCase):
                             self.check_pixel_value(overlay_id, 325, y, [200.0/255.0, 1.0, 0.0, 1.0], eps=eps)
                             self.check_pixel_value(overlay_id, 340, y, [200.0/255.0, 1.0, 0.0, 1.0], eps=eps)
                     elif overlay == rd.DebugOverlay.Depth:
+                        # Background around the outside should not be changed by the overlay
+                        self.check_pixel_value(overlay_id, 35, 35, [0.0, 0.0, 0.0, 0.0])
+                        self.check_pixel_value(overlay_id, 40, 30, [0.0, 0.0, 0.0, 0.0])
+                        self.check_pixel_value(overlay_id, 320, 35, [0.0, 0.0, 0.0, 0.0])
+                        self.check_pixel_value(overlay_id, 200, 285, [0.0, 0.0, 0.0, 0.0])
+
+
                         self.check_pixel_value(overlay_id, 150, 90, [0.0, 1.0, 0.0, 1.0], eps=eps)
                         self.check_pixel_value(overlay_id, 150, 130, [0.0, 1.0, 0.0, 1.0], eps=eps)
                         # Intersection with lesser depth - depth fail


### PR DESCRIPTION
## Description
- extend depth overlay test to clear a rectangle of the stencil buffer to 0x1
- extend depth overlay python test to check depth overlay texture is black in pixels outside of drawcall
- change D3D12_PixelHistory config variable to be a developer config variable
- fix leaking buffer on D3D11 by removing reference after the buffer is used
- D3D12 depth overlay clear stencil buffer to zero in case when it the depth buffer is not copied
- fix Vulkan validation errors on AMD when creating depth overlay pipelines

## Testing
- tested on nVidia & AMD with Vulkan validation layers enabled
- tested on nVidia using D3D11 reproduction for leaking buffer
- tested on nVidia on D3D12 reproduction for depth buffer stencil issue
- ran automated *_Overlay_Tests on nVidia and AMD