### PR TITLE
Fix pixel history on unknown format descriptors.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -1078,6 +1078,9 @@ private:
 
       // TODO: What about D16? Still copy as 32 bit?
       DXGI_FORMAT depthFormat = m_SavedState.dsv.GetDSV().Format;
+      // Descriptors with unknown type are valid and indicate to use the resource's format
+      if(depthFormat == DXGI_FORMAT_UNKNOWN)
+        depthFormat = depthImage->GetDesc().Format;
 
       D3D12CopyPixelParams depthCopyParams = targetCopyParams;
       depthCopyParams.srcImage = depthImage;


### PR DESCRIPTION
Testing the new pixel history feature on d3d12 indicated there are issues when the bound depth stencil uses a descriptor with format DXGI_FORMAT_UNKNOWN. See attached screenshots of captures of identical samples in D3D11 vs D3D12 (without the proposed changes applied). 
D3D11
![test_d3d11](https://github.com/baldurk/renderdoc/assets/1256627/e5ec4338-4cf3-4004-8f07-d5732e954def)
D3D12
![test_d3d12](https://github.com/baldurk/renderdoc/assets/1256627/adf90d12-b296-4c63-b259-cd9a66a7650a)
