### PR TITLE
Fix D3D12 Pixel History crash, fix D3D11 Buffer discard memory trample

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -831,7 +831,7 @@ private:
     ModifyPSOForStencilIncrement(eid, pipeDesc, true);
 
     bool dxil =
-        DXBC::DXBCContainer::CheckForDXIL(pipeDesc.VS.pShaderBytecode, pipeDesc.VS.BytecodeLength);
+        DXBC::DXBCContainer::CheckForDXIL(pipeDesc.PS.pShaderBytecode, pipeDesc.PS.BytecodeLength);
 
     ID3DBlob *psBlob =
         m_pDevice->GetShaderCache()->MakeFixedColShader(D3D12ShaderCache::HIGHLIGHT, dxil);
@@ -1146,7 +1146,7 @@ private:
     D3D12_EXPANDED_PIPELINE_STATE_STREAM_DESC desc;
     origPSO->Fill(desc);
 
-    bool dxil = DXBC::DXBCContainer::CheckForDXIL(desc.VS.pShaderBytecode, desc.VS.BytecodeLength);
+    bool dxil = DXBC::DXBCContainer::CheckForDXIL(desc.PS.pShaderBytecode, desc.PS.BytecodeLength);
     ID3DBlob *psBlob =
         m_pDevice->GetShaderCache()->MakeFixedColShader(D3D12ShaderCache::HIGHLIGHT, dxil);
     if(psBlob == NULL)
@@ -1684,7 +1684,7 @@ private:
     if(pipeCreateFlags & PipelineCreationFlags_FixedColorShader)
     {
       bool dxil =
-          DXBC::DXBCContainer::CheckForDXIL(pipeDesc.VS.pShaderBytecode, pipeDesc.VS.BytecodeLength);
+          DXBC::DXBCContainer::CheckForDXIL(pipeDesc.PS.pShaderBytecode, pipeDesc.PS.BytecodeLength);
 
       ID3DBlob *FixedColorPS = m_ShaderCache->GetFixedColorShader(dxil);
       pipeDesc.PS.pShaderBytecode = FixedColorPS->GetBufferPointer();
@@ -2132,7 +2132,7 @@ struct D3D12PixelHistoryPerFragmentCallback : D3D12PixelHistoryCallback
     else
     {
       bool dxil =
-          DXBC::DXBCContainer::CheckForDXIL(pipeDesc.VS.pShaderBytecode, pipeDesc.VS.BytecodeLength);
+          DXBC::DXBCContainer::CheckForDXIL(pipeDesc.PS.pShaderBytecode, pipeDesc.PS.BytecodeLength);
 
       // TODO: This shader outputs to SV_Target0, will we need to modify the
       // shader (or patch it) if the target image isn't RT0?

--- a/util/test/demos/d3d11/d3d11_discard_zoo.cpp
+++ b/util/test/demos/d3d11/d3d11_discard_zoo.cpp
@@ -100,8 +100,12 @@ RD_TEST(D3D11_Discard_Zoo, D3D11GraphicsTest)
     ID3D11BufferPtr rtvbuf = MakeBuffer().Size(1024).RTV();
     ID3D11BufferPtr srvbuf = MakeBuffer().Size(1024).SRV();
     ID3D11BufferPtr buf = MakeBuffer().Size(1024).Vertex();
+    ID3D11BufferPtr stagingBuf = MakeBuffer().Size(1022).Staging();
+    ID3D11BufferPtr dynamicBuf = MakeBuffer().Size(1026).Vertex().Mappable();
 
     SetDebugName(buf, "Buffer");
+    SetDebugName(dynamicBuf, "Buffer Staging");
+    SetDebugName(stagingBuf, "Buffer Dynamic");
     SetDebugName(srvbuf, "BufferSRV");
     SetDebugName(rtvbuf, "BufferRTV");
 
@@ -129,6 +133,8 @@ RD_TEST(D3D11_Discard_Zoo, D3D11GraphicsTest)
         ctx->UpdateSubresource(rtvbuf, 0, NULL, empty, 1024, 1024);
         ctx->UpdateSubresource(srvbuf, 0, NULL, empty, 1024, 1024);
         ctx->UpdateSubresource(buf, 0, NULL, empty, 1024, 1024);
+        ctx->UpdateSubresource(stagingBuf, 0, NULL, empty, 1024, 1024);
+        ctx->UpdateSubresource(dynamicBuf, 0, NULL, empty, 1024, 1024);
 
         ID3D11RenderTargetViewPtr rt;
 
@@ -269,6 +275,8 @@ RD_TEST(D3D11_Discard_Zoo, D3D11GraphicsTest)
 
       // discard the buffer
       ctx1->DiscardResource(buf);
+      ctx1->DiscardResource(stagingBuf);
+      ctx1->DiscardResource(dynamicBuf);
 
       // discard the whole SRV buffer (can't discard a rect)
       DiscardView<ID3D11ShaderResourceViewPtr>(


### PR DESCRIPTION
## Description

- D3D12 Pixel History use PS instead of VS to detect DXIL to fix crash when doing pixel history on `DispatchMesh` drawcall
- D3D11 Test for discard on Staging and Dynamic Buffers
- D3D11 Discard bug fix for Dynamic, Staging Buffers
  - Staging buffers can't use D3D11_MAP_WRITE_DISCARD.
  - The memory copy loop was counting in bytes but copying in 4-byte chunks leading to memory trampling.
 
## Testing
- `D3D11_Discard_Zoo` functional test
- D3D12 Pixel History on D3D12 mesh shading dragon mesh example
