### PR TITLE
SPIR-V debugger: Fix error message parameters not matching format

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
@@ -206,7 +206,7 @@ static void ClampScalars(rdcspv::DebugAPIWrapper *apiWrapper, const ShaderVariab
     apiWrapper->AddDebugMessage(
         MessageCategory::Execution, MessageSeverity::High, MessageSource::RuntimeWarning,
         StringFormat::Fmt("Invalid scalar index %u at matrix %s with %u columns. Clamping to %u",
-                          scalar0, var.columns, var.name.c_str(), var.columns - 1));
+                          scalar0, var.name.c_str(), var.columns, var.columns - 1));
     scalar0 = RDCMIN((uint8_t)1, var.columns) - 1;
   }
   if(scalar1 > var.rows && scalar1 != 0xff)
@@ -214,7 +214,7 @@ static void ClampScalars(rdcspv::DebugAPIWrapper *apiWrapper, const ShaderVariab
     apiWrapper->AddDebugMessage(
         MessageCategory::Execution, MessageSeverity::High, MessageSource::RuntimeWarning,
         StringFormat::Fmt("Invalid scalar index %u at matrix %s with %u rows. Clamping to %u",
-                          scalar1, var.rows, var.name.c_str(), var.rows - 1));
+                          scalar1, var.name.c_str(), var.rows, var.rows - 1));
     scalar1 = RDCMIN((uint8_t)1, var.rows) - 1;
   }
 }

--- a/util/test/demos/vk/vk_shader_debug_zoo.cpp
+++ b/util/test/demos/vk/vk_shader_debug_zoo.cpp
@@ -1548,6 +1548,20 @@ void main()
       Color = varscope_test(flatLocalCoord, inpos, inposIncreased);
       break;
     }
+    case 176:
+    {
+      ivec2 coord = ivec2(zeroi + 20, zeroi + 20);
+      Color = texelFetch(sampledImages[cbuf.uniformIndex+1], coord, 0);
+      mat4 mat;
+      // force out of bounds matrix lookup to make sure it doesn't crash
+      float temp = mat[int(Color.r)+70][int(Color.g)+80];
+      if (int(temp/(temp+10000.0)) == 1)
+      {
+        Color.r = Color.r;
+      }
+      Color += vec4(1.0, 1.0, 1.0, 1.0);
+      break;
+    }
     default: break;
   }
 }


### PR DESCRIPTION
## Description

Fixes a potential crash when displaying an error message about invalid scalar index on a matrix

Checked `AddDebugMessage` calls in `spirv_debug_setup.cpp` to make sure the parameters match the format specifiers