### PR TITLE
Opening DDS file better estimate size of mip-tail closes #3179

### DIFF
--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -1222,7 +1222,7 @@ RDResult load_dds_from_file(StreamReader *reader, read_dds_data &ret)
      uint64_t(ret.depth) > fileSize || uint64_t(ret.slices) > fileSize ||
      uint64_t(ret.mips) > fileSize || uint64_t(ret.slices) * ret.mips > fileSize ||
      (uint64_t(ret.width) * uint64_t(ret.height) * uint64_t(ret.depth) *
-      RDCMAX(uint64_t(ret.slices), uint64_t(ret.mips))) /
+      RDCMAX(uint64_t(ret.slices), uint64_t(RDCMIN(2U, ret.mips)))) /
              16 >
          fileSize)
   {


### PR DESCRIPTION
## Description

If a mip-tail exists estimate that it will be the same size as mip 0

## Testing

Reproduction DDS file in issue #3179 
Opening a collection of test DDS files 