### PR TITLE
Fix D3D12 pixel history lacking primIDs for draws without a PS.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -989,6 +989,7 @@ struct D3D12ColorAndStencilCallback : public D3D12PixelHistoryCallback
 
     size_t storeOffset =
         m_EventIndices.size() * sizeof(D3D12EventInfo) + offsetof(struct D3D12EventInfo, premod);
+    m_SavedState = m_pDevice->GetQueue()->GetCommandData()->GetCurRenderState();
     CopyPixel(eid, cmd, storeOffset);
   }
   bool PostDispatch(uint32_t eid, ID3D12GraphicsCommandListX *cmd)
@@ -1959,6 +1960,7 @@ struct D3D12PixelHistoryPerFragmentCallback : D3D12PixelHistoryCallback
                                    D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL, 0.0f, 0, 1,
                                    &state.scissors[0]);
 
+        state.rts.resize(1);
         state.rts[0] = *m_CallbackInfo.colorDescriptor;
         state.dsv = *m_CallbackInfo.dsDescriptor;
         state.pipe = GetResID(psosIter[i]);


### PR DESCRIPTION
* No rendertarget was bound to the primitive ID generating draw because rts is empty in draws without a rendertarget bound in the base draw. Setting rts[0] was presumably stomping memory instead in this case.
* Included is a fix for validation layer error thrown when reproducing the problem, in D3D12ColorAndStencilCallback during a Pre/PostDispatch CopyPixel uses the value of m_SavedState but was not set. In the case of rpFlags, the value was uninitialized because D3D12RenderState does not include it in its constructor. That caused an invalid resource transition to be issued and was fortunately caught by the debug layer, otherwise it was thus far invisible when running without debug on.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Testing pixel history on a draw without a render target bound indicates a problem exists in collecting the primitive IDs.
Before:
![image](https://github.com/baldurk/renderdoc/assets/1256627/4afbaa21-ec86-4f41-9c58-3a1d17e1f09c)
After:
![image](https://github.com/baldurk/renderdoc/assets/1256627/c2b19ff2-4d8c-4706-a3be-d10a98cd1bf7)

Note that the stencil value shown in the pixel history is still incorrect in this case, it should show that the draw output a stencil value of 1. That is the next issue I am looking into. 
There are also a number of validation layer warnings about PSOs and pixel shaders having mismatched render target outputs being thrown, which are worth looking into as well. 
