### PR TITLE
Fix D3D12 pixel history missing stencil copy.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -1073,6 +1073,20 @@ private:
 
     CopyImagePixel(cmd, targetCopyParams, offset);
 
+    if(IsDepthAndStencilFormat(m_CallbackInfo.targetDesc.Format))
+    {
+      D3D12CopyPixelParams stencilCopyParams = targetCopyParams;
+      stencilCopyParams.srcImageFormat =
+          GetDepthSRVFormat(m_CallbackInfo.targetImage->GetDesc().Format, 1);
+      stencilCopyParams.copyFormat = DXGI_FORMAT_R8_TYPELESS;
+      stencilCopyParams.planeSlice = 1;
+      stencilCopyParams.srcImageState =
+          m_SavedState.dsv.GetDSV().Flags & D3D12_DSV_FLAG_READ_ONLY_STENCIL
+              ? D3D12_RESOURCE_STATE_DEPTH_READ
+              : D3D12_RESOURCE_STATE_DEPTH_WRITE;
+      CopyImagePixel(cmd, stencilCopyParams, offset + sizeof(float));
+    }
+
     // If the target image is a depth/stencil view, we already copied the value above.
     if(IsDepthFormat(m_CallbackInfo.targetDesc.Format))
       return;


### PR DESCRIPTION
* When viewing pixel history on a depth stencil, the depth value was copied but the stencil value was not.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Before:
![image](https://github.com/baldurk/renderdoc/assets/1256627/f0b26920-b599-4bed-902b-20c2c51bfcde)
After:
![Screenshot 2023-12-21 183156](https://github.com/baldurk/renderdoc/assets/1256627/b2d80231-cba8-4780-9b7e-02335bfbab67)
