### PR TITLE
Expose 'debugOutputMute' option to the user interface

### DIFF
--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -284,6 +284,19 @@ void CaptureDialog::on_CaptureCallstacks_toggled(bool checked)
   }
 }
 
+void CaptureDialog::on_APIValidation_toggled(bool checked)
+{
+  if(ui->APIValidation->isChecked())
+  {
+    ui->DebugOutputMute->setEnabled(true);
+  }
+  else
+  {
+    ui->DebugOutputMute->setChecked(true); // mute debug if API validation is disabled
+    ui->DebugOutputMute->setEnabled(false);
+  }
+}
+
 void CaptureDialog::on_processFilter_textChanged(const QString &filter)
 {
   QSortFilterProxyModel *model = (QSortFilterProxyModel *)ui->processList->model();
@@ -928,11 +941,13 @@ void CaptureDialog::SetSettings(CaptureSettings settings)
   ui->CaptureAllCmdLists->setChecked(settings.options.captureAllCmdLists);
   ui->DelayForDebugger->setValue(settings.options.delayForDebugger);
   ui->VerifyBufferAccess->setChecked(settings.options.verifyBufferAccess);
+  ui->DebugOutputMute->setChecked(settings.options.debugOutputMute);
   ui->AutoStart->setChecked(settings.autoStart);
   ui->SoftMemoryLimit->setValue(settings.options.softMemoryLimit);
 
   // force flush this state
   on_CaptureCallstacks_toggled(ui->CaptureCallstacks->isChecked());
+  on_APIValidation_toggled(ui->DebugOutputMute->isChecked());
 
   if(settings.numQueuedFrames > 0)
   {
@@ -977,6 +992,7 @@ CaptureSettings CaptureDialog::Settings()
   ret.options.captureAllCmdLists = ui->CaptureAllCmdLists->isChecked();
   ret.options.delayForDebugger = (uint32_t)ui->DelayForDebugger->value();
   ret.options.verifyBufferAccess = ui->VerifyBufferAccess->isChecked();
+  ret.options.debugOutputMute = ui->DebugOutputMute->isChecked();
   ret.options.softMemoryLimit = (uint32_t)ui->SoftMemoryLimit->value();
 
   if(ui->queueFrameCap->isChecked())

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -287,7 +287,8 @@ void CaptureDialog::on_APIValidation_toggled(const bool checked)
 
   if(!checked)
   {
-    ui->DebugOutputMute->setChecked(true); // mute debug if API validation is disabled
+    // mute debug if API validation is disabled
+    ui->DebugOutputMute->setChecked(true);
   }
 }
 

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -947,7 +947,7 @@ void CaptureDialog::SetSettings(CaptureSettings settings)
 
   // force flush this state
   on_CaptureCallstacks_toggled(ui->CaptureCallstacks->isChecked());
-  on_APIValidation_toggled(ui->DebugOutputMute->isChecked());
+  on_APIValidation_toggled(ui->APIValidation->isChecked());
 
   if(settings.numQueuedFrames > 0)
   {

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.cpp
@@ -271,29 +271,23 @@ void CaptureDialog::SetInjectMode(bool inject)
   }
 }
 
-void CaptureDialog::on_CaptureCallstacks_toggled(bool checked)
+void CaptureDialog::on_CaptureCallstacks_toggled(const bool checked)
 {
-  if(ui->CaptureCallstacks->isChecked())
-  {
-    ui->CaptureCallstacksOnlyActions->setEnabled(true);
-  }
-  else
+  ui->CaptureCallstacksOnlyActions->setEnabled(checked);
+
+  if(!checked)
   {
     ui->CaptureCallstacksOnlyActions->setChecked(false);
-    ui->CaptureCallstacksOnlyActions->setEnabled(false);
   }
 }
 
-void CaptureDialog::on_APIValidation_toggled(bool checked)
+void CaptureDialog::on_APIValidation_toggled(const bool checked)
 {
-  if(ui->APIValidation->isChecked())
-  {
-    ui->DebugOutputMute->setEnabled(true);
-  }
-  else
+  ui->DebugOutputMute->setEnabled(checked);
+
+  if(!checked)
   {
     ui->DebugOutputMute->setChecked(true); // mute debug if API validation is disabled
-    ui->DebugOutputMute->setEnabled(false);
   }
 }
 

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.h
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.h
@@ -104,6 +104,8 @@ private slots:
 
   void on_CaptureCallstacks_toggled(bool checked);
 
+  void on_APIValidation_toggled(bool checked);
+
   // manual slots
   void vulkanLayerWarn_mouseClick();
   void androidWarn_mouseClick();

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
@@ -530,6 +530,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="DebugOutputMute">
+        <property name="toolTip">
+         <string>When enabled, will mute API debugging output when the API validation mode option is enabled.</string>
+        </property>
+        <property name="text">
+         <string>Debug Output Mute</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QFrame" name="SoftMemoryLimitFrame">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">

--- a/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/CaptureDialog.ui
@@ -532,7 +532,7 @@
       <item>
        <widget class="QCheckBox" name="DebugOutputMute">
         <property name="toolTip">
-         <string>When enabled, will mute API debugging output when the API validation mode option is enabled.</string>
+         <string>Mute API validation debug output.</string>
         </property>
         <property name="text">
          <string>Debug Output Mute</string>


### PR DESCRIPTION
## Description

Add a new check box to the existing option: 'debugOutputMute':
- Enabled if API Validation is checked
- Disabled and set to true if API Validation is unchecked

Changed the on_CaptureCallstacks_toggled to use the boolean (now const) parameter
Created the on_APIValidation_toggled based on on_CaptureCallstacks_toggled 

![image](https://github.com/baldurk/renderdoc/assets/77353979/7d662a2c-d365-45a1-be82-792bbbe247bb)

![image](https://github.com/baldurk/renderdoc/assets/77353979/d12daa29-f498-4569-b83b-db78001479a1)

_Made these changes after trying to identify an issue that was occurring when I tried to run my application in renderdoc due to an unsupported Vulkan extension, and messages were being suppressed by this option._