### PR TITLE
Small fixes and changes to GL, VK, D3D11 and D3D12 pixel history tests

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -2986,6 +2986,7 @@ rdcarray<PixelModification> D3D12Replay::PixelHistory(rdcarray<EventUsage> event
           else
             history[h].postMod.depth =
                 GetDepthValue(DXGI_FORMAT_D32_FLOAT_S8X24_UINT, fragInfo[offset].postMod);
+          history[h].postMod.stencil = -2;
         }
         // If it is not the first fragment for the event, set the preMod to the
         // postMod of the previous fragment.

--- a/util/test/demos/d3d12/d3d12_pixel_history.cpp
+++ b/util/test/demos/d3d12/d3d12_pixel_history.cpp
@@ -457,6 +457,7 @@ float4 main(v2f vertIn, uint primId : SV_PrimitiveID, uint sampleId : SV_SampleI
       depthState.StencilEnable = FALSE;
       pass.backgroundPipe = baselinePSO;
 
+      depthState.StencilEnable = TRUE;
       pass.noPsPipe = baselinePSO.PS(NULL);
 
       depthState.StencilEnable = TRUE;
@@ -564,8 +565,10 @@ float4 main(v2f vertIn, uint primId : SV_PrimitiveID, uint sampleId : SV_SampleI
         cmd->DrawInstanced(3, 1, 0, 0);
 
         setMarker(cmd, "Unbound Fragment Shader");
+        cmd->OMSetStencilRef(0x33);
         cmd->SetPipelineState(pass.noPsPipe);
         cmd->DrawInstanced(3, 1, 3, 0);
+        cmd->OMSetStencilRef(0x55);
 
         setMarker(cmd, "Stencil Write");
         cmd->SetPipelineState(pass.stencilWritePipe);

--- a/util/test/demos/vk/vk_pixel_history.cpp
+++ b/util/test/demos/vk/vk_pixel_history.cpp
@@ -391,8 +391,12 @@ void main()
     VkPipeline backgroundPipe = createGraphicsPipeline(pipeCreateInfo);
 
     pipeCreateInfo.stages = {vertexShader};
+    pipeCreateInfo.depthStencilState.stencilTestEnable = VK_TRUE;
+    pipeCreateInfo.depthStencilState.front.reference = 0x33;
     VkPipeline noFsPipe = createGraphicsPipeline(pipeCreateInfo);
     pipeCreateInfo.stages = {vertexShader, fragmentShader};
+    pipeCreateInfo.depthStencilState.stencilTestEnable = VK_FALSE;
+    pipeCreateInfo.depthStencilState.front.reference = 0x55;
 
     pipeCreateInfo.depthStencilState.stencilTestEnable = VK_TRUE;
     pipeCreateInfo.depthStencilState.front.compareOp = VK_COMPARE_OP_GREATER;

--- a/util/test/tests/D3D11/D3D11_Pixel_History_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_Pixel_History_Zoo.py
@@ -59,6 +59,14 @@ class D3D11_Pixel_History_Zoo(rdtest.TestCase):
                                                                                   modifs[i + 1].eventId,
                                                                                   value_selector(modifs[i].preMod.col)))
 
+                # A fragment event : postMod.stencil should be unknown
+                if modifs[i].eventId == modifs[i+1].eventId:
+                    if modifs[i].postMod.stencil != -1 and modifs[i].postMod.stencil != -2:
+                        raise rdtest.TestFailureException(
+                        "postmod stencil at {} primitive {}: {} is not unknown".format(modifs[i].eventId,
+                                                                                  modifs[i].primitiveID,
+                                                                                  modifs[i].postMod.stencil))
+
                 if self.get_action(modifs[i].eventId).flags & rd.ActionFlags.Drawcall:
                     if not rdtest.value_compare(value_selector(modifs[i].shaderOut.col), shader_out):
                         raise rdtest.TestFailureException(

--- a/util/test/tests/GL/GL_Pixel_History.py
+++ b/util/test/tests/GL/GL_Pixel_History.py
@@ -16,7 +16,7 @@ class GL_Pixel_History(rdtest.TestCase):
             if action is None:
                 break
 
-            rdtest.log.success(f'Test {action.eventId} started.')
+            rdtest.log.success(f'Testing Event {action.eventId} started.')
             self.controller.SetFrameEvent(action.eventId, True)
 
             pipe: rd.PipeState = self.controller.GetPipelineState()
@@ -25,7 +25,7 @@ class GL_Pixel_History(rdtest.TestCase):
             sub = rd.Subresource()
 
             texDescription : rd.TextureDescription = self.get_texture(tex)
-            print(f"format: {texDescription.format.Name()}")
+            rdtest.log.print("Testing format {}".format(texDescription.format.Name()))
 
             if texDescription.format.type == rd.ResourceFormatType.R5G5B5A1 or texDescription.format.type == rd.ResourceFormatType.R5G6B5:
                 eps = 1.0 / 32.0 
@@ -38,9 +38,8 @@ class GL_Pixel_History(rdtest.TestCase):
             else:
                 eps = 2.0 / 16384.0
 
-            
-
             x, y = 190, 149
+            rdtest.log.print("Testing pixel {}, {}".format(x, y))
             events = [glclear.eventId, action.eventId]
             modifs: List[rd.PixelModification] = self.controller.PixelHistory(tex, x, y, sub, rt.typeCast)
             self.check_events(events, modifs, False)
@@ -48,29 +47,22 @@ class GL_Pixel_History(rdtest.TestCase):
             self.check_shader_out_with_postmod(modifs[-1].shaderOut.col.floatValue, modifs[-1].postMod.col.floatValue, texDescription.format.compCount, eps)
 
             x, y = 328, 199
+            rdtest.log.print("Testing pixel {}, {}".format(x, y))
             events = [glclear.eventId]
             modifs: List[rd.pixelModification] = self.controller.PixelHistory(tex, x, y, sub, rt.typeCast)
             self.check_events(events, modifs, False)
             self.check_pixel_value(tex, x, y, modifs[-1].postMod.col.floatValue, sub=sub, cast=rt.typeCast, eps=eps)
 
-            rdtest.log.success('Test {} completed.'.format(action.eventId))
-
+            rdtest.log.success('Testing Event {} completed.'.format(action.eventId))
 
     def check_events(self, events, modifs, hasSecondary):
         eventMatchingModifs = modifs[(-1 * len(events)):]
-        print(f"Events: {events}, Modifs: {modifs}, EventMatchingModifs: {eventMatchingModifs}")
 
         # modifications can show results from previous colour passes which we don't care about for now, so we only check the last relevant modifs
         for i in range(len(eventMatchingModifs)):
             self.check(eventMatchingModifs[i].eventId == events[i], f"Expected event with id {events[i]}, but got {eventMatchingModifs[i].eventId}")
 
-
-
     def check_shader_out_with_postmod(self, shaderOut, postMod, compCount: int, eps: float):
-        print(f"shaderOut: {shaderOut}, posMod: {postMod}")
-
-        diff = 0
-
         for i in range(compCount):
             if not rdtest.value_compare(shaderOut[i], postMod[i], eps=eps):
                 raise rdtest.TestFailureException(f"shaderOut and postMod differ by {shaderOut[i] - postMod[i]}")

--- a/util/test/tests/GL/GL_Pixel_History.py
+++ b/util/test/tests/GL/GL_Pixel_History.py
@@ -3,6 +3,7 @@ import rdtest
 from typing import List
 
 class GL_Pixel_History(rdtest.TestCase):
+    slow_test = True
     demos_test_name = 'GL_Pixel_History'
     demos_frame_cap = 10
 


### PR DESCRIPTION
## Description

- Vk & D3D12: Check the post mod stencil at pixel location 110,100
- Vk & D3D12: Check the post mod stencil is unknown at pixel location 275, 260 for fragment zero of a multi-fragment event
- Vk, D3D11 & D3D12: Validate that in a fragment event the postMod stencil value should be unknown (-1 or -2)
- This test validates the D3D12 pixel history code change in 4815adaa83b
- Tidy up python logging in GL Pixel History and marked it as a slow test
- D3D12 Pixel History set fragment postMod stencil to unknown (-2)
