### PR TITLE
Fix D3D12 pixel history MSAA test issues.

### DIFF
--- a/renderdoc/data/hlsl/d3d12_pixelhistory.hlsl
+++ b/renderdoc/data/hlsl/d3d12_pixelhistory.hlsl
@@ -40,7 +40,7 @@ Texture2DArray<float> copyin_depth : register(t0);
 Texture2DArray<uint> copyin_stencil : register(t1);
 
 Texture2DMSArray<float> copyin_depth_ms : register(t2);
-Texture2DMSArray<uint> copyin_stencil_ms : register(t3);
+Texture2DMSArray<uint2> copyin_stencil_ms : register(t3);
 
 Texture2DArray<float4> copyin_float : register(t4);
 Texture2DMSArray<float4> copyin_float_ms : register(t5);
@@ -70,7 +70,7 @@ RWBuffer<int> copyout_int : register(u4);
     }
     else if(copy_stencil)
     {
-      uint val = copyin_stencil_ms.sample[src_coord.z][uint3(src_coord.xy, src_coord.w)];
+      uint val = copyin_stencil_ms.sample[src_coord.z][uint3(src_coord.xy, src_coord.w)].g;
       copyout_stencil[dst_slot] = val;
     }
     else

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -1087,6 +1087,7 @@ private:
                                            ? D3D12_RESOURCE_STATE_DEPTH_READ
                                            : D3D12_RESOURCE_STATE_DEPTH_WRITE;
       targetCopyParams.srcImageFormat = GetDepthSRVFormat(m_CallbackInfo.targetDesc.Format, 0);
+      targetCopyParams.depthcopy = true;
       targetCopyParams.copyFormat = DXGI_FORMAT_R32_TYPELESS;
       offset += offsetof(struct D3D12PixelHistoryValue, depth);
     }


### PR DESCRIPTION
* Add missing resource transitions for the dispatch copy to fix validation issues encountered while running the test.
* Adjust the component mapping to fix stencil copies failing to output anything, which manifested as the fragment only showing one primitive without correct output data.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Before: 
![d3d12_pixel_history_before](https://github.com/baldurk/renderdoc/assets/1256627/3545c7e5-a6f5-48e9-8fad-cc015fd9eacf)
After:
![d3d12_pixel_history_after](https://github.com/baldurk/renderdoc/assets/1256627/d1c6c82e-578c-4ffb-ac00-bcf6856ec98a)

Sampling stencil via an SRV was different in D3D11 and I've had trouble finding information about how this is intended to be done in D3D12, the shader component mapping is the best I've come up with thus far. It appears that the plane slice works for a Texture2D, but Texture2DMS does not provide such a specifier. I'm happy to change it if there is a different preferred method. 