### PR TITLE
GL ELEMENT_ARRAY_BUFFER_BINDING issue not working for VAO == 0

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -4682,23 +4682,14 @@ void WrappedOpenGL::glBindVertexArray(GLuint array)
   {
     ContextData &cd = GetCtxData();
 
-    if(array == 0)
-    {
-      cd.m_VertexArrayRecord = record = NULL;
+    cd.m_VertexArrayRecord = record =
+        GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), array));
 
-      cd.m_BufferRecord[BufferIdx(eGL_ELEMENT_ARRAY_BUFFER)] = NULL;
-    }
-    else
-    {
-      cd.m_VertexArrayRecord = record =
-          GetResourceManager()->GetResourceRecord(VertexArrayRes(GetCtx(), array));
+    GLuint buffer = 0;
+    GL.glGetIntegerv(eGL_ELEMENT_ARRAY_BUFFER_BINDING, (GLint *)&buffer);
 
-      GLuint buffer = 0;
-      GL.glGetIntegerv(eGL_ELEMENT_ARRAY_BUFFER_BINDING, (GLint *)&buffer);
-
-      cd.m_BufferRecord[BufferIdx(eGL_ELEMENT_ARRAY_BUFFER)] =
-          GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
-    }
+    cd.m_BufferRecord[BufferIdx(eGL_ELEMENT_ARRAY_BUFFER)] =
+        GetResourceManager()->GetResourceRecord(BufferRes(GetCtx(), buffer));
   }
 
   if(IsActiveCapturing(m_State))


### PR DESCRIPTION
For array == 0 previous value should be restored instead of NULL assignment.