### PR TITLE
Add D3D12 pixel history depth bounds test.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -1260,6 +1260,19 @@ struct D3D12TestsFailedCallback : public D3D12PixelHistoryCallback
     uint32_t eventFlags = CalculateEventFlags(pipeState);
     m_EventFlags[eid] = eventFlags;
 
+    WrappedID3D12PipelineState *origPSO =
+        m_pDevice->GetResourceManager()->GetCurrentAs<WrappedID3D12PipelineState>(pipeState.pipe);
+    if(origPSO == NULL)
+      RDCERR("Failed to retrieve original PSO for pixel history.");
+
+    D3D12_EXPANDED_PIPELINE_STATE_STREAM_DESC pipeDesc;
+    origPSO->Fill(pipeDesc);
+
+    if(pipeDesc.DepthStencilState.DepthBoundsTestEnable)
+      m_EventDepthBounds[eid] = {pipeState.depthBoundsMin, pipeState.depthBoundsMax};
+    else
+      m_EventDepthBounds[eid] = {};
+
     // TODO: figure out if the shader has early fragments tests turned on,
     // based on the currently bound fragment shader.
     bool earlyFragmentTests = false;
@@ -1288,6 +1301,13 @@ struct D3D12TestsFailedCallback : public D3D12PixelHistoryCallback
   {
     auto it = m_EventFlags.find(eventId);
     if(it == m_EventFlags.end())
+      RDCERR("Can't find event flags for event %u", eventId);
+    return it->second;
+  }
+  rdcpair<float, float> GetEventDepthBounds(uint32_t eventId)
+  {
+    auto it = m_EventDepthBounds.find(eventId);
+    if(it == m_EventDepthBounds.end())
       RDCERR("Can't find event flags for event %u", eventId);
     return it->second;
   }
@@ -1745,6 +1765,7 @@ private:
   rdcarray<uint32_t> m_Events;
   // Key is event ID, value is the flags for that event.
   std::map<uint32_t, uint32_t> m_EventFlags;
+  std::map<uint32_t, rdcpair<float, float>> m_EventDepthBounds;
   // Key is a pair <Base pipeline, pipeline flags>
   std::map<rdcpair<ResourceId, uint32_t>, ID3D12PipelineState *> m_PipeCache;
   // Key: pair <event ID, test>
@@ -3036,6 +3057,13 @@ rdcarray<PixelModification> D3D12Replay::PixelHistory(rdcarray<EventUsage> event
 
         if(!passed)
           history[h].depthTestFailed = true;
+
+        rdcpair<float, float> depthBounds = tfCb->GetEventDepthBounds(history[h].eventId);
+
+        if((history[h].preMod.depth < depthBounds.first ||
+            history[h].preMod.depth > depthBounds.second) &&
+           depthBounds.second > depthBounds.first)
+          history[h].depthBoundsFailed = true;
       }
     }
   }


### PR DESCRIPTION
* Copied from the Vulkan implementation.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
Before:
![d3d12_pixel_history_before](https://github.com/baldurk/renderdoc/assets/1256627/489b28e1-4203-4733-b38a-d5177445788c)

After:
![d3d12_pixel_history_after](https://github.com/baldurk/renderdoc/assets/1256627/b9790680-73cf-46a1-bb8d-098d409d1aaa)

Figured I'd sneak in a last one of these for 2023, according to my time at least. Happy new year!