### PR TITLE
Fix D3D11_2 GetResourceTiling return unsupport value

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device2_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device2_wrap.cpp
@@ -74,9 +74,10 @@ void WrappedID3D11Device::GetResourceTiling(
   if(m_pDevice2 == NULL)
     return;
 
-  m_pDevice2->GetResourceTiling(pTiledResource, pNumTilesForEntireResource, pPackedMipDesc,
-                                pStandardTileShapeForNonPackedMips, pNumSubresourceTilings,
-                                FirstSubresourceTilingToGet, pSubresourceTilingsForNonPackedMips);
+  m_pDevice2->GetResourceTiling(UnwrapResource(pTiledResource), pNumTilesForEntireResource,
+                                pPackedMipDesc, pStandardTileShapeForNonPackedMips,
+                                pNumSubresourceTilings, FirstSubresourceTilingToGet,
+                                pSubresourceTilingsForNonPackedMips);
 }
 
 HRESULT WrappedID3D11Device::CheckMultisampleQualityLevels1(DXGI_FORMAT Format, UINT SampleCount,


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

See Issue #3200 

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
