### PR TITLE
Fix Vulkan wireframe overlay, set the dynamic state polygonMode

### DIFF
--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -902,6 +902,7 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
         else if(m_pDriver->GetDeviceEnabledFeatures().fillModeNonSolid)
         {
           rs->polygonMode = VK_POLYGON_MODE_LINE;
+          state.polygonMode = rs->polygonMode;
         }
         else if(prevstate.primitiveTopology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST ||
                 prevstate.primitiveTopology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP ||


### PR DESCRIPTION
## Description

When replaying capture using `vkCmdSetPolygonModeEXT(VK_POLYGON_MODE_FILL)`
Set the render state `polygonMode` to match the graphics pipeline setting