### PR TITLE
Add missing strings for Vulkan task and mesh shaders.

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_shader_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_shader_funcs.cpp
@@ -517,8 +517,10 @@ bool WrappedVulkan::Serialise_vkCreateGraphicsPipelines(
               DerivedResource(device, shadId);
               DerivedResource(pipe, shadId);
 
-              const char *names[] = {" vertex shader", " tess control shader", " tess eval shader",
-                                     " geometry shader", " fragment shader"};
+              const char *names[] = {" vertex shader",    " tess control shader",
+                                     " tess eval shader", " geometry shader",
+                                     " fragment shader",  NULL,
+                                     " task shader",      " mesh shader"};
 
               if(shadName)
                 GetReplay()->GetResourceDesc(shadId).SetCustomName(shadName->pObjectName);


### PR DESCRIPTION
## Description
Fixes a crash when replaying a capture that uses mesh/task shaders with GPL.