### PR TITLE
Collection of small fixes: SPIR-V Bitcast fixes, D3D12 Pixel History D16 test, D3D11 TiledResource changes

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device3_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device3_wrap.cpp
@@ -125,6 +125,10 @@ HRESULT WrappedID3D11Device::CreateTexture2D1(const D3D11_TEXTURE2D_DESC1 *pDesc
   if(m_pDevice3 == NULL)
     return E_NOINTERFACE;
 
+  // Tiled resources are not supported
+  if(pDesc1 && pDesc1->MiscFlags & D3D11_RESOURCE_MISC_TILED)
+    return DXGI_ERROR_UNSUPPORTED;
+
   // validation, returns S_FALSE for valid params, or an error code
   if(ppTexture2D == NULL)
     return m_pDevice3->CreateTexture2D1(pDesc1, pInitialData, NULL);

--- a/renderdoc/driver/shaders/spirv/spirv_debug.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug.cpp
@@ -1297,16 +1297,17 @@ void ThreadState::StepNext(ShaderDebugState *state, const rdcarray<ThreadState> 
           srcByteCount = 1;
 
         uint32_t dstByteCount = type.scalar().width / 8;
+        uint32_t dstColumns = (type.type == DataType::ScalarType) ? 1 : type.vector().count;
 
         // must be identical bit count
-        RDCASSERT(dstByteCount * type.vector().count == srcByteCount * var.columns);
+        RDCASSERT(dstByteCount * dstColumns == srcByteCount * var.columns);
 
         // because this is a bitcast, we leave var.value entirely alone. There is the same number of
         // bytes so the union handles it. E.g. uv[0], uv[1] being bitcast to a single 64-bit
         // corresponds exactly to the LSB and MSB of u64v[0]
 
         var.type = type.scalar().Type();
-        var.columns = type.vector().count & 0xff;
+        var.columns = dstColumns & 0xff;
       }
 
       SetDst(cast.result, var);

--- a/util/test/demos/d3d11/d3d11_parameter_zoo.cpp
+++ b/util/test/demos/d3d11/d3d11_parameter_zoo.cpp
@@ -60,9 +60,39 @@ RD_TEST(D3D11_Parameter_Zoo, D3D11GraphicsTest)
 
     ctx1->SwapDeviceContextState(ctxstate_off, NULL);
 
+    std::string features1_tiled_resources("Features1: D3D11_TILED_RESOURCES_SUPPORTED");
+    std::string features2_tiled_resources("Features2: D3D11_TILED_RESOURCES_SUPPORTED");
+    std::string create_tiled_buffer("CreateTiledBuffer: Passed");
+    std::string create_tile_pool_buffer("CreateTile_PoolBuffer: Passed");
+    std::string create_tiled_texture2D("CreateTiledTexture2D: Passed");
+    std::string create_tiled_texture2D1("CreateTiledTexture2D1: Passed");
     if(dev2)
     {
-      // Test GetResourceTiling returns correct parameters for wrapped textures
+      D3D11_FEATURE_DATA_D3D11_OPTIONS1 features1;
+      CHECK_HR(dev2->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS1, &features1, sizeof(features1)));
+      if(features1.TiledResourcesTier == D3D11_TILED_RESOURCES_NOT_SUPPORTED)
+        features1_tiled_resources = "Features1: D3D11_TILED_RESOURCES_NOT_SUPPORTED";
+
+      D3D11_FEATURE_DATA_D3D11_OPTIONS2 features2;
+      CHECK_HR(dev2->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS2, &features2, sizeof(features2)));
+      if(features2.TiledResourcesTier == D3D11_TILED_RESOURCES_NOT_SUPPORTED)
+        features2_tiled_resources = "Features2: D3D11_TILED_RESOURCES_NOT_SUPPORTED";
+
+      // Check trying to create tiled resources fails
+      D3D11_BUFFER_DESC bufDesc = {};
+      bufDesc.ByteWidth = 1024;
+      bufDesc.Usage = D3D11_USAGE_DEFAULT;
+      bufDesc.StructureByteStride = 1;
+      bufDesc.CPUAccessFlags = 0;
+      bufDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+      bufDesc.MiscFlags = D3D11_RESOURCE_MISC_TILED;
+      if(FAILED(dev2->CreateBuffer(&bufDesc, NULL, NULL)))
+        create_tiled_buffer = "CreateTiledBuffer: Failed";
+
+      bufDesc.MiscFlags = D3D11_RESOURCE_MISC_TILE_POOL;
+      if(FAILED(dev2->CreateBuffer(&bufDesc, NULL, NULL)))
+        create_tile_pool_buffer = "CreateTile_PoolBuffer: Failed";
+
       D3D11_TEXTURE2D_DESC texDesc = {};
       texDesc.Width = 8;
       texDesc.Height = 8;
@@ -75,24 +105,25 @@ RD_TEST(D3D11_Parameter_Zoo, D3D11GraphicsTest)
       texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
       texDesc.CPUAccessFlags = 0;
       texDesc.MiscFlags = D3D11_RESOURCE_MISC_TILED;
-
-      ID3D11Texture2DPtr tiledTexture;
-      CHECK_HR(dev2->CreateTexture2D(&texDesc, NULL, &tiledTexture));
-
-      uint32_t numTiles;
-      D3D11_PACKED_MIP_DESC packed;
-      D3D11_TILE_SHAPE tileShape;
-      uint32_t numSubTiles = 1;
-      uint32_t firstSubTile = 0;
-      D3D11_SUBRESOURCE_TILING subTiling;
-      dev2->GetResourceTiling(tiledTexture, &numTiles, &packed, &tileShape, &numSubTiles,
-                              firstSubTile, &subTiling);
-      if(tileShape.WidthInTexels == 0)
-        TEST_FATAL("WidthInTexels is zero");
-      if(tileShape.HeightInTexels == 0)
-        TEST_FATAL("HeightInTexels is zero");
-      if(tileShape.DepthInTexels == 0)
-        TEST_FATAL("DepthInTexels is zero");
+      if(FAILED(dev2->CreateTexture2D(&texDesc, NULL, NULL)))
+        create_tiled_texture2D = "CreateTiledTexture2D: Failed";
+    }
+    if(dev3)
+    {
+      D3D11_TEXTURE2D_DESC1 texDesc = {};
+      texDesc.Width = 8;
+      texDesc.Height = 8;
+      texDesc.MipLevels = 1;
+      texDesc.ArraySize = 1;
+      texDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+      texDesc.SampleDesc.Count = 1;
+      texDesc.SampleDesc.Quality = 0;
+      texDesc.Usage = D3D11_USAGE_DEFAULT;
+      texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+      texDesc.CPUAccessFlags = 0;
+      texDesc.MiscFlags = D3D11_RESOURCE_MISC_TILED;
+      if(FAILED(dev3->CreateTexture2D1(&texDesc, NULL, NULL)))
+        create_tiled_texture2D1 = "CreateTiledTexture2D1: Failed";
     }
 
     while(Running())
@@ -133,6 +164,13 @@ RD_TEST(D3D11_Parameter_Zoo, D3D11GraphicsTest)
       ctx->OMSetRenderTargets(1, &bbRTV.GetInterfacePtr(), NULL);
 
       ctx->Draw(3, 0);
+
+      setMarker(features1_tiled_resources);
+      setMarker(features2_tiled_resources);
+      setMarker(create_tiled_buffer);
+      setMarker(create_tile_pool_buffer);
+      setMarker(create_tiled_texture2D);
+      setMarker(create_tiled_texture2D1);
 
       Present();
 

--- a/util/test/tests/D3D11/D3D11_Parameter_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_Parameter_Zoo.py
@@ -34,6 +34,18 @@ class D3D11_Parameter_Zoo(rdtest.TestCase):
         self.check_pixel_value(overlay_id, int(0.5 * v.width), int(0.5 * v.height), [0.8, 0.1, 0.8, 1.0],
                                eps=1.0 / 256.0)
 
+        expected_markers = [
+            "Features1: D3D11_TILED_RESOURCES_NOT_SUPPORTED",
+            "Features2: D3D11_TILED_RESOURCES_NOT_SUPPORTED",
+            "CreateTiledBuffer: Failed",
+            "CreateTile_PoolBuffer: Failed",
+            "CreateTiledTexture2D: Failed",
+            "CreateTiledTexture2D1: Failed",
+        ]
+        for marker in expected_markers:
+            if self.find_action(marker) == None:
+                raise rdtest.TestFailureException("Failed to find marker `{}`".format(marker))
+
         out.Shutdown()
 
         rdtest.log.success("Overlay color is as expected")


### PR DESCRIPTION
## Description
- SPIR-V Debugger fix Bitcast from vector to scalar (with tests)
- D3D12 Pixel History Simple D16 test (test validates code a4ff65b59aa)
- D3D11: Improve handling of unsupported tiled resources feature (with tests)
  - Return `DXGI_ERROR_UNSUPPORTED` if try to create tiled resources from `CreateBuffer()`, `CreateTexture2D()`, `CreateTexture2D1()`
  - Return `D3D11_TILED_RESOURCES_NOT_SUPPORTED` in `CheckFeatures()` with `D3D11_FEATURE_D3D11_OPTIONS1`
