### PR TITLE
Depth overlay updates : only use the stencil mask approach when the shader exports depth

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_overlay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_overlay.cpp
@@ -2120,6 +2120,21 @@ ResourceId D3D12Replay::RenderOverlay(ResourceId texid, FloatVector clearCol, De
       ID3D12Resource *renderDepthStencil = NULL;
       bool useDepthWriteStencilPass = (overlay == DebugOverlay::Depth) && renderDepth;
 
+      if(useDepthWriteStencilPass)
+      {
+        useDepthWriteStencilPass = false;
+        WrappedID3D12PipelineState::ShaderEntry *wrappedPS = pipe->PS();
+        if(wrappedPS)
+        {
+          ShaderReflection &reflection = pipe->PS()->GetDetails();
+          for(SigParameter &output : reflection.outputSignature)
+          {
+            if(output.systemValue == ShaderBuiltin::DepthOutput)
+              useDepthWriteStencilPass = true;
+          }
+        }
+      }
+
       HRESULT hr;
       DXGI_FORMAT dsFmt = dsViewDesc.Format;
       // the depth overlay uses stencil buffer as a mask for the passing pixels

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -1644,6 +1644,24 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
         if(overlay == DebugOverlay::Depth)
           useDepthWriteStencilPass = true;
 
+        if(useDepthWriteStencilPass)
+        {
+          useDepthWriteStencilPass = false;
+          const VulkanCreationInfo::Pipeline::Shader &ps = pipeInfo.shaders[4];
+          if(ps.module != ResourceId())
+          {
+            ShaderReflection *reflection = ps.refl;
+            if(reflection)
+            {
+              for(SigParameter &output : reflection->outputSignature)
+              {
+                if(output.systemValue == ShaderBuiltin::DepthOutput)
+                  useDepthWriteStencilPass = true;
+              }
+            }
+          }
+        }
+
         VkAttachmentDescription attDescs[] = {
             {0, overlayFormat, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD,
              VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,

--- a/util/test/demos/gl/gl_overlay_test.cpp
+++ b/util/test/demos/gl/gl_overlay_test.cpp
@@ -108,6 +108,25 @@ void main()
 
 )EOSHADER";
 
+  std::string discardpixel = R"EOSHADER(
+
+in v2f vertIn;
+
+layout(location = 0, index = 0) out vec4 Color;
+
+void main()
+{
+	Color = vertIn.col;
+
+	if ((gl_FragCoord.x > 327.0) && (gl_FragCoord.x < 339.0) &&
+      (gl_FragCoord.y > 252.0) && (gl_FragCoord.y < 262.0))
+	{
+    discard;
+  }
+}
+
+)EOSHADER";
+
   int main()
   {
     // initialise, create window, create context, etc
@@ -182,6 +201,11 @@ void main()
         {Vec3f(-1.3f, -1.3f, 0.95f), Vec4f(0.1f, 0.1f, 0.5f, 1.0f), Vec2f(0.0f, 0.0f)},
         {Vec3f(0.0f, 1.3f, 0.95f), Vec4f(0.1f, 0.1f, 0.5f, 1.0f), Vec2f(0.0f, 1.0f)},
         {Vec3f(1.3f, -1.3f, 0.95f), Vec4f(0.1f, 0.1f, 0.5f, 1.0f), Vec2f(1.0f, 0.0f)},
+
+        // discard rectangle
+        {Vec3f(0.6f, +0.7f, 0.5f), Vec4f(0.0f, 0.0f, 0.0f, 1.0f), Vec2f(0.0f, 0.0f)},
+        {Vec3f(0.7f, +0.9f, 0.5f), Vec4f(0.0f, 0.0f, 0.0f, 1.0f), Vec2f(0.0f, 1.0f)},
+        {Vec3f(0.8f, +0.7f, 0.5f), Vec4f(0.0f, 0.0f, 0.0f, 1.0f), Vec2f(1.0f, 0.0f)},
     };
 
     GLuint vb = MakeBuffer();
@@ -200,6 +224,7 @@ void main()
     GLuint program = MakeProgram(common + vertex, common + pixel);
     GLuint whiteprogram = MakeProgram(common + vertex, whitepixel);
     GLuint fragdepthprogram = MakeProgram(common + vertex, common + fragdepthpixel);
+    GLuint discardprogram = MakeProgram(common + vertex, common + discardpixel);
 
     const char *fmtNames[] = {"D24_S8", "D32F_S8", "D16_S0", "D24_S0", "D32F_S0"};
     GLenum fmts[] = {GL_DEPTH24_STENCIL8, GL_DEPTH32F_STENCIL8, GL_DEPTH_COMPONENT16,
@@ -354,6 +379,11 @@ void main()
           glStencilFunc(GL_GREATER, 0x55, 0xff);
           glUseProgram(fragdepthprogram);
           glDrawArrays(GL_TRIANGLES, 9, 24);
+
+          markerName = "Discard " + markerName;
+          setMarker(markerName);
+          glUseProgram(discardprogram);
+          glDrawArrays(GL_TRIANGLES, 36, 3);
           glUseProgram(program);
 
           if(!is_msaa)

--- a/util/test/rdtest/shared/Overlay_Test.py
+++ b/util/test/rdtest/shared/Overlay_Test.py
@@ -421,6 +421,16 @@ class Overlay_Test(rdtest.TestCase):
                 else:
                     rdtest.log.success("All normal overlays are as expected Format {}".format(fmt))
 
+            # Shader with discard
+            test_marker: rd.ActionDescription = self.find_action("Discard " + marker_name, base_event)
+            self.controller.SetFrameEvent(test_marker.next.eventId, True)
+            pipe: rd.PipeState = self.controller.GetPipelineState()
+            tex.overlay = rd.DebugOverlay.Depth
+            out.SetTextureDisplay(tex)
+            out.Display()
+            overlay_id: rd.ResourceId = out.GetDebugOverlayTexID()
+            self.check_pixel_value(overlay_id, 330, 40, [0.0, 1.0, 0.0, 1.0], eps=eps)
+
             # Check the viewport overlay especially
             view_marker: rd.ActionDescription = self.find_action("Viewport Test " + fmt, base_event)
 


### PR DESCRIPTION
## Description
- use the non-stencil mask approach by default
- use the stencil mask approach when the shader exports depth
- the stencil mask approach shows discarded fragments as failing the depth test and the non-stencil mask approach ignores discarded fragments
- added depth overlay test for a shader using discard but not exporting depth (test fails before the code change and passes after the code change)
