### PR TITLE
Fix handle leaks during probe for remote devices

### DIFF
--- a/renderdoc/core/remote_server.cpp
+++ b/renderdoc/core/remote_server.cpp
@@ -1247,7 +1247,10 @@ RENDERDOC_CreateRemoteServerConnection(const rdcstr &URL, IRemoteServer **rend)
   }
 
   if(rend == NULL)
+  {
+    SAFE_DELETE(sock);
     return RDResult(ResultCode::Succeeded);
+  }
 
   if(protocol)
     *rend = protocol->CreateRemoteServer(sock, deviceID);

--- a/renderdoc/os/win32/win32_process.cpp
+++ b/renderdoc/os/win32/win32_process.cpp
@@ -1060,6 +1060,12 @@ uint32_t Process::LaunchProcess(const rdcstr &app, const rdcstr &workingDir, con
   {
     if(!internal)
       RDCWARN("Couldn't launch process '%s'", appPath.c_str());
+
+    if(hChildStdError_Rd != NULL)
+      CloseHandle(hChildStdError_Rd);
+    if(hChildStdOutput_Rd != NULL)
+      CloseHandle(hChildStdOutput_Rd);
+
     return 0;
   }
 


### PR DESCRIPTION
This PR fixes two handle leaks that occur when RenderDoc probes for remote devices.

Logic was added to RENDERDOC_CreateRemoteServerConnection to close a socket left open when the function was used to test but not maintain a connection to a remote device, and to the windows platform specialization of Process::LaunchProcess to close handles for reading from stdout and stderr that could be left open if the process failed to launch