### PR TITLE
Multi-queue capture serialisation ordering, respecting fence blocking/signalling

### DIFF
--- a/renderdoc/api/replay/rdcarray.h
+++ b/renderdoc/api/replay/rdcarray.h
@@ -323,11 +323,11 @@ public:
   }
 
   template <typename... ConstructArgs>
-  void emplace_back(ConstructArgs... args)
+  void emplace_back(ConstructArgs &&...args)
   {
     const size_t lastIdx = size();
     reserve(size() + 1);
-    new(elems + lastIdx) T(std::forward<ConstructArgs...>(args)...);
+    new(elems + lastIdx) T(std::forward<ConstructArgs>(args)...);
     setUsedCount(usedCount + 1);
   }
 

--- a/renderdoc/serialise/serialiser.h
+++ b/renderdoc/serialise/serialiser.h
@@ -1806,7 +1806,7 @@ public:
   }
 
   template <typename ChunkType>
-  ChunkType GetChunkType()
+  ChunkType GetChunkType() const
   {
     return (ChunkType)m_ChunkType;
   }
@@ -1842,7 +1842,7 @@ public:
     return ret;
   }
 
-  void Write(Serialiser<SerialiserMode::Writing> &ser)
+  void Write(Serialiser<SerialiserMode::Writing> &ser) const
   {
     ser.GetWriter()->Write((const void *)m_Data, (size_t)m_Length);
   }

--- a/util/test/tests/D3D12/D3D12_Multi_Wait_Before_Signal.py
+++ b/util/test/tests/D3D12/D3D12_Multi_Wait_Before_Signal.py
@@ -4,15 +4,9 @@ import rdtest
 class D3D12_Multi_Wait_Before_Signal(rdtest.TestCase):
     demos_test_name = 'D3D12_Multi_Wait_Before_Signal'
 
-    def check_support(self):
-        # TODO: Enable this if/when rdoc can reorder from the original submission
-        # order, which blocks multiple queues with waits that get signalled by
-        # later submissions to other queues.
-        return False, 'Renderdoc does not yet adequately reorder capture replay'
-
     def check_capture(self):
         draw_marker: rd.ActionDescription = self.find_action("Last draw")
-        self.controller.SetFrameEvent(draw_marker.eventId, False)
+        self.controller.SetFrameEvent(draw_marker.previous.eventId, False)
 
         pipe: rd.PipeState = self.controller.GetPipelineState()
 


### PR DESCRIPTION
## Description

In short: This makes a capture's linear sequence of events better match the sequence that the GPU actually executes (currently for D3D12 only).  This enables and fixes the `D3D12_Multi_Wait_Before_Signal` test and should fix/improve Renderdoc replaying of multi-queue captures for work that get submitted out of 'execution' order, which is totally fine for applications to do but which caused RD problems.

In more detail, from the main commit message -
```

Instead of serialising captured chunks purely by ascending event ID, which fails
to correctly replay the 'D3D12_Multi_Wait_Before_Signal' test, this walks the
commands for all captured queues and blocks/defers serialising queue commands
that are subsequent to a blocked 'fence wait'.

When queue serialisation reaches a blocked 'wait' it cycles queues to try to
serialise the next unblocked queue command chunks.

It tracks fence signal values within the capture so that we can resume serialising
queue command chunks after a suitably signalled, previously blocked fence 'wait'.

This could result in deadlocking the serialisation if a queue waits on a fence that
is signalled outside the scope of what is captured.  To deal with this, we first
assume that 'waited on' fences that are never seen to be signalled in our capture
records are simply considered signalled so we'll never block on them.  Then, if we
detect a deadlock on any other fence waits, we try to conservatively emulate a
suitable fence signal outside the capture's scope (happens in D3D12_Sharing test).
If all else fails, we resort to the previous event-ID-ordered serialisation.
```

Although the changes are quite isolated, they're not quite trivial, so in anticipation of some feedback and discussion, I thought it best to start this off as a draft PR.
