### PR TITLE
D3D12 Pixel History fix for a large number of drawcall events

### DIFF
--- a/util/test/demos/d3d12/d3d12_pixel_history.cpp
+++ b/util/test/demos/d3d12/d3d12_pixel_history.cpp
@@ -217,6 +217,14 @@ float4 main(v2f vertIn, uint primId : SV_PrimitiveID, uint sampleId : SV_SampleI
         {Vec3f(-0.7f, 0.5f, 0.33f), Vec4f(1.0f, 1.0f, 0.0f, 1.0f), Vec2f(0.0f, 1.0f)},
         {Vec3f(-0.6f, 0.3f, 0.33f), Vec4f(1.0f, 1.0f, 0.0f, 1.0f), Vec2f(0.0f, 0.0f)},
         {Vec3f(-0.8f, 0.3f, 0.33f), Vec4f(1.0f, 1.0f, 0.0f, 1.0f), Vec2f(1.0f, 0.0f)},
+        // 1000 draws of 1 triangle
+        {Vec3f(-0.7f, 0.0f, 0.33f), Vec4f(0.5f, 1.0f, 0.0f, 1.0f), Vec2f(0.0f, 1.0f)},
+        {Vec3f(-0.8f, 0.2f, 0.33f), Vec4f(0.5f, 1.0f, 0.0f, 1.0f), Vec2f(1.0f, 0.0f)},
+        {Vec3f(-0.6f, 0.2f, 0.33f), Vec4f(0.5f, 1.0f, 0.0f, 1.0f), Vec2f(0.0f, 0.0f)},
+        // 1000 instances of 1 triangle
+        {Vec3f(-0.7f, 0.6f, 0.33f), Vec4f(1.0f, 0.5f, 0.0f, 1.0f), Vec2f(0.0f, 1.0f)},
+        {Vec3f(-0.8f, 0.8f, 0.33f), Vec4f(1.0f, 0.5f, 0.0f, 1.0f), Vec2f(1.0f, 0.0f)},
+        {Vec3f(-0.6f, 0.8f, 0.33f), Vec4f(1.0f, 0.5f, 0.0f, 1.0f), Vec2f(0.0f, 0.0f)},
     };
 
     ID3D12ResourcePtr vb = MakeBuffer().Data(VBData);
@@ -607,6 +615,17 @@ float4 main(v2f vertIn, uint primId : SV_PrimitiveID, uint sampleId : SV_SampleI
         setMarker(cmd, "Depth Bounds Clip");
         cmd->OMSetDepthBounds(0.4f, 0.6f);
         cmd->DrawInstanced(3, 1, 66, 0);
+
+        pushMarker(cmd, "Stress Test");
+        pushMarker(cmd, "Lots of Drawcalls");
+        setMarker(cmd, "1000 Draws");
+        cmd->SetPipelineState(pass.depthWritePipe);
+        for(int d = 0; d < 1000; ++d)
+          cmd->DrawInstanced(3, 1, 72, 0);
+        popMarker(cmd);
+        setMarker(cmd, "1000 Instances");
+        cmd->DrawInstanced(3, 1000, 75, 0);
+        popMarker(cmd);
 
         // Add a marker so we can easily locate this draw
         setMarker(cmd, "Test Begin");


### PR DESCRIPTION
## Description

- Handle large buffer offsets by computing a width and height for the footprint along with a destination `X` and destination `Y`.
- Previously the footprint was treated as a 1D Texture and that has a maximum width of 16384 which equated to 128 events of D3D12EventInfo data for example.
- Extended D3D12 Pixel History Test Setup to include large number of drawcall events
  - 1000 drawcalls of 1 instance of 1 triangle
  - 1 drawcall of 1000 instances of 1 triangle
  - The new drawcalls are not verified in the python except to make sure the existing tests work when the capture has a lot of drawcall events in it.
  - The extra events in the test setup made the test fail until the replay code was fixed to handle the large number of drawcall events.
  - After the replay code fix the test passes but only shows a maximum of 255 fragments in the drawcall of 1000 instances (that is a future fix).
