### PR TITLE
Vulkan Shader debugger support for buffer device address

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_processor.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_processor.cpp
@@ -215,6 +215,14 @@ void Decorations::Register(const DecorationAndParamData &decoration)
   {
     flags = Flags(flags | ColMajor);
   }
+  else if(decoration == Decoration::Restrict)
+  {
+    flags = Flags(flags | Restrict);
+  }
+  else if(decoration == Decoration::Aliased)
+  {
+    flags = Flags(flags | Aliased);
+  }
   else if(decoration == Decoration::Location)
   {
     RDCASSERT(!(flags & HasArrayStride));

--- a/renderdoc/driver/shaders/spirv/spirv_processor.h
+++ b/renderdoc/driver/shaders/spirv/spirv_processor.h
@@ -272,6 +272,8 @@ struct Decorations
     BufferBlock = 0x2,
     RowMajor = 0x4,
     ColMajor = 0x8,
+    Restrict = 0x10,
+    Aliased = 0x20,
 
     // which packed decorations have been set
     HasLocation = 0x01000000,

--- a/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
@@ -1125,12 +1125,24 @@ void Reflector::MakeReflection(const GraphicsAPI sourceAPI, const ShaderStage st
   // specialisation constant gathering
   ConstantBlock specblock;
 
+  // declare pointerTypes for all declared physical pointer types first. This allows the debugger
+  // to easily match pointer types itself
+  for(auto it = dataTypes.begin(); it != dataTypes.end(); ++it)
+  {
+    if(it->second.type == DataType::PointerType &&
+       it->second.pointerType.storage == rdcspv::StorageClass::PhysicalStorageBuffer)
+    {
+      pointerTypes.insert(std::make_pair(it->second.InnerType(), (uint16_t)pointerTypes.size()));
+    }
+  }
+
   for(const Variable &global : globals)
   {
     if(global.storage == StorageClass::Input || global.storage == StorageClass::Output)
     {
       // variable type must be a pointer of the same storage class
       RDCASSERT(dataTypes[global.type].type == DataType::PointerType);
+      RDCASSERT(dataTypes[global.type].pointerType.storage == global.storage);
       const DataType &baseType = dataTypes[dataTypes[global.type].InnerType()];
 
       const bool isInput = (global.storage == StorageClass::Input);

--- a/renderdoc/driver/vulkan/vk_info.h
+++ b/renderdoc/driver/vulkan/vk_info.h
@@ -626,6 +626,7 @@ struct VulkanCreationInfo
     VkMemoryRequirements mrq;
   };
   std::unordered_map<ResourceId, Buffer> m_Buffer;
+  rdcflatmap<uint64_t, ResourceId> m_BufferAddresses;
 
   struct BufferView
   {

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -1430,6 +1430,7 @@ bool WrappedVulkan::Serialise_vkBindBufferMemory(SerialiserType &ser, VkDevice d
         bufInfo.gpuAddress = ObjDisp(device)->GetBufferDeviceAddress(Unwrap(device), &getInfo);
       else if(GetExtensions(GetRecord(device)).ext_EXT_buffer_device_address)
         bufInfo.gpuAddress = ObjDisp(device)->GetBufferDeviceAddressEXT(Unwrap(device), &getInfo);
+      m_CreationInfo.m_BufferAddresses[bufInfo.gpuAddress] = GetResID(buffer);
     }
 
     m_CreationInfo.m_Memory[GetResID(memory)].BindMemory(memoryOffset, mrq.size,
@@ -2840,6 +2841,7 @@ bool WrappedVulkan::Serialise_vkBindBufferMemory2(SerialiserType &ser, VkDevice 
           bufInfo.gpuAddress = ObjDisp(device)->GetBufferDeviceAddress(Unwrap(device), &getInfo);
         else if(GetExtensions(GetRecord(device)).ext_EXT_buffer_device_address)
           bufInfo.gpuAddress = ObjDisp(device)->GetBufferDeviceAddressEXT(Unwrap(device), &getInfo);
+        m_CreationInfo.m_BufferAddresses[bufInfo.gpuAddress] = GetResID(bindInfo.buffer);
       }
 
       // the memory is immediately dirty because we don't use dirty tracking, it's too expensive to

--- a/util/test/demos/test_common.h
+++ b/util/test/demos/test_common.h
@@ -158,6 +158,16 @@ struct Vec4u
   uint32_t x, y, z, w;
 };
 
+struct Vec2u
+{
+  Vec2u(uint32_t X = 0, uint32_t Y = 0)
+  {
+    x = X;
+    y = Y;
+  }
+  uint32_t x, y;
+};
+
 struct DefaultA2V
 {
   Vec3f pos;

--- a/util/test/tests/Vulkan/VK_KHR_Buffer_Address.py
+++ b/util/test/tests/Vulkan/VK_KHR_Buffer_Address.py
@@ -1,0 +1,82 @@
+import renderdoc as rd
+import rdtest
+
+class VK_KHR_Buffer_Address(rdtest.TestCase):
+    demos_test_name = 'VK_KHR_Buffer_Address'
+
+    def check_capture(self):
+        if not self.controller.GetAPIProperties().shaderDebugging:
+            rdtest.log.success("Shader debugging not enabled, skipping test")
+            return
+
+        x = 100
+        y = 150
+
+        for test_name in ["Draw 1", "Draw 2", "Draw 3"]:
+            rdtest.log.print("Test {}".format(test_name))
+            action: rd.ActionDescription = self.find_action(test_name)
+            action = action.next
+            self.controller.SetFrameEvent(action.eventId, True)
+            pipe: rd.PipeState = self.controller.GetPipelineState()
+
+            if not pipe.GetShaderReflection(rd.ShaderStage.Pixel).debugInfo.debuggable:
+                raise rdtest.TestFailureException("Test {} shader can not be debugged".format(test_name))
+
+            # Debug the pixel shader
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.ReplayController.NoPreference,
+                                                                        rd.ReplayController.NoPreference)
+            if trace.debugger is None:
+                self.controller.FreeTrace(trace)
+                raise rdtest.TestFailureException("Test {} did not debug at all".format(test_name))
+
+            cycles, variables = self.process_trace(trace)
+            output: rd.SourceVariableMapping = self.find_output_source_var(trace, rd.ShaderBuiltin.ColorOutput, 0)
+            debugged = self.evaluate_source_var(output, variables)
+            self.check_pixel_value(pipe.GetOutputTargets()[0].resourceId, x, y, debugged.value.f32v[0:4])
+            self.controller.FreeTrace(trace)
+            x = x + 100
+
+            inst = 0
+            postvs = self.get_postvs(action, rd.MeshDataStage.VSOut, instance=inst)
+            for vtx in range(action.numIndices):
+                idx = vtx
+                self.check_debug(vtx, idx, inst, postvs)
+
+        rdtest.log.success("All tests matched")
+
+
+    def check_debug(self, vtx, idx, inst, postvs):
+        trace: rd.ShaderDebugTrace = self.controller.DebugVertex(vtx, inst, idx, 0)
+
+        if trace.debugger is None:
+            self.controller.FreeTrace(trace)
+
+            raise rdtest.TestFailureException("Couldn't debug vertex {} in instance {}".format(vtx, inst))
+
+        cycles, variables = self.process_trace(trace)
+
+        for var in trace.sourceVars:
+            var: rd.SourceVariableMapping
+            if var.variables[0].type == rd.DebugVariableType.Variable and var.signatureIndex >= 0:
+                name = var.name
+
+                if name not in postvs[vtx].keys():
+                    raise rdtest.TestFailureException("Don't have expected output for {}".format(name))
+
+                expect = postvs[vtx][name]
+                value = self.evaluate_source_var(var, variables)
+
+                if len(expect) != value.columns:
+                    raise rdtest.TestFailureException(
+                        "Output {} at vert {} (idx {}) instance {} has different size ({} values) to expectation ({} values)"
+                            .format(name, vtx, idx, inst, value.columns, len(expect)))
+
+                debugged = value.value.f32v[0:value.columns]
+
+                if not rdtest.value_compare(expect, debugged):
+                    raise rdtest.TestFailureException(
+                        "Debugged value {} at vert {} (idx {}) instance {}: {} doesn't exactly match postvs output {}".format(
+                            name, vtx, idx, inst, debugged, expect))
+        rdtest.log.success('Successfully debugged vertex {} in instance {}'
+                           .format(vtx, inst))
+


### PR DESCRIPTION
## Description
- Added new pointer type "Physical Pointer"
- Added debugger support for:
  - `Op::ConvertPtrToU`
  - `Op::ConvertUToPtr`
  - `Op::PtrAccessChain`
  - `Op::InBoundsPtrAccessChain`
 - Mostly plumbing support to end up at `ReadFromPointer` and `WriteThroughPointer` with the correct pointer address (and offset)

## Test Coverage
- Added python scripts for basic Test for `VK_Ext_Buffer_Address` and `VK_KHR_Buffer_Address`
  - Compare the pixel shader debugger result against the GPU rendered output
  - Compare the vertex shader debugger results against the postVS output
- Added SPV test cases to `VK_Shader_Debug_Zoo` using KHR BDA
  - `OpBitcast` uint2 address to a pointer and load from the pointer
  - `OpPtrAccessChain` : float[] : ArrayStride 4
  - `OpPtrAccessChain` : float[] : ArrayStride 8
  - `OpPtrAccessChain` : float[] : ArrayStride 12
  - Convert u64 address to a pointer and load from the pointer
  - Convert u64 address to a pointer and back to a u64 address, load from the address
  - Arithmetic on a u64 address then convert u64 address to a pointer and load from the pointer
  - Generate a u64 address using arithmetic on two u32 values and load from the address

## Screenshots of Debugging
- Pointer being displayed as resolving buffer plus byte offset (_3545)
![image](https://github.com/baldurk/renderdoc/assets/39392/66cf5bc5-c0da-4725-9d3d-b0098757ecc6)
- Clicking on the resource link opens the buffer viewer at the correct offset
![image](https://github.com/baldurk/renderdoc/assets/39392/b715abd3-07e3-48b8-9274-984740222ca2)
- Pointer value displayed as buffer plus offset (_3507) and then the loaded value shown (_3508)
![image](https://github.com/baldurk/renderdoc/assets/39392/3031f78b-af1a-4fa7-a0f5-e9449d923dff)
