### PR TITLE
Fix DXBC pixel shader debugging with non-zero indexed semantic

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_debug.cpp
@@ -5198,6 +5198,11 @@ void GatherPSInputDataForInitialValues(const DXBC::DXBCContainer *dxbc,
       }
     }
 
+    if(sig.semanticIndex != 0)
+    {
+      psInputDefinition += ToStr(sig.semanticIndex);
+    }
+
     psInputDefinition += ";\n";
 
     int firstElem = sig.regChannelMask & 0x1   ? 0


### PR DESCRIPTION
## Description

While using DirectX 12, DXBC pixel shader debugging doesn't work, when semantic(s) with non-zero indexes is/are used between VS and PS stages. I've added semantic index to generated debug shader input to fix interstage communication between original VS and generated PS. Also very simple application, that reproduces issue is added: it is from official DirectX 12 samples from Microsoft, with COLOR semantic in PS input changed to COLOR1
[HelloTriangle.zip](https://github.com/baldurk/renderdoc/files/13960798/HelloTriangle.zip)
