### PR TITLE
Fix DXBC pixel shader debugging with non-zero indexed semantic

### DIFF
--- a/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
+++ b/renderdoc/driver/shaders/dxbc/dxbc_container.cpp
@@ -1915,7 +1915,7 @@ DXBCContainer::DXBCContainer(const bytebuf &ByteCode, const rdcstr &debugInfoPat
         for(uint32_t j = 0; j < sign->numElems; j++)
         {
           SigParameter &b = (*sig)[j];
-          if(i != j && a.semanticName == b.semanticName)
+          if(i != j && a.semanticName == b.semanticName || a.semanticIndex != 0)
           {
             a.needSemanticIndex = true;
             break;


### PR DESCRIPTION
## Description
While using DirectX 12, DXBC pixel shader debugging doesn't work, when semantic with non-zero index is used between VS and PS stages and is a single semantic with this name. I've added semantic index to generated debug shader input to fix interstage communication between original VS and generated PS, when semantic index is not zero. I kept previous logic as well to not to change behavior when more than one semantics with the same name are used and one of them is not indexed, like COLOR (turns to COLOR0) and COLOR1. 

Also very simple application, that reproduces issue is added: it is from official DirectX 12 samples from Microsoft, with COLOR semantic in PS input changed to COLOR1
[HelloTriangle.zip](https://github.com/baldurk/renderdoc/files/13961126/HelloTriangle.zip)
