### PR TITLE
Metal: MTLComputeCommandEncoder Dependency Structs

### DIFF
--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -235,6 +235,14 @@ void DoSerialise(SerialiserType &ser, RDMTL::AttributeDescriptor &el)
 }
 
 template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, RDMTL::BufferLayoutDescriptor &el)
+{
+  SERIALISE_MEMBER(stride);
+  SERIALISE_MEMBER(stepFunction);
+  SERIALISE_MEMBER(stepRate);
+}
+
+template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, RDMTL::FunctionGroup &el)
 {
   SERIALISE_MEMBER(callsite);
@@ -377,6 +385,7 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexAttributeDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexBufferLayoutDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::AttributeDescriptor);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::BufferLayoutDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::FunctionGroup);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::LinkedFunctions);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -227,6 +227,14 @@ void DoSerialise(SerialiserType &ser, RDMTL::VertexDescriptor &el)
 }
 
 template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, RDMTL::AttributeDescriptor &el)
+{
+  SERIALISE_MEMBER(bufferIndex);
+  SERIALISE_MEMBER(offset);
+  SERIALISE_MEMBER(format);
+}
+
+template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, RDMTL::FunctionGroup &el)
 {
   SERIALISE_MEMBER(callsite);
@@ -368,6 +376,7 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::PipelineBufferDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexAttributeDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexBufferLayoutDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexDescriptor);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::AttributeDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::FunctionGroup);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::LinkedFunctions);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -378,6 +378,15 @@ void DoSerialise(SerialiserType &ser, RDMTL::RenderPassDescriptor &el)
   SERIALISE_MEMBER(sampleBufferAttachments);
 };
 
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, RDMTL::ComputePassSampleBufferAttachmentDescriptor &el)
+{
+  // TODO: when WrappedCounterSampleBuffer exists
+  // SERIALISE_MEMBER(sampleBuffer);
+  SERIALISE_MEMBER(startOfEncoderSampleIndex);
+  SERIALISE_MEMBER(endOfEncoderSampleIndex);
+}
+
 INSTANTIATE_SERIALISE_TYPE(NS::String *);
 INSTANTIATE_SERIALISE_TYPE(NS::Range)
 INSTANTIATE_SERIALISE_TYPE(MTL::TextureSwizzleChannels);
@@ -404,3 +413,4 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassColorAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassDepthAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassStencilAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassDescriptor);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::ComputePassSampleBufferAttachmentDescriptor);

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -387,6 +387,27 @@ void DoSerialise(SerialiserType &ser, RDMTL::ComputePassSampleBufferAttachmentDe
   SERIALISE_MEMBER(endOfEncoderSampleIndex);
 }
 
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, RDMTL::ComputePipelineDescriptor &el)
+{
+  SERIALISE_MEMBER(label);
+  SERIALISE_MEMBER(computeFunction);
+  SERIALISE_MEMBER(threadGroupSizeIsMultipleOfThreadExecution);
+  SERIALISE_MEMBER(maxTotalThreadsPerThreadgroup);
+  SERIALISE_MEMBER(maxCallStackDepth);
+  SERIALISE_MEMBER(stageInputDescriptor);
+  SERIALISE_MEMBER(buffers);
+  SERIALISE_MEMBER(supportIndirectCommandBuffers);
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // SERIALISE_MEMBER(preloadedLibraries);
+  // Deprecated
+  // SERIALISE_MEMBER(insertLibraries);
+  SERIALISE_MEMBER(linkedFunctions);
+  SERIALISE_MEMBER(supportAddingBinaryFunctions);
+  // TODO: when WrappedMTLBinaryArchive exists
+  // SERIALISE_MEMBER(binaryArchives);
+}
+
 INSTANTIATE_SERIALISE_TYPE(NS::String *);
 INSTANTIATE_SERIALISE_TYPE(NS::Range)
 INSTANTIATE_SERIALISE_TYPE(MTL::TextureSwizzleChannels);
@@ -414,3 +435,4 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassDepthAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassStencilAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::ComputePassSampleBufferAttachmentDescriptor);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::ComputePipelineDescriptor);

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -243,6 +243,15 @@ void DoSerialise(SerialiserType &ser, RDMTL::BufferLayoutDescriptor &el)
 }
 
 template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, RDMTL::StageInputOutputDescriptor &el)
+{
+  SERIALISE_MEMBER(attributes);
+  SERIALISE_MEMBER(layouts);
+  SERIALISE_MEMBER(indexBufferIndex);
+  SERIALISE_MEMBER(indexType);
+}
+
+template <typename SerialiserType>
 void DoSerialise(SerialiserType &ser, RDMTL::FunctionGroup &el)
 {
   SERIALISE_MEMBER(callsite);
@@ -386,6 +395,7 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexBufferLayoutDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::VertexDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::AttributeDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::BufferLayoutDescriptor);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::StageInputOutputDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::FunctionGroup);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::LinkedFunctions);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_serialise.cpp
+++ b/renderdoc/driver/metal/metal_serialise.cpp
@@ -408,6 +408,13 @@ void DoSerialise(SerialiserType &ser, RDMTL::ComputePipelineDescriptor &el)
   // SERIALISE_MEMBER(binaryArchives);
 }
 
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, RDMTL::ComputePassDescriptor &el)
+{
+  SERIALISE_MEMBER(sampleBufferAttachments);
+  SERIALISE_MEMBER(dispatchType);
+}
+
 INSTANTIATE_SERIALISE_TYPE(NS::String *);
 INSTANTIATE_SERIALISE_TYPE(NS::Range)
 INSTANTIATE_SERIALISE_TYPE(MTL::TextureSwizzleChannels);
@@ -436,3 +443,4 @@ INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassStencilAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::RenderPassDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::ComputePassSampleBufferAttachmentDescriptor);
 INSTANTIATE_SERIALISE_TYPE(RDMTL::ComputePipelineDescriptor);
+INSTANTIATE_SERIALISE_TYPE(RDMTL::ComputePassDescriptor);

--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1201,6 +1201,24 @@ rdcstr DoStringise(const MTL::AttributeFormat &el)
 }
 
 template <>
+rdcstr DoStringise(const MTL::StepFunction &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::StepFunction)
+  {
+    MTL_STRINGISE_ENUM(StepFunctionConstant);
+    MTL_STRINGISE_ENUM(StepFunctionPerVertex);
+    MTL_STRINGISE_ENUM(StepFunctionPerInstance);
+    MTL_STRINGISE_ENUM(StepFunctionPerPatch);
+    MTL_STRINGISE_ENUM(StepFunctionPerPatchControlPoint);
+    MTL_STRINGISE_ENUM(StepFunctionThreadPositionInGridX);
+    MTL_STRINGISE_ENUM(StepFunctionThreadPositionInGridY);
+    MTL_STRINGISE_ENUM(StepFunctionThreadPositionInGridXIndexed);
+    MTL_STRINGISE_ENUM(StepFunctionThreadPositionInGridYIndexed);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
 rdcstr DoStringise(const MetalResourceType &el)
 {
   RDCCOMPILE_ASSERT((uint32_t)MetalResourceType::eResMax == 11, "MetalResourceType changed");

--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1137,6 +1137,70 @@ rdcstr DoStringise(const MTL::IndexType &el)
 }
 
 template <>
+rdcstr DoStringise(const MTL::AttributeFormat &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::AttributeFormat)
+  {
+    MTL_STRINGISE_ENUM(AttributeFormatInvalid);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar2);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar3);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar4);
+    MTL_STRINGISE_ENUM(AttributeFormatChar2);
+    MTL_STRINGISE_ENUM(AttributeFormatChar3);
+    MTL_STRINGISE_ENUM(AttributeFormatChar4);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar2Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar3Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar4Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatChar2Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatChar3Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatChar4Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort2);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort3);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort4);
+    MTL_STRINGISE_ENUM(AttributeFormatShort2);
+    MTL_STRINGISE_ENUM(AttributeFormatShort3);
+    MTL_STRINGISE_ENUM(AttributeFormatShort4);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort2Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort3Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort4Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatShort2Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatShort3Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatShort4Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatHalf2);
+    MTL_STRINGISE_ENUM(AttributeFormatHalf3);
+    MTL_STRINGISE_ENUM(AttributeFormatHalf4);
+    MTL_STRINGISE_ENUM(AttributeFormatFloat);
+    MTL_STRINGISE_ENUM(AttributeFormatFloat2);
+    MTL_STRINGISE_ENUM(AttributeFormatFloat3);
+    MTL_STRINGISE_ENUM(AttributeFormatFloat4);
+    MTL_STRINGISE_ENUM(AttributeFormatInt);
+    MTL_STRINGISE_ENUM(AttributeFormatInt2);
+    MTL_STRINGISE_ENUM(AttributeFormatInt3);
+    MTL_STRINGISE_ENUM(AttributeFormatInt4);
+    MTL_STRINGISE_ENUM(AttributeFormatUInt);
+    MTL_STRINGISE_ENUM(AttributeFormatUInt2);
+    MTL_STRINGISE_ENUM(AttributeFormatUInt3);
+    MTL_STRINGISE_ENUM(AttributeFormatUInt4);
+    MTL_STRINGISE_ENUM(AttributeFormatInt1010102Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUInt1010102Normalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar4Normalized_BGRA);
+    MTL_STRINGISE_ENUM(AttributeFormatUChar);
+    MTL_STRINGISE_ENUM(AttributeFormatChar);
+    MTL_STRINGISE_ENUM(AttributeFormatUCharNormalized);
+    MTL_STRINGISE_ENUM(AttributeFormatCharNormalized);
+    MTL_STRINGISE_ENUM(AttributeFormatUShort);
+    MTL_STRINGISE_ENUM(AttributeFormatShort);
+    MTL_STRINGISE_ENUM(AttributeFormatUShortNormalized);
+    MTL_STRINGISE_ENUM(AttributeFormatShortNormalized);
+    MTL_STRINGISE_ENUM(AttributeFormatHalf);
+    // TODO: When metal-cpp is updated to SDK 14.x
+    // MTL_STRINGISE_ENUM(AttributeFormatFloatRG11B10);
+    // MTL_STRINGISE_ENUM(AttributeFormatFloatRGB9E5);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
 rdcstr DoStringise(const MetalResourceType &el)
 {
   RDCCOMPILE_ASSERT((uint32_t)MetalResourceType::eResMax == 11, "MetalResourceType changed");

--- a/renderdoc/driver/metal/metal_stringise.cpp
+++ b/renderdoc/driver/metal/metal_stringise.cpp
@@ -1219,6 +1219,17 @@ rdcstr DoStringise(const MTL::StepFunction &el)
 }
 
 template <>
+rdcstr DoStringise(const MTL::DispatchType &el)
+{
+  BEGIN_ENUM_STRINGISE(MTL::DispatchType)
+  {
+    MTL_STRINGISE_ENUM(DispatchTypeSerial);
+    MTL_STRINGISE_ENUM(DispatchTypeConcurrent);
+  }
+  END_ENUM_STRINGISE()
+}
+
+template <>
 rdcstr DoStringise(const MetalResourceType &el)
 {
   RDCCOMPILE_ASSERT((uint32_t)MetalResourceType::eResMax == 11, "MetalResourceType changed");

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -681,4 +681,54 @@ void ComputePassSampleBufferAttachmentDescriptor::CopyTo(
   objc->setEndOfEncoderSampleIndex(endOfEncoderSampleIndex);
 }
 
+ComputePipelineDescriptor::ComputePipelineDescriptor(MTL::ComputePipelineDescriptor *objc)
+    : computeFunction(GetWrapped(objc->computeFunction())),
+      threadGroupSizeIsMultipleOfThreadExecution(
+          objc->threadGroupSizeIsMultipleOfThreadExecutionWidth()),
+      maxTotalThreadsPerThreadgroup(objc->maxTotalThreadsPerThreadgroup()),
+      maxCallStackDepth(objc->maxCallStackDepth()),
+      stageInputDescriptor(objc->stageInputDescriptor()),
+      supportIndirectCommandBuffers(objc->supportIndirectCommandBuffers()),
+      linkedFunctions(objc->linkedFunctions()),
+      supportAddingBinaryFunctions(objc->supportAddingBinaryFunctions())
+{
+  if(objc->label())
+    label.assign(objc->label()->utf8String());
+  GETOBJCARRAY(PipelineBufferDescriptor, MAX_COMPUTE_PASS_BUFFER_ATTACHMENTS, buffers, ValidData);
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // GETWRAPPEDNSARRAY(DynamicLibrary, preloadedLibraries)
+  // Deprecated
+  // GETWRAPPEDNSARRAY(DynamicLibrary, insertLibraries)
+  // GETWRAPPEDNSARRAY(DynamicLibrary, linkedFunctions)
+  // TODO: when WrappedMTLBinaryArchive exists
+  // GETWRAPPEDNSARRAY(BinaryArchive, binaryArchives);
+}
+
+ComputePipelineDescriptor::operator MTL::ComputePipelineDescriptor *()
+{
+  MTL::ComputePipelineDescriptor *objc = MTL::ComputePipelineDescriptor::alloc()->init();
+  if(label.length() > 0)
+  {
+    objc->setLabel(NS::String::string(label.data(), NS::UTF8StringEncoding));
+  }
+  objc->setComputeFunction(Unwrap(computeFunction));
+  objc->setThreadGroupSizeIsMultipleOfThreadExecutionWidth(threadGroupSizeIsMultipleOfThreadExecution);
+  objc->setMaxTotalThreadsPerThreadgroup(maxTotalThreadsPerThreadgroup);
+  objc->setMaxCallStackDepth(maxCallStackDepth);
+  stageInputDescriptor.CopyTo(objc->stageInputDescriptor());
+  objc->setSupportIndirectCommandBuffers(supportIndirectCommandBuffers);
+  linkedFunctions.CopyTo(objc->linkedFunctions());
+  objc->setSupportAddingBinaryFunctions(supportAddingBinaryFunctions);
+  COPYTOOBJCARRAY(PipelineBufferDescriptor, buffers);
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // objc->setPreloadedLibraries(CreateUnwrappedNSArray<MTL::DynamicLibrary *>(preloadedLibraries));
+  // Deprecated
+  // objc->setInsertLibraries(CreateUnwrappedNSArray<MTL::DynamicLibrary *>(insertLibraries));
+  // objc->setLinkedFunctions(CreateUnwrappedNSArray<MTL::DynamicLibrary *>(linkedFunctions));
+  // TODO: when WrappedMTLBinaryArchive exists
+  // objc->setBinaryArchives(CreateUnwrappedNSArray<MTL::BinaryArchive *>(binaryArchives));
+  // GETWRAPPEDNSARRAY(BinaryArchive, binaryArchives);
+  return objc;
+}
+
 }    // namespace RDMTL

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -322,6 +322,18 @@ void VertexDescriptor::CopyTo(MTL::VertexDescriptor *objc)
   COPYTOOBJCARRAY(VertexAttributeDescriptor, attributes);
 }
 
+AttributeDescriptor::AttributeDescriptor(MTL::AttributeDescriptor *objc)
+    : bufferIndex(objc->bufferIndex()), offset(objc->offset()), format(objc->format())
+{
+}
+
+void AttributeDescriptor::CopyTo(MTL::AttributeDescriptor *objc)
+{
+  objc->setBufferIndex(bufferIndex);
+  objc->setOffset(offset);
+  objc->setFormat(format);
+}
+
 LinkedFunctions::LinkedFunctions(MTL::LinkedFunctions *objc)
 {
   GETWRAPPEDNSARRAY(Function, functions);

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -334,6 +334,18 @@ void AttributeDescriptor::CopyTo(MTL::AttributeDescriptor *objc)
   objc->setFormat(format);
 }
 
+BufferLayoutDescriptor::BufferLayoutDescriptor(MTL::BufferLayoutDescriptor *objc)
+    : stride(objc->stride()), stepFunction(objc->stepFunction()), stepRate(objc->stepRate())
+{
+}
+
+void BufferLayoutDescriptor::CopyTo(MTL::BufferLayoutDescriptor *objc)
+{
+  objc->setStride(stride);
+  objc->setStepFunction(stepFunction);
+  objc->setStepRate(stepRate);
+}
+
 LinkedFunctions::LinkedFunctions(MTL::LinkedFunctions *objc)
 {
   GETWRAPPEDNSARRAY(Function, functions);

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -150,6 +150,20 @@ static bool ValidData(MTL::RenderPassSampleBufferAttachmentDescriptor *descripto
   return true;
 }
 
+static bool ValidData(MTL::AttributeDescriptor *descriptor)
+{
+  if(descriptor->format() == MTL::AttributeFormatInvalid)
+    return false;
+  return true;
+}
+
+static bool ValidData(MTL::BufferLayoutDescriptor *descriptor)
+{
+  if(descriptor->stride() == 0)
+    return false;
+  return true;
+}
+
 template <typename MTL_TYPE>
 static void GetWrappedNSArray(rdcarray<typename UnwrapHelper<MTL_TYPE>::Outer *> &to, NS::Array *from)
 {
@@ -344,6 +358,21 @@ void BufferLayoutDescriptor::CopyTo(MTL::BufferLayoutDescriptor *objc)
   objc->setStride(stride);
   objc->setStepFunction(stepFunction);
   objc->setStepRate(stepRate);
+}
+
+StageInputOutputDescriptor::StageInputOutputDescriptor(MTL::StageInputOutputDescriptor *objc)
+    : indexBufferIndex(objc->indexBufferIndex()), indexType(objc->indexType())
+{
+  GETOBJCARRAY(AttributeDescriptor, MAX_COMPUTE_PASS_BUFFER_ATTACHMENTS, attributes, ValidData);
+  GETOBJCARRAY(BufferLayoutDescriptor, MAX_COMPUTE_PASS_BUFFER_ATTACHMENTS, layouts, ValidData);
+}
+
+void StageInputOutputDescriptor::CopyTo(MTL::StageInputOutputDescriptor *objc)
+{
+  COPYTOOBJCARRAY(AttributeDescriptor, attributes);
+  COPYTOOBJCARRAY(BufferLayoutDescriptor, layouts);
+  objc->setIndexBufferIndex(indexBufferIndex);
+  objc->setIndexType(indexType);
 }
 
 LinkedFunctions::LinkedFunctions(MTL::LinkedFunctions *objc)

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -164,6 +164,13 @@ static bool ValidData(MTL::BufferLayoutDescriptor *descriptor)
   return true;
 }
 
+static bool ValidData(MTL::ComputePassSampleBufferAttachmentDescriptor *descriptor)
+{
+  if(!descriptor->sampleBuffer())
+    return false;
+  return true;
+}
+
 template <typename MTL_TYPE>
 static void GetWrappedNSArray(rdcarray<typename UnwrapHelper<MTL_TYPE>::Outer *> &to, NS::Array *from)
 {
@@ -728,6 +735,21 @@ ComputePipelineDescriptor::operator MTL::ComputePipelineDescriptor *()
   // TODO: when WrappedMTLBinaryArchive exists
   // objc->setBinaryArchives(CreateUnwrappedNSArray<MTL::BinaryArchive *>(binaryArchives));
   // GETWRAPPEDNSARRAY(BinaryArchive, binaryArchives);
+  return objc;
+}
+
+ComputePassDescriptor::ComputePassDescriptor(MTL::ComputePassDescriptor *objc)
+    : dispatchType(objc->dispatchType())
+{
+  GETOBJCARRAY(ComputePassSampleBufferAttachmentDescriptor,
+               MAX_COMPUTE_PASS_SAMPLE_BUFFER_ATTACHMENTS, sampleBufferAttachments, ValidData);
+}
+
+ComputePassDescriptor::operator MTL::ComputePassDescriptor *()
+{
+  MTL::ComputePassDescriptor *objc = MTL::ComputePassDescriptor::alloc()->init();
+  COPYTOOBJCARRAY(ComputePassSampleBufferAttachmentDescriptor, sampleBufferAttachments);
+  objc->setDispatchType(dispatchType);
   return objc;
 }
 

--- a/renderdoc/driver/metal/metal_types.cpp
+++ b/renderdoc/driver/metal/metal_types.cpp
@@ -665,4 +665,20 @@ RenderPassDescriptor::operator MTL::RenderPassDescriptor *()
   return objc;
 }
 
+ComputePassSampleBufferAttachmentDescriptor::ComputePassSampleBufferAttachmentDescriptor(
+    MTL::ComputePassSampleBufferAttachmentDescriptor *objc)
+    : startOfEncoderSampleIndex(objc->startOfEncoderSampleIndex()),
+      endOfEncoderSampleIndex(objc->endOfEncoderSampleIndex())
+{
+}
+
+void ComputePassSampleBufferAttachmentDescriptor::CopyTo(
+    MTL::ComputePassSampleBufferAttachmentDescriptor *objc)
+{
+  // TODO: when WrappedMTLCounterSampleBuffer exists
+  // objc->setSampleBuffer(Unwrap(sampleBuffer));
+  objc->setStartOfEncoderSampleIndex(startOfEncoderSampleIndex);
+  objc->setEndOfEncoderSampleIndex(endOfEncoderSampleIndex);
+}
+
 }    // namespace RDMTL

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -163,6 +163,7 @@ MTL_DECLARE_REFLECTION_TYPE(DepthClipMode);
 MTL_DECLARE_REFLECTION_TYPE(TriangleFillMode);
 MTL_DECLARE_REFLECTION_TYPE(CullMode);
 MTL_DECLARE_REFLECTION_TYPE(IndexType);
+MTL_DECLARE_REFLECTION_TYPE(StepFunction);
 MTL_DECLARE_REFLECTION_TYPE(AttributeFormat);
 
 template <>
@@ -273,6 +274,18 @@ struct AttributeDescriptor
   NS::UInteger bufferIndex = 0;
   NS::UInteger offset = 0;
   MTL::AttributeFormat format = MTL::AttributeFormatInvalid;
+};
+
+// MTLBufferLayoutDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLStageInputOutputDescriptor.h
+struct BufferLayoutDescriptor
+{
+  BufferLayoutDescriptor() = default;
+  BufferLayoutDescriptor(MTL::BufferLayoutDescriptor *objc);
+  void CopyTo(MTL::BufferLayoutDescriptor *objc);
+  NS::UInteger stride = 0;
+  MTL::StepFunction stepFunction = MTL::StepFunctionConstant;
+  NS::UInteger stepRate = 0;
 };
 
 // Helper struct for holding MTLLinkedFunctions::groups data
@@ -473,6 +486,7 @@ RDMTL_DECLARE_REFLECTION_STRUCT(VertexAttributeDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(VertexBufferLayoutDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(VertexDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(AttributeDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(BufferLayoutDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(FunctionGroup);
 RDMTL_DECLARE_REFLECTION_STRUCT(LinkedFunctions);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -474,6 +474,19 @@ struct RenderPassDescriptor
   rdcarray<RenderPassSampleBufferAttachmentDescriptor> sampleBufferAttachments;
 };
 
+// MTLComputePassSampleBufferAttachmentDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLComputePass.h
+struct ComputePassSampleBufferAttachmentDescriptor
+{
+  ComputePassSampleBufferAttachmentDescriptor() = default;
+  ComputePassSampleBufferAttachmentDescriptor(MTL::ComputePassSampleBufferAttachmentDescriptor *objc);
+  void CopyTo(MTL::ComputePassSampleBufferAttachmentDescriptor *objc);
+  // TODO: when WrappedMTLCounterSampleBuffer exists
+  // MTLCounterSampleBuffer *sampleBuffer = NULL;
+  NS::UInteger startOfEncoderSampleIndex = MTLCounterDontSample;
+  NS::UInteger endOfEncoderSampleIndex = MTLCounterDontSample;
+};
+
 }    // namespace RDMTL
 
 template <>
@@ -511,3 +524,4 @@ RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassDepthAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassStencilAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassSampleBufferAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(ComputePassSampleBufferAttachmentDescriptor);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -33,6 +33,7 @@ const uint32_t MAX_RENDER_PASS_COLOR_ATTACHMENTS = 8;
 const uint32_t MAX_RENDER_PASS_BUFFER_ATTACHMENTS = 31;
 const uint32_t MAX_VERTEX_SHADER_ATTRIBUTES = 31;
 const uint32_t MAX_RENDER_PASS_SAMPLE_BUFFER_ATTACHMENTS = 4;
+const uint32_t MAX_COMPUTE_PASS_BUFFER_ATTACHMENTS = 31;
 
 // Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCounters.h
 #ifndef MTLCounterDontSample
@@ -288,6 +289,19 @@ struct BufferLayoutDescriptor
   NS::UInteger stepRate = 0;
 };
 
+// MTLStageInputOutputDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLStageInputOutputDescriptor.h
+struct StageInputOutputDescriptor
+{
+  StageInputOutputDescriptor() = default;
+  StageInputOutputDescriptor(MTL::StageInputOutputDescriptor *objc);
+  void CopyTo(MTL::StageInputOutputDescriptor *objc);
+  rdcarray<AttributeDescriptor> attributes;
+  rdcarray<BufferLayoutDescriptor> layouts;
+  NS::UInteger indexBufferIndex = 0;
+  MTL::IndexType indexType = MTL::IndexType::IndexTypeUInt16;
+};
+
 // Helper struct for holding MTLLinkedFunctions::groups data
 // NSDictionary<NSString*, NSArray<id<MTLFunction>>*> *groups;
 struct FunctionGroup
@@ -487,6 +501,7 @@ RDMTL_DECLARE_REFLECTION_STRUCT(VertexBufferLayoutDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(VertexDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(AttributeDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(BufferLayoutDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(StageInputOutputDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(FunctionGroup);
 RDMTL_DECLARE_REFLECTION_STRUCT(LinkedFunctions);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -163,6 +163,7 @@ MTL_DECLARE_REFLECTION_TYPE(DepthClipMode);
 MTL_DECLARE_REFLECTION_TYPE(TriangleFillMode);
 MTL_DECLARE_REFLECTION_TYPE(CullMode);
 MTL_DECLARE_REFLECTION_TYPE(IndexType);
+MTL_DECLARE_REFLECTION_TYPE(AttributeFormat);
 
 template <>
 inline rdcliteral TypeName<NS::Range>()
@@ -260,6 +261,18 @@ struct VertexDescriptor
   void CopyTo(MTL::VertexDescriptor *objc);
   rdcarray<VertexBufferLayoutDescriptor> layouts;
   rdcarray<VertexAttributeDescriptor> attributes;
+};
+
+// MTLAttributeDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLStageInputOutputDescriptor.h
+struct AttributeDescriptor
+{
+  AttributeDescriptor() = default;
+  AttributeDescriptor(MTL::AttributeDescriptor *objc);
+  void CopyTo(MTL::AttributeDescriptor *objc);
+  NS::UInteger bufferIndex = 0;
+  NS::UInteger offset = 0;
+  MTL::AttributeFormat format = MTL::AttributeFormatInvalid;
 };
 
 // Helper struct for holding MTLLinkedFunctions::groups data
@@ -459,6 +472,7 @@ RDMTL_DECLARE_REFLECTION_STRUCT(PipelineBufferDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(VertexAttributeDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(VertexBufferLayoutDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(VertexDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(AttributeDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(FunctionGroup);
 RDMTL_DECLARE_REFLECTION_STRUCT(LinkedFunctions);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPipelineDescriptor);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -487,6 +487,31 @@ struct ComputePassSampleBufferAttachmentDescriptor
   NS::UInteger endOfEncoderSampleIndex = MTLCounterDontSample;
 };
 
+// MTLComputePipelineDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLComputePipeline.h
+struct ComputePipelineDescriptor
+{
+  ComputePipelineDescriptor() = default;
+  ComputePipelineDescriptor(MTL::ComputePipelineDescriptor *objc);
+  explicit operator MTL::ComputePipelineDescriptor *();
+  rdcstr label;
+  WrappedMTLFunction *computeFunction = NULL;
+  bool threadGroupSizeIsMultipleOfThreadExecution = false;
+  NS::UInteger maxTotalThreadsPerThreadgroup = 0;
+  NS::UInteger maxCallStackDepth = 1;
+  StageInputOutputDescriptor stageInputDescriptor;
+  rdcarray<RDMTL::PipelineBufferDescriptor> buffers;
+  bool supportIndirectCommandBuffers = false;
+  // TODO: when WrappedMTLDynamicLibrary exists
+  // rdcarray<WrappedMTLDynamicLibrary*> preloadedLibraries;
+  // Deprecated
+  // rdcarray<WrappedMTLDynamicLibrary*> insertLibraries;
+  RDMTL::LinkedFunctions linkedFunctions;
+  bool supportAddingBinaryFunctions = false;
+  // TODO: when WrappedMTLBinaryArchive exists
+  // rdcarray<WrappedMTLBinaryArchive*> binaryArchives;
+};
+
 }    // namespace RDMTL
 
 template <>
@@ -525,3 +550,4 @@ RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassStencilAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassSampleBufferAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(ComputePassSampleBufferAttachmentDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(ComputePipelineDescriptor);

--- a/renderdoc/driver/metal/metal_types.h
+++ b/renderdoc/driver/metal/metal_types.h
@@ -34,6 +34,7 @@ const uint32_t MAX_RENDER_PASS_BUFFER_ATTACHMENTS = 31;
 const uint32_t MAX_VERTEX_SHADER_ATTRIBUTES = 31;
 const uint32_t MAX_RENDER_PASS_SAMPLE_BUFFER_ATTACHMENTS = 4;
 const uint32_t MAX_COMPUTE_PASS_BUFFER_ATTACHMENTS = 31;
+const uint32_t MAX_COMPUTE_PASS_SAMPLE_BUFFER_ATTACHMENTS = 4;
 
 // Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLCounters.h
 #ifndef MTLCounterDontSample
@@ -166,6 +167,7 @@ MTL_DECLARE_REFLECTION_TYPE(CullMode);
 MTL_DECLARE_REFLECTION_TYPE(IndexType);
 MTL_DECLARE_REFLECTION_TYPE(StepFunction);
 MTL_DECLARE_REFLECTION_TYPE(AttributeFormat);
+MTL_DECLARE_REFLECTION_TYPE(DispatchType);
 
 template <>
 inline rdcliteral TypeName<NS::Range>()
@@ -512,6 +514,17 @@ struct ComputePipelineDescriptor
   // rdcarray<WrappedMTLBinaryArchive*> binaryArchives;
 };
 
+// MTLComputePassDescriptor : based on the interface defined in
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/Metal.framework/Headers/MTLComputePass.h
+struct ComputePassDescriptor
+{
+  ComputePassDescriptor() = default;
+  ComputePassDescriptor(MTL::ComputePassDescriptor *objc);
+  explicit operator MTL::ComputePassDescriptor *();
+  rdcarray<ComputePassSampleBufferAttachmentDescriptor> sampleBufferAttachments;
+  MTL::DispatchType dispatchType = MTL::DispatchTypeSerial;
+};
+
 }    // namespace RDMTL
 
 template <>
@@ -551,3 +564,4 @@ RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassSampleBufferAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(RenderPassDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(ComputePassSampleBufferAttachmentDescriptor);
 RDMTL_DECLARE_REFLECTION_STRUCT(ComputePipelineDescriptor);
+RDMTL_DECLARE_REFLECTION_STRUCT(ComputePassDescriptor);


### PR DESCRIPTION
## Description

Adds serialisation code for all structs and enums that `MTLComputeCommandEncoder` and its dependencies rely on.