### PR TITLE
D3D12 Fixes for Execute Indirect and Pixel History 

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -3536,14 +3536,15 @@ void WrappedID3D12GraphicsCommandList::ResetAndRecordExecuteIndirectStates(
     else
     {
       state.indirectState.argsToProcess = argumentsReplayed % numArgsPerExec + numArgsPerExec;
-      BytesToRead += comSig->sig.ByteStride;
-    }
+      if(argumentsReplayed % numArgsPerExec != 0)
+        BytesToRead += comSig->sig.ByteStride;
 
-    // skip all but the last executes we care about
-    while(argumentsReplayed > state.indirectState.argsToProcess)
-    {
-      ArgumentBufferOffset += comSig->sig.ByteStride;
-      argumentsReplayed -= numArgsPerExec;
+      // skip all but the last executes we care about
+      while(argumentsReplayed > state.indirectState.argsToProcess)
+      {
+        ArgumentBufferOffset += comSig->sig.ByteStride;
+        argumentsReplayed -= numArgsPerExec;
+      }
     }
 
     Unwrap(list)->CopyBufferRegion(Unwrap(buf), offs, Unwrap(pArgumentBuffer), ArgumentBufferOffset,

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -657,7 +657,9 @@ protected:
       dst.PlacedFootprint.Footprint.Height = 1;
       dst.PlacedFootprint.Footprint.Depth = 1;
       dst.PlacedFootprint.Footprint.Format = p.copyFormat;
-      dst.PlacedFootprint.Footprint.RowPitch = dst.PlacedFootprint.Footprint.Width * elementSize;
+      dst.PlacedFootprint.Footprint.RowPitch =
+          AlignUp(dst.PlacedFootprint.Footprint.Width * elementSize,
+                  (uint32_t)D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 
       D3D12_BOX srcBox = {};
       srcBox.left = p.x;

--- a/renderdoc/driver/d3d12/d3d12_state.cpp
+++ b/renderdoc/driver/d3d12/d3d12_state.cpp
@@ -125,7 +125,6 @@ void D3D12RenderState::ResolvePendingIndirectState(WrappedID3D12Device *device)
           device->GetResIDFromOrigAddr(va, id, offs);
 
           ID3D12Resource *res = GetResourceManager()->GetLiveAs<ID3D12Resource>(id);
-          RDCASSERT(res);
 
           if(arg.VertexBuffer.Slot >= vbuffers.size())
             vbuffers.resize(arg.VertexBuffer.Slot + 1);
@@ -147,7 +146,6 @@ void D3D12RenderState::ResolvePendingIndirectState(WrappedID3D12Device *device)
           device->GetResIDFromOrigAddr(ib->BufferLocation, id, offs);
 
           ID3D12Resource *res = GetResourceManager()->GetLiveAs<ID3D12Resource>(id);
-          RDCASSERT(res);
 
           ibuffer.buf = GetResID(res);
           ibuffer.offs = offs;

--- a/util/test/tests/D3D12/D3D12_Execute_Indirect.py
+++ b/util/test/tests/D3D12/D3D12_Execute_Indirect.py
@@ -172,4 +172,28 @@ class D3D12_Execute_Indirect(rdtest.TestCase):
                     raise rdtest.TestFailureException(
                         "Detected an exploded polygon with {} selected".format(action.GetName(sdfile)))
 
-            rdtest.log.success("Pass {} of unordered draw was correct")
+            rdtest.log.success(f"Pass {passNum} of unordered draw was correct")
+
+        # This does not draw anything but its argument buffer is fully used with no spare bytes
+        # Iterate over every draw and check the replay has valid output target
+        action = self.find_action("Full Arg Buffer")
+        action = self.find_action("IndirectDraw", action.eventId)
+        for drawNum in range(3):
+            self.controller.SetFrameEvent(action.eventId + drawNum, False)
+            pipe = self.controller.GetPipelineState()
+            if len(pipe.GetOutputTargets()) != 1:
+                raise rdtest.TestFailureException(
+                    f"With event {action.eventId + drawNum} selected we should have one output target but there is {len(pipe.GetOutputTargets())}")
+        rdtest.log.success("Fully used argument buffer with multiple draws replayed")
+
+        # This does not draw anything but its argument buffer is fully used with no spare bytes
+        # Iterate over every draw and check the replay has valid output target
+        action = self.find_action("Full Arg Buffer: State + Draw")
+        action = self.find_action("IndirectDraw", action.eventId)
+        for drawNum in range(3):
+            self.controller.SetFrameEvent(action.eventId + drawNum, False)
+            pipe = self.controller.GetPipelineState()
+            if len(pipe.GetOutputTargets()) != 1:
+                raise rdtest.TestFailureException(
+                    f"With event {action.eventId + drawNum} selected we should have one output target but there is {len(pipe.GetOutputTargets())}")
+        rdtest.log.success("Fully used argument buffer with multiple states + draws replayed")


### PR DESCRIPTION
## Description
- Fix out of bounds read access on the ExecuteIndirect source argument buffer 
- Fix for D3D12 Pixel History support for `typeCast` of `CompType::Typeless` i.e. common on swapchains

## Testing
### ExecuteIndirect Change
- reproduction project for original crash
- add test cases to `D3D12_Execute_Indirect` which expose the crash and show it is fixed
- tested on Microsoft D3D12 Execute Indirect sample project

### Pixel History
- very simple reproduction which has one triangle on a `R8G8B8A8_TYPELESS` swapchain
- pixel history on a depth/stencil buffer which had a `typeCast` to `CompType::Depth` and was backed by a `R16_TYPELESS`  format
- pixel history on complex captures working backwords from the swapchain through to the render targets