### PR TITLE
D3D12 Pixel History support for direct DispatchMesh draws

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -4844,7 +4844,10 @@ void WrappedID3D12Device::ReplayDraw(ID3D12GraphicsCommandListX *cmd, const Acti
 {
   if(action.drawIndex == 0)
   {
-    if(action.flags & ActionFlags::Indexed)
+    if(action.flags & ActionFlags::MeshDispatch)
+      cmd->DispatchMesh(action.dispatchDimension[0], action.dispatchDimension[1],
+                        action.dispatchDimension[2]);
+    else if(action.flags & ActionFlags::Indexed)
       cmd->DrawIndexedInstanced(action.numIndices, action.numInstances, action.indexOffset,
                                 action.baseVertex, action.instanceOffset);
     else

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -2262,7 +2262,11 @@ struct D3D12PixelHistoryPerFragmentCallback : D3D12PixelHistoryCallback
       pipeDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
     }
 
-    if(pipeDesc.GS.pShaderBytecode != NULL || pipeDesc.GS.BytecodeLength > 0)
+    if(pipeDesc.MS.pShaderBytecode != NULL || pipeDesc.MS.BytecodeLength > 0)
+    {
+      RDCWARN("Can't get primitive ID at event %u due to mesh shader usage", eid);
+    }
+    else if(pipeDesc.GS.pShaderBytecode != NULL || pipeDesc.GS.BytecodeLength > 0)
     {
       RDCWARN("Can't get primitive ID at event %u due to geometry shader usage", eid);
     }


### PR DESCRIPTION
## Description
- D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH_MESH is not supported (need Execute Indirect support first)
