### PR TITLE
D3D12 pixel history execute indirect.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -4047,6 +4047,10 @@ bool WrappedID3D12GraphicsCommandList::Serialise_ExecuteIndirect(
                   MaxCommandCount);
           for(uint32_t i = 0; i < count; i++)
           {
+            m_Cmd->m_IndirectData.commandSig = pCommandSignature;
+            m_Cmd->m_IndirectData.argsBuffer = patched.first;
+            m_Cmd->m_IndirectData.argsOffset = patched.second;
+
             uint32_t eventId = m_Cmd->HandlePreCallback(list, ActionFlags::Drawcall,
                                                         (i + 1) * comSig->sig.arguments.count());
 
@@ -4060,6 +4064,10 @@ bool WrappedID3D12GraphicsCommandList::Serialise_ExecuteIndirect(
                                             patched.second, NULL, 0);
               m_Cmd->m_ActionCallback->PostRedraw(eventId, list);
             }
+
+            m_Cmd->m_IndirectData.commandSig = NULL;
+            m_Cmd->m_IndirectData.argsBuffer = NULL;
+            m_Cmd->m_IndirectData.argsOffset = 0;
 
             patched.second += comSig->sig.ByteStride;
           }

--- a/renderdoc/driver/d3d12/d3d12_commands.h
+++ b/renderdoc/driver/d3d12/d3d12_commands.h
@@ -358,6 +358,13 @@ struct D3D12CommandData
 
   rdcarray<D3D12ActionTreeNode *> m_RootActionStack;
 
+  struct IndirectReplayData
+  {
+    ID3D12CommandSignature *commandSig = NULL;
+    ID3D12Resource *argsBuffer = NULL;
+    UINT64 argsOffset = 0;
+  } m_IndirectData;
+
   rdcarray<D3D12ActionTreeNode *> &GetActionStack()
   {
     if(m_LastCmdListID != ResourceId())

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -4839,3 +4839,24 @@ void WrappedID3D12Device::ReplayLog(uint32_t startEventID, uint32_t endEventID,
     ExecuteLists();
   }
 }
+
+void WrappedID3D12Device::ReplayDraw(ID3D12GraphicsCommandListX *cmd, const ActionDescription &action)
+{
+  if(action.drawIndex == 0)
+  {
+    if(action.flags & ActionFlags::Indexed)
+      cmd->DrawIndexedInstanced(action.numIndices, action.numInstances, action.indexOffset,
+                                action.baseVertex, action.instanceOffset);
+    else
+      cmd->DrawInstanced(action.numIndices, action.numInstances, action.vertexOffset,
+                         action.instanceOffset);
+  }
+  else
+  {
+    // TODO: support replay of draws not in callback
+    D3D12CommandData *cmdData = m_Queue->GetCommandData();
+    RDCASSERT(cmdData->m_IndirectData.commandSig != NULL);
+    cmd->ExecuteIndirect(cmdData->m_IndirectData.commandSig, 1, cmdData->m_IndirectData.argsBuffer,
+                         cmdData->m_IndirectData.argsOffset, NULL, 0);
+  }
+}

--- a/renderdoc/driver/d3d12/d3d12_device.h
+++ b/renderdoc/driver/d3d12/d3d12_device.h
@@ -1004,6 +1004,7 @@ public:
 
   RDResult ReadLogInitialisation(RDCFile *rdc, bool storeStructuredBuffers);
   void ReplayLog(uint32_t startEventID, uint32_t endEventID, ReplayLogType replayType);
+  void ReplayDraw(ID3D12GraphicsCommandListX *cmd, const ActionDescription &action);
 
   void SetStructuredExport(uint64_t sectionVersion)
   {


### PR DESCRIPTION
* Cache indirect parameters pre-callback so they can be used for replay.
* Move ReplayDraw implementation to device so it can be re-used.
* Non-callback support left as a TODO + Assert.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
In D3D12 only one draw/dispatch can be contained in ExecuteIndirect arguments and it has to be the last argument, so we don't have to handle disabling other draws/dispatches like the Vulkan implementation does. 
The ExecuteIndirect replay path was previously not implemented, so any draw/dispatch that was preceded by a resource assignment in its argument buffer could not have pixel history performed on it.

Sample used for testing:
https://drive.google.com/file/d/1_VCverVpLhZTNnlnj2ZpJvodJ87kA799/view?usp=sharing

Result:
![image](https://github.com/baldurk/renderdoc/assets/1256627/6611eba3-c39e-42d4-92bc-25b978465741)
