### PR TITLE
D3D12 Pixel History state tracking for capture resources.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_manager.cpp
+++ b/renderdoc/driver/d3d12/d3d12_manager.cpp
@@ -692,7 +692,7 @@ void D3D12ResourceManager::ApplyBarriers(BarrierSet &barriers,
 
     auto it = states.find(id);
     if(it == states.end())
-      return;
+      continue;
 
     SubresourceStateVector &st = it->second;
 
@@ -726,7 +726,7 @@ void D3D12ResourceManager::ApplyBarriers(BarrierSet &barriers,
 
     auto it = states.find(id);
     if(it == states.end())
-      return;
+      continue;
 
     SubresourceStateVector &st = it->second;
 


### PR DESCRIPTION
* For capture resources, use the actual resource state at the time of the event rather than a hardcoded state.
* When hardcoded RT source state was used, on UAV events attempting to transition a texture which was not created with the RTV flag from that state caused a device removal.
* Includes a fix provided by Jake to ApplyBarriers that caused an incorrect state to be returned in this usage.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
Sample which reproduces a device removal error (with or without validation):
https://drive.google.com/file/d/1ccY0vw0saRBAWMM7hAxb4MTost6cebzv/view?usp=sharing

The error:
> D3D12 ERROR: ID3D12CommandList::ResourceBarrier: D3D12_RESOURCE_STATES has bits that mismatch support required from D3D12_RESOURCE_FLAGS. [ RESOURCE_MANIPULATION ERROR # 524: RESOURCE_BARRIER_MISMATCHING_MISC_FLAGS]

Results with fix:
![image](https://github.com/baldurk/renderdoc/assets/1256627/821a5743-ac02-4ce6-ad3a-2247b438154e)