### PR TITLE
D3D12 Pixel History handle resolve events.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_command_list_wrap.cpp
@@ -5098,8 +5098,15 @@ bool WrappedID3D12GraphicsCommandList::Serialise_ResolveSubresource(
       if(m_Cmd->InRerecordRange(m_Cmd->m_LastCmdListID))
       {
         ID3D12GraphicsCommandListX *list = m_Cmd->RerecordCmdList(m_Cmd->m_LastCmdListID);
+        uint32_t eventId = m_Cmd->HandlePreCallback(list, ActionFlags::Resolve);
         Unwrap(list)->ResolveSubresource(Unwrap(pDstResource), DstSubresource, Unwrap(pSrcResource),
                                          SrcSubresource, Format);
+        if(eventId && m_Cmd->m_ActionCallback->PostMisc(eventId, ActionFlags::Resolve, list))
+        {
+          Unwrap(list)->ResolveSubresource(Unwrap(pDstResource), DstSubresource,
+                                           Unwrap(pSrcResource), SrcSubresource, Format);
+          m_Cmd->m_ActionCallback->PostRemisc(eventId, ActionFlags::Resolve, list);
+        }
       }
     }
     else


### PR DESCRIPTION
* Add action callbacks for ResolveSubresource so pixel history can record pre- and post-mods for the events.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
Sample used for repro and testing:
https://drive.google.com/file/d/1P81Nd4_BjuNoIUIScDEPT1SjqTUHbahg/view?usp=sharing
Note that my other PR for resource state tracking (#3247) is necessary to run pixel history on this sample without validation errors.

Before:
![image](https://github.com/baldurk/renderdoc/assets/1256627/e92e919e-99bb-4695-bd70-3b24cd309eaf)

After:
![image](https://github.com/baldurk/renderdoc/assets/1256627/b70510a3-c7b2-4c79-aa87-6286bfd9033f)
