### PR TITLE
Enable the D3D12 Pixel History feature

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -89,8 +89,6 @@
 #include "d3d12_replay.h"
 #include "d3d12_shader_cache.h"
 
-RDOC_EXTERN_CONFIG(bool, D3D12_PixelHistory);
-
 struct D3D12CopyPixelParams
 {
   // The image being copied from
@@ -2736,9 +2734,6 @@ rdcarray<PixelModification> D3D12Replay::PixelHistory(rdcarray<EventUsage> event
                                                       const Subresource &sub, CompType typeCast)
 {
   rdcarray<PixelModification> history;
-
-  if(!D3D12_PixelHistory())
-    return history;
 
   if(events.empty())
     return history;

--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -48,8 +48,6 @@
 RDOC_CONFIG(bool, D3D12_HardwareCounters, true,
             "Enable support for IHV-specific hardware counters on D3D12.");
 
-RDOC_DEBUG_CONFIG(bool, D3D12_PixelHistory, false, "BETA: Enable D3D12 pixel history support.");
-
 // this is global so we can free it even after D3D12Replay is destroyed
 static HMODULE D3D12Lib = NULL;
 
@@ -309,7 +307,7 @@ APIProperties D3D12Replay::GetAPIProperties()
       (m_DriverInfo.vendor == GPUVendor::AMD || m_DriverInfo.vendor == GPUVendor::Samsung) &&
       m_RGP != NULL && m_RGP->DriverSupportsInterop();
   ret.shaderDebugging = true;
-  ret.pixelHistory = D3D12_PixelHistory();
+  ret.pixelHistory = true;
 
   return ret;
 }


### PR DESCRIPTION
## Description

Removed the developer config option D3D12_PixelHistory
