### PR TITLE
Vulkan Multiview support for pixel shader debugging

### DIFF
--- a/docs/python_api/renderdoc/analysis.rst
+++ b/docs/python_api/renderdoc/analysis.rst
@@ -80,3 +80,9 @@ Pixel History
 
 .. autoclass:: PixelValue
   :members:
+
+Shader Debuging
+---------------
+
+.. autoclass:: DebugPixelInputs
+  :members:

--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -2620,9 +2620,9 @@ IBufferViewer *CaptureContext::ViewConstantBuffer(ShaderStage stage, uint32_t sl
 }
 
 IPixelHistoryView *CaptureContext::ViewPixelHistory(ResourceId texID, uint32_t x, uint32_t y,
-                                                    const TextureDisplay &display)
+                                                    uint32_t view, const TextureDisplay &display)
 {
-  return new PixelHistoryView(*this, texID, QPoint(x, y), display, m_MainWindow);
+  return new PixelHistoryView(*this, texID, QPoint(x, y), view, display, m_MainWindow);
 }
 
 QWidget *CaptureContext::CreateBuiltinWindow(const rdcstr &objectName)

--- a/qrenderdoc/Code/CaptureContext.h
+++ b/qrenderdoc/Code/CaptureContext.h
@@ -269,7 +269,7 @@ public:
                                      const rdcstr &format = "") override;
 
   IBufferViewer *ViewConstantBuffer(ShaderStage stage, uint32_t slot, uint32_t idx) override;
-  IPixelHistoryView *ViewPixelHistory(ResourceId texID, uint32_t x, uint32_t y,
+  IPixelHistoryView *ViewPixelHistory(ResourceId texID, uint32_t x, uint32_t y, uint32_t view,
                                       const TextureDisplay &display) override;
 
   QWidget *CreateBuiltinWindow(const rdcstr &objectName) override;

--- a/qrenderdoc/Code/Interface/QRDInterface.h
+++ b/qrenderdoc/Code/Interface/QRDInterface.h
@@ -2624,12 +2624,13 @@ operation.
 :param renderdoc.ResourceId id: The ID of the texture to show the history of.
 :param int x: The x co-ordinate of the pixel to search for.
 :param int y: The y co-ordinate of the pixel to search for.
+:param int view: The layered or multiview rendering view index of the pixel to search for.
 :param renderdoc.TextureDisplay display: The texture display configuration to use when looking up
   the history.
 :return: The new :class:`PixelHistoryView` window opened, but not shown.
 :rtype: PixelHistoryView
 )");
-  virtual IPixelHistoryView *ViewPixelHistory(ResourceId id, uint32_t x, uint32_t y,
+  virtual IPixelHistoryView *ViewPixelHistory(ResourceId id, uint32_t x, uint32_t y, uint32_t view,
                                               const TextureDisplay &display) = 0;
 
   DOCUMENT(R"(Creates and returns a built-in window.

--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -593,7 +593,7 @@ private:
   }
 };
 
-PixelHistoryView::PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint point,
+PixelHistoryView::PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint point, uint32_t view,
                                    const TextureDisplay &display, QWidget *parent)
     : QFrame(parent), ui(new Ui::PixelHistoryView), m_Ctx(ctx)
 {
@@ -604,6 +604,7 @@ PixelHistoryView::PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint p
   m_Pixel = point;
   m_Display = display;
   m_ID = id;
+  m_View = view;
 
   updateWindowTitle();
 
@@ -752,6 +753,7 @@ void PixelHistoryView::startDebug(EventTag tag)
     DebugPixelInputs inputs;
     inputs.sample = m_Display.subresource.sample;
     inputs.primitive = tag.primitive;
+    inputs.view = m_View;
     trace = r->DebugPixel((uint32_t)m_Pixel.x(), (uint32_t)m_Pixel.y(), inputs);
 
     if(trace->debugger == NULL)

--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -749,8 +749,10 @@ void PixelHistoryView::startDebug(EventTag tag)
   ShaderDebugTrace *trace = NULL;
 
   m_Ctx.Replay().AsyncInvoke([this, &trace, &done, tag](IReplayController *r) {
-    trace = r->DebugPixel((uint32_t)m_Pixel.x(), (uint32_t)m_Pixel.y(),
-                          m_Display.subresource.sample, tag.primitive);
+    DebugPixelInputs inputs;
+    inputs.sample = m_Display.subresource.sample;
+    inputs.primitive = tag.primitive;
+    trace = r->DebugPixel((uint32_t)m_Pixel.x(), (uint32_t)m_Pixel.y(), inputs);
 
     if(trace->debugger == NULL)
     {

--- a/qrenderdoc/Windows/PixelHistoryView.h
+++ b/qrenderdoc/Windows/PixelHistoryView.h
@@ -40,7 +40,7 @@ class PixelHistoryView : public QFrame, public IPixelHistoryView, public ICaptur
   Q_OBJECT
 
 public:
-  explicit PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint point,
+  explicit PixelHistoryView(ICaptureContext &ctx, ResourceId id, QPoint point, uint32_t view,
                             const TextureDisplay &display, QWidget *parent = 0);
   ~PixelHistoryView();
 
@@ -74,6 +74,7 @@ private:
   ResourceId m_ID;
   TextureDisplay m_Display;
   QPoint m_Pixel;
+  uint32_t m_View;
   PixelHistoryItemModel *m_Model;
   bool m_ShowFailures = true;
   void startDebug(EventTag tag);

--- a/qrenderdoc/Windows/PythonShell.cpp
+++ b/qrenderdoc/Windows/PythonShell.cpp
@@ -851,10 +851,10 @@ struct CaptureContextInvoker : ObjectForwarder<ICaptureContext>
   }
 
   virtual IPixelHistoryView *ViewPixelHistory(ResourceId texID, uint32_t x, uint32_t y,
-                                              const TextureDisplay &display) override
+                                              uint32_t view, const TextureDisplay &display) override
   {
     return InvokeRetFunction<IPixelHistoryView *>(&ICaptureContext::ViewPixelHistory, texID, x, y,
-                                                  display);
+                                                  view, display);
   }
 
   virtual QWidget *CreateBuiltinWindow(const rdcstr &objectName) override

--- a/qrenderdoc/Windows/ShaderMessageViewer.cpp
+++ b/qrenderdoc/Windows/ShaderMessageViewer.cpp
@@ -337,13 +337,22 @@ ShaderMessageViewer::ShaderMessageViewer(ICaptureContext &ctx, ShaderStageMask s
 
       m_Ctx.Replay().AsyncInvoke([&trace, &done, msg](IReplayController *r) {
         if(msg.stage == ShaderStage::Compute)
+        {
           trace = r->DebugThread(msg.location.compute.workgroup, msg.location.compute.thread);
+        }
         else if(msg.stage == ShaderStage::Vertex)
+        {
           trace = r->DebugVertex(msg.location.vertex.vertexIndex, msg.location.vertex.instance,
                                  msg.location.vertex.vertexIndex, msg.location.vertex.view);
+        }
         else if(msg.stage == ShaderStage::Pixel)
-          trace = r->DebugPixel(msg.location.pixel.x, msg.location.pixel.y,
-                                msg.location.pixel.sample, msg.location.pixel.primitive);
+        {
+          DebugPixelInputs inputs;
+          inputs.sample = msg.location.pixel.sample;
+          inputs.primitive = msg.location.pixel.primitive;
+          inputs.view = msg.location.pixel.view;
+          trace = r->DebugPixel(msg.location.pixel.x, msg.location.pixel.y, inputs);
+        }
 
         if(trace && trace->debugger == NULL)
         {

--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -4098,7 +4098,9 @@ void TextureViewer::on_debugPixelContext_clicked()
   ShaderDebugTrace *trace = NULL;
 
   m_Ctx.Replay().AsyncInvoke([this, &trace, &done, x, y](IReplayController *r) {
-    trace = r->DebugPixel((uint32_t)x, (uint32_t)y, m_TexDisplay.subresource.sample, ~0U);
+    DebugPixelInputs inputs;
+    inputs.sample = m_TexDisplay.subresource.sample;
+    trace = r->DebugPixel((uint32_t)x, (uint32_t)y, inputs);
 
     if(trace->debugger == NULL)
     {

--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -4097,9 +4097,11 @@ void TextureViewer::on_debugPixelContext_clicked()
   bool done = false;
   ShaderDebugTrace *trace = NULL;
 
-  m_Ctx.Replay().AsyncInvoke([this, &trace, &done, x, y](IReplayController *r) {
+  uint32_t view = m_TexDisplay.subresource.slice - m_Following.GetFirstArraySlice(m_Ctx);
+  m_Ctx.Replay().AsyncInvoke([this, &trace, &done, x, y, view](IReplayController *r) {
     DebugPixelInputs inputs;
     inputs.sample = m_TexDisplay.subresource.sample;
+    inputs.view = view;
     trace = r->DebugPixel((uint32_t)x, (uint32_t)y, inputs);
 
     if(trace->debugger == NULL)
@@ -4159,7 +4161,8 @@ void TextureViewer::on_pixelHistory_clicked()
   if(m_TexDisplay.flipY)
     y = (int)(mipHeight - 1) - y;
 
-  IPixelHistoryView *hist = m_Ctx.ViewPixelHistory(texptr->resourceId, x, y, m_TexDisplay);
+  uint32_t view = m_TexDisplay.subresource.slice - m_Following.GetFirstArraySlice(m_Ctx);
+  IPixelHistoryView *hist = m_Ctx.ViewPixelHistory(texptr->resourceId, x, y, view, m_TexDisplay);
 
   m_Ctx.AddDockWindow(hist->Widget(), DockReference::TransientPopupArea, this, 0.3f);
 

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -2235,3 +2235,23 @@ struct Thumbnail
 };
 
 DECLARE_REFLECTION_STRUCT(Thumbnail);
+
+DOCUMENT(
+    "Contains the properties used to select which fragment to debug, used as an input to "
+    "DebugPixel.");
+struct DebugPixelInputs
+{
+  DOCUMENT("");
+  DebugPixelInputs() : sample(~0U), primitive(~0U), view(~0U) {}
+  DebugPixelInputs(const DebugPixelInputs &) = default;
+  DebugPixelInputs &operator=(const DebugPixelInputs &) = default;
+
+  DOCUMENT("The multi-sampled sample.");
+  uint32_t sample;
+  DOCUMENT("The primitive index.");
+  uint32_t primitive;
+  DOCUMENT("The layered or multiview rendering view index.");
+  uint32_t view;
+};
+
+DECLARE_REFLECTION_STRUCT(DebugPixelInputs);

--- a/renderdoc/api/replay/renderdoc_replay.h
+++ b/renderdoc/api/replay/renderdoc_replay.h
@@ -967,15 +967,16 @@ bucket when the pixel values are divided between ``minval`` and ``maxval``.
 
 :param int x: The x co-ordinate.
 :param int y: The y co-ordinate.
-:param int sample: The multi-sampled sample. Ignored if non-multisampled texture.
-:param int primitive: Debug the pixel from this primitive if there's ambiguity. If set to
+:param DebugPixelInputs inputs: Specific properties to select which fragment to debug e.g.
+  sample: The multi-sampled sample. Ignored if non-multisampled texture.
+  primitive: Debug the pixel from this primitive if there's ambiguity. If set to
   :data:`NoPreference` then a random fragment writing to the given co-ordinate is debugged.
-:return: The resulting trace resulting from debugging. Destroy with
-  :meth:`FreeTrace`.
+  view: Debug the fragment writing to this view for layered or multiview rendering, 
+  ignored if set to :data:`NoPreference`.
+:return: The resulting trace resulting from debugging. Destroy with :meth:`FreeTrace`.
 :rtype: ShaderDebugTrace
 )");
-  virtual ShaderDebugTrace *DebugPixel(uint32_t x, uint32_t y, uint32_t sample,
-                                       uint32_t primitive) = 0;
+  virtual ShaderDebugTrace *DebugPixel(uint32_t x, uint32_t y, const DebugPixelInputs &inputs) = 0;
 
   DOCUMENT(R"(Retrieve a debugging trace from running a compute thread.
 

--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -318,8 +318,8 @@ public:
   {
     return new ShaderDebugTrace();
   }
-  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                               uint32_t primitive)
+  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                               const DebugPixelInputs &inputs)
   {
     return new ShaderDebugTrace();
   }

--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -1577,7 +1577,7 @@ ShaderDebugTrace *ReplayProxy::DebugVertex(uint32_t eventId, uint32_t vertid, ui
 template <typename ParamSerialiser, typename ReturnSerialiser>
 ShaderDebugTrace *ReplayProxy::Proxied_DebugPixel(ParamSerialiser &paramser, ReturnSerialiser &retser,
                                                   uint32_t eventId, uint32_t x, uint32_t y,
-                                                  uint32_t sample, uint32_t primitive)
+                                                  const DebugPixelInputs &inputs)
 {
   const ReplayProxyPacket expectedPacket = eReplayProxy_DebugPixel;
   ReplayProxyPacket packet = eReplayProxy_DebugPixel;
@@ -1588,15 +1588,14 @@ ShaderDebugTrace *ReplayProxy::Proxied_DebugPixel(ParamSerialiser &paramser, Ret
     SERIALISE_ELEMENT(eventId);
     SERIALISE_ELEMENT(x);
     SERIALISE_ELEMENT(y);
-    SERIALISE_ELEMENT(sample);
-    SERIALISE_ELEMENT(primitive);
+    SERIALISE_ELEMENT(inputs);
     END_PARAMS();
   }
 
   {
     REMOTE_EXECUTION();
     if(paramser.IsReading() && !paramser.IsErrored() && !m_IsErrored)
-      ret = m_Remote->DebugPixel(eventId, x, y, sample, primitive);
+      ret = m_Remote->DebugPixel(eventId, x, y, inputs);
     else
       ret = new ShaderDebugTrace;
   }
@@ -1606,10 +1605,10 @@ ShaderDebugTrace *ReplayProxy::Proxied_DebugPixel(ParamSerialiser &paramser, Ret
   return ret;
 }
 
-ShaderDebugTrace *ReplayProxy::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                          uint32_t primitive)
+ShaderDebugTrace *ReplayProxy::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                                          const DebugPixelInputs &inputs)
 {
-  PROXY_FUNCTION(DebugPixel, eventId, x, y, sample, primitive);
+  PROXY_FUNCTION(DebugPixel, eventId, x, y, inputs);
 }
 
 template <typename ParamSerialiser, typename ReturnSerialiser>
@@ -2948,7 +2947,7 @@ bool ReplayProxy::Tick(int type)
     case eReplayProxy_ReplaceResource: ReplaceResource(ResourceId(), ResourceId()); break;
     case eReplayProxy_RemoveReplacement: RemoveReplacement(ResourceId()); break;
     case eReplayProxy_DebugVertex: DebugVertex(0, 0, 0, 0, 0); break;
-    case eReplayProxy_DebugPixel: DebugPixel(0, 0, 0, 0, 0); break;
+    case eReplayProxy_DebugPixel: DebugPixel(0, 0, 0, DebugPixelInputs()); break;
     case eReplayProxy_DebugThread:
     {
       DebugThread(0, {}, {});

--- a/renderdoc/core/replay_proxy.h
+++ b/renderdoc/core/replay_proxy.h
@@ -533,7 +533,7 @@ public:
   IMPLEMENT_FUNCTION_PROXIED(ShaderDebugTrace *, DebugVertex, uint32_t eventId, uint32_t vertid,
                              uint32_t instid, uint32_t idx, uint32_t view);
   IMPLEMENT_FUNCTION_PROXIED(ShaderDebugTrace *, DebugPixel, uint32_t eventId, uint32_t x,
-                             uint32_t y, uint32_t sample, uint32_t primitive);
+                             uint32_t y, const DebugPixelInputs &inputs);
   IMPLEMENT_FUNCTION_PROXIED(ShaderDebugTrace *, DebugThread, uint32_t eventId,
                              const rdcfixedarray<uint32_t, 3> &groupid,
                              const rdcfixedarray<uint32_t, 3> &threadid);

--- a/renderdoc/driver/d3d11/d3d11_replay.h
+++ b/renderdoc/driver/d3d11/d3d11_replay.h
@@ -275,8 +275,8 @@ public:
                                            uint32_t y, const Subresource &sub, CompType typeCast);
   ShaderDebugTrace *DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid, uint32_t idx,
                                 uint32_t view);
-  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                               uint32_t primitive);
+  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                               const DebugPixelInputs &inputs);
   ShaderDebugTrace *DebugThread(uint32_t eventId, const rdcfixedarray<uint32_t, 3> &groupid,
                                 const rdcfixedarray<uint32_t, 3> &threadid);
   rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger);

--- a/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
+++ b/renderdoc/driver/d3d11/d3d11_shaderdebug.cpp
@@ -1791,11 +1791,14 @@ ShaderDebugTrace *D3D11Replay::DebugVertex(uint32_t eventId, uint32_t vertid, ui
   return ret;
 }
 
-ShaderDebugTrace *D3D11Replay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                          uint32_t primitive)
+ShaderDebugTrace *D3D11Replay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                                          const DebugPixelInputs &inputs)
 {
   using namespace DXBCBytecode;
   using namespace DXBCDebug;
+
+  uint32_t sample = inputs.sample;
+  uint32_t primitive = inputs.primitive;
 
   D3D11MarkerRegion region(
       StringFormat::Fmt("DebugPixel @ %u of (%u,%u) %u / %u", eventId, x, y, sample, primitive));

--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -234,8 +234,8 @@ public:
                                            uint32_t y, const Subresource &sub, CompType typeCast);
   ShaderDebugTrace *DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid, uint32_t idx,
                                 uint32_t view);
-  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                               uint32_t primitive);
+  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                               const DebugPixelInputs &inputs);
   ShaderDebugTrace *DebugThread(uint32_t eventId, const rdcfixedarray<uint32_t, 3> &groupid,
                                 const rdcfixedarray<uint32_t, 3> &threadid);
   rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger);

--- a/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_shaderdebug.cpp
@@ -1891,12 +1891,15 @@ ShaderDebugTrace *D3D12Replay::DebugVertex(uint32_t eventId, uint32_t vertid, ui
   return ret;
 }
 
-ShaderDebugTrace *D3D12Replay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                          uint32_t primitive)
+ShaderDebugTrace *D3D12Replay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                                          const DebugPixelInputs &inputs)
 {
   using namespace DXBC;
   using namespace DXBCBytecode;
   using namespace DXBCDebug;
+
+  uint32_t sample = inputs.sample;
+  uint32_t primitive = inputs.primitive;
 
   D3D12MarkerRegion debugpixRegion(
       m_pDevice->GetQueue()->GetReal(),

--- a/renderdoc/driver/gl/gl_replay.cpp
+++ b/renderdoc/driver/gl/gl_replay.cpp
@@ -3794,8 +3794,8 @@ ShaderDebugTrace *GLReplay::DebugVertex(uint32_t eventId, uint32_t vertid, uint3
   return new ShaderDebugTrace();
 }
 
-ShaderDebugTrace *GLReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                       uint32_t primitive)
+ShaderDebugTrace *GLReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                                       const DebugPixelInputs &inputs)
 {
   GLNOTIMP("DebugPixel");
   return new ShaderDebugTrace();

--- a/renderdoc/driver/gl/gl_replay.h
+++ b/renderdoc/driver/gl/gl_replay.h
@@ -247,8 +247,8 @@ public:
                                            uint32_t y, const Subresource &sub, CompType typeCast);
   ShaderDebugTrace *DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid, uint32_t idx,
                                 uint32_t view);
-  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                               uint32_t primitive);
+  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                               const DebugPixelInputs &inputs);
   ShaderDebugTrace *DebugThread(uint32_t eventId, const rdcfixedarray<uint32_t, 3> &groupid,
                                 const rdcfixedarray<uint32_t, 3> &threadid);
   rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger);

--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -442,8 +442,8 @@ public:
                                            uint32_t y, const Subresource &sub, CompType typeCast);
   ShaderDebugTrace *DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid, uint32_t idx,
                                 uint32_t view);
-  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                               uint32_t primitive);
+  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                               const DebugPixelInputs &inputs);
   ShaderDebugTrace *DebugThread(uint32_t eventId, const rdcfixedarray<uint32_t, 3> &groupid,
                                 const rdcfixedarray<uint32_t, 3> &threadid);
   rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger);

--- a/renderdoc/driver/vulkan/vk_shaderdebug.cpp
+++ b/renderdoc/driver/vulkan/vk_shaderdebug.cpp
@@ -3052,15 +3052,17 @@ struct PSHit
   Vec4f pos;
   uint32_t prim;
   uint32_t sample;
+  uint32_t view;
   uint32_t valid;
   float ddxDerivCheck;
+  uint32_t padding[3];
   // PSInput base, ddx, ....
 };
 
 static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structStride,
                                  VulkanCreationInfo::ShaderModuleReflection &shadRefl,
                                  const uint32_t paramAlign, StorageMode storageMode,
-                                 bool usePrimitiveID, bool useSampleID)
+                                 bool usePrimitiveID, bool useSampleID, bool useViewIndex)
 {
   rdcspv::Editor editor(fragspv);
 
@@ -3182,7 +3184,7 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
     rdcspv::Id base;
     rdcspv::Id type;
     uint32_t member = ~0U;
-  } fragCoord, primitiveID, sampleIndex;
+  } fragCoord, primitiveID, sampleIndex, viewIndex;
 
   // look to see which ones are already provided
   for(size_t i = 0; i < shadRefl.refl->inputSignature.size(); i++)
@@ -3206,6 +3208,14 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
     else if(param.systemValue == ShaderBuiltin::MSAASampleIndex)
     {
       access = &sampleIndex;
+
+      access->type = VarTypeCompType(param.varType) == CompType::SInt
+                         ? editor.DeclareType(rdcspv::scalar<int32_t>())
+                         : editor.DeclareType(rdcspv::scalar<uint32_t>());
+    }
+    else if(param.systemValue == ShaderBuiltin::MultiViewIndex)
+    {
+      access = &viewIndex;
 
       access->type = VarTypeCompType(param.varType) == CompType::SInt
                          ? editor.DeclareType(rdcspv::scalar<int32_t>())
@@ -3274,6 +3284,25 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
     addedInputs.push_back(sampleIndex.base);
 
     editor.AddCapability(rdcspv::Capability::SampleRateShading);
+  }
+
+  if(viewIndex.base == rdcspv::Id() && useViewIndex)
+  {
+    rdcspv::Id type = editor.DeclareType(rdcspv::scalar<uint32_t>());
+    rdcspv::Id ptrType = editor.DeclareType(rdcspv::Pointer(type, rdcspv::StorageClass::Input));
+
+    viewIndex.base =
+        editor.AddVariable(rdcspv::OpVariable(ptrType, editor.MakeId(), rdcspv::StorageClass::Input));
+    viewIndex.type = type;
+
+    editor.AddDecoration(rdcspv::OpDecorate(
+        viewIndex.base,
+        rdcspv::DecorationParam<rdcspv::Decoration::BuiltIn>(rdcspv::BuiltIn::ViewIndex)));
+    editor.AddDecoration(rdcspv::OpDecorate(viewIndex.base, rdcspv::Decoration::Flat));
+
+    addedInputs.push_back(viewIndex.base);
+
+    editor.AddCapability(rdcspv::Capability::MultiView);
   }
 
   rdcspv::Id PSInput;
@@ -3381,10 +3410,13 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
       uint32Type,
       // uint sample;
       uint32Type,
+      // uint view;
+      uint32Type,
       // uint valid;
       uint32Type,
       // float ddxDerivCheck;
       floatType,
+      // <uint3 padding>
 
       // IN
       PSInput,
@@ -3423,6 +3455,12 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
 
     editor.AddDecoration(rdcspv::OpMemberDecorate(
         PSHit, member, rdcspv::DecorationParam<rdcspv::Decoration::Offset>(offs)));
+    editor.SetMemberName(PSHit, member, "view");
+    offs += sizeof(uint32_t);
+    member++;
+
+    editor.AddDecoration(rdcspv::OpMemberDecorate(
+        PSHit, member, rdcspv::DecorationParam<rdcspv::Decoration::Offset>(offs)));
     editor.SetMemberName(PSHit, member, "valid");
     offs += sizeof(uint32_t);
     member++;
@@ -3432,6 +3470,9 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
     editor.SetMemberName(PSHit, member, "ddxDerivCheck");
     offs += sizeof(uint32_t);
     member++;
+
+    // <uint3 padding>
+    offs += sizeof(uint32_t) * 3;
 
     RDCASSERT((offs % sizeof(Vec4f)) == 0);
     RDCASSERT((structStride % sizeof(Vec4f)) == 0);
@@ -3471,14 +3512,14 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
 
   editor.AddDecoration(rdcspv::OpDecorate(
       PSHitRTArray, rdcspv::DecorationParam<rdcspv::Decoration::ArrayStride>(structStride * 5 +
-                                                                             sizeof(Vec4f) * 2)));
+                                                                             sizeof(Vec4f) * 3)));
 
   rdcspv::Id bufBase = editor.DeclareStructType({
       // uint hit_count;
       uint32Type,
-      // uint test;
+      // uint total_count;
       uint32Type,
-      // <uint3 padding>
+      // <uint2 padding>
 
       //  PSHit hits[];
       PSHitRTArray,
@@ -3553,6 +3594,8 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
     // add the extension
     editor.AddExtension(storageMode == KHR_bda ? "SPV_KHR_physical_storage_buffer"
                                                : "SPV_EXT_physical_storage_buffer");
+    if(useViewIndex)
+      editor.AddExtension("SPV_KHR_multiview");
 
     // change the memory model to physical storage buffer 64
     rdcspv::Iter it = editor.Begin(rdcspv::Section::MemoryModel);
@@ -3878,12 +3921,44 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
           ops.add(rdcspv::OpAccessChain(uint32BufPtr, editor.MakeId(), hit, {getUIntConst(2)}));
       ops.add(rdcspv::OpStore(storePtr, loaded, alignedAccess));
 
+      if(viewIndex.base != rdcspv::Id())
+      {
+        if(viewIndex.member == ~0U)
+        {
+          loaded = ops.add(rdcspv::OpLoad(viewIndex.type, editor.MakeId(), viewIndex.base));
+        }
+        else
+        {
+          rdcspv::Id inPtrType =
+              editor.DeclareType(rdcspv::Pointer(viewIndex.type, rdcspv::StorageClass::Input));
+
+          rdcspv::Id viewidxptr =
+              ops.add(rdcspv::OpAccessChain(inPtrType, editor.MakeId(), viewIndex.base,
+                                            {editor.AddConstantImmediate(viewIndex.member)}));
+          loaded = ops.add(rdcspv::OpLoad(viewIndex.type, editor.MakeId(), viewidxptr));
+        }
+
+        // if it was loaded as signed int by the shader and not as unsigned by us, bitcast to
+        // unsigned.
+        if(viewIndex.type != uint32Type)
+          loaded = ops.add(rdcspv::OpBitcast(uint32Type, editor.MakeId(), loaded));
+      }
+      else
+      {
+        // explicitly store 0
+        loaded = getUIntConst(0);
+      }
+
       storePtr =
           ops.add(rdcspv::OpAccessChain(uint32BufPtr, editor.MakeId(), hit, {getUIntConst(3)}));
+      ops.add(rdcspv::OpStore(storePtr, loaded, alignedAccess));
+
+      storePtr =
+          ops.add(rdcspv::OpAccessChain(uint32BufPtr, editor.MakeId(), hit, {getUIntConst(4)}));
       ops.add(rdcspv::OpStore(storePtr, editor.AddConstantImmediate(validMagicNumber), alignedAccess));
 
       // store ddx(gl_FragCoord.x) to check that derivatives are working
-      storePtr = ops.add(rdcspv::OpAccessChain(floatBufPtr, editor.MakeId(), hit, {getUIntConst(4)}));
+      storePtr = ops.add(rdcspv::OpAccessChain(floatBufPtr, editor.MakeId(), hit, {getUIntConst(5)}));
       rdcspv::Id fragCoord_ddx_x =
           ops.add(rdcspv::OpCompositeExtract(floatType, editor.MakeId(), fragCoord_ddx, {0}));
       ops.add(rdcspv::OpStore(storePtr, fragCoord_ddx_x, alignedAccess));
@@ -3892,11 +3967,11 @@ static void CreatePSInputFetcher(rdcarray<uint32_t> &fragspv, uint32_t &structSt
         rdcspv::Id inputPtrType = editor.DeclareType(rdcspv::Pointer(PSInput, bufferClass));
 
         rdcspv::Id outputPtrs[Variant_Count] = {
-            ops.add(rdcspv::OpAccessChain(inputPtrType, editor.MakeId(), hit, {getUIntConst(5)})),
             ops.add(rdcspv::OpAccessChain(inputPtrType, editor.MakeId(), hit, {getUIntConst(6)})),
             ops.add(rdcspv::OpAccessChain(inputPtrType, editor.MakeId(), hit, {getUIntConst(7)})),
             ops.add(rdcspv::OpAccessChain(inputPtrType, editor.MakeId(), hit, {getUIntConst(8)})),
             ops.add(rdcspv::OpAccessChain(inputPtrType, editor.MakeId(), hit, {getUIntConst(9)})),
+            ops.add(rdcspv::OpAccessChain(inputPtrType, editor.MakeId(), hit, {getUIntConst(10)})),
         };
 
         for(size_t i = 0; i < values.size(); i++)
@@ -4300,6 +4375,43 @@ ShaderDebugTrace *VulkanReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_
     RDCLOG("useSampleID is %u because of bare capability", useSampleID);
   }
 
+  bool useViewIndex = (view == ~0U) ? false : true;
+  if(useViewIndex)
+  {
+    ResourceId rp = state.GetRenderPass();
+    if(rp != ResourceId())
+    {
+      const VulkanCreationInfo::RenderPass &rpInfo =
+          m_pDriver->GetDebugManager()->GetRenderPassInfo(rp);
+      for(auto it = rpInfo.subpasses.begin(); it != rpInfo.subpasses.end(); ++it)
+      {
+        if(it->multiviews.isEmpty())
+        {
+          if(Vulkan_Debug_ShaderDebugLogging())
+            RDCLOG(
+                "Disabling useViewIndex because at least one subpass does not have multiple views");
+          useViewIndex = false;
+          break;
+        }
+      }
+    }
+    else
+    {
+      useViewIndex = pipe.viewMask != 0;
+      if(!useViewIndex && Vulkan_Debug_ShaderDebugLogging())
+        RDCLOG("Disabling useViewIndex because viewMask is zero");
+    }
+  }
+  else
+  {
+    if(Vulkan_Debug_ShaderDebugLogging())
+      RDCLOG("Disabling useViewIndex from input view %u", view);
+  }
+  if(useViewIndex)
+  {
+    builtins[ShaderBuiltin::MultiViewIndex] = ShaderVariable(rdcstr(), view, 0U, 0U, 0U);
+  }
+
   StorageMode storageMode = Binding;
 
   if(m_pDriver->GetExtensions(NULL).ext_KHR_buffer_device_address)
@@ -4349,7 +4461,7 @@ ShaderDebugTrace *VulkanReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_
 
   uint32_t structStride = 0;
   CreatePSInputFetcher(fragspv, structStride, shadRefl, paramAlign, storageMode, usePrimitiveID,
-                       useSampleID);
+                       useSampleID, useViewIndex);
 
   if(!Vulkan_Debug_PSDebugDumpDirPath().empty())
     FileIO::WriteAll(Vulkan_Debug_PSDebugDumpDirPath() + "/debug_psinput_after.spv", fragspv);
@@ -4489,8 +4601,8 @@ ShaderDebugTrace *VulkanReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_
   }
 
   // create fragment shader with modified code
-  VkShaderModuleCreateInfo moduleCreateInfo = {VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
 
+  VkShaderModuleCreateInfo moduleCreateInfo = {VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
   VkSpecializationMapEntry specMaps[] = {
       {
           (uint32_t)InputSpecConstant::Address,
@@ -4722,6 +4834,13 @@ ShaderDebugTrace *VulkanReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_
     {
       RDCWARN("Hit %u doesn't have valid derivatives", i);
       continue;
+    }
+
+    // if we're looking for a specific view, ignore hits from the wrong view
+    if(useViewIndex)
+    {
+      if(hit->view != view)
+        continue;
     }
 
     // see if this hit is a closer match than the previous winner.

--- a/renderdoc/driver/vulkan/vk_shaderdebug.cpp
+++ b/renderdoc/driver/vulkan/vk_shaderdebug.cpp
@@ -4176,7 +4176,7 @@ ShaderDebugTrace *VulkanReplay::DebugVertex(uint32_t eventId, uint32_t vertid, u
 }
 
 ShaderDebugTrace *VulkanReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
-                                           uint32_t sample, uint32_t primitive)
+                                           const DebugPixelInputs &inputs)
 {
   if(!GetAPIProperties().shaderDebugging)
   {
@@ -4193,11 +4193,15 @@ ShaderDebugTrace *VulkanReplay::DebugPixel(uint32_t eventId, uint32_t x, uint32_
   VkDevice dev = m_pDriver->GetDev();
   VkResult vkr = VK_SUCCESS;
 
+  uint32_t sample = inputs.sample;
+  uint32_t primitive = inputs.primitive;
+  uint32_t view = inputs.view;
+
   const VulkanRenderState &state = m_pDriver->GetRenderState();
   VulkanCreationInfo &c = m_pDriver->m_CreationInfo;
 
-  rdcstr regionName = StringFormat::Fmt("DebugPixel @ %u of (%u,%u) sample %u primitive %u",
-                                        eventId, x, y, sample, primitive);
+  rdcstr regionName = StringFormat::Fmt("DebugPixel @ %u of (%u,%u) sample %u primitive %u view %u",
+                                        eventId, x, y, sample, primitive, view);
 
   VkMarkerRegion region(regionName);
 

--- a/renderdoc/replay/dummy_driver.cpp
+++ b/renderdoc/replay/dummy_driver.cpp
@@ -257,8 +257,8 @@ ShaderDebugTrace *DummyDriver::DebugVertex(uint32_t eventId, uint32_t vertid, ui
   return new ShaderDebugTrace;
 }
 
-ShaderDebugTrace *DummyDriver::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                          uint32_t primitive)
+ShaderDebugTrace *DummyDriver::DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                                          const DebugPixelInputs &inputs)
 {
   return new ShaderDebugTrace;
 }

--- a/renderdoc/replay/dummy_driver.h
+++ b/renderdoc/replay/dummy_driver.h
@@ -101,8 +101,8 @@ public:
                                            uint32_t y, const Subresource &sub, CompType typeCast);
   ShaderDebugTrace *DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid, uint32_t idx,
                                 uint32_t view);
-  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                               uint32_t primitive);
+  ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                               const DebugPixelInputs &inputs);
   ShaderDebugTrace *DebugThread(uint32_t eventId, const rdcfixedarray<uint32_t, 3> &groupid,
                                 const rdcfixedarray<uint32_t, 3> &threadid);
   rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger);

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -991,6 +991,16 @@ void DoSerialise(SerialiserType &ser, ReplayOptions &el)
   SIZE_CHECK(48);
 }
 
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, DebugPixelInputs &el)
+{
+  SERIALISE_MEMBER(sample);
+  SERIALISE_MEMBER(primitive);
+  SERIALISE_MEMBER(view);
+
+  SIZE_CHECK(12);
+}
+
 #pragma region Common pipeline state
 
 template <typename SerialiserType>
@@ -2474,6 +2484,7 @@ INSTANTIATE_SERIALISE_TYPE(CounterResult)
 INSTANTIATE_SERIALISE_TYPE(CounterValue)
 INSTANTIATE_SERIALISE_TYPE(GPUDevice)
 INSTANTIATE_SERIALISE_TYPE(ReplayOptions)
+INSTANTIATE_SERIALISE_TYPE(DebugPixelInputs)
 INSTANTIATE_SERIALISE_TYPE(D3D11Pipe::Layout)
 INSTANTIATE_SERIALISE_TYPE(D3D11Pipe::InputAssembly)
 INSTANTIATE_SERIALISE_TYPE(D3D11Pipe::View)

--- a/renderdoc/replay/replay_controller.cpp
+++ b/renderdoc/replay/replay_controller.cpp
@@ -1619,14 +1619,13 @@ ShaderDebugTrace *ReplayController::DebugVertex(uint32_t vertid, uint32_t instid
   return ret;
 }
 
-ShaderDebugTrace *ReplayController::DebugPixel(uint32_t x, uint32_t y, uint32_t sample,
-                                               uint32_t primitive)
+ShaderDebugTrace *ReplayController::DebugPixel(uint32_t x, uint32_t y, const DebugPixelInputs &inputs)
 {
   CHECK_REPLAY_THREAD();
 
   RENDERDOC_PROFILEFUNCTION();
 
-  ShaderDebugTrace *ret = m_pDevice->DebugPixel(m_EventID, x, y, sample, primitive);
+  ShaderDebugTrace *ret = m_pDevice->DebugPixel(m_EventID, x, y, inputs);
   FatalErrorCheck();
 
   SetFrameEvent(m_EventID, true);

--- a/renderdoc/replay/replay_controller.h
+++ b/renderdoc/replay/replay_controller.h
@@ -203,7 +203,7 @@ public:
   rdcarray<PixelModification> PixelHistory(ResourceId target, uint32_t x, uint32_t y,
                                            const Subresource &sub, CompType typeCast);
   ShaderDebugTrace *DebugVertex(uint32_t vertid, uint32_t instid, uint32_t idx, uint32_t view);
-  ShaderDebugTrace *DebugPixel(uint32_t x, uint32_t y, uint32_t sample, uint32_t primitive);
+  ShaderDebugTrace *DebugPixel(uint32_t x, uint32_t y, const DebugPixelInputs &inputs);
   ShaderDebugTrace *DebugThread(const rdcfixedarray<uint32_t, 3> &groupid,
                                 const rdcfixedarray<uint32_t, 3> &threadid);
   rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger);

--- a/renderdoc/replay/replay_driver.h
+++ b/renderdoc/replay/replay_driver.h
@@ -217,8 +217,8 @@ public:
                                                    CompType typeCast) = 0;
   virtual ShaderDebugTrace *DebugVertex(uint32_t eventId, uint32_t vertid, uint32_t instid,
                                         uint32_t idx, uint32_t view) = 0;
-  virtual ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y, uint32_t sample,
-                                       uint32_t primitive) = 0;
+  virtual ShaderDebugTrace *DebugPixel(uint32_t eventId, uint32_t x, uint32_t y,
+                                       const DebugPixelInputs &inputs) = 0;
   virtual ShaderDebugTrace *DebugThread(uint32_t eventId, const rdcfixedarray<uint32_t, 3> &groupid,
                                         const rdcfixedarray<uint32_t, 3> &threadid) = 0;
   virtual rdcarray<ShaderDebugState> ContinueDebug(ShaderDebugger *debugger) = 0;

--- a/util/test/demos/CMakeLists.txt
+++ b/util/test/demos/CMakeLists.txt
@@ -135,6 +135,7 @@ set(VULKAN_SRC
         vk/vk_multi_entry.cpp
         vk/vk_multi_present.cpp
         vk/vk_multi_thread_windows.cpp
+        vk/vk_multi_view.cpp
         vk/vk_overlay_test.cpp
         vk/vk_parameter_zoo.cpp
         vk/vk_pixel_history.cpp

--- a/util/test/demos/demos.vcxproj
+++ b/util/test/demos/demos.vcxproj
@@ -319,6 +319,7 @@
     <ClCompile Include="vk\vk_mesh_zoo.cpp" />
     <ClCompile Include="vk\vk_multi_entry.cpp" />
     <ClCompile Include="vk\vk_multi_present.cpp" />
+    <ClCompile Include="vk\vk_multi_view.cpp" />
     <ClCompile Include="vk\vk_parameter_zoo.cpp" />
     <ClCompile Include="vk\vk_imageless_framebuffer.cpp" />
     <ClCompile Include="vk\vk_image_layouts.cpp" />

--- a/util/test/demos/demos.vcxproj.filters
+++ b/util/test/demos/demos.vcxproj.filters
@@ -685,6 +685,9 @@
     <ClCompile Include="d3d12\d3d12_multi_wait_before_signal.cpp">
       <Filter>D3D12\demos</Filter>
     </ClCompile>
+    <ClCompile Include="vk\vk_multi_view.cpp">
+      <Filter>Vulkan\demos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="D3D11">

--- a/util/test/demos/vk/vk_helpers.h
+++ b/util/test/demos/vk/vk_helpers.h
@@ -1477,6 +1477,12 @@ struct RenderPassCreator : private VkRenderPassCreateInfo
     return (const VkRenderPassCreateInfo *)this;
   }
 
+  RenderPassCreator &next(const void *next)
+  {
+    this->pNext = next;
+    return *this;
+  }
+
 private:
   void bake()
   {

--- a/util/test/demos/vk/vk_multi_view.cpp
+++ b/util/test/demos/vk/vk_multi_view.cpp
@@ -1,0 +1,304 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "vk_test.h"
+
+RD_TEST(VK_Multi_View, VulkanGraphicsTest)
+{
+  static constexpr const char *Description =
+      "Basic multi-view test like VK_Simple_Triangle but for multi-view rendering";
+
+  const std::string common = R"EOSHADER(
+
+#version 460 core
+
+#extension GL_EXT_multiview : require
+
+#define v2f v2f_block \
+{                     \
+	vec4 pos;           \
+	vec4 col;           \
+	vec4 uv;            \
+}
+
+)EOSHADER";
+
+  const std::string multiviewVertex = common + R"EOSHADER(
+
+layout(location = 0) in vec3 Position;
+layout(location = 1) in vec4 Color;
+layout(location = 2) in vec2 UV;
+
+layout(location = 0) out v2f vertOut;
+
+void main()
+{
+	vertOut.pos = vec4(Position.xyz*vec3(1,-1,1), 1);
+	gl_Position = vertOut.pos;
+	vertOut.col = Color;
+	vertOut.uv = vec4(UV.xy, 0, 1);
+
+  if (gl_ViewIndex == 0)
+	  vertOut.col = vec4(1, 0, 0, 1);
+  if (gl_ViewIndex == 1)
+	  vertOut.col = vec4(0, 1, 0, 1);
+}
+
+)EOSHADER";
+
+  const std::string multiViewGeom = common + R"EOSHADER(
+
+layout(triangles) in;
+layout(triangle_strip, max_vertices = 3) out;
+
+layout(location = 0) in v2f_block
+{
+	vec4 pos;
+	vec4 col;
+	vec4 uv;
+} gin[3];
+
+layout(location = 0) out g2f_block
+{
+	vec4 pos;
+	vec4 col;
+	vec4 uv;
+} gout;
+
+void main()
+{
+  for(int i = 0; i < 3; i++)
+  {
+    gl_Position = gl_in[i].gl_Position;
+
+    gout.pos = gin[i].pos;
+    gout.col = gin[i].col;
+    gout.uv = gin[i].uv;
+
+    if (gl_ViewIndex == 0)
+      gout.col = vec4(1, 0, 0, 1);
+    if (gl_ViewIndex == 1)
+      gout.col = vec4(0, 1, 0, 1);
+    EmitVertex();
+  }
+  EndPrimitive();
+}
+
+)EOSHADER";
+  const std::string multiViewPixel = common + R"EOSHADER(
+
+layout(location = 0) in v2f vertIn;
+
+layout(location = 0, index = 0) out vec4 Color;
+
+void main()
+{
+	Color = vertIn.col;
+  if (gl_ViewIndex == 0)
+	  Color = vec4(1, 0, 0, 1);
+  if (gl_ViewIndex == 1)
+	  Color = vec4(0, 1, 0, 1);
+}
+
+)EOSHADER";
+  void Prepare(int argc, char **argv)
+  {
+    features.geometryShader = VK_TRUE;
+    devExts.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+
+    VulkanGraphicsTest::Prepare(argc, argv);
+
+    static VkPhysicalDeviceMultiviewFeaturesKHR multiview = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR,
+    };
+
+    getPhysFeatures2(&multiview);
+    if(!multiview.multiview)
+      Avail = "Multiview feature 'multiview' not available";
+
+    devInfoNext = &multiview;
+  }
+
+  int main()
+  {
+    // initialise, create window, create context, etc
+    if(!Init())
+      return 3;
+
+    vkh::RenderPassCreator renderPassCreateInfo;
+
+    renderPassCreateInfo.attachments.push_back(vkh::AttachmentDescription(
+        mainWindow->format, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE, VK_SAMPLE_COUNT_1_BIT,
+        VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE));
+
+    renderPassCreateInfo.addSubpass(
+        {VkAttachmentReference({0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL})});
+
+    uint32_t countViews = 2;
+    uint32_t viewMask = (1 << countViews) - 1;
+    uint32_t correlationMask = viewMask;
+    uint32_t countLayers = countViews + 2;
+
+    VkRenderPassMultiviewCreateInfo rpMultiviewCreateInfo = {
+        VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO};
+    rpMultiviewCreateInfo.subpassCount = 1;
+    rpMultiviewCreateInfo.pViewMasks = &viewMask;
+    rpMultiviewCreateInfo.correlationMaskCount = 1;
+    rpMultiviewCreateInfo.pCorrelationMasks = &correlationMask;
+
+    renderPassCreateInfo.next((void *)&rpMultiviewCreateInfo);
+
+    VkRenderPass renderPass = createRenderPass(renderPassCreateInfo);
+
+    AllocatedImage fbColourImage(
+        this,
+        vkh::ImageCreateInfo(mainWindow->scissor.extent.width, mainWindow->scissor.extent.height, 0,
+                             mainWindow->format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 1, countLayers),
+        VmaAllocationCreateInfo({0, VMA_MEMORY_USAGE_GPU_ONLY}));
+
+    VkImageViewCreateInfo colourViewInfo = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+    colourViewInfo.image = fbColourImage.image;
+    colourViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+    colourViewInfo.format = mainWindow->format;
+    colourViewInfo.flags = 0;
+    colourViewInfo.subresourceRange = {};
+    colourViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    colourViewInfo.subresourceRange.baseMipLevel = 0;
+    colourViewInfo.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
+    colourViewInfo.subresourceRange.baseArrayLayer = 1;
+    colourViewInfo.subresourceRange.layerCount = countViews;
+    VkImageView fbColourView = createImageView(&colourViewInfo);
+
+    VkFramebuffer framebuffer = createFramebuffer(
+        vkh::FramebufferCreateInfo(renderPass, {fbColourView}, mainWindow->scissor.extent));
+
+    VkPipelineLayout layout = createPipelineLayout(vkh::PipelineLayoutCreateInfo());
+
+    vkh::GraphicsPipelineCreateInfo pipeCreateInfo;
+
+    pipeCreateInfo.layout = layout;
+    pipeCreateInfo.renderPass = renderPass;
+
+    VkPipelineColorBlendAttachmentState colorBlendAttachment = {};
+    colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    colorBlendAttachment.blendEnable = VK_FALSE;
+    pipeCreateInfo.colorBlendState.attachments = {colorBlendAttachment};
+    pipeCreateInfo.depthStencilState.depthTestEnable = VK_FALSE;
+    pipeCreateInfo.depthStencilState.stencilTestEnable = VK_FALSE;
+
+    pipeCreateInfo.vertexInputState.vertexBindingDescriptions = {vkh::vertexBind(0, DefaultA2V)};
+    pipeCreateInfo.vertexInputState.vertexAttributeDescriptions = {
+        vkh::vertexAttr(0, 0, DefaultA2V, pos),
+        vkh::vertexAttr(1, 0, DefaultA2V, col),
+        vkh::vertexAttr(2, 0, DefaultA2V, uv),
+    };
+
+    pipeCreateInfo.stages = {
+        CompileShaderModule(multiviewVertex, ShaderLang::glsl, ShaderStage::vert, "main"),
+        CompileShaderModule(VKDefaultPixel, ShaderLang::glsl, ShaderStage::frag, "main"),
+    };
+
+    std::vector<std::string> testNames;
+    std::vector<VkPipeline> testPipes;
+    testPipes.push_back(createGraphicsPipeline(pipeCreateInfo));
+    testNames.push_back("Vertex: viewIndex");
+
+    pipeCreateInfo.stages = {
+        CompileShaderModule(VKDefaultVertex, ShaderLang::glsl, ShaderStage::vert, "main"),
+        CompileShaderModule(multiViewPixel, ShaderLang::glsl, ShaderStage::frag, "main"),
+    };
+    testPipes.push_back(createGraphicsPipeline(pipeCreateInfo));
+    testNames.push_back("Fragment: viewIndex");
+
+    pipeCreateInfo.stages = {
+        CompileShaderModule(VKDefaultVertex, ShaderLang::glsl, ShaderStage::vert, "main"),
+        CompileShaderModule(VKDefaultPixel, ShaderLang::glsl, ShaderStage::frag, "main"),
+        CompileShaderModule(multiViewGeom, ShaderLang::glsl, ShaderStage::geom, "main"),
+    };
+    testPipes.push_back(createGraphicsPipeline(pipeCreateInfo));
+    testNames.push_back("Geometry: viewIndex");
+
+    pipeCreateInfo.stages = {
+        CompileShaderModule(VKDefaultVertex, ShaderLang::glsl, ShaderStage::vert, "main"),
+        CompileShaderModule(VKDefaultPixel, ShaderLang::glsl, ShaderStage::frag, "main"),
+    };
+    testPipes.push_back(createGraphicsPipeline(pipeCreateInfo));
+    testNames.push_back("No viewIndex");
+
+    AllocatedBuffer vb(
+        this,
+        vkh::BufferCreateInfo(sizeof(DefaultTri),
+                              VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT),
+        VmaAllocationCreateInfo({0, VMA_MEMORY_USAGE_CPU_TO_GPU}));
+
+    vb.upload(DefaultTri);
+
+    while(Running())
+    {
+      VkCommandBuffer cmd = GetCommandBuffer();
+
+      vkBeginCommandBuffer(cmd, vkh::CommandBufferBeginInfo());
+      VkImage swapimg =
+          StartUsingBackbuffer(cmd, VK_ACCESS_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_GENERAL);
+
+      vkCmdClearColorImage(cmd, swapimg, VK_IMAGE_LAYOUT_GENERAL,
+                           vkh::ClearColorValue(0.2f, 0.2f, 0.2f, 1.0f), 1,
+                           vkh::ImageSubresourceRange());
+
+      // Render multiview to its own framebuffer
+
+      vkCmdBeginRenderPass(cmd,
+                           vkh::RenderPassBeginInfo(renderPass, framebuffer, mainWindow->scissor,
+                                                    {vkh::ClearValue(0.2f, 0.3f, 0.4f, 1.0f)}),
+                           VK_SUBPASS_CONTENTS_INLINE);
+
+      for(size_t i = 0; i < testPipes.size(); ++i)
+      {
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, testPipes[i]);
+        vkCmdSetViewport(cmd, 0, 1, &mainWindow->viewport);
+        vkCmdSetScissor(cmd, 0, 1, &mainWindow->scissor);
+        vkh::cmdBindVertexBuffers(cmd, 0, {vb.buffer}, {0});
+        setMarker(cmd, testNames[i]);
+        vkCmdDraw(cmd, 3, 1, 0, 0);
+      }
+
+      vkCmdEndRenderPass(cmd);
+
+      // TODO: in the future could copy the multiview renderpass to the framebuffer (left, right)
+      FinishUsingBackbuffer(cmd, VK_ACCESS_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_GENERAL);
+
+      vkEndCommandBuffer(cmd);
+
+      Submit(0, 1, {cmd});
+
+      Present();
+    }
+
+    return 0;
+  }
+};
+
+REGISTER_TEST();

--- a/util/test/rdtest/shared/Buffer_Truncation.py
+++ b/util/test/rdtest/shared/Buffer_Truncation.py
@@ -122,8 +122,7 @@ class Buffer_Truncation(rdtest.TestCase):
             # Debug the shader
             trace: rd.ShaderDebugTrace = self.controller.DebugPixel(int(pipe.GetViewport(0).width/2),
                                                                     int(pipe.GetViewport(0).height/2),
-                                                                    rd.ReplayController.NoPreference,
-                                                                    rd.ReplayController.NoPreference)
+                                                                    rd.DebugPixelInputs())
 
             if trace.debugger is None:
                 self.controller.FreeTrace(trace)

--- a/util/test/tests/D3D11/D3D11_CBuffer_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_CBuffer_Zoo.py
@@ -31,8 +31,7 @@ class D3D11_CBuffer_Zoo(rdtest.TestCase):
                 rd.ShaderStage.Pixel).debugInfo.debuggable:
             trace: rd.ShaderDebugTrace = self.controller.DebugPixel(int(pipe.GetViewport(0).width / 2.0),
                                                                     int(pipe.GetViewport(0).height / 2.0),
-                                                                    rd.ReplayController.NoPreference,
-                                                                    rd.ReplayController.NoPreference)
+                                                                    rd.DebugPixelInputs())
 
             debugVars = dict()
 

--- a/util/test/tests/D3D11/D3D11_PrimitiveID.py
+++ b/util/test/tests/D3D11/D3D11_PrimitiveID.py
@@ -10,7 +10,9 @@ class D3D11_PrimitiveID(rdtest.TestCase):
         self.controller.SetFrameEvent(action.eventId, True)
         pipe: rd.PipeState = self.controller.GetPipelineState()
 
-        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.ReplayController.NoPreference, prim)
+        inputs = rd.DebugPixelInputs()
+        inputs.primitive = prim
+        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, inputs)
 
         sourceVars: List[rd.SourceVariableMapping] = list(trace.sourceVars)
         cycles, variables = self.process_trace(trace)

--- a/util/test/tests/D3D11/D3D11_Shader_Debug_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_Shader_Debug_Zoo.py
@@ -22,8 +22,7 @@ class D3D11_Shader_Debug_Zoo(rdtest.TestCase):
         rdtest.log.begin_section("General tests")
         for test in range(action.numInstances):
             # Debug the shader
-            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4 * test, 0, rd.ReplayController.NoPreference,
-                                                                    rd.ReplayController.NoPreference)
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4 * test, 0, rd.DebugPixelInputs())
 
             cycles, variables = self.process_trace(trace)
 
@@ -52,8 +51,7 @@ class D3D11_Shader_Debug_Zoo(rdtest.TestCase):
         pipe: rd.PipeState = self.controller.GetPipelineState()
 
         # Debug the shader
-        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(0, 4, rd.ReplayController.NoPreference,
-                                                                rd.ReplayController.NoPreference)
+        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(0, 4, rd.DebugPixelInputs())
 
         cycles, variables = self.process_trace(trace)
 
@@ -79,8 +77,9 @@ class D3D11_Shader_Debug_Zoo(rdtest.TestCase):
         pipe: rd.PipeState = self.controller.GetPipelineState()
         for test in range(4):
             # Debug the shader
-            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4, 4, test,
-                                                                    rd.ReplayController.NoPreference)
+            inputs = rd.DebugPixelInputs()
+            inputs.sample = test
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4, 4, inputs)
 
             # Validate that the correct sample index was debugged
             sampRegister = self.find_input_source_var(trace, rd.ShaderBuiltin.MSAASampleIndex)

--- a/util/test/tests/D3D11/D3D11_Shader_Linkage_Zoo.py
+++ b/util/test/tests/D3D11/D3D11_Shader_Linkage_Zoo.py
@@ -19,8 +19,7 @@ class D3D11_Shader_Linkage_Zoo(rdtest.TestCase):
             pipe: rd.PipeState = self.controller.GetPipelineState()
 
             # Debug the shader
-            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(200, 150, rd.ReplayController.NoPreference,
-                                                                    rd.ReplayController.NoPreference)
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(200, 150, rd.DebugPixelInputs())
             if trace.debugger is None:
                 failed = True
                 rdtest.log.error("Test {} could not be debugged.".format(event_name))

--- a/util/test/tests/D3D12/D3D12_CBuffer_Zoo.py
+++ b/util/test/tests/D3D12/D3D12_CBuffer_Zoo.py
@@ -103,8 +103,7 @@ class D3D12_CBuffer_Zoo(rdtest.TestCase):
                 rd.ShaderStage.Pixel).debugInfo.debuggable:
             trace: rd.ShaderDebugTrace = self.controller.DebugPixel(int(pipe.GetViewport(0).width / 2.0),
                                                                     int(pipe.GetViewport(0).height / 2.0),
-                                                                    rd.ReplayController.NoPreference,
-                                                                    rd.ReplayController.NoPreference)
+                                                                    rd.DebugPixelInputs())
 
             debugVars = dict()
 

--- a/util/test/tests/D3D12/D3D12_PrimitiveID.py
+++ b/util/test/tests/D3D12/D3D12_PrimitiveID.py
@@ -14,7 +14,9 @@ class D3D12_PrimitiveID(rdtest.TestCase):
             rdtest.log.print("Skipping undebuggable shader at {}.".format(action.eventId))
             return
 
-        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.ReplayController.NoPreference, prim)
+        inputs = rd.DebugPixleInputs()
+        inputs.primitive = prim
+        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, inputs)
 
         cycles, variables = self.process_trace(trace)
 

--- a/util/test/tests/D3D12/D3D12_Resource_Mapping_Zoo.py
+++ b/util/test/tests/D3D12/D3D12_Resource_Mapping_Zoo.py
@@ -14,8 +14,7 @@ class D3D12_Resource_Mapping_Zoo(rdtest.TestCase):
             return
 
         # Debug the shader
-        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.ReplayController.NoPreference,
-                                                                rd.ReplayController.NoPreference)
+        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.DebugPixelInputs())
 
         cycles, variables = self.process_trace(trace)
 

--- a/util/test/tests/D3D12/D3D12_Shader_Debug_Zoo.py
+++ b/util/test/tests/D3D12/D3D12_Shader_Debug_Zoo.py
@@ -33,8 +33,7 @@ class D3D12_Shader_Debug_Zoo(rdtest.TestCase):
             # Loop over every test
             for test in range(action.numInstances):
                 # Debug the shader
-                trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4 * test, 0, rd.ReplayController.NoPreference,
-                                                                        rd.ReplayController.NoPreference)
+                trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4 * test, 0, rd.DebugPixelInputs())
 
                 cycles, variables = self.process_trace(trace)
 
@@ -65,8 +64,9 @@ class D3D12_Shader_Debug_Zoo(rdtest.TestCase):
         pipe: rd.PipeState = self.controller.GetPipelineState()
         for test in range(4):
             # Debug the shader
-            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4, 4, test,
-                                                                    rd.ReplayController.NoPreference)
+            inputs = rd.DebugPixelInputs()
+            inputs.sample = test
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(4, 4, inputs)
 
             # Validate that the correct sample index was debugged
             sampRegister = self.find_input_source_var(trace, rd.ShaderBuiltin.MSAASampleIndex)
@@ -113,7 +113,9 @@ class D3D12_Shader_Debug_Zoo(rdtest.TestCase):
         rdtest.log.success("VertexSample VS was debugged correctly")
 
         # Debug the pixel shader
-        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(51, 51, 0, rd.ReplayController.NoPreference)
+        inputs = rd.DebugPixelInputs()
+        inputs.sample = 0
+        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(51, 51, inputs)
 
         cycles, variables = self.process_trace(trace)
 
@@ -157,7 +159,9 @@ class D3D12_Shader_Debug_Zoo(rdtest.TestCase):
         rdtest.log.success("Banned signature VS was debugged correctly")
 
         # Debug the pixel shader
-        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(64, 64, 0, rd.ReplayController.NoPreference)
+        inputs = rd.DebugPixelInputs()
+        inputs.sample = 0
+        trace: rd.ShaderDebugTrace = self.controller.DebugPixel(64, 64, inputs)
 
         cycles, variables = self.process_trace(trace)
 

--- a/util/test/tests/D3D12/D3D12_Shader_Linkage_Zoo.py
+++ b/util/test/tests/D3D12/D3D12_Shader_Linkage_Zoo.py
@@ -27,8 +27,7 @@ class D3D12_Shader_Linkage_Zoo(rdtest.TestCase):
                 continue
 
             # Debug the shader
-            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(200, 150, rd.ReplayController.NoPreference,
-                                                                    rd.ReplayController.NoPreference)
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(200, 150, rd.DebugPixelInputs())
             if trace.debugger is None:
                 failed = True
                 rdtest.log.error("Test {} could not be debugged.".format(event_name))

--- a/util/test/tests/D3D12/D3D12_Vertex_UAV.py
+++ b/util/test/tests/D3D12/D3D12_Vertex_UAV.py
@@ -48,8 +48,7 @@ class D3D12_Vertex_UAV(rdtest.TestCase):
                     continue
 
                 # Debug the shader
-                trace = self.controller.DebugPixel(50, 50, rd.ReplayController.NoPreference,
-                                                   rd.ReplayController.NoPreference)
+                trace = self.controller.DebugPixel(50, 50, rd.DebugPixelInputs())
                 if trace.debugger is None:
                     raise rdtest.TestFailureException("Pixel shader at {} could not be debugged.".format(name))
                     self.controller.FreeTrace(trace)

--- a/util/test/tests/Iter_Test.py
+++ b/util/test/tests/Iter_Test.py
@@ -243,7 +243,10 @@ class Iter_Test(rdtest.TestCase):
 
             pipe: rd.PipeState = self.controller.GetPipelineState()
 
-            trace = self.controller.DebugPixel(x, y, 0, lastmod.primitiveID)
+            inputs = rd.DebugPixelInputs()
+            inputs.sample = 0
+            inputs.primitive = lastmod.primitiveID;
+            trace = self.controller.DebugPixel(x, y, inputs)
 
             if trace.debugger is None:
                 self.controller.FreeTrace(trace)

--- a/util/test/tests/Vulkan/VK_Graphics_Pipeline.py
+++ b/util/test/tests/Vulkan/VK_Graphics_Pipeline.py
@@ -138,7 +138,10 @@ class VK_Graphics_Pipeline(rdtest.TestCase):
             raise rdtest.TestFailureException(
                 "History for drawcall output is wrong: {}".format(history[1].shaderOut.col.floatValue))
 
-        trace = self.controller.DebugPixel(200, 150, 0, 0)
+        inputs = rd.DebugPixelInputs()
+        inputs.sample = 0
+        inputs.primitive = 0
+        trace = self.controller.DebugPixel(200, 150, inputs)
 
         if trace.debugger is None:
             raise rdtest.TestFailureException("No pixel debug result")

--- a/util/test/tests/Vulkan/VK_KHR_Buffer_Address.py
+++ b/util/test/tests/Vulkan/VK_KHR_Buffer_Address.py
@@ -23,8 +23,7 @@ class VK_KHR_Buffer_Address(rdtest.TestCase):
                 raise rdtest.TestFailureException("Test {} shader can not be debugged".format(test_name))
 
             # Debug the pixel shader
-            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.ReplayController.NoPreference,
-                                                                        rd.ReplayController.NoPreference)
+            trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.DebugPixelInputs())
             if trace.debugger is None:
                 self.controller.FreeTrace(trace)
                 raise rdtest.TestFailureException("Test {} did not debug at all".format(test_name))

--- a/util/test/tests/Vulkan/VK_Multi_Entry.py
+++ b/util/test/tests/Vulkan/VK_Multi_Entry.py
@@ -97,8 +97,11 @@ class VK_Multi_Entry(rdtest.TestCase):
             raise rdtest.TestFailureException(
                 "History for drawcall output is wrong: {}".format(history[1].shaderOut.col.floatValue))
 
-        trace = self.controller.DebugPixel(200, 150, 0, 0)
-
+        inputs = rd.DebugPixelInputs()
+        inputs.sample = 0
+        inputs.primitive = 0
+        trace = self.controller.DebugPixel(200, 150, inputs)
+    
         refl: rd.ShaderReflection = pipe.GetShaderReflection(rd.ShaderStage.Pixel)
 
         self.check(len(refl.readOnlyResources) == 1)

--- a/util/test/tests/Vulkan/VK_Multi_View.py
+++ b/util/test/tests/Vulkan/VK_Multi_View.py
@@ -1,0 +1,85 @@
+import renderdoc as rd
+import rdtest
+
+class VK_Multi_View(rdtest.TestCase):
+    demos_test_name = 'VK_Multi_View'
+
+    def check_capture(self):
+        if not self.controller.GetAPIProperties().shaderDebugging:
+            rdtest.log.success("Shader debugging not enabled, skipping test")
+            return
+
+        x = 200
+        y = 150
+
+        for test_name in ["Vertex: viewIndex", "Geometry: viewIndex", "Fragment: viewIndex", "No viewIndex"]:
+            rdtest.log.print("Test {}".format(test_name))
+            action: rd.ActionDescription = self.find_action(test_name).next
+            self.controller.SetFrameEvent(action.eventId, True)
+
+            pipe: rd.PipeState = self.controller.GetPipelineState()
+            if not pipe.GetShaderReflection(rd.ShaderStage.Pixel).debugInfo.debuggable:
+                raise rdtest.TestFailureException("Test {} shader can not be debugged".format(test_name))
+
+            for view in range(2):
+                # Debug the pixel shader
+                inputs = rd.DebugPixelInputs()
+                inputs.view = view
+                trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, inputs)
+                if trace.debugger is None:
+                    self.controller.FreeTrace(trace)
+                    raise rdtest.TestFailureException("Test {} view {} did not debug at all".format(test_name, view))
+
+                cycles, variables = self.process_trace(trace)
+                output: rd.SourceVariableMapping = self.find_output_source_var(trace, rd.ShaderBuiltin.ColorOutput, 0)
+                debugged = self.evaluate_source_var(output, variables)
+                slice = view + 1
+                sub = rd.Subresource(0, slice, 0)
+                self.check_pixel_value(pipe.GetOutputTargets()[0].resourceId, x, y, debugged.value.f32v[0:4], sub=sub)
+                self.controller.FreeTrace(trace)
+
+                inst = 0
+                postvs = self.get_postvs(action, rd.MeshDataStage.VSOut, instance=inst, view=view)
+                for vtx in range(action.numIndices):
+                    idx = vtx
+                    self.check_debug(vtx, idx, inst, view, postvs)
+                rdtest.log.print(f"View {view} Slice {slice} passed")
+
+        rdtest.log.success("All tests matched")
+
+
+    def check_debug(self, vtx, idx, inst, view, postvs):
+        trace: rd.ShaderDebugTrace = self.controller.DebugVertex(vtx, inst, idx, view)
+
+        if trace.debugger is None:
+            self.controller.FreeTrace(trace)
+
+            raise rdtest.TestFailureException("Couldn't debug vertex {} in instance {} for view {}".format(vtx, inst, view))
+
+        cycles, variables = self.process_trace(trace)
+
+        for var in trace.sourceVars:
+            var: rd.SourceVariableMapping
+            if var.variables[0].type == rd.DebugVariableType.Variable and var.signatureIndex >= 0:
+                name = var.name
+
+                if name not in postvs[vtx].keys():
+                    raise rdtest.TestFailureException("Don't have expected output for {}".format(name))
+
+                expect = postvs[vtx][name]
+                value = self.evaluate_source_var(var, variables)
+
+                if len(expect) != value.columns:
+                    raise rdtest.TestFailureException(
+                        "Output {} at vert {} (idx {}) instance {} view {} has different size ({} values) to expectation ({} values)"
+                            .format(name, vtx, idx, inst, view, value.columns, len(expect)))
+
+                debugged = value.value.f32v[0:value.columns]
+
+                if not rdtest.value_compare(expect, debugged):
+                    raise rdtest.TestFailureException(
+                        "Debugged value {} at vert {} (idx {}) instance {} view {}: {} doesn't exactly match postvs output {}".format(
+                            name, vtx, idx, inst, view, debugged, expect))
+        rdtest.log.success('Successfully debugged vertex {} in instance {} for view {}'
+                           .format(vtx, inst, view))
+

--- a/util/test/tests/Vulkan/VK_Shader_Debug_Zoo.py
+++ b/util/test/tests/Vulkan/VK_Shader_Debug_Zoo.py
@@ -30,8 +30,7 @@ class VK_Shader_Debug_Zoo(rdtest.TestCase):
                     y = 4 * child + 1
 
                     # Debug the shader
-                    trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.ReplayController.NoPreference,
-                                                                            rd.ReplayController.NoPreference)
+                    trace: rd.ShaderDebugTrace = self.controller.DebugPixel(x, y, rd.DebugPixelInputs())
 
                     if trace.debugger is None:
                         failed = True


### PR DESCRIPTION
## Description
- Implement Issue #3097 
  - Output `ViewIndex` into the pixel shader hits array
  - Select the pixel shader input which matches the `viewIndex` to the passed in `slice` parameter
    - uses the first colour attachment image view to convert `slice` to `viewIndex` 
  - Ignore the view parameter if set to ~0U (`rd.ReplayController.NoPreference`) 
  - Ignore the view parameter if any subpass has an empty multiviews

## Testing
- Tested using Sascha Williams `multiview` sample
- New Automated Test `VK_Multi_View`
  - colour attachment has four array slices and the imageView starts at slice array index of one
  - Vertex shader output Red for view 0, Green for view 1, fragment shader is pass thru and does not use viewIndex
  - Fragment shader output Red for view 0, Green for view 1, vertex shader does not use viewIndex
  - Geometry shader output Red for view 0, Green for view 1, fragment shader is pass thru and does not use viewIndex
  - Vertex shader output fixed colour to pass thru fragment, neither shader uses viewIndex 
  - Not implemented (because Mesh Shader does not currently support multiview): Mesh shader output Red for view 0, Green for view 1, fragment shader does not use viewIndex 
  - Python checks vertex and pixel shader debug output against replay rendering output
- Ran D3D11_, D3D12_, VK_, GL_ automated tests locally to check the python compiles with the extra required parameter for `DebugPixel` including slow tests and check Iter-Test and Repeat-Load