### PR TITLE
D3D12 pixel history fixes

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -2566,6 +2566,7 @@ bool D3D12DebugManager::PixelHistorySetupResources(D3D12PixelHistoryResources &r
   imageDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
   imageDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
   imageDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+  imageDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
   hr = m_pDevice->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &imageDesc,
                                           D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,


### PR DESCRIPTION
## Description

Fixes found when testing pixel history on Texture 1D, 2D, 3D and different formats
- Increase the padding to make the event info structures and members aligned to 16-bytes and 12-bytes (48-bytes) to fix problem when copying from a source texture with 12-bytes per pixel i.e. R32G32B32.
- Force the scratch render targets to be Texture2D to fix device timeouts when performing history on Texture1D and Texture3D targets

### Example of history after the fix for a R32G32B32 target mip = 2
![image](https://github.com/baldurk/renderdoc/assets/39392/db8e8a2d-08de-4d11-a0e0-53592ddb3bcc)

### Known issues not fixed in this PR and being worked on
- Pixel history on slice > 0 of a Texture3D leads to device timeout (invalid subresource is being used in a barrier)
- Pixel History on UINT/SINT targets has incorrect "Tex Out" in the per fragment data because the integer data is being interpreted as float data but it needs to be cast (Vulkan is likely to have the same problem)