### PR TITLE
Pixel history fixes

### DIFF
--- a/qrenderdoc/Windows/PixelHistoryView.cpp
+++ b/qrenderdoc/Windows/PixelHistoryView.cpp
@@ -324,7 +324,7 @@ public:
         }
       }
 
-      if(role == Qt::BackgroundRole && (m_IsDepth || m_IsFloat))
+      if(role == Qt::BackgroundRole)
       {
         // pre mod color
         if(col == 2)
@@ -487,9 +487,27 @@ private:
 
     float rangesize = (m_Display.rangeMax - m_Display.rangeMin);
 
-    float r = val.col.floatValue[0];
-    float g = val.col.floatValue[1];
-    float b = val.col.floatValue[2];
+    float r = 0.0f;
+    float g = 0.0f;
+    float b = 0.0f;
+    if(m_IsFloat)
+    {
+      r = val.col.floatValue[0];
+      g = val.col.floatValue[1];
+      b = val.col.floatValue[2];
+    }
+    else if(m_IsUint)
+    {
+      r = val.col.uintValue[0];
+      g = val.col.uintValue[1];
+      b = val.col.uintValue[2];
+    }
+    else if(m_IsSint)
+    {
+      r = val.col.intValue[0];
+      g = val.col.intValue[1];
+      b = val.col.intValue[2];
+    }
 
     if(!m_Display.red)
       r = 0.0f;

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -3010,14 +3010,19 @@ void FillInColor(ResourceFormat fmt, const D3D12PixelHistoryValue &value, Modifi
 void ConvertAndFillInColor(ResourceFormat srcFmt, ResourceFormat outFmt,
                            const D3D12PixelHistoryValue &value, ModificationValue &mod)
 {
-  FloatVector v4 = DecodeFormattedComponents(srcFmt, value.color);
-
-  // To properly handle some cases of component bounds, roundtrip through encoding again
-  uint8_t tempColor[32];
-  EncodeFormattedComponents(outFmt, v4, (byte *)tempColor);
-  v4 = DecodeFormattedComponents(outFmt, tempColor);
-
-  memcpy(mod.col.floatValue.data(), &v4, sizeof(v4));
+  if((outFmt.compType == CompType::UInt) || (outFmt.compType == CompType::SInt))
+  {
+    PixelHistoryDecode(srcFmt, value.color, mod.col);
+  }
+  else
+  {
+    FloatVector v4 = DecodeFormattedComponents(srcFmt, value.color);
+    // To properly handle some cases of component bounds, roundtrip through encoding again
+    uint8_t tempColor[32];
+    EncodeFormattedComponents(outFmt, v4, (byte *)tempColor);
+    v4 = DecodeFormattedComponents(outFmt, tempColor);
+    memcpy(mod.col.floatValue.data(), &v4, sizeof(v4));
+  }
 }
 
 float GetDepthValue(DXGI_FORMAT depthFormat, const D3D12PixelHistoryValue &value)

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -2549,6 +2549,7 @@ bool D3D12DebugManager::PixelHistorySetupResources(D3D12PixelHistoryResources &r
   imageDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
   imageDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
   imageDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+  imageDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
 
   hr = m_pDevice->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &imageDesc,
                                           D3D12_RESOURCE_STATE_RENDER_TARGET, NULL,


### PR DESCRIPTION
## Description

### D3D12
Fixes found when testing pixel history on Texture 1D, 2D, 3D and different formats
- Increase the padding to make the event info structures and members aligned to 16-bytes and 12-bytes (48-bytes) to fix problem when copying from a source texture with 12-bytes per pixel i.e. R32G32B32.
- Force the scratch render targets to be Texture2D to fix device timeouts when performing history on Texture1D and Texture3D targets
- Fixed copy source parameters and subresource for pixel history on slice > 0 of a Texture3D (thanks to Jovan for the patch).
- Pixel History on UINT/SINT targets had incorrect "Tex After" in the per fragment data because the integer data is being interpreted as float data but it needs to be cast (Vulkan has the same problem)
- Simplified the image state tracking code. The CPU tracking of image states does not include state changes which haven't been replayed on the CPU yet but will be submitted to the GPU earlier than the current CPU event i.e. a command list with barrier changes is recorded after the current command list but submitted before it.
- Change the D3D12_Pixel_History test to have multiple command lists to demonstrate the problem with CPU tracking of image states.

### UI
- Draw the background colour for UINT and SINT targets

### Example of history after the fix for a R32G32B32 target mip = 2
![image](https://github.com/baldurk/renderdoc/assets/39392/db8e8a2d-08de-4d11-a0e0-53592ddb3bcc)

### Example of the UI drawing the background colour for UINT target
![image](https://github.com/baldurk/renderdoc/assets/39392/fb06fc33-69c2-4a25-8683-2c8c0c762f65)
