### PR TITLE
Fix Mac compatibility for Vulkan 1.3.216+

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1515,6 +1515,10 @@ static const VkExtensionProperties supportedExtensions[] = {
         VK_KHR_PIPELINE_LIBRARY_SPEC_VERSION,
     },
     {
+        VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
+        VK_KHR_PORTABILITY_ENUMERATION_SPEC_VERSION,
+    },
+    {
         VK_KHR_PRESENT_ID_EXTENSION_NAME,
         VK_KHR_PRESENT_ID_SPEC_VERSION,
     },

--- a/renderdoc/driver/vulkan/vk_layer.cpp
+++ b/renderdoc/driver/vulkan/vk_layer.cpp
@@ -46,7 +46,7 @@ extern "C" const rdcstr VulkanLayerJSONBasename;
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT extern "C" __declspec(dllexport)
 
-#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID)
+#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID) || ENABLED(RDOC_APPLE)
 
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
## Description

According to documentation https://vulkan.lunarg.com/doc/sdk/1.3.275.0/mac/getting_started.html since 1.3.216 VK_ERROR_INCOMPATIBLE_DRIVER should be provided to avoid VK_ERROR_INCOMPATIBLE_DRIVER error.