### PR TITLE
Fix posix ApplyEnvironmentModifications for repeated modifications

### DIFF
--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -415,7 +415,7 @@ void ApplyEnvironmentModifications(rdcarray<EnvironmentModification> &modificati
   {
     EnvironmentModification &m = modifications[i];
 
-    rdcstr value = currentEnv[m.name.c_str()];
+    rdcstr &value = currentEnv[m.name.c_str()];
 
     ApplySingleEnvMod(m, value);
 


### PR DESCRIPTION
This behavior is correctly applied on Windows but on posix systems would fail to apply duplicate entries that should be additive, such as multiple prepends. Previously only the last modification would win.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Prior to this change, the following code on posix would result in just `def` being prepended, with no `abc`.

```
Process::RegisterEnvironmentModification(EnvironmentModification(
    EnvMod::Prepend,
    EnvSep::Platform,
    "SOME_ENV_VAR",
    "abc"));
Process::RegisterEnvironmentModification(EnvironmentModification(
    EnvMod::Prepend,
    EnvSep::Platform,
    "SOME_ENV_VAR",
    "def"));
```
