### PR TITLE
Fix `vkEnumeratePhysicalDeviceGroups` being non-conformant with Vulkan specification

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_get_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_get_funcs.cpp
@@ -920,12 +920,14 @@ VkResult WrappedVulkan::vkEnumeratePhysicalDeviceGroups(
   uint32_t physicalDevicesNumber = 0;
   vkEnumeratePhysicalDevices(instance, &physicalDevicesNumber, NULL);
 
-  // Return number of available device groups.
+  // vkEnumeratePhysicalDeviceGroups - Return number of available physical device groups.
   if(pPhysicalDeviceGroupProperties == NULL)
   {
     *pPhysicalDeviceGroupCount = physicalDevicesNumber;
     return VK_SUCCESS;
   }
+
+  // vkEnumeratePhysicalDeviceGroups - Query properties of available physical device groups.
 
   // Number of physical device groups to query.
   *pPhysicalDeviceGroupCount = RDCMIN(*pPhysicalDeviceGroupCount, physicalDevicesNumber);


### PR DESCRIPTION
Fix for #3261

## Description

RenderDoc's `vkEnumeratePhysicalDeviceGroups` implementation was non-compliant with Vulkan specification.

When `vkEnumeratePhysicalDeviceGroups` has been called to query less than the total number of available device groups, then `pPhysicalDeviceGroupCount` parameter was overridden with the total amount of available device groups. However, Vulkan specification says that the amount of device groups written to `pPhysicalDeviceGroupProperties` should be returned instead.

In such cases, this was causing Vulkan loader (`vulkan-1.dll`) to crash on preparing `vkEnumeratePhysicalDeviceGroups` trampoline.

To fix this issue, I have reworked `vkEnumeratePhysicalDeviceGroups` implementation to be Vulkan specification compliant. I have also made some improvements, like early exit and replacement of raw memory management with `rdcarray` container.