### PR TITLE
Renable Diagnostic Log Windows

### DIFF
--- a/qrenderdoc/Windows/MainWindow.h
+++ b/qrenderdoc/Windows/MainWindow.h
@@ -175,6 +175,7 @@ private slots:
   void on_action_Manage_Remote_Servers_triggered();
   void on_action_Settings_triggered();
   void on_action_View_Documentation_triggered();
+  void on_action_Diagnostic_Log_triggered() { showDiagnosticLogView(); }
   void on_action_Source_on_GitHub_triggered();
   void on_action_Build_Release_Downloads_triggered();
   void on_action_Show_Tips_triggered();

--- a/qrenderdoc/Windows/MainWindow.ui
+++ b/qrenderdoc/Windows/MainWindow.ui
@@ -164,6 +164,7 @@
     <addaction name="action_Counter_Viewer"/>
     <addaction name="action_Resource_Inspector"/>
     <addaction name="action_Comments"/>
+    <addaction name="action_Diagnostic_Log"/>
     <addaction name="separator"/>
     <addaction name="extension_dummy_Window"/>
    </widget>
@@ -493,6 +494,11 @@
   <action name="action_Manage_Extensions">
    <property name="text">
     <string>Manage Extensions</string>
+   </property>
+  </action>
+  <action name="action_Diagnostic_Log">
+   <property name="text">
+    <string>Dia&amp;gnostic Log</string>
    </property>
   </action>
   <action name="action_Open_Capture_with_Options">


### PR DESCRIPTION
[Why]
Diagnostic Log Windows was disabled since v1.20.
It is useful for debugging.

[How]
Renable Diagnostic Log Windows UI.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
