### PR TITLE
Vulkan acceleration structure manager

### DIFF
--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -40,6 +40,8 @@ set(sources
     vk_serialise.cpp
     vk_stringise.cpp
     vk_layer.cpp
+    vk_acceleration_structure.h
+    vk_acceleration_structure.cpp
     imagestate_tests.cpp
     imgrefs_tests.cpp
     official/vk_layer.h

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Development|Win32">
@@ -155,6 +155,7 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="vk_resources.cpp" />
+    <ClCompile Include="vk_acceleration_structure.cpp" />
     <ClCompile Include="wrappers\vk_cmd_funcs.cpp" />
     <ClCompile Include="wrappers\vk_dynamic_funcs.cpp" />
     <ClCompile Include="wrappers\vk_descriptor_funcs.cpp" />
@@ -186,6 +187,7 @@
     <ClInclude Include="official\vulkan_xlib.h" />
     <ClInclude Include="official\vulkan_xlib_xrandr.h" />
     <ClInclude Include="precompiled.h" />
+    <ClInclude Include="vk_acceleration_structure.h" />
     <ClInclude Include="vk_common.h" />
     <ClInclude Include="vk_core.h" />
     <ClInclude Include="vk_debug.h" />

--- a/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
+++ b/renderdoc/driver/vulkan/renderdoc_vulkan.vcxproj.filters
@@ -151,12 +151,18 @@
     <ClCompile Include="vk_msaa_buffer_conv.cpp">
       <Filter>Replay</Filter>
     </ClCompile>
+    <ClCompile Include="vk_acceleration_structure.cpp">
+      <Filter>Replay</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="vk_replay.h">
       <Filter>Replay</Filter>
     </ClInclude>
     <ClInclude Include="vk_debug.h">
+      <Filter>Replay</Filter>
+    </ClInclude>
+    <ClInclude Include="vk_acceleration_structure.h">
       <Filter>Replay</Filter>
     </ClInclude>
     <ClInclude Include="vk_resources.h">

--- a/renderdoc/driver/vulkan/vk_acceleration_structure.cpp
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.cpp
@@ -1,0 +1,392 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#include "vk_acceleration_structure.h"
+#include "core/settings.h"
+#include "vk_core.h"
+
+RDOC_EXTERN_CONFIG(bool, Vulkan_Debug_SingleSubmitFlushing);
+
+namespace
+{
+// Although the serialised data is implementation-defined in general, the header is defined:
+// https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap37.html#vkCmdCopyAccelerationStructureToMemoryKHR
+constexpr std::size_t handleCountOffset = VK_UUID_SIZE + VK_UUID_SIZE + 8 + 8;
+constexpr VkDeviceSize handleCountSize = 8;
+
+// Spec says VkCopyAccelerationStructureToMemoryInfoKHR::dst::deviceAddress must be 256 bytes aligned
+constexpr VkDeviceSize asBufferAlignment = 256;
+}
+
+bool VulkanAccelerationStructureManager::Prepare(VkAccelerationStructureKHR unwrappedAs,
+                                                 const rdcarray<uint32_t> &queueFamilyIndices,
+                                                 ASMemory &result)
+{
+  const VkDeviceSize serialisedSize = SerialisedASSize(unwrappedAs);
+
+  const VkDevice d = m_pDriver->GetDev();
+  VkResult vkr = VK_SUCCESS;
+
+  // since this happens during capture, we don't want to start serialising extra buffer creates,
+  // leave this buffer as unwrapped
+  VkBuffer dstBuf = VK_NULL_HANDLE;
+
+  VkBufferCreateInfo bufInfo = {
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+      NULL,
+      0,
+      serialisedSize,
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+  };
+
+  // we make the buffer concurrently accessible by all queue families to not invalidate the
+  // contents of the memory we're reading back from.
+  bufInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
+  bufInfo.queueFamilyIndexCount = (uint32_t)queueFamilyIndices.size();
+  bufInfo.pQueueFamilyIndices = queueFamilyIndices.data();
+
+  // spec requires that CONCURRENT must specify more than one queue family. If there is only one
+  // queue family, we can safely use exclusive.
+  if(bufInfo.queueFamilyIndexCount == 1)
+    bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+  vkr = ObjDisp(d)->CreateBuffer(Unwrap(d), &bufInfo, NULL, &dstBuf);
+  m_pDriver->CheckVkResult(vkr);
+
+  m_pDriver->AddPendingObjectCleanup(
+      [d, dstBuf]() { ObjDisp(d)->DestroyBuffer(Unwrap(d), dstBuf, NULL); });
+
+  VkMemoryRequirements mrq = {};
+  ObjDisp(d)->GetBufferMemoryRequirements(Unwrap(d), dstBuf, &mrq);
+
+  mrq.alignment = RDCMAX(mrq.alignment, asBufferAlignment);
+
+  const MemoryAllocation readbackmem = m_pDriver->AllocateMemoryForResource(
+      true, mrq, MemoryScope::InitialContents, MemoryType::Readback);
+  if(readbackmem.mem == VK_NULL_HANDLE)
+    return false;
+
+  vkr = ObjDisp(d)->BindBufferMemory(Unwrap(d), dstBuf, Unwrap(readbackmem.mem), readbackmem.offs);
+  m_pDriver->CheckVkResult(vkr);
+
+  const VkBufferDeviceAddressInfo addrInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
+                                              dstBuf};
+  const VkDeviceAddress dstBufAddr = ObjDisp(d)->GetBufferDeviceAddressKHR(Unwrap(d), &addrInfo);
+
+  VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
+  if(cmd == VK_NULL_HANDLE)
+  {
+    RDCERR("Couldn't acquire command buffer");
+    return false;
+  }
+
+  const VkDeviceSize nonCoherentAtomSize = m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize;
+  byte *mappedDstBuffer = NULL;
+  VkDeviceSize size;
+
+  if(m_pDriver->GetDriverInfo().MaliBrokenASDeviceSerialisation())
+  {
+    size = AlignUp(serialisedSize, nonCoherentAtomSize);
+
+    vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(readbackmem.mem), readbackmem.offs, size, 0,
+                                (void **)&mappedDstBuffer);
+    m_pDriver->CheckVkResult(vkr);
+
+    // Copy the data using host-commands but into mapped memory
+    VkCopyAccelerationStructureToMemoryInfoKHR copyInfo = {
+        VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, NULL};
+    copyInfo.src = unwrappedAs;
+    copyInfo.dst.hostAddress = mappedDstBuffer;
+    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
+    ObjDisp(d)->CopyAccelerationStructureToMemoryKHR(Unwrap(d), VK_NULL_HANDLE, &copyInfo);
+  }
+  else
+  {
+    VkCopyAccelerationStructureToMemoryInfoKHR copyInfo = {
+        VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, NULL};
+    copyInfo.src = unwrappedAs;
+    copyInfo.dst.deviceAddress = dstBufAddr;
+    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
+    ObjDisp(d)->CmdCopyAccelerationStructureToMemoryKHR(Unwrap(cmd), &copyInfo);
+
+    // It's not ideal but we have to flush here because we need to map the data in order to read
+    // the BLAS addresses which means we need to have ensured that it has been copied beforehand
+    m_pDriver->CloseInitStateCmd();
+    m_pDriver->SubmitCmds();
+    m_pDriver->FlushQ();
+
+    // Now serialised AS data has been copied to a readable buffer, we need to expose the data to
+    // the host
+    size = AlignUp(handleCountOffset + handleCountSize, nonCoherentAtomSize);
+
+    vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(readbackmem.mem), readbackmem.offs, size, 0,
+                                (void **)&mappedDstBuffer);
+    m_pDriver->CheckVkResult(vkr);
+  }
+
+  // invalidate the cpu cache for this memory range to avoid reading stale data
+  const VkMappedMemoryRange range = {
+      VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, NULL, Unwrap(readbackmem.mem), readbackmem.offs, size,
+  };
+  vkr = ObjDisp(d)->InvalidateMappedMemoryRanges(Unwrap(d), 1, &range);
+  m_pDriver->CheckVkResult(vkr);
+
+  // Count the BLAS device addresses to update the AS type
+  const uint64_t handleCount = *(uint64_t *)(mappedDstBuffer + handleCountOffset);
+  result = {readbackmem, true};
+  result.isTLAS = handleCount > 0;
+
+  ObjDisp(d)->UnmapMemory(Unwrap(d), Unwrap(result.alloc.mem));
+
+  return true;
+}
+
+template <typename SerialiserType>
+bool VulkanAccelerationStructureManager::Serialise(SerialiserType &ser, ResourceId id,
+                                                   const VkInitialContents *initial,
+                                                   CaptureState state)
+{
+  VkDevice d = !IsStructuredExporting(state) ? m_pDriver->GetDev() : VK_NULL_HANDLE;
+  const bool replayingAndReading = ser.IsReading() && IsReplayMode(state);
+  VkResult vkr = VK_SUCCESS;
+
+  byte *contents = NULL;
+  uint64_t contentsSize = initial ? initial->mem.size : 0;
+  MemoryAllocation mappedMem;
+
+  // Serialise this separately so that it can be used on reading to prepare the upload memory
+  SERIALISE_ELEMENT(contentsSize);
+
+  const VkDeviceSize nonCoherentAtomSize = m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize;
+
+  // the memory/buffer that we allocated on read, to upload the initial contents.
+  MemoryAllocation uploadMemory;
+  VkBuffer uploadBuf = VK_NULL_HANDLE;
+
+  if(ser.IsWriting())
+  {
+    if(initial && initial->mem.mem != VK_NULL_HANDLE)
+    {
+      const VkDeviceSize size = AlignUp(initial->mem.size, nonCoherentAtomSize);
+
+      mappedMem = initial->mem;
+      vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(mappedMem.mem), initial->mem.offs, size, 0,
+                                  (void **)&contents);
+      m_pDriver->CheckVkResult(vkr);
+
+      // invalidate the cpu cache for this memory range to avoid reading stale data
+      const VkMappedMemoryRange range = {
+          VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, NULL, Unwrap(mappedMem.mem), mappedMem.offs, size,
+      };
+
+      vkr = ObjDisp(d)->InvalidateMappedMemoryRanges(Unwrap(d), 1, &range);
+      m_pDriver->CheckVkResult(vkr);
+    }
+  }
+  else if(IsReplayMode(state) && !ser.IsErrored())
+  {
+    // create a buffer with memory attached, which we will fill with the initial contents
+    const VkBufferCreateInfo bufInfo = {
+        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        NULL,
+        0,
+        contentsSize,
+        VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+    };
+
+    vkr = m_pDriver->vkCreateBuffer(d, &bufInfo, NULL, &uploadBuf);
+    m_pDriver->CheckVkResult(vkr);
+
+    VkMemoryRequirements mrq = {};
+    m_pDriver->vkGetBufferMemoryRequirements(d, uploadBuf, &mrq);
+
+    mrq.alignment = RDCMAX(mrq.alignment, asBufferAlignment);
+
+    uploadMemory = m_pDriver->AllocateMemoryForResource(true, mrq, MemoryScope::InitialContents,
+                                                        MemoryType::Upload);
+
+    if(uploadMemory.mem == VK_NULL_HANDLE)
+      return false;
+
+    vkr = m_pDriver->vkBindBufferMemory(d, uploadBuf, uploadMemory.mem, uploadMemory.offs);
+    m_pDriver->CheckVkResult(vkr);
+
+    mappedMem = uploadMemory;
+
+    vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(mappedMem.mem), mappedMem.offs,
+                                AlignUp(mappedMem.size, nonCoherentAtomSize), 0, (void **)&contents);
+    m_pDriver->CheckVkResult(vkr);
+
+    if(!contents)
+    {
+      RDCERR("Manually reporting failed memory map");
+      m_pDriver->CheckVkResult(VK_ERROR_MEMORY_MAP_FAILED);
+      return false;
+    }
+
+    if(vkr != VK_SUCCESS)
+      return false;
+  }
+
+  // not using SERIALISE_ELEMENT_ARRAY so we can deliberately avoid allocation - we serialise
+  // directly into upload memory
+  ser.Serialise("Serialised AS"_lit, contents, contentsSize, SerialiserFlags::NoFlags).Important();
+
+  // unmap the resource we mapped before - we need to do this on read and on write.
+  bool isTLAS = false;
+  if(!IsStructuredExporting(state) && mappedMem.mem != VK_NULL_HANDLE)
+  {
+    if(replayingAndReading)
+    {
+      // first ensure we flush the writes from the cpu to gpu memory
+      const VkMappedMemoryRange range = {
+          VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,        NULL, Unwrap(mappedMem.mem), mappedMem.offs,
+          AlignUp(mappedMem.size, nonCoherentAtomSize),
+      };
+
+      vkr = ObjDisp(d)->FlushMappedMemoryRanges(Unwrap(d), 1, &range);
+      m_pDriver->CheckVkResult(vkr);
+
+      // Read the AS's BLAS handle count to determine if it's top or bottom level
+      isTLAS = *((uint64_t *)(contents + handleCountOffset)) > 0;
+    }
+
+    ObjDisp(d)->UnmapMemory(Unwrap(d), Unwrap(mappedMem.mem));
+  }
+
+  SERIALISE_CHECK_READ_ERRORS();
+
+  if(IsReplayMode(state) && contentsSize > 0)
+  {
+    VkInitialContents initialContents(eResAccelerationStructureKHR, uploadMemory);
+    initialContents.isTLAS = isTLAS;
+    initialContents.buf = uploadBuf;
+
+    m_pDriver->GetResourceManager()->SetInitialContents(id, initialContents);
+  }
+
+  return true;
+}
+
+template bool VulkanAccelerationStructureManager::Serialise(ReadSerialiser &ser, ResourceId id,
+                                                            const VkInitialContents *initial,
+                                                            CaptureState state);
+template bool VulkanAccelerationStructureManager::Serialise(WriteSerialiser &ser, ResourceId id,
+                                                            const VkInitialContents *initial,
+                                                            CaptureState state);
+
+void VulkanAccelerationStructureManager::Apply(ResourceId id, const VkInitialContents &initial)
+{
+  VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
+  if(cmd == VK_NULL_HANDLE)
+  {
+    RDCERR("Couldn't acquire command buffer");
+    return;
+  }
+
+  const VkAccelerationStructureKHR unwrappedAs =
+      Unwrap(m_pDriver->GetResourceManager()->GetCurrentHandle<VkAccelerationStructureKHR>(id));
+  const VkDevice d = m_pDriver->GetDev();
+
+  VkMarkerRegion::Begin(StringFormat::Fmt("Initial state for %s", ToStr(id).c_str()), cmd);
+
+  if(m_pDriver->GetDriverInfo().MaliBrokenASDeviceSerialisation())
+  {
+    const VkDeviceSize size =
+        AlignUp(initial.mem.size, m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize);
+
+    // Copy the data using host-commands but from mapped memory
+    byte *mappedSrcBuffer = NULL;
+    VkResult vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(initial.mem.mem), initial.mem.offs, size,
+                                         0, (void **)&mappedSrcBuffer);
+    m_pDriver->CheckVkResult(vkr);
+
+    VkCopyMemoryToAccelerationStructureInfoKHR copyInfo = {
+        VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR};
+    copyInfo.src.hostAddress = mappedSrcBuffer;
+    copyInfo.dst = unwrappedAs;
+    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
+    ObjDisp(d)->CopyMemoryToAccelerationStructureKHR(Unwrap(d), VK_NULL_HANDLE, &copyInfo);
+  }
+  else
+  {
+    const VkBufferDeviceAddressInfo addrInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
+                                                Unwrap(initial.buf)};
+    const VkDeviceAddress uploadBufAddr = ObjDisp(d)->GetBufferDeviceAddressKHR(Unwrap(d), &addrInfo);
+
+    VkCopyMemoryToAccelerationStructureInfoKHR copyInfo = {
+        VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR};
+    copyInfo.src.deviceAddress = uploadBufAddr;
+    copyInfo.dst = unwrappedAs;
+    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
+    ObjDisp(d)->CmdCopyMemoryToAccelerationStructureKHR(Unwrap(cmd), &copyInfo);
+  }
+
+  VkMarkerRegion::End(cmd);
+
+  if(Vulkan_Debug_SingleSubmitFlushing())
+  {
+    m_pDriver->CloseInitStateCmd();
+    m_pDriver->SubmitCmds();
+    m_pDriver->FlushQ();
+  }
+}
+
+VkDeviceSize VulkanAccelerationStructureManager::SerialisedASSize(VkAccelerationStructureKHR as)
+{
+  VkDevice d = m_pDriver->GetDev();
+
+  // Create query pool
+  VkQueryPoolCreateInfo info = {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+  info.queryCount = 1;
+  info.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR;
+
+  VkQueryPool pool;
+  VkResult vkr = ObjDisp(d)->CreateQueryPool(Unwrap(d), &info, NULL, &pool);
+  m_pDriver->CheckVkResult(vkr);
+
+  // Reset query pool
+  VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
+  ObjDisp(d)->CmdResetQueryPool(Unwrap(cmd), pool, 0, 1);
+
+  // Get the size
+  ObjDisp(d)->CmdWriteAccelerationStructuresPropertiesKHR(
+      Unwrap(cmd), 1, &as, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR, pool, 0);
+
+  m_pDriver->CloseInitStateCmd();
+  m_pDriver->SubmitCmds();
+  m_pDriver->FlushQ();
+
+  VkDeviceSize size = 0;
+  vkr = ObjDisp(d)->GetQueryPoolResults(Unwrap(d), pool, 0, 1, sizeof(VkDeviceSize), &size,
+                                        sizeof(VkDeviceSize), VK_QUERY_RESULT_WAIT_BIT);
+  m_pDriver->CheckVkResult(vkr);
+
+  // Clean up
+  ObjDisp(d)->DestroyQueryPool(Unwrap(d), pool, NULL);
+
+  return size;
+}

--- a/renderdoc/driver/vulkan/vk_acceleration_structure.h
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "vk_manager.h"
+
+class WrappedVulkan;
+
+class VulkanAccelerationStructureManager
+{
+public:
+  struct ASMemory
+  {
+    MemoryAllocation alloc;
+    bool isTLAS;
+  };
+
+  VulkanAccelerationStructureManager(WrappedVulkan *driver) : m_pDriver(driver) {}
+
+  // Called when the initial state is prepared.  Any TLAS and BLAS data is copied into temporary
+  // buffers and the handles for that memory and the buffers is stored in the init state
+  bool Prepare(VkAccelerationStructureKHR unwrappedAs, const rdcarray<uint32_t> &queueFamilyIndices,
+               ASMemory &result);
+
+  template <typename SerialiserType>
+  bool Serialise(SerialiserType &ser, ResourceId id, const VkInitialContents *initial,
+                 CaptureState state);
+
+  // Called when the initial state is applied.  The AS data is deserialised from the upload buffer
+  // into the acceleration structure
+  void Apply(ResourceId id, const VkInitialContents &initial);
+
+private:
+  VkDeviceSize SerialisedASSize(VkAccelerationStructureKHR as);
+
+  WrappedVulkan *m_pDriver;
+};

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -1038,7 +1038,15 @@ rdcarray<ResourceId> VulkanResourceManager::InitialContentResources()
   rdcarray<ResourceId> resources =
       ResourceManager<VulkanResourceManagerConfiguration>::InitialContentResources();
   std::sort(resources.begin(), resources.end(), [this](ResourceId a, ResourceId b) {
-    return m_InitialContents[a].data.type < m_InitialContents[b].data.type;
+    const InitialContentData &aData = m_InitialContents[a].data;
+    const InitialContentData &bData = m_InitialContents[b].data;
+
+    // Always sort BLASs before TLASs, as a TLAS holds device addresses for it's BLASs
+    // and we make sure those addresses are valid
+    if(!aData.isTLAS && bData.isTLAS)
+      return true;
+
+    return aData.type < bData.type;
   });
   return resources;
 }

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -133,6 +133,8 @@ struct VkInitialContents
   // sparse bind. Similar to the descriptors above
   rdcarray<AspectSparseTable> *sparseTables;
   SparseBinding *sparseBind;
+
+  bool isTLAS;    // If the contents are an AS, this determines if it is a TLAS or BLAS
 };
 
 struct VulkanResourceManagerConfiguration

--- a/renderdoc/driver/vulkan/vk_memory.cpp
+++ b/renderdoc/driver/vulkan/vk_memory.cpp
@@ -319,9 +319,16 @@ MemoryAllocation WrappedVulkan::AllocateMemoryForResource(bool buffer, VkMemoryR
         break;
     }
 
+    // if ray tracing acceleration structures are in use, then allocate memory with buffer device
+    // address support enabled
+    VkMemoryAllocateFlagsInfo flagsInfo = {
+        VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO,
+        NULL,
+        VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT,
+    };
     VkMemoryAllocateInfo info = {
         VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-        NULL,
+        AccelerationStructures() ? &flagsInfo : NULL,
         allocSize * 1024 * 1024,
         memoryTypeIndex,
     };

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -2121,6 +2121,9 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
                 dstel.type = BindType::InputAttachment;
                 break;
               case DescriptorSlotType::InlineBlock: dstel.type = BindType::ConstantBuffer; break;
+              case DescriptorSlotType::AccelerationStructure:
+                dstel.type = BindType::ReadWriteBuffer;
+                break;
               case DescriptorSlotType::Unwritten:
               case DescriptorSlotType::Count: dstel.type = BindType::Unknown; break;
             }
@@ -2272,7 +2275,8 @@ void VulkanReplay::SavePipelineState(uint32_t eventId)
             else if(descriptorType == DescriptorSlotType::StorageBuffer ||
                     descriptorType == DescriptorSlotType::StorageBufferDynamic ||
                     descriptorType == DescriptorSlotType::UniformBuffer ||
-                    descriptorType == DescriptorSlotType::UniformBufferDynamic)
+                    descriptorType == DescriptorSlotType::UniformBufferDynamic ||
+                    descriptorType == DescriptorSlotType::AccelerationStructure)
             {
               destSlots.binds[a].viewResourceId = ResourceId();
 

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -7633,6 +7633,16 @@ bool WrappedVulkan::Serialise_vkCmdBuildAccelerationStructuresIndirectKHR(
     for(uint32_t i = 0; i < infoCount; ++i)
       tmpMaxPrimitiveCounts[i] = maxPrimitives[i].data();
 
+    m_LastCmdBufferID = GetResourceManager()->GetOriginalID(GetResID(commandBuffer));
+
+    if(IsActiveReplaying(m_State))
+    {
+      if(InRerecordRange(m_LastCmdBufferID))
+        commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
+      else
+        return true;
+    }
+
     ObjDisp(commandBuffer)
         ->CmdBuildAccelerationStructuresIndirectKHR(Unwrap(commandBuffer), infoCount,
                                                     unwrappedInfos, pIndirectDeviceAddresses,
@@ -7732,9 +7742,20 @@ bool WrappedVulkan::Serialise_vkCmdBuildAccelerationStructuresKHR(
       unwrappedInfos[i] = *UnwrapStructAndChain(m_State, memory, &pInfos[i]);
 
     // Convert the rangeInfos back to a C-style array-of-arrays
-    rdcarray<const VkAccelerationStructureBuildRangeInfoKHR *> tmpBuildRangeInfos(nullptr, infoCount);
+    rdcarray<const VkAccelerationStructureBuildRangeInfoKHR *> tmpBuildRangeInfos;
+    tmpBuildRangeInfos.resize(infoCount);
     for(uint32_t i = 0; i < infoCount; ++i)
       tmpBuildRangeInfos[i] = rangeInfos[i].data();
+
+    m_LastCmdBufferID = GetResourceManager()->GetOriginalID(GetResID(commandBuffer));
+
+    if(IsActiveReplaying(m_State))
+    {
+      if(InRerecordRange(m_LastCmdBufferID))
+        commandBuffer = RerecordCmdBuf(m_LastCmdBufferID);
+      else
+        return true;
+    }
 
     ObjDisp(commandBuffer)
         ->CmdBuildAccelerationStructuresKHR(Unwrap(commandBuffer), infoCount, unwrappedInfos,
@@ -7790,28 +7811,6 @@ void WrappedVulkan::vkCmdBuildAccelerationStructuresKHR(
                                                         eFrameRef_CompleteWrite);
     }
   }
-}
-
-// CPU-side VK_KHR_acceleration_structure calls are not supported for now
-VkResult WrappedVulkan::vkCopyAccelerationStructureKHR(VkDevice device,
-                                                       VkDeferredOperationKHR deferredOperation,
-                                                       const VkCopyAccelerationStructureInfoKHR *pInfo)
-{
-  return VK_ERROR_UNKNOWN;
-}
-
-VkResult WrappedVulkan::vkCopyAccelerationStructureToMemoryKHR(
-    VkDevice device, VkDeferredOperationKHR deferredOperation,
-    const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo)
-{
-  return VK_ERROR_UNKNOWN;
-}
-
-VkResult WrappedVulkan::vkCopyMemoryToAccelerationStructureKHR(
-    VkDevice device, VkDeferredOperationKHR deferredOperation,
-    const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo)
-{
-  return VK_ERROR_UNKNOWN;
 }
 
 template <typename SerialiserType>
@@ -7961,6 +7960,28 @@ VkResult WrappedVulkan::vkWriteAccelerationStructuresPropertiesKHR(
 
   return ObjDisp(device)->WriteAccelerationStructuresPropertiesKHR(
       Unwrap(device), accelerationStructureCount, unwrappedASes, queryType, dataSize, pData, stride);
+}
+
+// CPU-side VK_KHR_acceleration_structure calls are not supported for now
+VkResult WrappedVulkan::vkCopyAccelerationStructureKHR(VkDevice device,
+                                                       VkDeferredOperationKHR deferredOperation,
+                                                       const VkCopyAccelerationStructureInfoKHR *pInfo)
+{
+  return VK_ERROR_UNKNOWN;
+}
+
+VkResult WrappedVulkan::vkCopyAccelerationStructureToMemoryKHR(
+    VkDevice device, VkDeferredOperationKHR deferredOperation,
+    const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo)
+{
+  return VK_ERROR_UNKNOWN;
+}
+
+VkResult WrappedVulkan::vkCopyMemoryToAccelerationStructureKHR(
+    VkDevice device, VkDeferredOperationKHR deferredOperation,
+    const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo)
+{
+  return VK_ERROR_UNKNOWN;
 }
 
 INSTANTIATE_FUNCTION_SERIALISED(VkResult, vkCreateCommandPool, VkDevice device,

--- a/renderdoc/driver/vulkan/wrappers/vk_get_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_get_funcs.cpp
@@ -852,6 +852,17 @@ void WrappedVulkan::vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice
   }
 
 #undef DISABLE_EDS3_FEATURE
+
+  // we don't want to report support for acceleration structure host commands
+  VkPhysicalDeviceAccelerationStructureFeaturesKHR *accStruct =
+      (VkPhysicalDeviceAccelerationStructureFeaturesKHR *)FindNextStruct(
+          pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR);
+
+  if(accStruct && accStruct->accelerationStructureHostCommands)
+  {
+    RDCWARN("Disabling support for acceleration structure host commands");
+    accStruct->accelerationStructureHostCommands = VK_FALSE;
+  }
 }
 
 void WrappedVulkan::vkGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,


### PR DESCRIPTION
Manages the capturing, serialising, and replay of acceleration structures for Vulkan.  It works in a similar way to how device memory is handled:
* A temporary host-accessible buffer is created for each AS
* The AS is serialised (in the Vulkan AS sense of the word) into it
* The buffer handle is stored in the initial contents and downloaded when appropriate
* Replay is handled similarly but in reverse

Note this is not currently wired up to the init state or descriptor functions yet - so doesn't do anything.  The complete work (coming in subsequent PRs) has been tested on a Vivo X90 Pro running Android 13 and on an RTX 3090 FE on Windows 11.

The serialiser version has been bumped for backwards compatibility with 'RenderDoc for Arm GPUs 2024.0'.

Normally this kind of functionality would be done directly in `WrappedVulkan`, I moved it out into its own type in order to ease merges from upstream but ended up keeping it as it's nicer to work with.  However the downside to that is some previously private `WrappedVulkan` methods have had to be made public - I'm happy to move everything inside `WrappedVulkan` if desired.