### PR TITLE
D3D12 Pixel History fix lack of integer clamping.

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -3013,6 +3013,28 @@ void ConvertAndFillInColor(ResourceFormat srcFmt, ResourceFormat outFmt,
   if((outFmt.compType == CompType::UInt) || (outFmt.compType == CompType::SInt))
   {
     PixelHistoryDecode(srcFmt, value.color, mod.col);
+    // Clamp values based on format
+    if(outFmt.compType == CompType::UInt)
+    {
+      uint32_t limits[4] = {
+          255,
+          UINT16_MAX,
+          0,
+          UINT32_MAX,
+      };
+      int limit_idx = outFmt.compByteWidth - 1;
+      for(size_t c = 0; c < outFmt.compCount; c++)
+        mod.col.uintValue[c] = RDCMIN(limits[limit_idx], mod.col.uintValue[c]);
+    }
+    else
+    {
+      int32_t limits[8] = {
+          INT8_MIN, INT8_MAX, INT16_MIN, INT16_MAX, 0, 0, INT32_MIN, INT32_MAX,
+      };
+      int limit_idx = 2 * (outFmt.compByteWidth - 1);
+      for(size_t c = 0; c < outFmt.compCount; c++)
+        mod.col.intValue[c] = RDCCLAMP(mod.col.intValue[c], limits[limit_idx], limits[limit_idx + 1]);
+    }
   }
   else
   {


### PR DESCRIPTION
* When the shader outputs a value larger than the texture format supports, the use of a 32bit target for history targets resulted in the Tex After for fragments showing a value larger than possible.
* The int/uint path for ConvertAndFillInColor was missing the clamping step that the other path includes.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Before:
![image](https://github.com/baldurk/renderdoc/assets/1256627/0dabe0f4-4a97-4190-b2b2-7cc51676cc32)

After:
![image](https://github.com/baldurk/renderdoc/assets/1256627/6521c271-82cf-4e7c-9151-5f09f848f7f4)
