### PR TITLE
Improve AArch64-only device Android handling

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -514,7 +514,8 @@ RDResult InstallRenderDocServer(const rdcstr &deviceID)
     // if adb produces this message we can be reasonably sure this is a 32-bit version that failed
     // to install on a 64-bit only device. However we need to account for the possibility that adb
     // might not produce this error even if that's the problem, so we still handle that below as well.
-    if(adbInstall.strStderror.contains("INSTALL_FAILED_NO_MATCHING_ABIS") &&
+    if((adbInstall.strStderror.contains("INSTALL_FAILED_NO_MATCHING_ABIS") ||
+        adbInstall.strStdout.contains("INSTALL_FAILED_NO_MATCHING_ABIS")) &&
        abi == ABI::armeabi_v7a && abis.contains(ABI::arm64_v8a))
     {
       RDCWARN(
@@ -548,6 +549,7 @@ RDResult InstallRenderDocServer(const rdcstr &deviceID)
         RDCWARN(
             "ARM32 package failed to install but ARM64 package succeeded. Assuming 64-bit only ARM "
             "device and ignoring.");
+        continue;
       }
       else if(versionCheck == AndroidVersionCheckResult::Correct)
       {


### PR DESCRIPTION
On Pixel 8 phones we were seeing 'INSTALL_FAILED_NO_MATCHING_ABIS' on stdout but it was being checked on stderr only.

The lack of 32bit support is detected again from CheckAndroidServerVersion(..) but it only prints to the log, no logic changes occur.  This then caused the 'force queryable' checking to be performed on a not-installed APK which ended up returning ResultCode::AndroidAPKVerifyFailed - which isn't really true.

The change is to check for INSTALL_FAILED_NO_MATCHING_ABIS on stdout too, and if that check still fails then the later check will bypass verfiication keeping the existing Succeeded result.