### PR TITLE
Added a context menu to Bookmark buttons to allow renaming and deleting.

### DIFF
--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -3683,3 +3683,15 @@ QVariant StructuredDataItemModel::data(const QModelIndex &index, int role) const
 
   return QVariant();
 }
+
+QRClickToolButton::QRClickToolButton(QWidget *parent) : QToolButton(parent)
+{
+}
+
+void QRClickToolButton::mousePressEvent(QMouseEvent *e)
+{
+  if(e->button() == Qt::RightButton)
+    emit rightClicked();
+  else
+    QToolButton::mousePressEvent(e);
+}

--- a/qrenderdoc/Code/QRDUtils.h
+++ b/qrenderdoc/Code/QRDUtils.h
@@ -35,6 +35,7 @@
 #include <QSharedPointer>
 #include <QSortFilterProxyModel>
 #include <QStyledItemDelegate>
+#include <QToolButton>
 #include "Code/Interface/QRDInterface.h"
 
 #if !defined(RELEASE) && !defined(__FreeBSD__)
@@ -988,3 +989,20 @@ void *AccessWaylandPlatformInterface(const QByteArray &resource, QWindow *window
 
 void UpdateVisibleColumns(rdcstr windowTitle, int columnCount, QHeaderView *header,
                           const QStringList &headers);
+
+// A version of QToolButton that can also handle right clicks
+class QRClickToolButton : public QToolButton
+{
+  Q_OBJECT
+
+public:
+  explicit QRClickToolButton(QWidget *parent = 0);
+
+private slots:
+  void mousePressEvent(QMouseEvent *e);
+
+signals:
+  void rightClicked();
+
+public slots:
+};

--- a/qrenderdoc/Windows/EventBrowser.cpp
+++ b/qrenderdoc/Windows/EventBrowser.cpp
@@ -5334,7 +5334,7 @@ void EventBrowser::repopulateBookmarks()
 
       QRClickToolButton *but = new QRClickToolButton(this);
 
-      but->setText(mark.text.empty() ? QString::number(EID) : mark.text);
+      but->setText(mark.text.empty() ? QString::number(EID) : (QString)mark.text);
       but->setCheckable(true);
       but->setAutoRaise(true);
       but->setProperty("eid", EID);
@@ -5428,7 +5428,7 @@ void EventBrowser::bookmarkContextMenu(QRClickToolButton *button, uint32_t EID)
       bool ok;
       editedBookmark.text = QInputDialog::getText(
           this, lit("Rename"), lit("New name:"), QLineEdit::Normal,
-          editedBookmark.text.empty() ? QString::number(EID) : editedBookmark.text, &ok);
+          editedBookmark.text.empty() ? QString::number(EID) : (QString)editedBookmark.text, &ok);
       if(ok && !editedBookmark.text.empty())
       {
         button->setText(editedBookmark.text);

--- a/qrenderdoc/Windows/EventBrowser.cpp
+++ b/qrenderdoc/Windows/EventBrowser.cpp
@@ -5344,7 +5344,8 @@ void EventBrowser::repopulateBookmarks()
           ui->events->setCurrentIndex(QModelIndex());
         highlightBookmarks();
       });
-      QObject::connect(but, &QRClickToolButton::rightClicked, [this, but, EID]() { bookmarkContextMenu(but, EID); });
+      QObject::connect(but, &QRClickToolButton::rightClicked,
+                       [this, but, EID]() { bookmarkContextMenu(but, EID); });
 
       m_BookmarkButtons[EID] = but;
 
@@ -5393,7 +5394,7 @@ void EventBrowser::highlightBookmarks()
   }
 }
 
-void EventBrowser::bookmarkContextMenu(QRClickToolButton* button, uint32_t EID)
+void EventBrowser::bookmarkContextMenu(QRClickToolButton *button, uint32_t EID)
 {
   QMenu contextMenu(this);
 
@@ -5406,14 +5407,12 @@ void EventBrowser::bookmarkContextMenu(QRClickToolButton* button, uint32_t EID)
   contextMenu.addAction(&renameBookmark);
   contextMenu.addAction(&deleteBookmark);
 
-  QObject::connect(&deleteBookmark, &QAction::triggered, [this, EID]()
-  {
+  QObject::connect(&deleteBookmark, &QAction::triggered, [this, EID]() {
     m_Ctx.RemoveBookmark(EID);
     repopulateBookmarks();
   });
 
-  QObject::connect(&renameBookmark, &QAction::triggered, [this, button, EID]()
-  {
+  QObject::connect(&renameBookmark, &QAction::triggered, [this, button, EID]() {
     EventBookmark editedBookmark;
     for(const EventBookmark &bookmark : m_Ctx.GetBookmarks())
     {
@@ -5428,11 +5427,8 @@ void EventBrowser::bookmarkContextMenu(QRClickToolButton* button, uint32_t EID)
     {
       bool ok;
       editedBookmark.text = QInputDialog::getText(
-          this,
-          lit("Rename"),
-          lit("New name:"), QLineEdit::Normal,
-          editedBookmark.text.empty() ? QString::number(EID) : editedBookmark.text,
-          &ok);
+          this, lit("Rename"), lit("New name:"), QLineEdit::Normal,
+          editedBookmark.text.empty() ? QString::number(EID) : editedBookmark.text, &ok);
       if(ok && !editedBookmark.text.empty())
       {
         button->setText(editedBookmark.text);

--- a/qrenderdoc/Windows/EventBrowser.h
+++ b/qrenderdoc/Windows/EventBrowser.h
@@ -28,7 +28,6 @@
 #include <QIcon>
 #include <QLabel>
 #include <QSet>
-#include <QToolButton>
 #include "Code/Interface/QRDInterface.h"
 
 namespace Ui
@@ -109,22 +108,6 @@ public:
 protected:
   void paintEvent(QPaintEvent *);
   void resizeEvent(QResizeEvent *);
-};
-
-class QRClickToolButton : public QToolButton
-{
-  Q_OBJECT
-
-public:
-  explicit QRClickToolButton(QWidget *parent = 0);
-
-private slots:
-  void mousePressEvent(QMouseEvent *e);
-
-signals:
-  void rightClicked();
-
-public slots:
 };
 
 class EventBrowser : public QFrame, public IEventBrowser, public ICaptureViewer
@@ -216,7 +199,7 @@ private:
   void jumpToBookmark(int idx);
   void repopulateBookmarks();
   void highlightBookmarks();
-  void bookmarkContextMenu(QRClickToolButton* button, uint32_t EID);
+  void bookmarkContextMenu(QRClickToolButton *button, uint32_t EID);
 
   int FindEvent(QModelIndex parent, QString filter, uint32_t after, bool forward);
   int FindEvent(QString filter, uint32_t after, bool forward);

--- a/qrenderdoc/Windows/EventBrowser.h
+++ b/qrenderdoc/Windows/EventBrowser.h
@@ -28,6 +28,7 @@
 #include <QIcon>
 #include <QLabel>
 #include <QSet>
+#include <QToolButton>
 #include "Code/Interface/QRDInterface.h"
 
 namespace Ui
@@ -108,6 +109,22 @@ public:
 protected:
   void paintEvent(QPaintEvent *);
   void resizeEvent(QResizeEvent *);
+};
+
+class QRClickToolButton : public QToolButton
+{
+  Q_OBJECT
+
+public:
+  explicit QRClickToolButton(QWidget *parent = 0);
+
+private slots:
+  void mousePressEvent(QMouseEvent *e);
+
+signals:
+  void rightClicked();
+
+public slots:
 };
 
 class EventBrowser : public QFrame, public IEventBrowser, public ICaptureViewer
@@ -199,6 +216,7 @@ private:
   void jumpToBookmark(int idx);
   void repopulateBookmarks();
   void highlightBookmarks();
+  void bookmarkContextMenu(QRClickToolButton* button, uint32_t EID);
 
   int FindEvent(QModelIndex parent, QString filter, uint32_t after, bool forward);
   int FindEvent(QString filter, uint32_t after, bool forward);
@@ -233,7 +251,7 @@ private:
 
   FlowLayout *m_BookmarkStripLayout;
   QSpacerItem *m_BookmarkSpacer;
-  QMap<uint32_t, QToolButton *> m_BookmarkButtons;
+  QMap<uint32_t, QRClickToolButton *> m_BookmarkButtons;
 
   RDLineEdit *m_BreadcrumbLocationText;
   RDToolButton *m_BreadcrumbLocationEditButton;

--- a/qrenderdoc/Windows/EventBrowser.h
+++ b/qrenderdoc/Windows/EventBrowser.h
@@ -216,7 +216,7 @@ private:
   void jumpToBookmark(int idx);
   void repopulateBookmarks();
   void highlightBookmarks();
-  void bookmarkContextMenu(QRClickToolButton* button, uint32_t EID);
+  void bookmarkContextMenu(QRClickToolButton *button, uint32_t EID);
 
   int FindEvent(QModelIndex parent, QString filter, uint32_t after, bool forward);
   int FindEvent(QString filter, uint32_t after, bool forward);


### PR DESCRIPTION
## Added context menu for Bookmarks to allow renaming and deleting

Subclassed the QToolButton to add a right-click signal.
Right-clicking a Bookmark button brings up a context menu with two options:
- Rename - Allows renaming the bookmark
- Delete - Deletes the bookmark

![image](https://github.com/baldurk/renderdoc/assets/16783712/1a8aea6c-4627-4bea-a899-206a50391272)

![image](https://github.com/baldurk/renderdoc/assets/16783712/0d800c02-7700-428f-aa2e-6cb4f2064b66)
