### PR TITLE
FlushPendingDead flushes dead resources when capturing

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_device.cpp
+++ b/renderdoc/driver/d3d11/d3d11_device.cpp
@@ -1846,10 +1846,6 @@ void WrappedID3D11Device::FlushPendingDead()
 {
   SCOPED_LOCK(m_D3DLock);
 
-  // to be safe, don't destroy anything while active capturing
-  if(IsActiveCapturing(m_State))
-    return;
-
   D3D11ResourceManager *rm = GetResourceManager();
 
   int pass = 0;


### PR DESCRIPTION
This prevents crashing when IDXGISwapChain::ResizeBuffers occurs during the capture, which seems to happen frequently in Unreal Editor.

## Description

Capturing D3D11 in Unreal Edtior crashed frequently for me.
Eventually I investigated and found that frequently in my captures, a call to IDXGISwapChain::ResizeBuffers occurred.
ResizeBuffers requires that there are no references to the swap chain textures, but I found that an active capture defers releasing resources until the capture is complete.
If ResizeBuffers occurred during a capture, the resize failed.
Unreal Editor detected the failure and intentionally crashed.
I removed the deferment, and Unreal no longer crashes during my captures.
I haven't noticed any negative consequences of removing the deferment.
