### PR TITLE
Fix typo in AndroidAPKInstallFailed message

### DIFF
--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -3139,7 +3139,7 @@ void MainWindow::showLaunchError(ResultDetails result)
       break;
     case ResultCode::AndroidAPKFolderNotFound: message = result.Message(); break;
     case ResultCode::AndroidAPKInstallFailed:
-      message = tr("%1.\n\nlease check that your device is connected and accessible to "
+      message = tr("%1.\n\nPlease check that your device is connected and accessible to "
                    "adb, and that installing APKs over USB is allowed.")
                     .arg(result.Message());
       break;


### PR DESCRIPTION
## Description

This message can be seen if the USB cable connecting the device is removed while the `adb install` command is running. (I ran into this by accident due to a low-quality cable.)

The previous message was this:

> Failed to install Android remote server for unknown reasons: Couldn't install APK(s). stderr: adb.exe: device '00000a740f4e6d93' not found
> .
>
> lease check that your device is connected and accessible to adb, and that installing APKs over USB is allowed.

This does also include a newline before a period, which looks a bit strange but I don't see a quick fix for that while keeping stderr, and the stderr output is fairly useful.

Before:
![OldLaunchError](https://github.com/baldurk/renderdoc/assets/127789813/2a781409-a799-4ef7-ab99-c4ce842c8ade)

After:
![NewLaunchError](https://github.com/baldurk/renderdoc/assets/127789813/53111273-9d7f-49b8-a3fd-fa00f51ee92c)


<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
