### PR TITLE
Fix 'android-<version>.jar' search path on MacOS

### DIFF
--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -152,7 +152,7 @@ if(ANDROID)
     if(APK_TARGET_ID STREQUAL "")
         # This seems different from the platform we're targetting,
         # default to the latest available that's greater or equal to our target platform
-        file(GLOB __platforms RELATIVE "${ANDROID_SDK_ROOT_PATH}/platforms" "${ANDROID_SDK_ROOT_PATH}/platforms/*")
+        file(GLOB __platforms RELATIVE "${ANDROID_SDK_ROOT_PATH}/platforms" "${ANDROID_SDK_ROOT_PATH}/platforms/android-*")
         list(SORT __platforms)
 
         # In case we don't find one, target the latest platform


### PR DESCRIPTION
## Description

The renderdoccmd android build assumes all files in 
'${ANDROID_SDK_ROOT_PATH}/platforms' are valid 
'android-(version).jar' platform libraries. Unfortunately, because MacOS 
litters its directories with metadata files called .DS_Store, 
that file actually wins this sorting logic and is incorrectly selected. 
This fixes the lib search logic to only consider android libraries.

