### PR TITLE
Add missing Indirect resource usage for indirect draw count buffers

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_draw_funcs.cpp
@@ -3177,6 +3177,14 @@ bool WrappedOpenGL::Serialise_glMultiDrawArraysIndirectCount(SerialiserType &ser
             EventUsage(m_CurEventID, ResourceUsage::Indirect));
       }
 
+      {
+        GLuint buf = 0;
+        GL.glGetIntegerv(eGL_PARAMETER_BUFFER_BINDING, (GLint *)&buf);
+
+        m_ResourceUses[GetResourceManager()->GetResID(BufferRes(GetCtx(), buf))].push_back(
+            EventUsage(m_CurEventID, ResourceUsage::Indirect));
+      }
+
       GLintptr offs = (GLintptr)offset;
 
       SDChunk *baseChunk = m_StructuredFile->chunks.back();
@@ -3408,6 +3416,14 @@ bool WrappedOpenGL::Serialise_glMultiDrawElementsIndirectCount(SerialiserType &s
       {
         GLuint buf = 0;
         GL.glGetIntegerv(eGL_DRAW_INDIRECT_BUFFER_BINDING, (GLint *)&buf);
+
+        m_ResourceUses[GetResourceManager()->GetResID(BufferRes(GetCtx(), buf))].push_back(
+            EventUsage(m_CurEventID, ResourceUsage::Indirect));
+      }
+
+      {
+        GLuint buf = 0;
+        GL.glGetIntegerv(eGL_PARAMETER_BUFFER_BINDING, (GLint *)&buf);
 
         m_ResourceUses[GetResourceManager()->GetResID(BufferRes(GetCtx(), buf))].push_back(
             EventUsage(m_CurEventID, ResourceUsage::Indirect));

--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -2999,6 +2999,8 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndirectCount(SerialiserType &ser,
 
       actionNode.resourceUsage.push_back(make_rdcpair(
           GetResID(buffer), EventUsage(actionNode.action.eventId, ResourceUsage::Indirect)));
+      actionNode.resourceUsage.push_back(make_rdcpair(
+          GetResID(countBuffer), EventUsage(actionNode.action.eventId, ResourceUsage::Indirect)));
 
       m_BakedCmdBufferInfo[m_LastCmdBufferID].curEventID++;
 
@@ -3345,6 +3347,8 @@ bool WrappedVulkan::Serialise_vkCmdDrawIndexedIndirectCount(
 
       actionNode.resourceUsage.push_back(make_rdcpair(
           GetResID(buffer), EventUsage(actionNode.action.eventId, ResourceUsage::Indirect)));
+      actionNode.resourceUsage.push_back(make_rdcpair(
+          GetResID(countBuffer), EventUsage(actionNode.action.eventId, ResourceUsage::Indirect)));
 
       m_BakedCmdBufferInfo[m_LastCmdBufferID].curEventID++;
 
@@ -5121,6 +5125,8 @@ bool WrappedVulkan::Serialise_vkCmdDrawMeshTasksIndirectCountEXT(
 
       actionNode.resourceUsage.push_back(make_rdcpair(
           GetResID(buffer), EventUsage(actionNode.action.eventId, ResourceUsage::Indirect)));
+      actionNode.resourceUsage.push_back(make_rdcpair(
+          GetResID(countBuffer), EventUsage(actionNode.action.eventId, ResourceUsage::Indirect)));
 
       m_BakedCmdBufferInfo[m_LastCmdBufferID].curEventID++;
 


### PR DESCRIPTION
The buffer containing the `uint32` draw count value for indirect draws with count was not marked as used as an indirect resource for the respective events of the following API calls: glMultiDrawArraysIndirectCount, glMultiDrawElementsIndirectCount, vkCmdDrawIndirectCount, vkCmdDrawIndexedIndirectCount, vkCmdDrawMeshTasksIndirectCountEXT