### PR TITLE
Vulkan AS descriptor and SPIR-V changes

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
@@ -1293,6 +1293,8 @@ ShaderDebugTrace *Debugger::BeginDebug(DebugAPIWrapper *api, const ShaderStage s
           innerName = "sampledImage";
         else if(innertype->type == DataType::ImageType)
           innerName = "image";
+        else if(innertype->type == DataType::AccelerationStructureType)
+          innerName = "accelerationStructure";
         sourceName = StringFormat::Fmt("_%s_set%u_bind%u", innerName.c_str(), decorations[v.id].set,
                                        decorations[v.id].binding);
       }
@@ -1376,6 +1378,14 @@ ShaderDebugTrace *Debugger::BeginDebug(DebugAPIWrapper *api, const ShaderStage s
           global.readOnlyResources.push_back(var);
           pointerIDs.push_back(GLOBAL_POINTER(v.id, readOnlyResources));
         }
+      }
+      else if(innertype->type == DataType::AccelerationStructureType)
+      {
+        var.type = VarType::ReadOnlyResource;
+        debugType = DebugVariableType::ReadOnlyResource;
+
+        global.readOnlyResources.push_back(var);
+        pointerIDs.push_back(GLOBAL_POINTER(v.id, readOnlyResources));
       }
       else
       {
@@ -3500,6 +3510,8 @@ uint32_t Debugger::WalkVariable(
     case DataType::ImageType:
     case DataType::SamplerType:
     case DataType::SampledImageType:
+    case DataType::RayQueryType:
+    case DataType::AccelerationStructureType:
     case DataType::UnknownType:
     {
       RDCERR("Unexpected variable type %d", type.type);

--- a/renderdoc/driver/shaders/spirv/spirv_disassemble.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_disassemble.cpp
@@ -361,7 +361,8 @@ rdcstr Reflector::Disassemble(const rdcstr &entryPoint,
         case Op::TypeSampler:
         case Op::TypeSampledImage:
         case Op::TypeFunction:
-        case Op::TypeRuntimeArray: continue;
+        case Op::TypeRuntimeArray:
+        case Op::TypeRayQueryKHR: continue;
 
         case Op::TypeForwardPointer:
         {

--- a/renderdoc/driver/shaders/spirv/spirv_processor.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_processor.cpp
@@ -799,6 +799,16 @@ void Processor::RegisterOp(Iter it)
 
     functionTypes[decoded.result] = FunctionType(decoded.returnType, decoded.parameters);
   }
+  else if(opdata.op == Op::TypeRayQueryKHR)
+  {
+    OpTypeRayQueryKHR decoded(it);
+    dataTypes[opdata.result] = DataType(decoded.result, DataType::RayQueryType);
+  }
+  else if(opdata.op == Op::TypeAccelerationStructureKHR)
+  {
+    OpTypeAccelerationStructureKHR decoded(it);
+    dataTypes[opdata.result] = DataType(decoded.result, DataType::AccelerationStructureType);
+  }
   else if(opdata.op == Op::Decorate)
   {
     OpDecorate decoded(it);
@@ -926,7 +936,8 @@ void Processor::UnregisterOp(Iter it)
   else if(opdata.op == Op::TypeVoid || opdata.op == Op::TypeBool || opdata.op == Op::TypeInt ||
           opdata.op == Op::TypeFloat || opdata.op == Op::TypeVector ||
           opdata.op == Op::TypeMatrix || opdata.op == Op::TypeStruct || opdata.op == Op::TypeArray ||
-          opdata.op == Op::TypePointer || opdata.op == Op::TypeRuntimeArray)
+          opdata.op == Op::TypePointer || opdata.op == Op::TypeRuntimeArray ||
+          opdata.op == Op::TypeRayQueryKHR || opdata.op == Op::TypeAccelerationStructureKHR)
   {
     dataTypes[opdata.result] = DataType();
   }

--- a/renderdoc/driver/shaders/spirv/spirv_processor.h
+++ b/renderdoc/driver/shaders/spirv/spirv_processor.h
@@ -334,6 +334,8 @@ struct DataType
     ImageType,
     SamplerType,
     SampledImageType,
+    RayQueryType,
+    AccelerationStructureType,
   };
 
   struct Child
@@ -372,7 +374,26 @@ struct DataType
   Id InnerType() const { return pointerType.baseId; }
   bool IsOpaqueType() const
   {
-    return type == ImageType || type == SamplerType || type == SampledImageType;
+    switch(type)
+    {
+      case Type::ScalarType:
+      case Type::VectorType:
+      case Type::MatrixType:
+      case Type::StructType:
+      case Type::PointerType:
+      case Type::ArrayType: return false;
+      case Type::ImageType:
+      case Type::SamplerType:
+      case Type::SampledImageType:
+      case Type::RayQueryType:
+      case Type::AccelerationStructureType: return true;
+      default:
+      {
+        RDCWARN("Unknown SPIR-V type!");
+        break;
+      }
+    }
+    return false;
   }
   Id id;
   rdcstr name;

--- a/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_reflect.cpp
@@ -852,6 +852,14 @@ void Reflector::PostParse()
         type.name = StringFormat::Fmt("Sampled%s",
                                       dataTypes[sampledImageTypes[type.id].baseId].name.c_str());
       }
+      else if(type.type == DataType::RayQueryType)
+      {
+        type.name = StringFormat::Fmt("rayQuery%u", type.id.value());
+      }
+      else if(type.type == DataType::AccelerationStructureType)
+      {
+        type.name = StringFormat::Fmt("accelerationStructure%u", type.id.value());
+      }
     }
   }
 
@@ -1446,6 +1454,15 @@ void Reflector::MakeReflection(const GraphicsAPI sourceAPI, const ShaderStage st
           samp.bindArraySize = arraySize;
 
           samplers.push_back(sortedsamp(global.id, samp));
+        }
+        else if(varType->type == DataType::AccelerationStructureType)
+        {
+          res.descriptorType = DescriptorType::AccelerationStructure;
+          res.variableType.baseType = VarType::ReadOnlyResource;
+          res.isTexture = false;
+          res.isReadOnly = true;
+
+          roresources.push_back(sortedres(global.id, res));
         }
         else
         {

--- a/renderdoc/driver/vulkan/vk_acceleration_structure.cpp
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.cpp
@@ -355,7 +355,7 @@ void VulkanAccelerationStructureManager::Apply(ResourceId id, const VkInitialCon
   }
 }
 
-VkDeviceSize VulkanAccelerationStructureManager::SerialisedASSize(VkAccelerationStructureKHR as)
+VkDeviceSize VulkanAccelerationStructureManager::SerialisedASSize(VkAccelerationStructureKHR unwrappedAs)
 {
   VkDevice d = m_pDriver->GetDev();
 
@@ -374,7 +374,8 @@ VkDeviceSize VulkanAccelerationStructureManager::SerialisedASSize(VkAcceleration
 
   // Get the size
   ObjDisp(d)->CmdWriteAccelerationStructuresPropertiesKHR(
-      Unwrap(cmd), 1, &as, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR, pool, 0);
+      Unwrap(cmd), 1, &unwrappedAs, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR,
+      pool, 0);
 
   m_pDriver->CloseInitStateCmd();
   m_pDriver->SubmitCmds();
@@ -382,7 +383,8 @@ VkDeviceSize VulkanAccelerationStructureManager::SerialisedASSize(VkAcceleration
 
   VkDeviceSize size = 0;
   vkr = ObjDisp(d)->GetQueryPoolResults(Unwrap(d), pool, 0, 1, sizeof(VkDeviceSize), &size,
-                                        sizeof(VkDeviceSize), VK_QUERY_RESULT_WAIT_BIT);
+                                        sizeof(VkDeviceSize),
+                                        VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
   m_pDriver->CheckVkResult(vkr);
 
   // Clean up

--- a/renderdoc/driver/vulkan/vk_acceleration_structure.h
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.h
@@ -53,7 +53,7 @@ public:
   void Apply(ResourceId id, const VkInitialContents &initial);
 
 private:
-  VkDeviceSize SerialisedASSize(VkAccelerationStructureKHR as);
+  VkDeviceSize SerialisedASSize(VkAccelerationStructureKHR unwrappedAs);
 
   WrappedVulkan *m_pDriver;
 };

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -577,7 +577,9 @@ constexpr DescriptorSlotType convert(VkDescriptorType type)
              ? DescriptorSlotType::StorageBufferDynamic
          : type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT     ? DescriptorSlotType::InputAttachment
          : type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK ? DescriptorSlotType::InlineBlock
-                                                           : DescriptorSlotType::Unwritten;
+         : type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR
+             ? DescriptorSlotType::AccelerationStructure
+             : DescriptorSlotType::Unwritten;
 }
 
 enum class DescriptorSlotImageLayout : EnumBaseType

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1088,7 +1088,8 @@ private:
                                    rdcarray<VkResourceRecord *> &cmdsWithReferences,
                                    std::unordered_set<ResourceId> &refdIDs);
   void AddRecordsForSecondaries(VkResourceRecord *record);
-  void UpdateImageStatesForSecondaries(VkResourceRecord *record);
+  void UpdateImageStatesForSecondaries(VkResourceRecord *record,
+                                       rdcarray<VkResourceRecord *> &accelerationStructures);
   void CaptureQueueSubmit(VkQueue queue, const rdcarray<VkCommandBuffer> &commandBuffers,
                           VkFence fence);
 

--- a/renderdoc/driver/vulkan/vk_info.h
+++ b/renderdoc/driver/vulkan/vk_info.h
@@ -129,6 +129,9 @@ struct DescSetLayout
   uint32_t inlineCount;
   uint32_t inlineByteSize;
 
+  uint32_t accelerationStructureWriteCount;
+  uint32_t accelerationStructureCount;
+
   // the cummulative stageFlags for all bindings in this layout
   VkShaderStageFlags anyStageFlags;
 
@@ -149,6 +152,9 @@ struct DescUpdateTemplateApplication
   rdcarray<VkBufferView> bufView;
   rdcarray<VkWriteDescriptorSetInlineUniformBlock> inlineUniform;
   bytebuf inlineData;
+
+  rdcarray<VkWriteDescriptorSetAccelerationStructureKHR> accelerationStructureWrite;
+  rdcarray<VkAccelerationStructureKHR> accelerationStructure;
 
   rdcarray<VkWriteDescriptorSet> writes;
 };
@@ -171,6 +177,8 @@ struct DescUpdateTemplate
   uint32_t imageInfoCount;
   uint32_t inlineInfoCount;
   uint32_t inlineByteSize;
+  uint32_t accelerationStructureWriteCount;
+  uint32_t accelerationStructureCount;
 
   rdcarray<VkDescriptorUpdateTemplateEntry> updates;
 };

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -104,6 +104,8 @@ struct VkInitialContents
     SAFE_DELETE_ARRAY(descriptorWrites);
     SAFE_DELETE_ARRAY(descriptorInfo);
     SAFE_DELETE_ARRAY(inlineInfo);
+    SAFE_DELETE_ARRAY(accelerationStructureWrites);
+    SAFE_DELETE_ARRAY(accelerationStructures);
     FreeAlignedBuffer(inlineData);
 
     rm->ResourceTypeRelease(GetWrapped(buf));
@@ -111,7 +113,7 @@ struct VkInitialContents
     SAFE_DELETE(sparseTables);
     SAFE_DELETE(sparseBind);
 
-    // MemoryAllocation is not free'd here
+    // MemoryAllocation and serialised ASes are not free'd here
   }
 
   // for descriptor heaps, when capturing we save the slots, when replaying we store direct writes
@@ -121,6 +123,9 @@ struct VkInitialContents
   VkWriteDescriptorSetInlineUniformBlock *inlineInfo;
   byte *inlineData;
   size_t inlineByteSize;
+  VkWriteDescriptorSetAccelerationStructureKHR *accelerationStructureWrites;
+  VkAccelerationStructureKHR *accelerationStructures;
+  size_t numAccelerationStructures;
   uint32_t numDescriptors;
 
   // for plain resources, we store the resource type and memory allocation details of the contents

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -2353,8 +2353,7 @@ void VulkanReplay::FillDescriptor(Descriptor &dstel, const DescriptorSetSlot &sr
   else if(descriptorType == DescriptorSlotType::StorageBuffer ||
           descriptorType == DescriptorSlotType::StorageBufferDynamic ||
           descriptorType == DescriptorSlotType::UniformBuffer ||
-          descriptorType == DescriptorSlotType::UniformBufferDynamic ||
-          descriptorType == DescriptorSlotType::AccelerationStructure)
+          descriptorType == DescriptorSlotType::UniformBufferDynamic)
   {
     dstel.view = ResourceId();
 
@@ -2363,6 +2362,16 @@ void VulkanReplay::FillDescriptor(Descriptor &dstel, const DescriptorSetSlot &sr
 
     dstel.byteOffset = srcel.offset;
     dstel.byteSize = srcel.GetRange();
+  }
+  else if(descriptorType == DescriptorSlotType::AccelerationStructure)
+  {
+    dstel.view = ResourceId();
+
+    if(srcel.resource != ResourceId())
+    {
+      dstel.resource = rm->GetOriginalID(srcel.resource);
+      dstel.byteSize = c.m_AccelerationStructure[srcel.resource].size;
+    }
   }
 }
 

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1111,6 +1111,9 @@ struct CmdBufferRecordingInfo
 
   std::unordered_map<ResourceId, MemRefs> memFrameRefs;
 
+  // A list of acceleration structures that this command buffer will build or copy
+  rdcarray<VkResourceRecord *> accelerationStructures;
+
   // AdvanceFrame/Present should be called after this buffer is submitted
   bool present;
   // BeginFrameCapture should be called *before* this buffer is submitted.
@@ -2212,6 +2215,7 @@ public:
     RDCASSERT(bakedCommands->cmdInfo->imageStates.empty());
     cmdInfo->imageStates.swap(bakedCommands->cmdInfo->imageStates);
     cmdInfo->memFrameRefs.swap(bakedCommands->cmdInfo->memFrameRefs);
+    cmdInfo->accelerationStructures.swap(bakedCommands->cmdInfo->accelerationStructures);
   }
 
   // we have a lot of 'cold' data in the resource record, as it can be accessed
@@ -2268,6 +2272,7 @@ public:
     DescPoolInfo *descPoolInfo;              // only for descriptor pools
     CmdPoolInfo *cmdPoolInfo;                // only for command pools
     uint32_t queueFamilyIndex;               // only for queues
+    bool accelerationStructureBuilt;         // only for acceleration structures
   };
 
   VkResourceRecord *bakedCommands;


### PR DESCRIPTION
* Includes a change where the AS is tracked in command buffers so that we know when it has been built - unbuilt ASes are skipped before serialisation
* Shader debugging which includes AS objects is disabled, as it is future work

