### PR TITLE
Add initial replay state initialization for VK_EXT_shader_object

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -5169,7 +5169,7 @@ void WrappedVulkan::AddUsage(VulkanActionTreeNode &actionNode, rdcarray<DebugMes
   {
     bool compute = (shad == 5);
     ResourceId pipe = (compute ? state.compute.pipeline : state.graphics.pipeline);
-    VulkanCreationInfo::Pipeline::Shader &sh = c.m_Pipeline[pipe].shaders[shad];
+    VulkanCreationInfo::ShaderEntry &sh = c.m_Pipeline[pipe].shaders[shad];
     if(sh.module == ResourceId())
       continue;
 

--- a/renderdoc/driver/vulkan/vk_info.cpp
+++ b/renderdoc/driver/vulkan/vk_info.cpp
@@ -818,7 +818,7 @@ bool CreateDescriptorWritesForSlotData(WrappedVulkan *vk, rdcarray<VkWriteDescri
   return ret;
 }
 
-void VulkanCreationInfo::Pipeline::Shader::ProcessStaticDescriptorAccess(
+void VulkanCreationInfo::ShaderEntry::ProcessStaticDescriptorAccess(
     ResourceId pushStorage, ResourceId specStorage, rdcarray<DescriptorAccess> &descriptorAccess,
     rdcarray<const DescSetLayout *> setLayoutInfos) const
 {
@@ -956,6 +956,89 @@ void VulkanCreationInfo::Pipeline::Shader::ProcessStaticDescriptorAccess(
   }
 }
 
+void VulkanCreationInfo::ShaderObject::Init(VulkanResourceManager *resourceMan,
+                                            VulkanCreationInfo &info, ResourceId id,
+                                            const VkShaderCreateInfoEXT *pCreateInfo)
+{
+  flags = pCreateInfo->flags;
+
+  shad.module = id;
+
+  shad.stage = StageFromIndex(StageIndex(pCreateInfo->stage));
+
+  nextStage = pCreateInfo->nextStage;
+
+  codeType = pCreateInfo->codeType;
+
+  // fake ShaderModule for SPIR-V processing and reflection
+  VkShaderModuleCreateInfo smInfo = {VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, NULL, 0};
+
+  if(codeType & VK_SHADER_CODE_TYPE_SPIRV_EXT)
+  {
+    smInfo.codeSize = pCreateInfo->codeSize;
+    smInfo.pCode = (const uint32_t *)pCreateInfo->pCode;
+  }
+
+  info.m_ShaderModule[id].Init(resourceMan, info, &smInfo);
+
+  shad.entryPoint = pCreateInfo->pName;
+
+  // descriptor set layouts
+  if(pCreateInfo->pSetLayouts)
+  {
+    descSetLayouts.resize(pCreateInfo->setLayoutCount);
+    for(uint32_t i = 0; i < pCreateInfo->setLayoutCount; i++)
+      descSetLayouts[i] = GetResID(pCreateInfo->pSetLayouts[i]);
+  }
+
+  // push constants
+  if(pCreateInfo->pPushConstantRanges)
+  {
+    pushRanges.reserve(pCreateInfo->pushConstantRangeCount);
+    for(uint32_t i = 0; i < pCreateInfo->pushConstantRangeCount; i++)
+      pushRanges.push_back(pCreateInfo->pPushConstantRanges[i]);
+  }
+
+  ShaderModuleReflectionKey key(shad.stage, shad.entryPoint, ResourceId());
+
+  // specialization info
+  if(pCreateInfo->pSpecializationInfo)
+  {
+    key = ShaderModuleReflectionKey(shad.stage, shad.entryPoint, id);
+
+    const byte *data = (const byte *)pCreateInfo->pSpecializationInfo->pData;
+
+    const VkSpecializationMapEntry *maps = pCreateInfo->pSpecializationInfo->pMapEntries;
+    for(uint32_t s = 0; s < pCreateInfo->pSpecializationInfo->mapEntryCount; s++)
+    {
+      SpecConstant spec;
+      spec.specID = maps[s].constantID;
+      memcpy(&spec.value, data + maps[s].offset, maps[s].size);
+      spec.dataSize = maps[s].size;
+      shad.specialization.push_back(spec);
+
+      virtualSpecialisationByteSize =
+          RDCMAX(virtualSpecialisationByteSize, uint32_t((spec.specID + 1) * sizeof(uint64_t)));
+    }
+  }
+
+  ShaderModuleReflection &reflData = info.m_ShaderModule[id].m_Reflections[key];
+
+  reflData.Init(resourceMan, id, info.m_ShaderModule[id].spirv, shad.entryPoint, pCreateInfo->stage,
+                shad.specialization);
+
+  shad.refl = reflData.refl;
+  shad.patchData = &reflData.patchData;
+
+  rdcarray<const DescSetLayout *> setLayoutInfos;
+  for(ResourceId setLayout : descSetLayouts)
+    setLayoutInfos.push_back(&info.m_DescSetLayout[setLayout]);
+
+  shad.ProcessStaticDescriptorAccess(info.pushConstantDescriptorStorage,
+                                     resourceMan->GetOriginalID(id), staticDescriptorAccess,
+                                     setLayoutInfos);
+}
+
 void VulkanCreationInfo::Pipeline::Init(VulkanResourceManager *resourceMan,
                                         VulkanCreationInfo &info, ResourceId id,
                                         const VkGraphicsPipelineCreateInfo *pCreateInfo)
@@ -1032,7 +1115,7 @@ void VulkanCreationInfo::Pipeline::Init(VulkanResourceManager *resourceMan,
     // convert shader bit to shader index
     int stageIndex = StageIndex(pCreateInfo->pStages[i].stage);
 
-    Shader &shad = shaders[stageIndex];
+    ShaderEntry &shad = shaders[stageIndex];
 
     VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *subgroupSize =
         (VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *)FindNextStruct(
@@ -1632,7 +1715,7 @@ void VulkanCreationInfo::Pipeline::Init(VulkanResourceManager *resourceMan,
   for(ResourceId setLayout : descSetLayouts)
     setLayoutInfos.push_back(&info.m_DescSetLayout[setLayout]);
 
-  for(const Shader &shad : shaders)
+  for(const ShaderEntry &shad : shaders)
     shad.ProcessStaticDescriptorAccess(info.pushConstantDescriptorStorage,
                                        resourceMan->GetOriginalID(id), staticDescriptorAccess,
                                        setLayoutInfos);
@@ -1654,7 +1737,7 @@ void VulkanCreationInfo::Pipeline::Init(VulkanResourceManager *resourceMan, Vulk
   // VkPipelineShaderStageCreateInfo
   {
     ResourceId shadid = GetResID(pCreateInfo->stage.module);
-    Shader &shad = shaders[5];    // 5 is the compute shader's index (VS, TCS, TES, GS, FS, CS)
+    ShaderEntry &shad = shaders[5];    // 5 is the compute shader's index (VS, TCS, TES, GS, FS, CS)
 
     VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *subgroupSize =
         (VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *)FindNextStruct(
@@ -1742,7 +1825,7 @@ void VulkanCreationInfo::Pipeline::Init(VulkanResourceManager *resourceMan, Vulk
   for(ResourceId setLayout : descSetLayouts)
     setLayoutInfos.push_back(&info.m_DescSetLayout[setLayout]);
 
-  for(const Shader &shad : shaders)
+  for(const ShaderEntry &shad : shaders)
     shad.ProcessStaticDescriptorAccess(info.pushConstantDescriptorStorage,
                                        resourceMan->GetOriginalID(id), staticDescriptorAccess,
                                        setLayoutInfos);

--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -1648,7 +1648,7 @@ ResourceId VulkanReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, D
         if(useDepthWriteStencilPass)
         {
           useDepthWriteStencilPass = false;
-          const VulkanCreationInfo::Pipeline::Shader &ps = pipeInfo.shaders[4];
+          const VulkanCreationInfo::ShaderEntry &ps = pipeInfo.shaders[4];
           if(ps.module != ResourceId())
           {
             ShaderReflection *reflection = ps.refl;

--- a/renderdoc/driver/vulkan/vk_postvs.cpp
+++ b/renderdoc/driver/vulkan/vk_postvs.cpp
@@ -2865,7 +2865,7 @@ void VulkanReplay::FetchMeshOut(uint32_t eventId, VulkanRenderState &state)
 
   const VulkanCreationInfo::Pipeline &pipeInfo = creationInfo.m_Pipeline[state.graphics.pipeline];
 
-  const VulkanCreationInfo::Pipeline::Shader &meshShad = pipeInfo.shaders[7];
+  const VulkanCreationInfo::ShaderEntry &meshShad = pipeInfo.shaders[7];
 
   const VulkanCreationInfo::ShaderModule &meshInfo = creationInfo.m_ShaderModule[meshShad.module];
   ShaderReflection *meshrefl = meshShad.refl;
@@ -3007,8 +3007,7 @@ void VulkanReplay::FetchMeshOut(uint32_t eventId, VulkanRenderState &state)
   // worst case buffer size could be massive
   if(pipeInfo.shaders[(size_t)ShaderStage::Task].refl)
   {
-    const VulkanCreationInfo::Pipeline::Shader &taskShad =
-        pipeInfo.shaders[(size_t)ShaderStage::Task];
+    const VulkanCreationInfo::ShaderEntry &taskShad = pipeInfo.shaders[(size_t)ShaderStage::Task];
 
     if(taskShad.patchData->invalidTaskPayload)
     {
@@ -3510,8 +3509,7 @@ void VulkanReplay::FetchMeshOut(uint32_t eventId, VulkanRenderState &state)
 
   if(taskDataAddress != 0)
   {
-    const VulkanCreationInfo::Pipeline::Shader &taskShad =
-        pipeInfo.shaders[(size_t)ShaderStage::Task];
+    const VulkanCreationInfo::ShaderEntry &taskShad = pipeInfo.shaders[(size_t)ShaderStage::Task];
 
     const VulkanCreationInfo::ShaderModule &taskInfo = creationInfo.m_ShaderModule[taskShad.module];
 

--- a/renderdoc/driver/vulkan/vk_shader_feedback.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_feedback.cpp
@@ -1752,7 +1752,7 @@ bool VulkanReplay::FetchShaderFeedback(uint32_t eventId)
       feedbackData.feedbackStorageSize += arraySize * sizeof(uint32_t);
     };
 
-    for(const VulkanCreationInfo::Pipeline::Shader &sh : pipeInfo.shaders)
+    for(const VulkanCreationInfo::ShaderEntry &sh : pipeInfo.shaders)
     {
       if(!sh.refl)
         continue;
@@ -2236,7 +2236,7 @@ bool VulkanReplay::FetchShaderFeedback(uint32_t eventId)
 
         msg.stage = stage;
 
-        const VulkanCreationInfo::Pipeline::Shader &sh = pipeInfo.shaders[(uint32_t)stage];
+        const VulkanCreationInfo::ShaderEntry &sh = pipeInfo.shaders[(uint32_t)stage];
 
         {
           VulkanCreationInfo::ShaderModule &mod = creationInfo.m_ShaderModule[sh.module];
@@ -2302,7 +2302,7 @@ bool VulkanReplay::FetchShaderFeedback(uint32_t eventId)
           msg.location.mesh.thread[2] = meshThread / (sh.refl->dispatchThreadsDimension[0] *
                                                       sh.refl->dispatchThreadsDimension[1]);
 
-          const VulkanCreationInfo::Pipeline::Shader &tasksh =
+          const VulkanCreationInfo::ShaderEntry &tasksh =
               pipeInfo.shaders[(uint32_t)ShaderStage::Task];
 
           if(tasksh.module == ResourceId())

--- a/renderdoc/driver/vulkan/wrappers/vk_shader_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_shader_funcs.cpp
@@ -415,6 +415,9 @@ bool WrappedVulkan::Serialise_vkCreateShadersEXT(SerialiserType &ser, VkDevice d
       {
         live = GetResourceManager()->WrapResource(Unwrap(device), sh);
         GetResourceManager()->AddLiveResource(Shader, sh);
+
+        m_CreationInfo.m_ShaderObject[live].Init(GetResourceManager(), m_CreationInfo, live,
+                                                 &CreateInfo);
       }
     }
 
@@ -491,6 +494,8 @@ VkResult WrappedVulkan::vkCreateShadersEXT(VkDevice device, uint32_t createInfoC
       else
       {
         GetResourceManager()->AddLiveResource(id, pShaders[i]);
+        m_CreationInfo.m_ShaderObject[id].Init(GetResourceManager(), m_CreationInfo, id,
+                                               &pCreateInfos[i]);
       }
     }
   }


### PR DESCRIPTION
Added ShaderObject struct to VulkanCreationInfo

Renamed VulkanCreationInfo::Pipeline::Shader to ShaderEntry to differentiate between ShaderModule and ShaderObject, and moved it out of Pipeline scope.