### PR TITLE
Remove the setting of rasterization samples in vkCmdSetSampleMaskEXT

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_dynamic_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_dynamic_funcs.cpp
@@ -3380,7 +3380,6 @@ bool WrappedVulkan::Serialise_vkCmdSetSampleMaskEXT(SerialiserType &ser,
 
           renderstate.dynamicStates[VkDynamicSampleMaskEXT] = true;
 
-          renderstate.rastSamples = samples;
           renderstate.sampleMask.assign(pSampleMask, ((samples - 1) / 32) + 1);
         }
       }


### PR DESCRIPTION
## Description
The argument detailing the number of samples in vkCmdSetSampleMaskEXT is necessary for interpreting the mask but should not be used to modify the dynamic state for rasterization samples.