### PR TITLE
fix huawei crash

### DIFF
--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -12,7 +12,7 @@
   <uses-feature android:glEsVersion="0x00030000" android:required="true" />
 
   <application android:debuggable="true" android:label="RenderDocCmd" android:icon="@drawable/icon" android:hasCode="true">
-    <activity android:name=".Loader" android:label="RenderDoc" android:exported="true" android:screenOrientation="landscape" android:configChanges="orientation|keyboardHidden">
+    <activity android:name=".Loader" android:label="RenderDoc" android:exported="true" android:screenOrientation="landscape" android:configChanges="orientation|keyboardHidden" android:theme="@android:style/Theme.NoTitleBar">
       <meta-data android:name="android.app.lib_name" android:value="renderdoccmd"/>
     </activity>
 


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Hi baldurk! 

I was trying to make renderdoc working on Huawei devices again in the last few days.

On Huawei mobile phone with HarmonyOS, it seems to crash when renderdoccmd's native activity is starting up and with weird crash stack says drawable icon resource is not found as described in #3091 

It seems to be caused by the title bar which is trying to load icon but failed on Huawei device only for some reason. I'm not an android expert but after trying various ways, it may be fixed by specify the activity style to NoTiltleBar.

I know this is a device specific problem which is annoying, maybe Huawei should fix this problem, but it's hard to make them realize this problem I guess. 

Really hope I can use renderdoc on Huawei devices again :)

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
