### PR TITLE
Add support for binding VK_EXT_shader_object state in replay.

### DIFF
--- a/renderdoc/api/replay/vk_pipestate.h
+++ b/renderdoc/api/replay/vk_pipestate.h
@@ -363,6 +363,9 @@ and size into specializationData can be obtained from the reflection info.
 :type: List[int]
 )")
   rdcarray<uint32_t> specializationIds;
+
+  DOCUMENT("Whether the shader is a shader object or shader module.");
+  bool shaderObject = false;
 };
 
 DOCUMENT("Describes the state of the fixed-function tessellator.");

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -4303,7 +4303,19 @@ void WrappedVulkan::ReplayLog(uint32_t startEventID, uint32_t endEventID, Replay
       else
       {
         // even outside of render passes, we need to restore the state
-        m_RenderState.BindPipeline(this, cmd, VulkanRenderState::BindInitial, false);
+        if(m_RenderState.compute.shaderObject || m_RenderState.graphics.shaderObject)
+        {
+          m_RenderState.BindShaderObjects(this, cmd, VulkanRenderState::BindInitial);
+
+          if(m_RenderState.compute.pipeline != ResourceId())
+            m_RenderState.BindPipeline(this, cmd, VulkanRenderState::BindCompute, false);
+          if(m_RenderState.graphics.pipeline != ResourceId())
+            m_RenderState.BindPipeline(this, cmd, VulkanRenderState::BindGraphics, false);
+        }
+        else
+        {
+          m_RenderState.BindPipeline(this, cmd, VulkanRenderState::BindInitial, false);
+        }
       }
 
       m_RenderState.subpassContents = subpassContents;
@@ -5169,7 +5181,12 @@ void WrappedVulkan::AddUsage(VulkanActionTreeNode &actionNode, rdcarray<DebugMes
   {
     bool compute = (shad == 5);
     ResourceId pipe = (compute ? state.compute.pipeline : state.graphics.pipeline);
-    VulkanCreationInfo::ShaderEntry &sh = c.m_Pipeline[pipe].shaders[shad];
+
+    bool shaderObject = (compute ? state.compute.shaderObject : state.graphics.shaderObject);
+
+    VulkanCreationInfo::ShaderEntry &sh = shaderObject
+                                              ? c.m_ShaderObject[state.shaderObjects[shad]].shad
+                                              : c.m_Pipeline[pipe].shaders[shad];
     if(sh.module == ResourceId())
       continue;
 

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1348,6 +1348,7 @@ public:
   bool MeshShaders() const { return m_MeshShaders; }
   bool ListRestart() const { return m_ListRestart; }
   bool AccelerationStructures() const { return m_AccelerationStructures; }
+  bool ShaderObject() const { return m_ShaderObject; }
   VulkanRenderState &GetRenderState() { return m_RenderState; }
   void SetActionCB(VulkanActionCallback *cb) { m_ActionCallback = cb; }
   void SetSubmitChain(void *submitChain) { m_SubmitChain = submitChain; }

--- a/renderdoc/driver/vulkan/vk_state.h
+++ b/renderdoc/driver/vulkan/vk_state.h
@@ -35,6 +35,9 @@ struct VulkanStatePipeline
 {
   ResourceId pipeline;
 
+  // shader object
+  bool shaderObject = false;
+
   struct DescriptorAndOffsets
   {
     ResourceId pipeLayout;
@@ -63,6 +66,8 @@ struct VulkanRenderState
   void BeginRenderPassAndApplyState(WrappedVulkan *vk, VkCommandBuffer cmd, PipelineBinding binding,
                                     bool obeySuspending);
   void BindPipeline(WrappedVulkan *vk, VkCommandBuffer cmd, PipelineBinding binding, bool subpass0);
+  void BindShaderObjects(WrappedVulkan *vk, VkCommandBuffer cmd, PipelineBinding binding);
+  void BindDynamicState(WrappedVulkan *vk, VkCommandBuffer cmd);
 
   void EndRenderPass(VkCommandBuffer cmd);
   void FinishSuspendedRenderPass(VkCommandBuffer cmd);
@@ -283,6 +288,9 @@ struct VulkanRenderState
       VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR,
   };
 
+  // shader objects
+  ResourceId shaderObjects[NumShaderStages];
+
   // attachment feedback loop
   VkImageAspectFlags feedbackAspects = VK_IMAGE_ASPECT_NONE;
 
@@ -297,6 +305,11 @@ private:
   void BindDescriptorSetsWithoutPipeline(WrappedVulkan *vk, VkCommandBuffer cmd,
                                          VulkanStatePipeline &pipe, VkPipelineBindPoint bindPoint);
 
+  void BindDescriptorSetsForShaders(WrappedVulkan *vk, VkCommandBuffer cmd,
+                                    VulkanStatePipeline &pipe, VkPipelineBindPoint bindPoint);
+
   void BindDescriptorSet(WrappedVulkan *vk, const DescSetLayout &descLayout, VkCommandBuffer cmd,
                          VkPipelineBindPoint bindPoint, uint32_t setIndex, uint32_t *dynamicOffsets);
+
+  void BindLastPushConstants(WrappedVulkan *vk, VkCommandBuffer cmd);
 };

--- a/renderdoc/replay/renderdoc_serialise.inl
+++ b/renderdoc/replay/renderdoc_serialise.inl
@@ -2025,7 +2025,9 @@ void DoSerialise(SerialiserType &ser, VKPipe::Shader &el)
   SERIALISE_MEMBER(specializationData);
   SERIALISE_MEMBER(specializationIds);
 
-  SIZE_CHECK(104);
+  SERIALISE_MEMBER(shaderObject);
+
+  SIZE_CHECK(112);
 }
 
 template <typename SerialiserType>
@@ -2286,7 +2288,7 @@ void DoSerialise(SerialiserType &ser, VKPipe::State &el)
 
   SERIALISE_MEMBER(conditionalRendering);
 
-  SIZE_CHECK(1744);
+  SIZE_CHECK(1808);
 }
 
 #pragma endregion Vulkan pipeline state


### PR DESCRIPTION
## Description
This PR updates Vulkan replay to support the binding of shader objects.