### PR TITLE
Android hardware buffer handling tweaks

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -885,6 +885,7 @@ struct ImageInfo
   uint16_t levelCount = 0;
   uint16_t sampleCount = 0;
   bool storage = false;
+  bool isAHB = false;
   VkExtent3D extent = {0, 0, 0};
   VkImageType imageType = VK_IMAGE_TYPE_2D;
   VkFormat format = VK_FORMAT_UNDEFINED;


### PR DESCRIPTION
* Calling `vkGetImageMemoryRequirements` on AHB-backed images before binding is out-of-spec, so that is now deferred until bind
* Calling `vkCreateImage` with an undefined format will cause an error to be returned