### PR TITLE
Grant MANAGE_EXTERNAL_STORAGE permission via adb shell appops

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -568,6 +568,14 @@ RDResult InstallRenderDocServer(const rdcstr &deviceID)
     // Only verify permissions if we are otherwise happy with the installation
     if(result != ResultCode::AndroidAPKVerifyFailed)
     {
+      if(apiVersion >= 30)
+      {
+        // Grant permission to access files
+        rdcstr cmd = "shell appops set --uid " + GetRenderDocPackageForABI(abi) +
+                     " MANAGE_EXTERNAL_STORAGE allow";
+        adbExecCommand(deviceID, cmd);
+      }
+
       AndroidInstallPermissionCheckResult permissionsCheck =
           CheckAndroidServerInstallPermissions(deviceID, GetRenderDocPackageForABI(abi), apiVersion);
       if(permissionsCheck != AndroidInstallPermissionCheckResult::Correct)


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

This removes the need to manually grant RenderDoc this permission via the (automatically-opened) settings screen. As far as I can tell, appops does not require root access and has existed since before the `MANAGE_EXTERNAL_STORAGE` permission was added in Android 10.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
