### PR TITLE
Update postvs and overlay helpers for VK_EXT_shader_object

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -92,6 +92,7 @@ public:
                                                    const MeshFormat &secondary);
 
   void PatchFixedColShader(VkShaderModule &mod, float col[4]);
+  void PatchFixedColShaderObject(VkShaderEXT &shad, float col[4]);
   void PatchLineStripIndexBuffer(const ActionDescription *action, GPUBuffer &indexBuffer,
                                  uint32_t &indexCount);
 

--- a/renderdoc/driver/vulkan/vk_shader_cache.h
+++ b/renderdoc/driver/vulkan/vk_shader_cache.h
@@ -113,6 +113,7 @@ public:
   VkPipelineCache GetPipeCache() { return m_PipelineCache; }
   void MakeGraphicsPipelineInfo(VkGraphicsPipelineCreateInfo &pipeCreateInfo, ResourceId pipeline);
   void MakeComputePipelineInfo(VkComputePipelineCreateInfo &pipeCreateInfo, ResourceId pipeline);
+  void MakeShaderObjectInfo(VkShaderCreateInfoEXT &shadCreateInfo, ResourceId shader);
 
   bool IsBuffer2MSSupported() { return m_Buffer2MSSupported; }
   void SetCaching(bool enabled) { m_CacheShaders = enabled; }


### PR DESCRIPTION
## Description

This PR updates postvs support for retrieving output from shader objects, so that the buffer data will show in the MeshViewer, and adds helper functions for render overlays.

Postvs
- Fetch Mesh/VS/TessGS Out
- InitPostVSBuffers

Overlay helpers
- PatchFixedColShaderObject
- MakeShaderObjectInfo