### PR TITLE
Bookmarks are now listed in menu.

### DIFF
--- a/qrenderdoc/Windows/ShaderViewer.h
+++ b/qrenderdoc/Windows/ShaderViewer.h
@@ -219,6 +219,8 @@ private:
   void MarkModification();
 
   void ConfigureBookmarkMenu();
+  void UpdateBookmarkMenu(QMenu *menu, QAction *nextAction, QAction *prevAction,
+                          QAction *clearAction);
 
   void PopulateCompileTools();
   void PopulateCompileToolParameters();
@@ -336,6 +338,8 @@ private:
 
   QList<QPair<ScintillaEdit *, int>> m_FindAllResults;
 
+  static const int BOOKMARK_MAX_MENU_ENTRY_LENGTH = 40;    // max length of bookmark names in menu
+  static const int BOOKMARK_MAX_MENU_ENTRY_COUNT = 30;     // max number of bookmarks listed in menu
   QMap<ScintillaEdit *, QList<sptr_t>> m_Bookmarks;
 
   static const int CURRENT_MARKER = 0;


### PR DESCRIPTION
## ShaderViewer bookmarks are now easily accessible from the menu

This is a simple change that makes the list of bookmarks in a file easily accessible from the Bookmark menu.
Clicking on a bookmark entry jumps to that line.

![qrenderdoc_cjp76ImdsT](https://github.com/baldurk/renderdoc/assets/16783712/aba13c8e-a4ba-431d-a572-f743c34774f5)
