### PR TITLE
extend `StoreCompressedTexData` for update & subupdate

### DIFF
--- a/renderdoc/driver/gl/gl_driver.h
+++ b/renderdoc/driver/gl/gl_driver.h
@@ -605,9 +605,10 @@ private:
   // many drivers will still try to access memory via legacy behaviour even on core profile.
   bool Check_SafeDraw(bool indexed);
 
-  void StoreCompressedTexData(ResourceId texId, GLenum target, GLint level, GLint xoffset,
-                              GLint yoffset, GLint zoffset, GLsizei width, GLsizei height,
-                              GLsizei depth, GLenum format, GLsizei imageSize, const void *pixels);
+  void StoreCompressedTexData(ResourceId texId, GLenum target, GLint level, bool subUpdate,
+                              GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width,
+                              GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize,
+                              const void *pixels);
 
   // no copy semantics
   WrappedOpenGL(const WrappedOpenGL &);


### PR DESCRIPTION
## Description

Extend `StoreCompressedTexData` with additional parameter `subUpdate`:
- when `subUpdate=false`, it is called from `glCompressedTextureImage2D/3D`, and code path remains the same.
- when `subUpdate=true`, it is called from `glCompressedTextureSubImage2D/3D`, and support sub region copy.