### PR TITLE
Add quad overdraw and tri-size overlay support for VK_EXT_shader_object

### DIFF
--- a/renderdoc/driver/vulkan/vk_state.cpp
+++ b/renderdoc/driver/vulkan/vk_state.cpp
@@ -669,14 +669,15 @@ void VulkanRenderState::BindDynamicState(WrappedVulkan *vk, VkCommandBuffer cmd)
         ibuffer.offs, type);
   }
 
-  if(vk->DynamicVertexInput() && dynamicStates[VkDynamicVertexInputEXT])
+  if((vk->DynamicVertexInput() || vk->ShaderObject()) && dynamicStates[VkDynamicVertexInputEXT])
   {
     ObjDisp(cmd)->CmdSetVertexInputEXT(Unwrap(cmd), (uint32_t)vertexBindings.size(),
                                        vertexBindings.data(), (uint32_t)vertexAttributes.size(),
                                        vertexAttributes.data());
   }
 
-  bool dynamicStride = dynamicStates[VkDynamicVertexInputBindingStride] && vk->ExtendedDynamicState();
+  bool dynamicStride = dynamicStates[VkDynamicVertexInputBindingStride] &&
+                       (vk->ExtendedDynamicState() || vk->ShaderObject());
 
   for(size_t i = 0; i < vbuffers.size(); i++)
   {


### PR DESCRIPTION
## Description

This PR adds support for the remaining Quad Overdraw (draw / pass) and Triangle Size (draw / pass) overlays for shader objects.
Included is a fix for replaying two dynamic state binds with shader objects.