### PR TITLE
Fix for d3d11 pixel history and pixel/fragment shader terminology. 

### DIFF
--- a/qrenderdoc/Code/QRDUtils.cpp
+++ b/qrenderdoc/Code/QRDUtils.cpp
@@ -1508,11 +1508,11 @@ QString ToQStr(const ResourceUsage usage, const GraphicsAPI apitype)
 
       case ResourceUsage::VS_Constants: return lit("VS - Constant Buffer");
       case ResourceUsage::GS_Constants: return lit("GS - Constant Buffer");
-      case ResourceUsage::HS_Constants: return lit("TCS - Constant Buffer");
-      case ResourceUsage::DS_Constants: return lit("TES - Constant Buffer");
-      case ResourceUsage::PS_Constants: return lit("FS - Constant Buffer");
+      case ResourceUsage::HS_Constants: return lit("HS - Constant Buffer");
+      case ResourceUsage::DS_Constants: return lit("DS - Constant Buffer");
+      case ResourceUsage::PS_Constants: return lit("PS - Constant Buffer");
       case ResourceUsage::CS_Constants: return lit("CS - Constant Buffer");
-      case ResourceUsage::TS_Constants: return lit("TS - Constant Buffer");
+      case ResourceUsage::TS_Constants: return lit("AS - Constant Buffer");
       case ResourceUsage::MS_Constants: return lit("MS - Constant Buffer");
       case ResourceUsage::All_Constants: return lit("All - Constant Buffer");
 
@@ -1520,21 +1520,21 @@ QString ToQStr(const ResourceUsage usage, const GraphicsAPI apitype)
 
       case ResourceUsage::VS_Resource: return lit("VS - Resource");
       case ResourceUsage::GS_Resource: return lit("GS - Resource");
-      case ResourceUsage::HS_Resource: return lit("TCS - Resource");
-      case ResourceUsage::DS_Resource: return lit("TES - Resource");
-      case ResourceUsage::PS_Resource: return lit("FS - Resource");
+      case ResourceUsage::HS_Resource: return lit("HS - Resource");
+      case ResourceUsage::DS_Resource: return lit("DS - Resource");
+      case ResourceUsage::PS_Resource: return lit("PS - Resource");
       case ResourceUsage::CS_Resource: return lit("CS - Resource");
-      case ResourceUsage::TS_Resource: return lit("TS - Resource");
+      case ResourceUsage::TS_Resource: return lit("AS - Resource");
       case ResourceUsage::MS_Resource: return lit("MS - Resource");
       case ResourceUsage::All_Resource: return lit("All - Resource");
 
       case ResourceUsage::VS_RWResource: return lit("VS - UAV");
-      case ResourceUsage::HS_RWResource: return lit("TCS - UAV");
-      case ResourceUsage::DS_RWResource: return lit("TES - UAV");
+      case ResourceUsage::HS_RWResource: return lit("HS - UAV");
+      case ResourceUsage::DS_RWResource: return lit("DS - UAV");
       case ResourceUsage::GS_RWResource: return lit("GS - UAV");
-      case ResourceUsage::PS_RWResource: return lit("FS - UAV");
+      case ResourceUsage::PS_RWResource: return lit("PS - UAV");
       case ResourceUsage::CS_RWResource: return lit("CS - UAV");
-      case ResourceUsage::TS_RWResource: return lit("TS - UAV");
+      case ResourceUsage::TS_RWResource: return lit("AS - UAV");
       case ResourceUsage::MS_RWResource: return lit("MS - UAV");
       case ResourceUsage::All_RWResource: return lit("All - UAV");
 
@@ -1573,9 +1573,9 @@ QString ToQStr(const ResourceUsage usage, const GraphicsAPI apitype)
 
       case ResourceUsage::VS_Constants: return lit("VS - Uniform Buffer");
       case ResourceUsage::GS_Constants: return lit("GS - Uniform Buffer");
-      case ResourceUsage::HS_Constants: return lit("HS - Uniform Buffer");
-      case ResourceUsage::DS_Constants: return lit("DS - Uniform Buffer");
-      case ResourceUsage::PS_Constants: return lit("PS - Uniform Buffer");
+      case ResourceUsage::HS_Constants: return lit("TCS - Uniform Buffer");
+      case ResourceUsage::DS_Constants: return lit("TES - Uniform Buffer");
+      case ResourceUsage::PS_Constants: return lit("FS - Uniform Buffer");
       case ResourceUsage::CS_Constants: return lit("CS - Uniform Buffer");
       case ResourceUsage::TS_Constants: return lit("TS - Uniform Buffer");
       case ResourceUsage::MS_Constants: return lit("MS - Uniform Buffer");
@@ -1585,9 +1585,9 @@ QString ToQStr(const ResourceUsage usage, const GraphicsAPI apitype)
 
       case ResourceUsage::VS_Resource: return lit("VS - Texture");
       case ResourceUsage::GS_Resource: return lit("GS - Texture");
-      case ResourceUsage::HS_Resource: return lit("HS - Texture");
-      case ResourceUsage::DS_Resource: return lit("DS - Texture");
-      case ResourceUsage::PS_Resource: return lit("PS - Texture");
+      case ResourceUsage::HS_Resource: return lit("TCS - Texture");
+      case ResourceUsage::DS_Resource: return lit("TES - Texture");
+      case ResourceUsage::PS_Resource: return lit("FS - Texture");
       case ResourceUsage::CS_Resource: return lit("CS - Texture");
       case ResourceUsage::TS_Resource: return lit("TS - Texture");
       case ResourceUsage::MS_Resource: return lit("MS - Texture");
@@ -1595,9 +1595,9 @@ QString ToQStr(const ResourceUsage usage, const GraphicsAPI apitype)
 
       case ResourceUsage::VS_RWResource: return lit("VS - Image/SSBO");
       case ResourceUsage::HS_RWResource: return lit("HS - Image/SSBO");
-      case ResourceUsage::DS_RWResource: return lit("DS - Image/SSBO");
-      case ResourceUsage::GS_RWResource: return lit("GS - Image/SSBO");
-      case ResourceUsage::PS_RWResource: return lit("PS - Image/SSBO");
+      case ResourceUsage::DS_RWResource: return lit("TCS - Image/SSBO");
+      case ResourceUsage::GS_RWResource: return lit("TES - Image/SSBO");
+      case ResourceUsage::PS_RWResource: return lit("FS - Image/SSBO");
       case ResourceUsage::CS_RWResource: return lit("CS - Image/SSBO");
       case ResourceUsage::TS_RWResource: return lit("TS - Image/SSBO");
       case ResourceUsage::MS_RWResource: return lit("MS - Image/SSBO");

--- a/renderdoc/driver/d3d11/d3d11_context.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context.cpp
@@ -1113,11 +1113,14 @@ void WrappedID3D11DeviceContext::AddUsage(const ActionDescription &a)
   //////////////////////////////
   // OM
 
-  for(int i = 0; i < D3D11_1_UAV_SLOT_COUNT; i++)
+  // We iterate over shader slots here, but the matching index in the UAV array
+  //    provided by the user has the first UAV mapping to UAVStartSlot at zero.
+  for(int i = pipe->OM.UAVStartSlot; i < D3D11_1_UAV_SLOT_COUNT; i++)
   {
-    if(pipe->PS.Used_UAV(i) && pipe->OM.UAVs[i])
+    if(pipe->PS.Used_UAV(i) && pipe->OM.UAVs[i - pipe->OM.UAVStartSlot])
     {
-      WrappedID3D11UnorderedAccessView1 *view = (WrappedID3D11UnorderedAccessView1 *)pipe->OM.UAVs[i];
+      WrappedID3D11UnorderedAccessView1 *view =
+          (WrappedID3D11UnorderedAccessView1 *)pipe->OM.UAVs[i - pipe->OM.UAVStartSlot];
       m_ResourceUses[view->GetResourceResID()].push_back(
           EventUsage(e, ResourceUsage::PS_RWResource, view->GetResourceID()));
     }


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
Repro:
https://drive.google.com/file/d/1ehgt_0JniqYZXUWLv02CAbIE1K9YO7xF/view?usp=sharing

Before:
![image](https://github.com/baldurk/renderdoc/assets/1256627/bdce5249-90b5-4352-b69b-22142683272e)

After:
![image](https://github.com/baldurk/renderdoc/assets/1256627/b8a0584c-ea46-4c54-9823-a9355f3e0b43)
