### PR TITLE
Non-local child removal fix

### DIFF
--- a/qrenderdoc/Windows/Dialogs/LiveCapture.h
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.h
@@ -157,6 +157,8 @@ private:
   bool checkAllowDelete();
   void deleteCaptureUnprompted(QListWidgetItem *item);
 
+  bool isLocal() const;
+
   Ui::LiveCapture *ui;
   ICaptureContext &m_Ctx;
   QString m_Hostname;


### PR DESCRIPTION
The frontend compares the registered child PIDs against the locally running ones, any that aren't in the list are removed - this is how dead procs are removed.  Unfortunately this causes any children from a remote context to be immediately removed.

After discussion with upstream, the agreed solution was to prevent child removal entirely for remote contexts as long as clicking on dead children does nothing.