### PR TITLE
Provide fallbacks within POSIX GetHomeFolderFilename()

### DIFF
--- a/renderdoc/os/posix/posix_stringio.cpp
+++ b/renderdoc/os/posix/posix_stringio.cpp
@@ -53,10 +53,23 @@ rdcstr GetTempRootPath();
 
 rdcstr GetHomeFolderFilename()
 {
-  passwd *pw = getpwuid(getuid());
-  const char *homedir = pw->pw_dir;
+  errno = 0;
+  const uid_t uid = getuid();
+  const passwd *pw = getpwuid(uid);
+  if(pw != NULL)
+  {
+    return pw->pw_dir;
+  }
 
-  return homedir;
+  RDCERR("Cannot find password file entry for %u: %s, falling back to $HOME", uid, strerror(errno));
+  const rdcstr homeEnv = Process::GetEnvVariable("HOME");
+  if(!homeEnv.empty())
+  {
+    return homeEnv;
+  }
+
+  RDCERR("$HOME is empty, returning temp path");
+  return GetTempFolderFilename();
 }
 
 rdcstr GetTempFolderFilename()


### PR DESCRIPTION
There are scenarios (specifically when running in anonymous containers) where there is no entry in the password file for the current user, this causes getpwuid() to return a NULL pointer promptly causing a segfault.

This change detects this and then attempts to read the $HOME env var, and if that fails it falls back to the temp dir.  Although the temp dir is not valid as a home dir, it is a valid path and so can be used by the calling function.
