### PR TITLE
jpeg-compressor: Reorder stdio.h include location

### DIFF
--- a/renderdoc/3rdparty/jpeg-compressor/jpge.cpp
+++ b/renderdoc/3rdparty/jpeg-compressor/jpge.cpp
@@ -10,6 +10,7 @@
 
 #include "jpge.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -897,7 +898,6 @@ bool jpeg_encoder::process_scanline(const void* pScanline)
 }
 
 // Higher level wrappers/examples (optional).
-#include <stdio.h>
 
 class cfile_stream : public output_stream
 {


### PR DESCRIPTION
Current, location ends up with compile errors with clang and glibc 2.40 fortified headers

| /mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux/renderdoc/1.33/recipe-sysroot/usr/include/bits/stdio2.h:128:13: error: use of undeclared identifier '__builtin___vfprintf_chk'; did you mean '__builtin___sprintf_chk'?
|   128 |   int __r = __builtin___vfprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1,
|       |             ^
| /mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux/renderdoc/1.33/recipe-sysroot/usr/include/bits/stdio2.h:128:39: error: cannot initialize a parameter of type 'char *' with an lvalue of type 'FILE *const __restrict' (aka 'jpge::_IO_FILE *const __restrict')
|   128 |   int __r = __builtin___vfprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1,
|       |                                       ^~~~~~~~

This re-ordering ensures that fortified function prototypes are used correctly.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
