### PR TITLE
Initialize D3D12_SAMPLER_DESC before modifying value

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_common.cpp
+++ b/renderdoc/driver/d3d12/d3d12_common.cpp
@@ -1093,7 +1093,7 @@ rdcstr PIX3DecodeEventString(const UINT64 *pData, UINT64 &color)
 
 D3D12_SAMPLER_DESC2 ConvertStaticSampler(const D3D12_STATIC_SAMPLER_DESC1 &samp)
 {
-  D3D12_SAMPLER_DESC2 desc;
+  D3D12_SAMPLER_DESC2 desc = {};
   desc.Filter = samp.Filter;
   desc.AddressU = samp.AddressU;
   desc.AddressV = samp.AddressV;


### PR DESCRIPTION
Small change to initialize D3D12_SAMPLER_DESC2. Before this change desc.Flags was uninitialized and we were using |= on it.

This change could also have just changed lines 1123 and 1129 to be a single '=' or only been line 1096. 