### PR TITLE
Fix Android env var collection

### DIFF
--- a/renderdoc/os/posix/posix_process.cpp
+++ b/renderdoc/os/posix/posix_process.cpp
@@ -59,12 +59,14 @@ void ResumeProcess(pid_t childPid, uint32_t delay = 0);
 #define PRELOAD_ENV_VAR "DYLD_INSERT_LIBRARIES"
 #define LIB_PATH_ENV_VAR "DYLD_LIBRARY_PATH"
 #define LIB_SUFFIX ".dylib"
+#define RD_EXECVPE execve
 
 #else
 
 #define PRELOAD_ENV_VAR "LD_PRELOAD"
 #define LIB_PATH_ENV_VAR "LD_LIBRARY_PATH"
 #define LIB_SUFFIX ".so"
+#define RD_EXECVPE execvpe
 
 #endif
 
@@ -626,8 +628,8 @@ static pid_t RunProcess(rdcstr appName, rdcstr workDir, const rdcstr &cmdLine, c
       }
 
       chdir(workDir.c_str());
-      execve(appPath.c_str(), argv, envp);
-      fprintf(stderr, "exec failed\n");
+      RD_EXECVPE(appPath.c_str(), argv, envp);
+      fprintf(stderr, "exec failed %s\n", strerror(errno));
       _exit(1);
     }
     else


### PR DESCRIPTION
RD uses set/getprop to emulate env vars configured from the host, and it uses Process::LaunchProcess to do this that in turn uses fork/execve to launch getprop.  execve doesn't take the shell lookup patterns to find getprop so it ultimately uses FileIO::FindFileInPath(..) to prepend the appropriate path - but this isn't implemented in the Android version.  This resulted in the capture options using default values.

This fix is just an almost-copy of the default POSIX implementation.  I also added slightly more error output to the execve failure logging too.