### PR TITLE
Softmem flush ID fix

### DIFF
--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -122,7 +122,7 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
 
       uint64_t start = ser.GetWriter()->GetOffset();
       {
-        uint64_t size = GetSize_InitialState(id, initData);
+        uint64_t size = GetSize_InitialState(flushId, initData);
 
         SCOPED_SERIALISE_CHUNK(SystemChunk::InitialContents, size);
 


### PR DESCRIPTION
The ResourceId being passed to GetSize_InitialState() to set the chunk size was the ID of the resource triggering the flush NOT the ID of the resource being flushed.