### PR TITLE
Vulkan AS rebuild-on-replay

### DIFF
--- a/renderdoc/driver/vulkan/vk_acceleration_structure.cpp
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.cpp
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include "vk_acceleration_structure.h"
+#include <numeric>
 #include "core/settings.h"
 #include "vk_core.h"
 
@@ -37,130 +38,801 @@ constexpr VkDeviceSize handleCountSize = 8;
 
 // Spec says VkCopyAccelerationStructureToMemoryInfoKHR::dst::deviceAddress must be 256 bytes aligned
 constexpr VkDeviceSize asBufferAlignment = 256;
+
+VkDeviceSize IndexTypeSize(VkIndexType type)
+{
+  switch(type)
+  {
+    case VK_INDEX_TYPE_UINT32: return 4;
+    case VK_INDEX_TYPE_UINT16: return 2;
+    default: return 0;
+  }
+}
 }
 
-bool VulkanAccelerationStructureManager::Prepare(VkAccelerationStructureKHR unwrappedAs,
-                                                 const rdcarray<uint32_t> &queueFamilyIndices,
-                                                 ASMemory &result)
+DECLARE_STRINGISE_TYPE(VkAccelerationStructureInfo::GeometryData::Triangles);
+DECLARE_STRINGISE_TYPE(VkAccelerationStructureInfo::GeometryData::Aabbs);
+DECLARE_STRINGISE_TYPE(VkAccelerationStructureInfo::GeometryData::Instances);
+DECLARE_STRINGISE_TYPE(VkAccelerationStructureInfo::GeometryData);
+DECLARE_STRINGISE_TYPE(VkAccelerationStructureInfo);
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAccelerationStructureInfo::GeometryData::Triangles &el)
 {
-  const VkDeviceSize serialisedSize = SerialisedASSize(unwrappedAs);
+  SERIALISE_MEMBER(vertexFormat);
+  SERIALISE_MEMBER(vertexStride);
+  SERIALISE_MEMBER(maxVertex);
+  SERIALISE_MEMBER(indexType);
+  SERIALISE_MEMBER(hasTransformData);
+}
+INSTANTIATE_SERIALISE_TYPE(VkAccelerationStructureInfo::GeometryData::Triangles);
 
-  const VkDevice d = m_pDriver->GetDev();
-  VkResult vkr = VK_SUCCESS;
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAccelerationStructureInfo::GeometryData::Aabbs &el)
+{
+  SERIALISE_MEMBER(stride);
+}
+INSTANTIATE_SERIALISE_TYPE(VkAccelerationStructureInfo::GeometryData::Aabbs);
 
-  // since this happens during capture, we don't want to start serialising extra buffer creates,
-  // leave this buffer as unwrapped
-  VkBuffer dstBuf = VK_NULL_HANDLE;
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAccelerationStructureInfo::GeometryData::Instances &el)
+{
+  // arrayOfPointers TODO
+}
+INSTANTIATE_SERIALISE_TYPE(VkAccelerationStructureInfo::GeometryData::Instances);
 
-  VkBufferCreateInfo bufInfo = {
-      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAccelerationStructureInfo::GeometryData &el)
+{
+  SERIALISE_MEMBER(geometryType);
+  SERIALISE_MEMBER_TYPED(VkGeometryFlagBitsKHR, flags).TypedAs("VkGeometryFlagsKHR"_lit);
+  SERIALISE_MEMBER(memSize);
+  SERIALISE_MEMBER(memAlignment);
+
+  switch(el.geometryType)
+  {
+    case VK_GEOMETRY_TYPE_TRIANGLES_KHR: SERIALISE_MEMBER(tris); break;
+    case VK_GEOMETRY_TYPE_AABBS_KHR: SERIALISE_MEMBER(aabbs); break;
+    case VK_GEOMETRY_TYPE_INSTANCES_KHR: SERIALISE_MEMBER(instances); break;
+    default: RDCASSERT(false);
+  }
+}
+INSTANTIATE_SERIALISE_TYPE(VkAccelerationStructureInfo::GeometryData);
+
+template <typename SerialiserType>
+void DoSerialise(SerialiserType &ser, VkAccelerationStructureInfo &el)
+{
+  SERIALISE_MEMBER(type);
+  SERIALISE_MEMBER_TYPED(VkBuildAccelerationStructureFlagBitsKHR, flags)
+      .TypedAs("VkBuildAccelerationStructureFlagsKHR"_lit);
+  SERIALISE_MEMBER(geometryData);
+  SERIALISE_MEMBER(buildRangeInfo);
+}
+INSTANTIATE_SERIALISE_TYPE(VkAccelerationStructureInfo);
+
+VkAccelerationStructureInfo::~VkAccelerationStructureInfo()
+{
+  for(const GeometryData &geoData : geometryData)
+  {
+    if(geoData.readbackMem != VK_NULL_HANDLE)
+      ObjDisp(device)->FreeMemory(Unwrap(device), geoData.readbackMem, NULL);
+  }
+}
+
+rdcarray<VkAccelerationStructureGeometryKHR> VkAccelerationStructureInfo::convertGeometryData() const
+{
+  rdcarray<VkAccelerationStructureGeometryKHR> result;
+  result.reserve(geometryData.size());
+
+  for(const VkAccelerationStructureInfo::GeometryData &g : geometryData)
+  {
+    VkAccelerationStructureGeometryDataKHR geoUnion = {};
+    switch(g.geometryType)
+    {
+      case VK_GEOMETRY_TYPE_TRIANGLES_KHR:
+      {
+        VkDeviceOrHostAddressConstKHR vData;
+        vData.deviceAddress = 0x0;
+
+        VkDeviceOrHostAddressConstKHR iData;
+        iData.deviceAddress = 0x0;
+
+        // vkGetAccelerationStructureBuildSizesKHR just checks if the transform BDA is non-null,
+        // so fudge that here
+        VkDeviceOrHostAddressConstKHR tData;
+        tData.deviceAddress = g.tris.hasTransformData ? 0x1 : 0x0;
+
+        geoUnion.triangles = VkAccelerationStructureGeometryTrianglesDataKHR{
+            VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR,
+            NULL,
+            g.tris.vertexFormat,
+            vData,
+            g.tris.vertexStride,
+            g.tris.maxVertex,
+            g.tris.indexType,
+            iData,
+            tData,
+        };
+        break;
+      }
+      case VK_GEOMETRY_TYPE_AABBS_KHR:
+      {
+        VkDeviceOrHostAddressConstKHR aData;
+        aData.deviceAddress = 0x0;
+
+        geoUnion.aabbs = VkAccelerationStructureGeometryAabbsDataKHR{
+            VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR,
+            NULL,
+            aData,
+            g.aabbs.stride,
+        };
+        break;
+      }
+      case VK_GEOMETRY_TYPE_INSTANCES_KHR:
+      {
+        VkDeviceOrHostAddressConstKHR iData;
+        iData.deviceAddress = 0x0;
+
+        geoUnion.instances = VkAccelerationStructureGeometryInstancesDataKHR{
+            VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR,
+            NULL,
+            false,
+            iData,
+        };
+        break;
+      }
+      default: RDCERR("Unhandled geometry type: %d", g.geometryType); return {};
+    }
+
+    result.push_back(
+        VkAccelerationStructureGeometryKHR{VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR,
+                                           NULL, g.geometryType, geoUnion, g.flags});
+  }
+
+  return result;
+}
+
+VulkanAccelerationStructureManager::VulkanAccelerationStructureManager(WrappedVulkan *driver)
+    : m_pDriver(driver), m_ReadbackDeleteThread(0)
+{
+}
+
+void VulkanAccelerationStructureManager::Shutdown()
+{
+  // stop the readback mem clean up thread
+  if(m_ReadbackDeleteThread)
+  {
+    Atomic::Inc32(&m_ExitReadbackDeleteThread);
+    Threading::JoinThread(m_ReadbackDeleteThread);
+    Threading::CloseThread(m_ReadbackDeleteThread);
+    m_ReadbackDeleteThread = 0;
+  }
+
+  // Clean up any scratch mem when the replay is shutdown
+  if(scratch.mem != VK_NULL_HANDLE)
+  {
+    const VkDevice d = m_pDriver->GetDev();
+
+    ObjDisp(d)->DestroyBuffer(Unwrap(d), scratch.buf, NULL);
+    ObjDisp(d)->FreeMemory(Unwrap(d), scratch.mem, NULL);
+
+    scratch = {};
+    scratchAddressUnion.deviceAddress = 0x0;
+  }
+}
+
+void VulkanAccelerationStructureManager::TrackInputBuffer(VkDevice device, VkResourceRecord *record)
+{
+  if(!m_pDriver->AccelerationStructures() || !IsBackgroundCapturing(m_pDriver->GetState()))
+    return;
+
+  SCOPED_LOCK(m_DeviceAddressLock);
+
+  const VkBufferDeviceAddressInfo addrInfo = {
+      VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
       NULL,
-      0,
-      serialisedSize,
-      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
-          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+      ToUnwrappedHandle<VkBuffer>(record->Resource),
   };
 
-  // we make the buffer concurrently accessible by all queue families to not invalidate the
-  // contents of the memory we're reading back from.
-  bufInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
-  bufInfo.queueFamilyIndexCount = (uint32_t)queueFamilyIndices.size();
-  bufInfo.pQueueFamilyIndices = queueFamilyIndices.data();
+  const VkDeviceAddress address =
+      ObjDisp(device)->GetBufferDeviceAddressKHR(Unwrap(device), &addrInfo);
+  m_DeviceAddressToRecord.emplace(address, record);
+}
 
-  // spec requires that CONCURRENT must specify more than one queue family. If there is only one
-  // queue family, we can safely use exclusive.
-  if(bufInfo.queueFamilyIndexCount == 1)
-    bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+void VulkanAccelerationStructureManager::UntrackInputBuffer(VkResourceRecord *record)
+{
+  if(!m_pDriver->AccelerationStructures() || !IsBackgroundCapturing(m_pDriver->GetState()))
+    return;
 
-  vkr = ObjDisp(d)->CreateBuffer(Unwrap(d), &bufInfo, NULL, &dstBuf);
-  m_pDriver->CheckVkResult(vkr);
+  SCOPED_LOCK(m_DeviceAddressLock);
 
-  m_pDriver->AddPendingObjectCleanup(
-      [d, dstBuf]() { ObjDisp(d)->DestroyBuffer(Unwrap(d), dstBuf, NULL); });
+  auto it = std::find_if(m_DeviceAddressToRecord.begin(), m_DeviceAddressToRecord.end(),
+                         [&](const auto &data) { return data.second == record; });
+  if(it != m_DeviceAddressToRecord.end())
+    m_DeviceAddressToRecord.erase(it);
+}
 
-  VkMemoryRequirements mrq = {};
-  ObjDisp(d)->GetBufferMemoryRequirements(Unwrap(d), dstBuf, &mrq);
+void VulkanAccelerationStructureManager::CopyInputBuffers(
+    VkCommandBuffer commandBuffer, const VkAccelerationStructureBuildGeometryInfoKHR &info,
+    const VkAccelerationStructureBuildRangeInfoKHR *buildRange)
+{
+  VkResourceRecord *cmdRecord = GetRecord(commandBuffer);
+  RDCASSERT(cmdRecord);
+  if(!cmdRecord)
+    return;
 
-  mrq.alignment = RDCMAX(mrq.alignment, asBufferAlignment);
+  VkDevice device = cmdRecord->cmdInfo->device;
 
-  const MemoryAllocation readbackmem = m_pDriver->AllocateMemoryForResource(
-      true, mrq, MemoryScope::InitialContents, MemoryType::Readback);
-  if(readbackmem.mem == VK_NULL_HANDLE)
-    return false;
+  VkResourceRecord *asRecord = GetRecord(info.dstAccelerationStructure);
+  RDCASSERT(asRecord);
+  if(!asRecord)
+    return;
 
-  vkr = ObjDisp(d)->BindBufferMemory(Unwrap(d), dstBuf, Unwrap(readbackmem.mem), readbackmem.offs);
-  m_pDriver->CheckVkResult(vkr);
-
-  const VkBufferDeviceAddressInfo addrInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
-                                              dstBuf};
-  const VkDeviceAddress dstBufAddr = ObjDisp(d)->GetBufferDeviceAddressKHR(Unwrap(d), &addrInfo);
-
-  VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
-  if(cmd == VK_NULL_HANDLE)
+  if(asRecord->accelerationStructureInfo != NULL)
   {
-    RDCERR("Couldn't acquire command buffer");
-    return false;
+    SCOPED_LOCK(m_ReadbackMemDeleteLock);
+    m_ReadbackMemToDelete.emplace(commandBuffer, asRecord->accelerationStructureInfo);
   }
 
-  const VkDeviceSize nonCoherentAtomSize = m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize;
-  byte *mappedDstBuffer = NULL;
-  VkDeviceSize size;
+  VkAccelerationStructureInfo *metadata = new VkAccelerationStructureInfo();
+  metadata->device = device;
+  metadata->type = info.type;
+  metadata->flags = info.flags;
+  metadata->accelerationStructure = info.dstAccelerationStructure;
 
-  if(m_pDriver->GetDriverInfo().MaliBrokenASDeviceSerialisation())
+  metadata->geometryData.reserve(info.geometryCount);
+  metadata->buildRangeInfo.reserve(info.geometryCount);
+
+  SCOPED_LOCK(m_DeviceAddressLock);
+  for(uint32_t i = 0; i < info.geometryCount; ++i)
   {
-    size = AlignUp(serialisedSize, nonCoherentAtomSize);
+    // Work out the buffer size needed for each geometry type
+    const VkAccelerationStructureGeometryKHR &geometry =
+        info.pGeometries != NULL ? info.pGeometries[i] : *(info.ppGeometries[i]);
+    const VkAccelerationStructureBuildRangeInfoKHR &rangeInfo = buildRange[i];
 
-    vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(readbackmem.mem), readbackmem.offs, size, 0,
-                                (void **)&mappedDstBuffer);
+    Allocation readbackmem;
+    rdcarray<VkBufferMemoryBarrier> barriers;
+    barriers.reserve(3);
+
+    switch(geometry.geometryType)
+    {
+      case VK_GEOMETRY_TYPE_TRIANGLES_KHR:
+      {
+        const VkAccelerationStructureGeometryTrianglesDataKHR &triInfo = geometry.geometry.triangles;
+
+        // Find the associated VkBuffers
+        const RecordAndOffset vertexBufferRecord =
+            GetDeviceAddressData(triInfo.vertexData.deviceAddress);
+        if(!vertexBufferRecord.record)
+        {
+          RDCERR("Unable to find VkBuffer for vertex data at 0x%llx",
+                 triInfo.vertexData.deviceAddress);
+          continue;
+        }
+
+        RecordAndOffset indexBufferRecord;
+        if(triInfo.indexType != VK_INDEX_TYPE_NONE_KHR)
+        {
+          indexBufferRecord = GetDeviceAddressData(triInfo.indexData.deviceAddress);
+          if(!indexBufferRecord.record)
+          {
+            RDCERR("Unable to find VkBuffer for index data at 0x%llx",
+                   triInfo.vertexData.deviceAddress);
+            continue;
+          }
+        }
+
+        RecordAndOffset transformBufferRecord;
+        if(triInfo.transformData.deviceAddress != VK_NULL_HANDLE)
+        {
+          transformBufferRecord = GetDeviceAddressData(triInfo.transformData.deviceAddress);
+          if(!transformBufferRecord.record)
+          {
+            RDCERR("Unable to find VkBuffer for transform data at 0x%llx",
+                   triInfo.vertexData.deviceAddress);
+            continue;
+          }
+        }
+
+        // Find the alignment requirements for each type
+        VkDeviceSize vertexAlignment = 0;
+        VkDeviceSize indexAlignment = 0;
+        VkDeviceSize transformAlignment = 0;
+
+        const VkBuffer vertexBuffer =
+            ToUnwrappedHandle<VkBuffer>(vertexBufferRecord.record->Resource);
+
+        VkBuffer indexBuffer = VK_NULL_HANDLE;
+        if(indexBufferRecord.record != NULL)
+          indexBuffer = ToUnwrappedHandle<VkBuffer>(indexBufferRecord.record->Resource);
+
+        VkBuffer transformBuffer = VK_NULL_HANDLE;
+        if(transformBufferRecord.record != NULL)
+          transformBuffer = ToUnwrappedHandle<VkBuffer>(transformBufferRecord.record->Resource);
+
+        VkDeviceSize vertexSize = 0;
+        VkDeviceSize indexSize = 0;
+        VkDeviceSize transformSize = 0;
+
+        VkDeviceSize vertexStart = 0;
+        VkDeviceSize indexStart = 0;
+        VkDeviceSize transformStart = 0;
+        {
+          VkMemoryRequirements mrq = {};
+
+          // Vertex buffer.  The complexity here is that the rangeInfo members are interpreted
+          // differently depending on whether or not index buffers are used
+          ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), vertexBuffer, &mrq);
+          vertexAlignment = mrq.alignment;
+          vertexSize = indexBuffer != VK_NULL_HANDLE
+                           ? vertexBufferRecord.record->memSize - vertexBufferRecord.offset
+                           : rangeInfo.primitiveCount * 3 * triInfo.vertexStride;
+          vertexStart =
+              indexBuffer != VK_NULL_HANDLE
+                  ? 0
+                  : rangeInfo.primitiveOffset + (triInfo.vertexStride * rangeInfo.firstVertex);
+
+          // Index buffer
+          if(indexBuffer != VK_NULL_HANDLE)
+          {
+            ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), indexBuffer, &mrq);
+            indexAlignment = mrq.alignment;
+            indexSize = rangeInfo.primitiveCount * 3 * IndexTypeSize(triInfo.indexType);
+            indexStart = rangeInfo.primitiveOffset;
+          }
+
+          // Transform buffer
+          if(transformBuffer != VK_NULL_HANDLE)
+          {
+            ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), transformBuffer, &mrq);
+            transformAlignment = mrq.alignment;
+            transformSize = sizeof(VkTransformMatrixKHR);
+            transformStart = rangeInfo.transformOffset;
+          }
+        }
+        const VkDeviceSize maxAlignment =
+            RDCMAX(RDCMAX(vertexAlignment, indexAlignment), transformAlignment);
+
+        // We want to copy the vertex, index, and transform data into one big block so sum the
+        // sizes up together
+        const VkDeviceSize totalMemSize = AlignUp(vertexSize, vertexAlignment) +
+                                          AlignUp(indexSize, indexAlignment) +
+                                          AlignUp(transformSize, transformAlignment);
+
+        readbackmem = CreateReadBackMemory(device, totalMemSize, maxAlignment);
+        if(readbackmem.mem == VK_NULL_HANDLE)
+        {
+          RDCERR("Unable to allocate AS triangle input buffer readback memory (size: %u bytes)",
+                 totalMemSize);
+          continue;
+        }
+
+        // Insert copy commands
+        VkBufferCopy region = {
+            vertexBufferRecord.offset + vertexStart,
+            0,
+            vertexSize,
+        };
+        ObjDisp(device)->CmdCopyBuffer(Unwrap(commandBuffer), vertexBuffer, readbackmem.buf, 1,
+                                       &region);
+
+        if(indexSize != 0)
+        {
+          region = {
+              indexBufferRecord.offset + indexStart,
+              AlignUp(vertexSize, vertexAlignment),
+              indexSize,
+          };
+          ObjDisp(device)->CmdCopyBuffer(Unwrap(commandBuffer), indexBuffer, readbackmem.buf, 1,
+                                         &region);
+        }
+
+        if(transformSize != 0)
+        {
+          region = {
+              transformBufferRecord.offset + transformStart,
+              AlignUp(vertexSize, vertexAlignment) + AlignUp(indexSize, indexAlignment),
+              transformSize,
+          };
+          ObjDisp(device)->CmdCopyBuffer(Unwrap(commandBuffer), transformBuffer, readbackmem.buf, 1,
+                                         &region);
+        }
+
+        // Prepare the barriers
+        barriers = {{
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+            NULL,
+            0,
+            0,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            vertexBuffer,
+            vertexBufferRecord.offset + vertexStart,
+            vertexSize,
+        }};
+        if(indexSize != 0)
+        {
+          barriers.push_back(barriers.back());
+          VkBufferMemoryBarrier &barrier = barriers.back();
+
+          barrier.buffer = indexBuffer;
+          barrier.offset = indexBufferRecord.offset + indexStart;
+          barrier.size = indexSize;
+        }
+        if(transformSize != 0)
+        {
+          barriers.push_back(barriers.back());
+          VkBufferMemoryBarrier &barrier = barriers.back();
+
+          barrier.buffer = transformBuffer;
+          barrier.offset = transformBufferRecord.offset + transformStart;
+          barrier.size = transformSize;
+        }
+
+        // Store the metadata
+        VkAccelerationStructureInfo::GeometryData geoData;
+        geoData.geometryType = geometry.geometryType;
+        geoData.flags = geometry.flags;
+        geoData.readbackMem = readbackmem.mem;
+        geoData.memSize = readbackmem.size;
+        geoData.memAlignment = maxAlignment;
+
+        geoData.tris.vertexFormat = geometry.geometry.triangles.vertexFormat;
+        geoData.tris.vertexStride = geometry.geometry.triangles.vertexStride;
+        geoData.tris.maxVertex = geometry.geometry.triangles.maxVertex;
+        geoData.tris.indexType = geometry.geometry.triangles.indexType;
+        geoData.tris.hasTransformData = transformSize != 0;
+
+        metadata->geometryData.push_back(geoData);
+
+        // Frustratingly rangeInfo.primitiveOffset represents either the offset into the index or
+        // vertex buffer depending if indices are in use or not
+        VkAccelerationStructureBuildRangeInfoKHR buildData;
+        buildData.primitiveCount = rangeInfo.primitiveCount;
+        buildData.primitiveOffset =
+            indexSize == 0 ? 0 : (uint32_t)AlignUp(vertexSize, vertexAlignment);
+        buildData.firstVertex = indexSize == 0 ? 0 : rangeInfo.firstVertex;
+        buildData.transformOffset =
+            (uint32_t)(AlignUp(vertexSize, vertexAlignment) + AlignUp(indexSize, indexAlignment));
+
+        metadata->buildRangeInfo.push_back(buildData);
+
+        break;
+      }
+      case VK_GEOMETRY_TYPE_AABBS_KHR:
+      {
+        const VkAccelerationStructureGeometryAabbsDataKHR &aabbInfo = geometry.geometry.aabbs;
+
+        // Find the associated VkBuffer
+        const RecordAndOffset bufferRecord = GetDeviceAddressData(aabbInfo.data.deviceAddress);
+        if(!bufferRecord.record)
+        {
+          RDCERR("Unable to find VkBuffer for AABB data at 0x%llx", aabbInfo.data.deviceAddress);
+          continue;
+        }
+
+        const VkBuffer buffer = ToUnwrappedHandle<VkBuffer>(bufferRecord.record->Resource);
+
+        const VkDeviceSize size = rangeInfo.primitiveCount * sizeof(VkAabbPositionsKHR);
+
+        // Get the alignment
+        VkMemoryRequirements mrq = {};
+        ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), buffer, &mrq);
+
+        // Allocate copy buffer
+        readbackmem = CreateReadBackMemory(device, size, mrq.alignment);
+        if(readbackmem.mem == VK_NULL_HANDLE)
+        {
+          RDCERR("Unable to allocate AS AABB input buffer readback memory (size: %u bytes)",
+                 mrq.size);
+          continue;
+        }
+
+        // Insert copy commands
+        VkBufferCopy region = {
+            bufferRecord.offset + rangeInfo.primitiveOffset,
+            0,
+            size,
+        };
+        ObjDisp(device)->CmdCopyBuffer(Unwrap(commandBuffer), buffer, readbackmem.buf, 1, &region);
+
+        // Prepare barrier
+        barriers = {{
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+            NULL,
+            0,
+            0,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            buffer,
+            bufferRecord.offset + rangeInfo.primitiveOffset,
+            size,
+        }};
+
+        // Store the metadata
+        VkAccelerationStructureInfo::GeometryData geoData;
+        geoData.geometryType = geometry.geometryType;
+        geoData.flags = geometry.flags;
+        geoData.readbackMem = readbackmem.mem;
+        geoData.memSize = readbackmem.size;
+        geoData.memAlignment = mrq.alignment;
+
+        geoData.aabbs.stride = aabbInfo.stride;
+
+        metadata->geometryData.push_back(geoData);
+
+        VkAccelerationStructureBuildRangeInfoKHR buildData = rangeInfo;
+        buildData.primitiveOffset = 0;
+
+        metadata->buildRangeInfo.push_back(buildData);
+
+        break;
+      }
+      case VK_GEOMETRY_TYPE_INSTANCES_KHR:
+      {
+        const VkAccelerationStructureGeometryInstancesDataKHR &instanceInfo =
+            geometry.geometry.instances;
+
+        // Find the associated VkBuffer
+        const RecordAndOffset bufferRecord = GetDeviceAddressData(instanceInfo.data.deviceAddress);
+        if(!bufferRecord.record)
+        {
+          RDCERR("Unable to find VkBuffer for instance data at 0x%llx",
+                 instanceInfo.data.deviceAddress);
+          continue;
+        }
+
+        const VkBuffer buffer = ToUnwrappedHandle<VkBuffer>(bufferRecord.record->Resource);
+
+        const VkDeviceSize size =
+            rangeInfo.primitiveCount * sizeof(VkAccelerationStructureInstanceKHR);
+
+        // Get the alignment
+        VkMemoryRequirements mrq = {};
+        ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), buffer, &mrq);
+
+        // Allocate copy buffer
+        readbackmem = CreateReadBackMemory(device, size, mrq.alignment);
+        if(readbackmem.mem == VK_NULL_HANDLE)
+        {
+          RDCERR("Unable to allocate AS instance input buffer readback memory (size: %u bytes)",
+                 size);
+          continue;
+        }
+
+        // Insert copy commands
+        VkBufferCopy region = {
+            bufferRecord.offset + rangeInfo.primitiveOffset,
+            0,
+            size,
+        };
+        ObjDisp(device)->CmdCopyBuffer(Unwrap(commandBuffer), buffer, readbackmem.buf, 1, &region);
+
+        // Prepare barrier
+        barriers = {{
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+            NULL,
+            0,
+            0,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            buffer,
+            bufferRecord.offset + rangeInfo.primitiveOffset,
+            size,
+        }};
+
+        // Store the metadata
+        VkAccelerationStructureInfo::GeometryData geoData;
+        geoData.geometryType = geometry.geometryType;
+        geoData.flags = geometry.flags;
+        geoData.readbackMem = readbackmem.mem;
+        geoData.memSize = readbackmem.size;
+        geoData.memAlignment = mrq.alignment;
+
+        metadata->geometryData.push_back(geoData);
+
+        VkAccelerationStructureBuildRangeInfoKHR buildData = rangeInfo;
+        buildData.primitiveOffset = 0;
+
+        metadata->buildRangeInfo.push_back(buildData);
+
+        break;
+      }
+      default: RDCERR("Unhandled geometry type: %d", geometry.geometryType); return;
+    }
+
+    // Insert barriers to block any other commands until the buffers are copied
+    if(!barriers.empty())
+    {
+      ObjDisp(device)->CmdPipelineBarrier(Unwrap(commandBuffer), VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0, VK_NULL_HANDLE,
+                                          static_cast<uint32_t>(barriers.size()), barriers.data(),
+                                          0, VK_NULL_HANDLE);
+    }
+
+    // We can schedule buffer deletion now as it isn't needed anymore
+    if(readbackmem.buf != VK_NULL_HANDLE)
+      m_pDriver->AddPendingObjectCleanup([device, readbackmem]() {
+        ObjDisp(device)->DestroyBuffer(Unwrap(device), readbackmem.buf, NULL);
+      });
+  }
+
+  // Attach the metadata to the AS record
+  asRecord->accelerationStructureInfo = metadata;
+}
+
+void VulkanAccelerationStructureManager::CopyAccelerationStructure(
+    VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureInfoKHR &pInfo)
+{
+  VkResourceRecord *srcRecord = GetRecord(pInfo.src);
+  RDCASSERT(srcRecord != NULL);
+  RDCASSERT(srcRecord->accelerationStructureInfo != NULL);
+
+  VkResourceRecord *dstRecord = GetRecord(pInfo.dst);
+  RDCASSERT(dstRecord != NULL);
+
+  // If there's existing metadata in the dst, then clean up any copied input buffers before we
+  // overwrite it
+  SAFE_DELETE(dstRecord->accelerationStructureInfo);
+
+  // We ignore the mode as it can only be a clone or compaction, and we perform the same task
+  // regardless
+  VkAccelerationStructureInfo *info = new VkAccelerationStructureInfo();
+  *info = *srcRecord->accelerationStructureInfo;
+  info->accelerationStructure = pInfo.dst;
+
+  // Duplicate the readbackMem.  The better solution would be to refCount the
+  // VkAccelerationStructureInfo
+  for(VkAccelerationStructureInfo::GeometryData &geom : info->geometryData)
+  {
+    const Allocation alloc = CreateReadBackMemory(info->device, geom.memSize, geom.memAlignment);
+
+    const VkBuffer srcBuffer = CreateReadBackBuffer(info->device, geom.memSize);
+    RDCASSERT(srcBuffer != VK_NULL_HANDLE);
+
+    VkResult vkr =
+        ObjDisp(info->device)->BindBufferMemory(Unwrap(info->device), srcBuffer, geom.readbackMem, 0);
+    RDCASSERT(vkr == VK_SUCCESS);
+
+    VkBufferCopy region = {
+        0,
+        0,
+        geom.memSize,
+    };
+    ObjDisp(info->device)->CmdCopyBuffer(Unwrap(commandBuffer), srcBuffer, alloc.buf, 1, &region);
+
+    geom.readbackMem = alloc.mem;
+  }
+
+  dstRecord->accelerationStructureInfo = info;
+}
+
+VkFence VulkanAccelerationStructureManager::DeleteReadbackMemOnCompletion(uint32_t submitCount,
+                                                                          const VkSubmitInfo *pSubmits,
+                                                                          VkFence fence)
+{
+  SCOPED_LOCK(m_ReadbackMemDeleteLock);
+
+  // Find any command buffers we're interested in
+  rdcarray<VkAccelerationStructureInfo *> infos;
+  for(uint32_t i = 0; i < submitCount; ++i)
+  {
+    for(uint32_t j = 0; j < pSubmits[i].commandBufferCount; ++j)
+    {
+      const VkCommandBuffer cmdBuf = pSubmits[i].pCommandBuffers[j];
+
+      const auto rng = m_ReadbackMemToDelete.equal_range(cmdBuf);
+      for(auto it = rng.first; it != rng.second; ++it)
+        infos.push_back(it->second);
+
+      m_ReadbackMemToDelete.erase(cmdBuf);
+    }
+  }
+
+  // Nothing to do
+  if(infos.empty())
+    return VK_NULL_HANDLE;
+
+  // Create a fence if the target hasn't provided one
+  VkFence asFence = VK_NULL_HANDLE;
+  if(fence == VK_NULL_HANDLE)
+  {
+    const VkDevice d = m_pDriver->GetDev();
+    const VkFenceCreateInfo info = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, NULL, 0};
+
+    const VkResult vkr = ObjDisp(d)->CreateFence(Unwrap(d), &info, NULL, &asFence);
     m_pDriver->CheckVkResult(vkr);
 
-    // Copy the data using host-commands but into mapped memory
-    VkCopyAccelerationStructureToMemoryInfoKHR copyInfo = {
-        VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, NULL};
-    copyInfo.src = unwrappedAs;
-    copyInfo.dst.hostAddress = mappedDstBuffer;
-    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
-    ObjDisp(d)->CopyAccelerationStructureToMemoryKHR(Unwrap(d), VK_NULL_HANDLE, &copyInfo);
+    m_DeleteFence.push_back(asFence);
   }
-  else
+
+  const VkFence fenceToUse = asFence == VK_NULL_HANDLE ? Unwrap(fence) : asFence;
+  m_ReadbackMemDeleteSync.emplace(fenceToUse, std::move(infos));
+
+  if(m_ReadbackDeleteThread == 0 && !m_ReadbackMemDeleteSync.empty())
   {
-    VkCopyAccelerationStructureToMemoryInfoKHR copyInfo = {
-        VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, NULL};
-    copyInfo.src = unwrappedAs;
-    copyInfo.dst.deviceAddress = dstBufAddr;
-    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
-    ObjDisp(d)->CmdCopyAccelerationStructureToMemoryKHR(Unwrap(cmd), &copyInfo);
+    m_ExitReadbackDeleteThread = 0;
+    m_ReadbackDeleteThread = Threading::CreateThread([this]() {
+      while(Atomic::CmpExch32(&m_ExitReadbackDeleteThread, 0, 0) == 0)
+      {
+        Threading::Sleep(20);
 
-    // It's not ideal but we have to flush here because we need to map the data in order to read
-    // the BLAS addresses which means we need to have ensured that it has been copied beforehand
-    m_pDriver->CloseInitStateCmd();
-    m_pDriver->SubmitCmds();
-    m_pDriver->FlushQ();
+        const VkDevice d = m_pDriver->GetDev();
+        if(d == VK_NULL_HANDLE)
+          return;
 
-    // Now serialised AS data has been copied to a readable buffer, we need to expose the data to
-    // the host
-    size = AlignUp(handleCountOffset + handleCountSize, nonCoherentAtomSize);
+        SCOPED_LOCK(m_ReadbackMemDeleteLock);
+        for(auto it = m_ReadbackMemDeleteSync.begin(); it != m_ReadbackMemDeleteSync.end();)
+        {
+          const VkResult vkr = ObjDisp(d)->GetFenceStatus(Unwrap(d), it->first);
+          if(vkr == VK_SUCCESS)
+          {
+            // Fence signalled so we can delete our readback mems, but check if the resource hasn't
+            // been deleted already just in case
+            for(VkAccelerationStructureInfo *info : it->second)
+            {
+              VkResourceRecord *asRecord = GetRecord(info->accelerationStructure);
+              if(asRecord != NULL)
+                SAFE_DELETE(info);
+            }
 
-    vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(readbackmem.mem), readbackmem.offs, size, 0,
-                                (void **)&mappedDstBuffer);
-    m_pDriver->CheckVkResult(vkr);
+            if(m_DeleteFence.contains(it->first))
+            {
+              ObjDisp(d)->DestroyFence(Unwrap(d), it->first, NULL);
+              m_DeleteFence.removeOne(it->first);
+            }
+
+            it = m_ReadbackMemDeleteSync.erase(it);
+            continue;
+          }
+          ++it;
+        }
+      }
+    });
   }
 
-  // invalidate the cpu cache for this memory range to avoid reading stale data
-  const VkMappedMemoryRange range = {
-      VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, NULL, Unwrap(readbackmem.mem), readbackmem.offs, size,
-  };
-  vkr = ObjDisp(d)->InvalidateMappedMemoryRanges(Unwrap(d), 1, &range);
-  m_pDriver->CheckVkResult(vkr);
+  return asFence;
+}
 
-  // Count the BLAS device addresses to update the AS type
-  const uint64_t handleCount = *(uint64_t *)(mappedDstBuffer + handleCountOffset);
-  result = {readbackmem, true};
-  result.isTLAS = handleCount > 0;
+uint64_t VulkanAccelerationStructureManager::GetSize_InitialState(ResourceId id,
+                                                                  const VkInitialContents &initial)
+{
+  const VkAccelerationStructureInfo *info = initial.accelerationStructureInfo;
+  RDCASSERT(info);
+  if(!info)
+    return 0;
 
-  ObjDisp(d)->UnmapMemory(Unwrap(d), Unwrap(result.alloc.mem));
+  // You can't just use sizeof(Triangles) due to padding
+  const uint64_t triangleSize = sizeof(VkFormat) +        // vertexFormat
+                                sizeof(VkDeviceSize) +    // vertexStride
+                                sizeof(uint32_t) +        // maxVertex
+                                sizeof(VkIndexType) +     // indexType
+                                sizeof(bool);             // hasTransformData
 
-  return true;
+  const uint64_t geomDataSize = sizeof(VkGeometryTypeKHR) +     // geometryType
+                                sizeof(VkGeometryFlagsKHR) +    // flags
+                                sizeof(VkDeviceSize) +          // memSize
+                                sizeof(VkDeviceSize) +          // memAlignment
+                                triangleSize;                   // Union size
+
+  const uint64_t numGeomData = info->geometryData.size();
+  const uint64_t numBuildInfo = info->buildRangeInfo.size();
+
+  // Sum up the metadata size
+  const uint64_t metadataSize =
+      sizeof(VkAccelerationStructureTypeKHR) +             // type
+      sizeof(VkBuildAccelerationStructureFlagsKHR) +       // flags
+      sizeof(uint64_t) + (geomDataSize * numGeomData) +    // geometryData
+      sizeof(uint64_t) +
+      (sizeof(VkAccelerationStructureBuildRangeInfoKHR) * numBuildInfo);    // buildRangeInfo
+
+  // Sum up the input buffer sizes
+  uint64_t bufferSize = 0;
+  for(const VkAccelerationStructureInfo::GeometryData &geom : info->geometryData)
+    bufferSize += sizeof(uint64_t) + geom.memSize + WriteSerialiser::GetChunkAlignment();
+
+  return 128ULL + metadataSize + bufferSize;
 }
 
 template <typename SerialiserType>
@@ -168,122 +840,156 @@ bool VulkanAccelerationStructureManager::Serialise(SerialiserType &ser, Resource
                                                    const VkInitialContents *initial,
                                                    CaptureState state)
 {
-  VkDevice d = !IsStructuredExporting(state) ? m_pDriver->GetDev() : VK_NULL_HANDLE;
-  const bool replayingAndReading = ser.IsReading() && IsReplayMode(state);
-  VkResult vkr = VK_SUCCESS;
-
-  byte *contents = NULL;
-  uint64_t contentsSize = initial ? initial->mem.size : 0;
-  MemoryAllocation mappedMem;
-
-  // Serialise this separately so that it can be used on reading to prepare the upload memory
-  SERIALISE_ELEMENT(contentsSize);
-
   const VkDeviceSize nonCoherentAtomSize = m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize;
 
-  // the memory/buffer that we allocated on read, to upload the initial contents.
-  MemoryAllocation uploadMemory;
-  VkBuffer uploadBuf = VK_NULL_HANDLE;
-
-  if(ser.IsWriting())
+  VkAccelerationStructureInfo *asInfo = initial ? initial->accelerationStructureInfo : NULL;
+  if(ser.IsReading())
   {
-    if(initial && initial->mem.mem != VK_NULL_HANDLE)
-    {
-      const VkDeviceSize size = AlignUp(initial->mem.size, nonCoherentAtomSize);
+    asInfo = new VkAccelerationStructureInfo();
+  }
 
-      mappedMem = initial->mem;
-      vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(mappedMem.mem), initial->mem.offs, size, 0,
+  RDCASSERT(asInfo != NULL);
+  SERIALISE_ELEMENT(*asInfo).Hidden();
+
+  VkDevice d = !IsStructuredExporting(state) ? m_pDriver->GetDev() : VK_NULL_HANDLE;
+  VkResult vkr = VK_SUCCESS;
+
+  for(VkAccelerationStructureInfo::GeometryData &geomData : asInfo->geometryData)
+  {
+    Allocation uploadMemory;
+    byte *contents = NULL;
+
+    if(ser.IsWriting())
+    {
+      // The input buffers have already been copied into readable memory, so they just need mapping
+      // and serialising
+      vkr = ObjDisp(d)->MapMemory(Unwrap(d), geomData.readbackMem, 0, geomData.memSize, 0,
                                   (void **)&contents);
       m_pDriver->CheckVkResult(vkr);
 
       // invalidate the cpu cache for this memory range to avoid reading stale data
       const VkMappedMemoryRange range = {
-          VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, NULL, Unwrap(mappedMem.mem), mappedMem.offs, size,
+          VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, NULL, geomData.readbackMem, 0, geomData.memSize,
       };
 
       vkr = ObjDisp(d)->InvalidateMappedMemoryRanges(Unwrap(d), 1, &range);
       m_pDriver->CheckVkResult(vkr);
     }
-  }
-  else if(IsReplayMode(state) && !ser.IsErrored())
-  {
-    // create a buffer with memory attached, which we will fill with the initial contents
-    const VkBufferCreateInfo bufInfo = {
-        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-        NULL,
-        0,
-        contentsSize,
-        VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
-            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-    };
-
-    vkr = m_pDriver->vkCreateBuffer(d, &bufInfo, NULL, &uploadBuf);
-    m_pDriver->CheckVkResult(vkr);
-
-    VkMemoryRequirements mrq = {};
-    m_pDriver->vkGetBufferMemoryRequirements(d, uploadBuf, &mrq);
-
-    mrq.alignment = RDCMAX(mrq.alignment, asBufferAlignment);
-
-    uploadMemory = m_pDriver->AllocateMemoryForResource(true, mrq, MemoryScope::InitialContents,
-                                                        MemoryType::Upload);
-
-    if(uploadMemory.mem == VK_NULL_HANDLE)
-      return false;
-
-    vkr = m_pDriver->vkBindBufferMemory(d, uploadBuf, uploadMemory.mem, uploadMemory.offs);
-    m_pDriver->CheckVkResult(vkr);
-
-    mappedMem = uploadMemory;
-
-    vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(mappedMem.mem), mappedMem.offs,
-                                AlignUp(mappedMem.size, nonCoherentAtomSize), 0, (void **)&contents);
-    m_pDriver->CheckVkResult(vkr);
-
-    if(!contents)
+    else if(IsReplayMode(state) && !ser.IsErrored())
     {
-      RDCERR("Manually reporting failed memory map");
-      m_pDriver->CheckVkResult(VK_ERROR_MEMORY_MAP_FAILED);
-      return false;
-    }
+      uploadMemory =
+          CreateReplayMemory(MemoryType::Upload, geomData.memSize, geomData.memAlignment,
+                             VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR);
+      if(uploadMemory.mem == VK_NULL_HANDLE)
+      {
+        RDCERR("Failed to allocate AS build data upload buffer");
+        return false;
+      }
 
-    if(vkr != VK_SUCCESS)
-      return false;
-  }
+      m_pDriver->AddPendingObjectCleanup([d, uploadMemory]() {
+        ObjDisp(d)->DestroyBuffer(Unwrap(d), uploadMemory.buf, NULL);
+        ObjDisp(d)->FreeMemory(Unwrap(d), uploadMemory.mem, NULL);
+      });
 
-  // not using SERIALISE_ELEMENT_ARRAY so we can deliberately avoid allocation - we serialise
-  // directly into upload memory
-  ser.Serialise("Serialised AS"_lit, contents, contentsSize, SerialiserFlags::NoFlags).Important();
-
-  // unmap the resource we mapped before - we need to do this on read and on write.
-  bool isTLAS = false;
-  if(!IsStructuredExporting(state) && mappedMem.mem != VK_NULL_HANDLE)
-  {
-    if(replayingAndReading)
-    {
-      // first ensure we flush the writes from the cpu to gpu memory
-      const VkMappedMemoryRange range = {
-          VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,        NULL, Unwrap(mappedMem.mem), mappedMem.offs,
-          AlignUp(mappedMem.size, nonCoherentAtomSize),
-      };
-
-      vkr = ObjDisp(d)->FlushMappedMemoryRanges(Unwrap(d), 1, &range);
+      vkr = ObjDisp(d)->MapMemory(Unwrap(d), uploadMemory.mem, 0,
+                                  AlignUp(geomData.memSize, nonCoherentAtomSize), 0,
+                                  (void **)&contents);
       m_pDriver->CheckVkResult(vkr);
 
-      // Read the AS's BLAS handle count to determine if it's top or bottom level
-      isTLAS = *((uint64_t *)(contents + handleCountOffset)) > 0;
+      if(!contents)
+      {
+        RDCERR("Manually reporting failed memory map");
+        m_pDriver->CheckVkResult(VK_ERROR_MEMORY_MAP_FAILED);
+        return false;
+      }
+
+      if(vkr != VK_SUCCESS)
+        return false;
     }
 
-    ObjDisp(d)->UnmapMemory(Unwrap(d), Unwrap(mappedMem.mem));
+    // not using SERIALISE_ELEMENT_ARRAY so we can deliberately avoid allocation - we serialise
+    // directly into upload memory
+    ser.Serialise("AS Input"_lit, contents, geomData.memSize, SerialiserFlags::NoFlags).Hidden();
+
+    if(!IsStructuredExporting(state))
+    {
+      if(uploadMemory.mem != VK_NULL_HANDLE)
+      {
+        // first ensure we flush the writes from the cpu to gpu memory
+        const VkMappedMemoryRange range = {
+            VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,          NULL, uploadMemory.mem, 0,
+            AlignUp(geomData.memSize, nonCoherentAtomSize),
+        };
+
+        vkr = ObjDisp(d)->FlushMappedMemoryRanges(Unwrap(d), 1, &range);
+        m_pDriver->CheckVkResult(vkr);
+
+        ObjDisp(d)->UnmapMemory(Unwrap(d), uploadMemory.mem);
+
+        // Allocate GPU memory and copy the AS input upload data into it
+        const VkBufferCreateInfo gpuBufInfo = {
+            VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+            NULL,
+            0,
+            geomData.memSize,
+            VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
+        };
+
+        VkBuffer gpuBuf = VK_NULL_HANDLE;
+        vkr = m_pDriver->vkCreateBuffer(d, &gpuBufInfo, NULL, &gpuBuf);
+        m_pDriver->CheckVkResult(vkr);
+
+        VkMemoryRequirements mrq = {};
+        m_pDriver->vkGetBufferMemoryRequirements(d, gpuBuf, &mrq);
+
+        mrq.alignment = RDCMAX(mrq.alignment, geomData.memAlignment);
+
+        const MemoryAllocation gpuMemory = m_pDriver->AllocateMemoryForResource(
+            true, mrq, MemoryScope::InitialContents, MemoryType::GPULocal);
+        if(gpuMemory.mem == VK_NULL_HANDLE)
+        {
+          RDCERR("Failed to allocate AS build data GPU buffer");
+          return false;
+        }
+
+        vkr = ObjDisp(d)->BindBufferMemory(Unwrap(d), Unwrap(gpuBuf), Unwrap(gpuMemory.mem),
+                                           gpuMemory.offs);
+        m_pDriver->CheckVkResult(vkr);
+
+        VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
+        if(cmd == VK_NULL_HANDLE)
+        {
+          RDCERR("Couldn't acquire command buffer");
+          return false;
+        }
+
+        VkBufferCopy region = {
+            0,
+            0,
+            AlignUp(geomData.memSize, nonCoherentAtomSize),
+        };
+        ObjDisp(d)->CmdCopyBuffer(Unwrap(cmd), uploadMemory.buf, Unwrap(gpuBuf), 1, &region);
+
+        geomData.replayBuf = gpuBuf;
+      }
+      else
+      {
+        ObjDisp(d)->UnmapMemory(Unwrap(d), geomData.readbackMem);
+      }
+    }
   }
 
   SERIALISE_CHECK_READ_ERRORS();
 
-  if(IsReplayMode(state) && contentsSize > 0)
+  if(IsReplayMode(state))
   {
-    VkInitialContents initialContents(eResAccelerationStructureKHR, uploadMemory);
-    initialContents.isTLAS = isTLAS;
-    initialContents.buf = uploadBuf;
+    VkInitialContents initialContents;
+    initialContents.type = eResAccelerationStructureKHR;
+    initialContents.isTLAS = asInfo->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR ||
+                             asInfo->type == VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+    initialContents.accelerationStructureInfo = asInfo;
 
     m_pDriver->GetResourceManager()->SetInitialContents(id, initialContents);
   }
@@ -300,6 +1006,92 @@ template bool VulkanAccelerationStructureManager::Serialise(WriteSerialiser &ser
 
 void VulkanAccelerationStructureManager::Apply(ResourceId id, const VkInitialContents &initial)
 {
+  VkAccelerationStructureInfo *asInfo = initial.accelerationStructureInfo;
+  RDCASSERT(asInfo);
+
+  rdcarray<VkAccelerationStructureGeometryKHR> asGeomData = asInfo->convertGeometryData();
+  RDCASSERT(!asGeomData.empty());
+  RDCASSERT(asInfo->geometryData.size() == asGeomData.size());
+
+  const VkDevice d = m_pDriver->GetDev();
+
+  if(!FixUpReplayBDAs(initial.accelerationStructureInfo, asGeomData))
+    return;
+
+  // Allocate the scratch buffer which involves working out how big it should be
+  VkAccelerationStructureBuildSizesInfoKHR sizeResult = {
+      VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR,
+      NULL,
+  };
+  {
+    const VkAccelerationStructureBuildGeometryInfoKHR sizeInfo = {
+        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR,
+        NULL,
+        asInfo->type,
+        asInfo->flags,
+        VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR,
+        VK_NULL_HANDLE,
+        VK_NULL_HANDLE,
+        (uint32_t)asGeomData.size(),
+        asGeomData.data(),
+        VK_NULL_HANDLE,
+    };
+
+    rdcarray<uint32_t> counts;
+    counts.reserve(asGeomData.size());
+    for(VkAccelerationStructureBuildRangeInfoKHR numPrims : asInfo->buildRangeInfo)
+    {
+      counts.push_back(numPrims.primitiveCount);
+    }
+
+    ObjDisp(d)->GetAccelerationStructureBuildSizesKHR(
+        Unwrap(d), VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &sizeInfo, counts.data(),
+        &sizeResult);
+  }
+
+  const VkPhysicalDevice physDev = m_pDriver->GetPhysDev();
+
+  VkPhysicalDeviceAccelerationStructurePropertiesKHR asProps = {
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR,
+  };
+  VkPhysicalDeviceProperties2 asPropsBase = {
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
+      &asProps,
+  };
+  ObjDisp(physDev)->GetPhysicalDeviceProperties2(Unwrap(physDev), &asPropsBase);
+
+  // We serialise the AS builds, so reuse the existing scratch
+  if(sizeResult.buildScratchSize > scratch.size || scratch.mem == VK_NULL_HANDLE)
+  {
+    // Delete the previous
+    if(scratch.mem != VK_NULL_HANDLE)
+    {
+      m_pDriver->AddPendingObjectCleanup([d, tmp = scratch]() {
+        ObjDisp(d)->DestroyBuffer(Unwrap(d), tmp.buf, NULL);
+        ObjDisp(d)->FreeMemory(Unwrap(d), tmp.mem, NULL);
+      });
+    }
+
+    scratch = CreateReplayMemory(MemoryType::GPULocal, sizeResult.buildScratchSize,
+                                 asProps.minAccelerationStructureScratchOffsetAlignment,
+                                 VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
+    if(scratch.mem == VK_NULL_HANDLE)
+    {
+      RDCERR("Failed to allocate AS build data scratch buffer");
+      return;
+    }
+
+    const VkBufferDeviceAddressInfo scratchAddressInfo = {
+        VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
+        NULL,
+        scratch.buf,
+    };
+
+    scratchAddressUnion.deviceAddress =
+        ObjDisp(d)->GetBufferDeviceAddressKHR(Unwrap(d), &scratchAddressInfo);
+  }
+
+  // Build the AS
   VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
   if(cmd == VK_NULL_HANDLE)
   {
@@ -307,88 +1099,245 @@ void VulkanAccelerationStructureManager::Apply(ResourceId id, const VkInitialCon
     return;
   }
 
-  const VkAccelerationStructureKHR unwrappedAs =
-      Unwrap(m_pDriver->GetResourceManager()->GetCurrentHandle<VkAccelerationStructureKHR>(id));
-  const VkDevice d = m_pDriver->GetDev();
+  const VkAccelerationStructureKHR wrappedAS =
+      m_pDriver->GetResourceManager()->GetCurrentHandle<VkAccelerationStructureKHR>(id);
 
-  VkMarkerRegion::Begin(StringFormat::Fmt("Initial state for %s", ToStr(id).c_str()), cmd);
+  const VkAccelerationStructureBuildGeometryInfoKHR asGeomInfo = {
+      VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR,
+      NULL,
+      asInfo->type,
+      asInfo->flags,
+      VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR,
+      VK_NULL_HANDLE,
+      Unwrap(wrappedAS),
+      (uint32_t)asGeomData.size(),
+      asGeomData.data(),
+      NULL,
+      scratchAddressUnion,
+  };
 
-  if(m_pDriver->GetDriverInfo().MaliBrokenASDeviceSerialisation())
-  {
-    const VkDeviceSize size =
-        AlignUp(initial.mem.size, m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize);
+  const VkAccelerationStructureBuildRangeInfoKHR *pBuildInfo = asInfo->buildRangeInfo.data();
+  ObjDisp(d)->CmdBuildAccelerationStructuresKHR(Unwrap(cmd), 1, &asGeomInfo, &pBuildInfo);
 
-    // Copy the data using host-commands but from mapped memory
-    byte *mappedSrcBuffer = NULL;
-    VkResult vkr = ObjDisp(d)->MapMemory(Unwrap(d), Unwrap(initial.mem.mem), initial.mem.offs, size,
-                                         0, (void **)&mappedSrcBuffer);
-    m_pDriver->CheckVkResult(vkr);
-
-    VkCopyMemoryToAccelerationStructureInfoKHR copyInfo = {
-        VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR};
-    copyInfo.src.hostAddress = mappedSrcBuffer;
-    copyInfo.dst = unwrappedAs;
-    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
-    ObjDisp(d)->CopyMemoryToAccelerationStructureKHR(Unwrap(d), VK_NULL_HANDLE, &copyInfo);
-  }
-  else
-  {
-    const VkBufferDeviceAddressInfo addrInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
-                                                Unwrap(initial.buf)};
-    const VkDeviceAddress uploadBufAddr = ObjDisp(d)->GetBufferDeviceAddressKHR(Unwrap(d), &addrInfo);
-
-    VkCopyMemoryToAccelerationStructureInfoKHR copyInfo = {
-        VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR};
-    copyInfo.src.deviceAddress = uploadBufAddr;
-    copyInfo.dst = unwrappedAs;
-    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
-    ObjDisp(d)->CmdCopyMemoryToAccelerationStructureKHR(Unwrap(cmd), &copyInfo);
-  }
-
-  VkMarkerRegion::End(cmd);
-
-  if(Vulkan_Debug_SingleSubmitFlushing())
-  {
-    m_pDriver->CloseInitStateCmd();
-    m_pDriver->SubmitCmds();
-    m_pDriver->FlushQ();
-  }
-}
-
-VkDeviceSize VulkanAccelerationStructureManager::SerialisedASSize(VkAccelerationStructureKHR unwrappedAs)
-{
-  VkDevice d = m_pDriver->GetDev();
-
-  // Create query pool
-  VkQueryPoolCreateInfo info = {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
-  info.queryCount = 1;
-  info.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR;
-
-  VkQueryPool pool;
-  VkResult vkr = ObjDisp(d)->CreateQueryPool(Unwrap(d), &info, NULL, &pool);
-  m_pDriver->CheckVkResult(vkr);
-
-  // Reset query pool
-  VkCommandBuffer cmd = m_pDriver->GetInitStateCmd();
-  ObjDisp(d)->CmdResetQueryPool(Unwrap(cmd), pool, 0, 1);
-
-  // Get the size
-  ObjDisp(d)->CmdWriteAccelerationStructuresPropertiesKHR(
-      Unwrap(cmd), 1, &unwrappedAs, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR,
-      pool, 0);
-
+  // We serialise the AS builds so we can have just a single scratch buffer and reuse it
   m_pDriver->CloseInitStateCmd();
   m_pDriver->SubmitCmds();
   m_pDriver->FlushQ();
+}
 
-  VkDeviceSize size = 0;
-  vkr = ObjDisp(d)->GetQueryPoolResults(Unwrap(d), pool, 0, 1, sizeof(VkDeviceSize), &size,
-                                        sizeof(VkDeviceSize),
-                                        VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+VkBuffer VulkanAccelerationStructureManager::CreateReadBackBuffer(VkDevice device, VkDeviceSize size)
+{
+  VkResult vkr = VK_SUCCESS;
+
+  VkBufferCreateInfo bufInfo = {
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+      NULL,
+      0,
+      size,
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+  };
+
+  // we make the buffer concurrently accessible by all queue families to not invalidate the
+  // contents of the memory we're reading back from.
+  bufInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
+  bufInfo.queueFamilyIndexCount = (uint32_t)m_pDriver->GetQueueFamilyIndices().size();
+  bufInfo.pQueueFamilyIndices = m_pDriver->GetQueueFamilyIndices().data();
+
+  // spec requires that CONCURRENT must specify more than one queue family. If there is only one
+  // queue family, we can safely use exclusive.
+  if(bufInfo.queueFamilyIndexCount == 1)
+    bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+  VkBuffer result;
+  vkr = ObjDisp(device)->CreateBuffer(Unwrap(device), &bufInfo, NULL, &result);
+  if(vkr != VK_SUCCESS)
+  {
+    RDCERR("Failed to create readback buffer");
+    return VK_NULL_HANDLE;
+  }
+
+  return result;
+}
+
+VulkanAccelerationStructureManager::Allocation VulkanAccelerationStructureManager::CreateReadBackMemory(
+    VkDevice device, VkDeviceSize size, VkDeviceSize alignment)
+{
+  VkResult vkr = VK_SUCCESS;
+
+  Allocation readbackmem;
+  readbackmem.buf = CreateReadBackBuffer(device, size);
+  if(readbackmem.buf == VK_NULL_HANDLE)
+    return {};
+
+  VkMemoryRequirements mrq = {};
+  ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), readbackmem.buf, &mrq);
+
+  if(alignment != 0)
+    mrq.alignment = RDCMAX(mrq.alignment, alignment);
+
+  readbackmem.size = AlignUp(mrq.size, mrq.alignment);
+  readbackmem.size =
+      AlignUp(readbackmem.size, m_pDriver->GetDeviceProps().limits.nonCoherentAtomSize);
+
+  VkMemoryAllocateFlagsInfo flagsInfo = {
+      VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO,
+      NULL,
+      VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT,
+  };
+  VkMemoryAllocateInfo info = {
+      VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+      &flagsInfo,
+      readbackmem.size,
+      m_pDriver->GetReadbackMemoryIndex(mrq.memoryTypeBits),
+  };
+
+  vkr = ObjDisp(device)->AllocateMemory(Unwrap(device), &info, NULL, &readbackmem.mem);
+  if(vkr != VK_SUCCESS)
+  {
+    RDCERR("Failed to allocate readback memory");
+    return {};
+  }
+
+  vkr = ObjDisp(device)->BindBufferMemory(Unwrap(device), readbackmem.buf, readbackmem.mem, 0);
+  if(vkr != VK_SUCCESS)
+  {
+    RDCERR("Failed to bind readback memory");
+    return {};
+  }
+
+  return readbackmem;
+}
+
+VulkanAccelerationStructureManager::Allocation VulkanAccelerationStructureManager::CreateReplayMemory(
+    MemoryType memType, VkDeviceSize size, VkDeviceSize alignment, VkBufferUsageFlags extraUsageFlags)
+{
+  const VkBufferCreateInfo bufInfo = {
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+      NULL,
+      0,
+      size,
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | extraUsageFlags,
+  };
+
+  const VkDevice d = m_pDriver->GetDev();
+  VkBuffer buf = VK_NULL_HANDLE;
+
+  VkResult vkr = ObjDisp(d)->CreateBuffer(Unwrap(d), &bufInfo, NULL, &buf);
   m_pDriver->CheckVkResult(vkr);
 
-  // Clean up
-  ObjDisp(d)->DestroyQueryPool(Unwrap(d), pool, NULL);
+  VkMemoryRequirements mrq = {};
+  ObjDisp(d)->GetBufferMemoryRequirements(Unwrap(d), buf, &mrq);
 
-  return size;
+  if(alignment != 0)
+    mrq.alignment = RDCMAX(mrq.alignment, alignment);
+
+  uint32_t memoryTypeIndex = 0;
+  switch(memType)
+  {
+    case MemoryType::Upload:
+      memoryTypeIndex = m_pDriver->GetUploadMemoryIndex(mrq.memoryTypeBits);
+      break;
+    case MemoryType::GPULocal:
+      memoryTypeIndex = m_pDriver->GetGPULocalMemoryIndex(mrq.memoryTypeBits);
+      break;
+    case MemoryType::Readback:
+      memoryTypeIndex = m_pDriver->GetReadbackMemoryIndex(mrq.memoryTypeBits);
+      break;
+  }
+
+  VkMemoryAllocateFlagsInfo flagsInfo = {
+      VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO,
+      NULL,
+      VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT,
+  };
+  VkMemoryAllocateInfo info = {
+      VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+      &flagsInfo,
+      size,
+      memoryTypeIndex,
+  };
+
+  VkDeviceMemory mem = VK_NULL_HANDLE;
+  vkr = ObjDisp(d)->AllocateMemory(Unwrap(d), &info, NULL, &mem);
+  m_pDriver->CheckVkResult(vkr);
+
+  vkr = ObjDisp(d)->BindBufferMemory(Unwrap(d), buf, mem, 0);
+  m_pDriver->CheckVkResult(vkr);
+
+  return {mem, size, buf};
+}
+
+bool VulkanAccelerationStructureManager::FixUpReplayBDAs(
+    VkAccelerationStructureInfo *asInfo, rdcarray<VkAccelerationStructureGeometryKHR> &geoms)
+{
+  RDCASSERT(asInfo);
+  RDCASSERT(asInfo->geometryData.size() == geoms.size());
+
+  const VkDevice d = m_pDriver->GetDev();
+
+  for(uint64_t i = 0; i < geoms.size(); ++i)
+  {
+    VkBuffer buf = asInfo->geometryData[i].replayBuf;
+    VkAccelerationStructureGeometryKHR &geom = geoms[i];
+
+    const VkBufferDeviceAddressInfo addrInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
+                                                Unwrap(buf)};
+    const VkDeviceAddress bufAddr = ObjDisp(d)->GetBufferDeviceAddressKHR(Unwrap(d), &addrInfo);
+
+    switch(geom.geometryType)
+    {
+      case VK_GEOMETRY_TYPE_TRIANGLES_KHR:
+      {
+        geom.geometry.triangles.vertexData.deviceAddress = bufAddr;
+        geom.geometry.triangles.indexData.deviceAddress = bufAddr;
+        geom.geometry.triangles.transformData.deviceAddress = bufAddr;
+        break;
+      }
+      case VK_GEOMETRY_TYPE_AABBS_KHR:
+      {
+        geom.geometry.aabbs.data.deviceAddress = bufAddr;
+        break;
+      }
+      case VK_GEOMETRY_TYPE_INSTANCES_KHR:
+      {
+        geom.geometry.instances.data.deviceAddress = bufAddr;
+        break;
+      }
+      default: RDCERR("Unhandled geometry type: %d", geom.geometryType); return false;
+    }
+  }
+
+  return true;
+}
+
+VulkanAccelerationStructureManager::RecordAndOffset VulkanAccelerationStructureManager::GetDeviceAddressData(
+    VkDeviceAddress address) const
+{
+  if(m_DeviceAddressToRecord.empty())
+    return {};
+
+  auto it =
+      std::lower_bound(m_DeviceAddressToRecord.begin(), m_DeviceAddressToRecord.end(), address,
+                       [](const auto &pair, VkDeviceAddress addr) { return pair.first < addr; });
+  if(it != m_DeviceAddressToRecord.end())
+  {
+    // It's a match!
+    if(it->first == address)
+      return {it->second, it->first, 0};
+
+    // The address is before the first entry starts
+    if(it == m_DeviceAddressToRecord.begin())
+      return {};
+  }
+
+  // The address is inbetween two entries, so work out the offset and make sure it's less than
+  // the buffer size
+  auto prevIt = std::prev(it);
+  const VkDeviceSize offset = address - prevIt->first;
+  if(offset >= prevIt->second->memSize)
+    return {};
+
+  return {prevIt->second, prevIt->first, offset};
 }

--- a/renderdoc/driver/vulkan/vk_common.cpp
+++ b/renderdoc/driver/vulkan/vk_common.cpp
@@ -1178,19 +1178,6 @@ VkDriverInfo::VkDriverInfo(const VkPhysicalDeviceProperties &physProps,
       qualcommLeakingUBOOffsets = true;
     }
   }
-
-  if(driverProps.driverID == VK_DRIVER_ID_ARM_PROPRIETARY)
-  {
-    if(Major() >= 36 && Major() < 43)
-    {
-      if(active)
-        RDCLOG(
-            "Using host acceleration structure deserialisation commands on Mali - update to a "
-            "newer "
-            "driver for fix");
-      maliBrokenASDeviceSerialisation = true;
-    }
-  }
 }
 
 FrameRefType GetRefType(DescriptorSlotType descType)

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -305,9 +305,6 @@ public:
   // If we do have a pipeline to bind, we should never be perturbing dynamic state in between static
   // pipeline binds.
   bool NVStaticPipelineRebindStates() const { return nvidiaStaticPipelineRebindStates; }
-  // On Mali there are some known issues regarding acceleration structure serialisation to device
-  // memory, for the affected driver versions we switch to the host command variants
-  bool MaliBrokenASDeviceSerialisation() const { return maliBrokenASDeviceSerialisation; }
 private:
   GPUVendor m_Vendor;
 
@@ -323,7 +320,6 @@ private:
   bool qualcommLineWidthCrash = false;
   bool intelBrokenOcclusionQueries = false;
   bool nvidiaStaticPipelineRebindStates = false;
-  bool maliBrokenASDeviceSerialisation = false;
 };
 
 enum

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -191,13 +191,13 @@ WrappedVulkan::~WrappedVulkan()
 
   SAFE_DELETE(m_StoredStructuredData);
 
+  SAFE_DELETE(m_ASManager);
+
   // in case the application leaked some objects, avoid crashing trying
   // to release them ourselves by clearing the resource manager.
   // In a well-behaved application, this should be a no-op.
   m_ResourceManager->ClearWithoutReleasing();
   SAFE_DELETE(m_ResourceManager);
-
-  SAFE_DELETE(m_ASManager);
 
   SAFE_DELETE(m_FrameReader);
 
@@ -1332,16 +1332,16 @@ static const VkExtensionProperties supportedExtensions[] = {
         VK_KHR_8BIT_STORAGE_EXTENSION_NAME,
         VK_KHR_8BIT_STORAGE_SPEC_VERSION,
     },
+    {
+        VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+        VK_KHR_ACCELERATION_STRUCTURE_SPEC_VERSION,
+    },
 #ifdef VK_KHR_android_surface
     {
         VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
         VK_KHR_ANDROID_SURFACE_SPEC_VERSION,
     },
 #endif
-    {
-        VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-        VK_KHR_ACCELERATION_STRUCTURE_SPEC_VERSION,
-    },
     {
         VK_KHR_BIND_MEMORY_2_EXTENSION_NAME,
         VK_KHR_BIND_MEMORY_2_SPEC_VERSION,

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1206,6 +1206,7 @@ public:
   void RemapQueueFamilyIndices(uint32_t &srcQueueFamily, uint32_t &dstQueueFamily);
   uint32_t GetQueueFamilyIndex() const { return m_QueueFamilyIdx; }
   bool ReleaseResource(WrappedVkRes *res);
+  const rdcarray<uint32_t> &GetQueueFamilyIndices() const { return m_QueueFamilyIndices; }
 
   void AddDebugMessage(MessageCategory c, MessageSeverity sv, MessageSource src, rdcstr d);
 

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -113,7 +113,8 @@ struct VkInitialContents
     SAFE_DELETE(sparseTables);
     SAFE_DELETE(sparseBind);
 
-    // MemoryAllocation and serialised ASes are not free'd here
+    // MemoryAllocation is not free'd here
+    // accelerationStructureInfo is owned by VkResourceRecord
   }
 
   // for descriptor heaps, when capturing we save the slots, when replaying we store direct writes
@@ -140,6 +141,7 @@ struct VkInitialContents
   SparseBinding *sparseBind;
 
   bool isTLAS;    // If the contents are an AS, this determines if it is a TLAS or BLAS
+  VkAccelerationStructureInfo *accelerationStructureInfo;
 };
 
 struct VulkanResourceManagerConfiguration

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -24,6 +24,7 @@
 
 #include "vk_resources.h"
 #include "maths/vec.h"
+#include "vk_acceleration_structure.h"
 #include "vk_info.h"
 
 WRAPPED_POOL_INST(WrappedVkInstance)
@@ -3981,6 +3982,9 @@ VkResourceRecord::~VkResourceRecord()
 
   if(resType == eResCommandPool)
     SAFE_DELETE(cmdPoolInfo);
+
+  if(resType == eResAccelerationStructureKHR)
+    SAFE_DELETE(accelerationStructureInfo);
 }
 
 void VkResourceRecord::MarkImageFrameReferenced(VkResourceRecord *img, const ImageRange &range,

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -2194,6 +2194,7 @@ inline FrameRefType MarkMemoryReferenced(std::unordered_map<ResourceId, MemRefs>
 
 struct DescUpdateTemplate;
 struct ImageLayouts;
+struct VkAccelerationStructureInfo;
 
 struct VkResourceRecord : public ResourceRecord
 {
@@ -2285,7 +2286,7 @@ public:
     DescPoolInfo *descPoolInfo;              // only for descriptor pools
     CmdPoolInfo *cmdPoolInfo;                // only for command pools
     uint32_t queueFamilyIndex;               // only for queues
-    bool accelerationStructureBuilt;         // only for acceleration structures
+    VkAccelerationStructureInfo *accelerationStructureInfo;    // only for acceleration structures
   };
 
   VkResourceRecord *bakedCommands;

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -7870,6 +7870,10 @@ void WrappedVulkan::vkCmdBuildAccelerationStructuresKHR(
 
       // Add to the command buffer metadata, so we can know when it has been submitted
       record->cmdInfo->accelerationStructures.push_back(GetRecord(geomInfo.dstAccelerationStructure));
+
+      if(IsBackgroundCapturing(m_State))
+        GetAccelerationStructureManager()->CopyInputBuffers(commandBuffer, geomInfo,
+                                                            ppBuildRangeInfos[i]);
     }
   }
 }
@@ -7921,6 +7925,9 @@ void WrappedVulkan::vkCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuf
 
     // Add to the command buffer metadata, so we can know when it has been submitted
     record->cmdInfo->accelerationStructures.push_back(GetRecord(pInfo->dst));
+
+    if(IsBackgroundCapturing(m_State))
+      GetAccelerationStructureManager()->CopyAccelerationStructure(commandBuffer, *pInfo);
   }
 }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -948,6 +948,8 @@ void WrappedVulkan::Shutdown()
   SubmitSemaphores();
   FlushQ();
 
+  GetAccelerationStructureManager()->Shutdown();
+
   // idle the device as well so that external queues are idle.
   if(m_Device)
   {

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -259,6 +259,8 @@ void WrappedVulkan::vkDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAl
 
     if(record->resInfo && record->resInfo->dedicatedMemory != ResourceId())
       GetResourceManager()->PreFreeMemory(record->resInfo->dedicatedMemory);
+
+    GetAccelerationStructureManager()->UntrackInputBuffer(record);
   }
 
   {

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -1525,6 +1525,9 @@ VkResult WrappedVulkan::vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkD
     // memory that has been allocated but not used, but that will be skipped or postponed as
     // appropriate.
     GetResourceManager()->MarkDirtyResource(GetResID(memory));
+
+    if(m_DeviceAddressResources.IDs.contains(record->GetResourceID()))
+      GetAccelerationStructureManager()->TrackInputBuffer(device, record);
   }
 
   return ret;
@@ -3026,6 +3029,9 @@ VkResult WrappedVulkan::vkBindBufferMemory2(VkDevice device, uint32_t bindInfoCo
       // memory that has been allocated but not used, but that will be skipped or postponed as
       // appropriate.
       GetResourceManager()->MarkDirtyResource(GetResID(pBindInfos[i].memory));
+
+      if(m_DeviceAddressResources.IDs.contains(bufrecord->GetResourceID()))
+        GetAccelerationStructureManager()->TrackInputBuffer(device, bufrecord);
     }
   }
 


### PR DESCRIPTION
As discussed privately this is the initial AS rebuild-on-replay patch that replaces the use of serialised AS data for capture replay.

# Implementation
## During Background Capture
### Mapping BDAs back to VkBuffers
In order to unify the input structs between host and device builds, the AS API uses addresses rather than `VkBuffer` handles, but there's no way of retrieving a handle from an address so we have to track all `VkBuffer` binds to map their addresses back to the owning handle.  This is done is in `TrackInputBuffer(..)` and `UntrackInputBuffer(..)`, the latter for when the resource is destroyed.  A complexity here is that when doing the lookup, users are allowed to manipulate the BDA so we have to find the buffer the address lies in and return the offset too.

### Gathering the Build Data
When an AS is built `CopyInputBuffers(..)` is called which gathers up a subset of the build data (`VkAccelerationStructureInfo`), and the corresponding input buffers are copied into a host-mappable readback buffer.  For triangle data there can be up to 3 input buffers, and they all concatenated into a single readback buffer when copied.  This data is then attached to the AS' `VkResourceRecord`, and the readback mem freed if the record is destroyed.

A complexity here is handling update builds, as we need to destroy the old readback mem but we aren't in control of the command buffer's lifetime so we have to destroy the mem asynchonously. This is done by mapping the `VkAccelerationStructureInfo` against the command buffer, and in `vkQueueSubmit` checking if any of the command buffers are the ones we are tracking.  If so, the associated `VkAccelerationStructureInfo`s are tracked against the submit's `VkFence` (or one is created if the user hasn't), and in a separate thread we check every 20ms (completely arbitrary interval) if any of the fences have signalled - and free the associated readback mems.

## Active Capture
The API serialisation is already inplace, so we're only concerned with writing initial contents data in this patch.

### Prepare
As the input buffers have already been duplicated there's nothing to do at this stage, except attach the `VkAccelerationStructureInfo` from the resource record to the associated `VkInitialContents`.

We also report the estimated size for softmem handling.  Although the duped buffers can't be freed after their chunks are serialised (they may be needed again for another capture in the same run), we can at least be honest how much GPU mem we're using.

### Serialise
The 'metadata' (`VkAccelerationStructureInfo`) is serialised followed by all the readback mems.  There's nothing exciting here.

## Replay
### Read Initial Contents
The `VkAccelerationStructureInfo` is read along with the buffer data.  Following the standard practice of reading into host-mappable upload mem and then copying into GPU local mem.  Because the input buffers were created by RD, they won't be modified during replay, so we can free the upload mem at this point.  The upload mem is allocated directly from the driver whereas the GPU mem comes from the intial state pool, so is cleaned up by RD's resource manager later.

### Apply
The `VkAccelerationStructureInfo` geom data is converted into 'proper' `VkAccelerationStructureGeometryKHR` instances, but they're missing the BDA addresses, so they're gathered and set.

The scratch buffer is also allocated.  The scratch buffer size on Arm **is too big**, so to manage the mem better at the expense of slow load times, we allocate a single scratch buffer and re-use it for each _serial_ AS build (replacing if too small).  The scratch buffer persists across the replay session.

# Testing
* Android 14 (AOSP), Pixel 8, Mali G715-Immortalis (unreleased driver).  Vulkan Samples Ray Queries, plus a raft of Arm and smartphone vendor tech demos I'm not allowed to share
* Ubuntu 24.04, Nvidia RTX 3090. Vulkan Samples Ray Queries, plus a raft of Arm tech demos I'm not allowed to share

Both with VVL enabled on capture and replay.

## Issues
* I haven't added host-command support
* No support for [vkCmdBuildAccelerationStructuresIndirectKHR](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap37.html#vkCmdBuildAccelerationStructuresIndirectKHR), for no other reason than it looks complicated and I haven't see anyone use it yet
* No support for `VkAccelerationStructureGeometryInstancesDataKHR::arrayOfPointers` for the same reason.  AFAICT there's no feature flag for it either
* Q2 RTX tech demo doesn't replay properly, the non-gun geometry is completely warped.  The obvious issue is that it appears to be building many TLASes with a single instance geometry type - with no primitives in it!  The spec doesn't say you _can't_ do that, but I've no idea how to handle this, neither ignoring the command or allocating some mem to keep a valid entry makes a difference.  I wondered if it was an odd interaction with RTP, but forcing RD to drop support for it doesn't change anything either.  As I'm writing this, I'm wondering if it's using `vkCmdBuildAccelerationStructuresIndirectKHR`...