### PR TITLE
Add support for VK_EXT_shader_object in Vulkan pixel history

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -1770,6 +1770,13 @@ const VulkanCreationInfo::Pipeline &VulkanDebugManager::GetPipelineInfo(Resource
   return it->second;
 }
 
+const VulkanCreationInfo::ShaderObject &VulkanDebugManager::GetShaderObjectInfo(ResourceId shader) const
+{
+  auto it = m_pDriver->m_CreationInfo.m_ShaderObject.find(shader);
+  RDCASSERT(it != m_pDriver->m_CreationInfo.m_ShaderObject.end());
+  return it->second;
+}
+
 const VulkanCreationInfo::ShaderModule &VulkanDebugManager::GetShaderInfo(ResourceId shader) const
 {
   auto it = m_pDriver->m_CreationInfo.m_ShaderModule.find(shader);

--- a/renderdoc/driver/vulkan/vk_debug.h
+++ b/renderdoc/driver/vulkan/vk_debug.h
@@ -111,6 +111,7 @@ public:
   const VulkanCreationInfo::Image &GetImageInfo(ResourceId img) const;
   const VulkanCreationInfo::ImageView &GetImageViewInfo(ResourceId imgView) const;
   const VulkanCreationInfo::Pipeline &GetPipelineInfo(ResourceId pipe) const;
+  const VulkanCreationInfo::ShaderObject &GetShaderObjectInfo(ResourceId shader) const;
   const VulkanCreationInfo::ShaderModule &GetShaderInfo(ResourceId shader) const;
   const VulkanCreationInfo::Framebuffer &GetFramebufferInfo(ResourceId fb) const;
   const VulkanCreationInfo::RenderPass &GetRenderPassInfo(ResourceId rp) const;


### PR DESCRIPTION
## Description

This PR adds helpers and conditional logic to the following Vulkan pixel history structs for drawing with shader objects:

- the pixel history shader cache
- the base Vulkan pixel history callback
- the derived occlusion, color and stencil, tests failed, per fragment, and discarded fragments callbacks