### PR TITLE
Vulkan AS rebuild-on-replay: On queue submission completion events

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -979,16 +979,9 @@ private:
 
   bytebuf m_MaskedMapData;
 
-  struct PendingCommandBufferCallbacks
-  {
-    VkEvent event;
-    VkCommandBuffer commandBuffer;
-    rdcarray<std::function<void()>> callbacks;
-  };
-
   Threading::CriticalSection m_PendingCmdBufferCallbacksLock;
-  rdcarray<PendingCommandBufferCallbacks> m_PendingCmdBufferCallbacks;
-  void MarkPendingCommandBufferAsDeleted(VkCommandBuffer commandBuffer);
+  rdcarray<VkPendingSubmissionCompleteCallbacks *> m_PendingCmdBufferCallbacks;
+  void InsertPendingCommandBufferCallbacksEvent(VkCommandBuffer commandBuffer);
   void AddPendingCommandBufferCallbacks(VkCommandBuffer commandBuffer);
   void CheckPendingCommandBufferCallbacks();
 

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -979,6 +979,19 @@ private:
 
   bytebuf m_MaskedMapData;
 
+  struct PendingCommandBufferCallbacks
+  {
+    VkEvent event;
+    VkCommandBuffer commandBuffer;
+    rdcarray<std::function<void()>> callbacks;
+  };
+
+  Threading::CriticalSection m_PendingCmdBufferCallbacksLock;
+  rdcarray<PendingCommandBufferCallbacks> m_PendingCmdBufferCallbacks;
+  void MarkPendingCommandBufferAsDeleted(VkCommandBuffer commandBuffer);
+  void AddPendingCommandBufferCallbacks(VkCommandBuffer commandBuffer);
+  void CheckPendingCommandBufferCallbacks();
+
   GPUAddressRangeTracker m_AddressTracker;
   GPUAddressRange CreateAddressRange(VkDevice device, VkBuffer buffer);
 

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1144,6 +1144,9 @@ struct CmdBufferRecordingInfo
   // A list of acceleration structures that this command buffer will build or copy
   rdcarray<VkResourceRecord *> accelerationStructures;
 
+  // A list of callbacks to be executed once the command buffer execution has been completed
+  rdcarray<std::function<void()>> pendingSubmissionCompleteCallbacks;
+
   // AdvanceFrame/Present should be called after this buffer is submitted
   bool present;
   // BeginFrameCapture should be called *before* this buffer is submitted.
@@ -2247,6 +2250,8 @@ public:
     cmdInfo->imageStates.swap(bakedCommands->cmdInfo->imageStates);
     cmdInfo->memFrameRefs.swap(bakedCommands->cmdInfo->memFrameRefs);
     cmdInfo->accelerationStructures.swap(bakedCommands->cmdInfo->accelerationStructures);
+    cmdInfo->pendingSubmissionCompleteCallbacks.swap(
+        bakedCommands->cmdInfo->pendingSubmissionCompleteCallbacks);
   }
 
   // we have a lot of 'cold' data in the resource record, as it can be accessed

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1382,10 +1382,7 @@ VkResult WrappedVulkan::vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
     // then begin is spec'd to implicitly reset. That means we need to tidy up
     // any existing baked commands before creating a new set.
     if(record->bakedCommands)
-    {
-      MarkPendingCommandBufferAsDeleted(commandBuffer);
       record->bakedCommands->Delete(GetResourceManager());
-    }
 
     record->bakedCommands = GetResourceManager()->AddResourceRecord(ResourceIDGen::GetNewUniqueID());
     record->bakedCommands->resType = eResCommandBuffer;
@@ -1674,7 +1671,7 @@ VkResult WrappedVulkan::vkEndCommandBuffer(VkCommandBuffer commandBuffer)
   RDCASSERT(record);
 
   if(IsCaptureMode(m_State))
-    AddPendingCommandBufferCallbacks(commandBuffer);
+    InsertPendingCommandBufferCallbacksEvent(commandBuffer);
 
   VkResult ret;
   SERIALISE_TIME_CALL(ret = ObjDisp(commandBuffer)->EndCommandBuffer(Unwrap(commandBuffer)));

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -345,8 +345,6 @@ void WrappedVulkan::vkFreeCommandBuffers(VkDevice device, VkCommandPool commandP
     if(pCommandBuffers[c] == VK_NULL_HANDLE)
       continue;
 
-    MarkPendingCommandBufferAsDeleted(pCommandBuffers[c]);
-
     WrappedVkDispRes *wrapped = (WrappedVkDispRes *)GetWrapped(pCommandBuffers[c]);
 
 #if ENABLED(VERBOSE_PARTIAL_REPLAY)

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -345,6 +345,8 @@ void WrappedVulkan::vkFreeCommandBuffers(VkDevice device, VkCommandPool commandP
     if(pCommandBuffers[c] == VK_NULL_HANDLE)
       continue;
 
+    MarkPendingCommandBufferAsDeleted(pCommandBuffers[c]);
+
     WrappedVkDispRes *wrapped = (WrappedVkDispRes *)GetWrapped(pCommandBuffers[c]);
 
 #if ENABLED(VERBOSE_PARTIAL_REPLAY)

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -1043,6 +1043,8 @@ void WrappedVulkan::CaptureQueueSubmit(VkQueue queue,
 
       record->bakedCommands->AddRef();
     }
+
+    AddPendingCommandBufferCallbacks(commandBuffers[i]);
   }
 
   if(backframe)

--- a/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_queue_funcs.cpp
@@ -1337,6 +1337,8 @@ void WrappedVulkan::CaptureQueueSubmit(VkQueue queue,
 
   for(VkResourceRecord *asRecord : accelerationStructures)
     asRecord->accelerationStructureInfo->accelerationStructureBuilt = true;
+
+  CheckPendingCommandBufferCallbacks();
 }
 
 template <typename SerialiserType>


### PR DESCRIPTION
If an AS build command is called on an already built AS (i.e. an update build) then we need to safely destroy the previously copied input buffers and their memory.  However at the point this happens, we do not own the command buffer so we don't know if the original data has actually been copied yet.

Using the mechanism in this patch we associate function objects with the command buffer that will be executed when the queue the command buffer is submitted to, has finished executing on the GPU.

This works by carying the function objects in command buffer and once it is submitted, we poll on a VkEvent we inserted.  Once signalled, we call the function objects in the order they were inserted.