### PR TITLE
Move edited VkShaderEXT creation to fix assert when editing shaders

### DIFF
--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -510,6 +510,7 @@ private:
   void ClearPostVSCache();
 
   void RefreshDerivedReplacements();
+  void ModifyReplacementIfShaderEXT(ResourceId from, ResourceId &to);
 
   bool RenderTextureInternal(TextureDisplay cfg, const ImageState &imageState,
                              VkRenderPassBeginInfo rpbegin, int flags);
@@ -823,6 +824,9 @@ private:
   rdcarray<ResourceDescription> m_Resources;
   rdcarray<DescriptorStoreDescription> m_DescriptorStores;
   std::map<ResourceId, size_t> m_ResourceIdx;
+
+  // tracks VkShaderEXT replacements for shader modules from BuildTargetShader
+  std::map<ResourceId, VkShaderEXT> m_ModuleIDToShaderObject;
 
   VKPipe::State *m_VulkanPipelineState = NULL;
 


### PR DESCRIPTION
## Description

Revises the shader edit implementation for VK_EXT_shader_object to remove reliance on the render state in BuildTargetShader and, instead, identify and create modified shader objects during resource replacement.