### PR TITLE
add r2d image loading support

### DIFF
--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -541,7 +541,7 @@ void MainWindow::on_action_Open_Capture_triggered()
 
   QString filename = RDDialog::getOpenFileName(
       this, tr("Select file to open"), m_Ctx.Config().LastCaptureFilePath,
-      tr("Capture Files (*.rdc);;Image Files (*.dds *.hdr *.exr *.bmp *.jpg "
+      tr("Capture Files (*.rdc);;Image Files (*.dds *.hdr *.exr *.r2d *.bmp *.jpg "
          "*.jpeg *.png *.tga *.gif *.psd);;All Files (*)"));
 
   if(!filename.isEmpty())

--- a/renderdoc/3rdparty/r2d/r2dLoad.cpp
+++ b/renderdoc/3rdparty/r2d/r2dLoad.cpp
@@ -1,0 +1,107 @@
+#include "r2dLoad.h"
+#include "lz4/lz4.h"
+
+bool r2dIsMagicHeader(const uint8_t* fourBytesHeader)
+{
+    return 'R' == fourBytesHeader[0] &&
+        '2' == fourBytesHeader[1] &&
+        'd' == fourBytesHeader[2] &&
+        '!' == fourBytesHeader[3];
+}
+
+enum kR2dFlags
+{
+    kR2dFloatPixel = 1<<0,
+    kR2dByteStreams = 1<<1
+};
+
+enum kR2dPackingMethod
+{
+    kR2dPackNone = 0,
+    kR2dPackLZ4 = 1
+};
+
+// Right now we only support RGBA float, LZ4 packed, byte stream un-interleaved
+bool R2dFileHeader::IsSupportedR2dFormat() const
+{
+    if (pixelStride != 16)
+        return false;
+    if (componentCount != 4)
+        return false;
+    if (0 == (flags & kR2dFloatPixel))    // float pixel
+        return false;
+    if (0 == (flags & kR2dByteStreams))    // un-interleaved byte stream
+        return false;
+    for (int i=0;i<4;i++)           // RGBA
+        if (componentTypes[i] != i)
+            return false;
+    if (packingType != uint8_t(kR2dPackLZ4))    // LZ4 packing
+        return false;
+    if (skip != 0)       // does not support additional future data for now
+        return false;
+
+    return true;
+}
+
+bool r2dImageLoadFromMemory(const uint8_t* src, size_t inSize, uint8_t* dst, size_t dstBufferSize)
+{
+    bool ret = false;
+
+    if (inSize < sizeof(R2dFileHeader))
+        return false;
+    const R2dFileHeader* header = (const R2dFileHeader*)src;
+    if (!header->IsSupportedR2dFormat())
+        return false;
+
+    if (dstBufferSize < header->w * header->h * 4 * sizeof(float))   // right now r2d only supports ARGB-float32
+        return false;
+
+    const uint32_t* read = (const uint32_t*)(header+1);
+    const uint8_t* packedData = (const uint8_t*)(read + header->blockCount * 2);    // 2 * 32bits per entry
+
+    uint32_t y0 = 0;
+    for (uint32_t b=0;b<header->blockCount;b++)
+    {
+        // depack each block
+        uint32_t scanlines = *read++;
+        uint32_t packedSize = *read++;
+
+        // alloc temp buffer
+        const int pixelCount = header->w * scanlines;
+        const int unpackedBlockSize = pixelCount * 4 * sizeof(float);
+        uint8_t* tmp = (uint8_t*)malloc(unpackedBlockSize);
+
+        // LZ4 depack
+        int lzRet = LZ4_decompress_safe((const char*)packedData, (char*)tmp, (int)packedSize, (int)unpackedBlockSize);
+        if (lzRet == unpackedBlockSize)
+        {
+            // un-interleave float data
+            uint8_t* write = dst + y0 * header->w * 4 * sizeof(float);
+            for (int i=0;i<pixelCount;i++)
+            {
+                for (int j = 0; j < 4*sizeof(float);j++)
+                    *write++ = tmp[i + j*pixelCount];
+            }
+        }
+        else
+        {
+            free(tmp);
+            return false;
+        }
+
+        free(tmp);
+
+        y0 += scanlines;
+        packedData += packedSize;
+    }
+
+    if ( y0 == header->h)
+    {
+        const float* pixels = (const float*)dst;
+        printf("%p\n", pixels);
+        ret = true;
+    }
+
+    return ret;
+}
+

--- a/renderdoc/3rdparty/r2d/r2dLoad.h
+++ b/renderdoc/3rdparty/r2d/r2dLoad.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdint.h>
+
+struct  R2dFileHeader
+{
+    uint8_t signature[4]; // 'R2d!'
+    uint32_t w;
+    uint32_t h;
+    uint8_t pixelStride;
+    uint8_t componentCount;
+    uint8_t flags;
+    uint8_t packingType;
+    uint8_t componentTypes[4];
+    uint32_t blockCount;
+    uint32_t skip;      // amount of bytes to skip for future extension
+    bool CheckSignature() const;
+    bool IsSupportedR2dFormat() const;
+};
+
+
+bool r2dIsMagicHeader(const uint8_t* fourBytesHeader);
+bool r2dImageLoadFromMemory(const uint8_t* src, size_t inSize, uint8_t* dst, size_t dstBufferSize);

--- a/renderdoc/renderdoc.vcxproj
+++ b/renderdoc/renderdoc.vcxproj
@@ -139,6 +139,7 @@
     <ClInclude Include="3rdparty\plthook\plthook.h" />
     <ClInclude Include="3rdparty\pugixml\pugiconfig.hpp" />
     <ClInclude Include="3rdparty\pugixml\pugixml.hpp" />
+    <ClInclude Include="3rdparty\r2d\r2dLoad.h" />
     <ClInclude Include="3rdparty\stb\stb_image.h" />
     <ClInclude Include="3rdparty\stb\stb_image_resize2.h" />
     <ClInclude Include="3rdparty\stb\stb_image_write.h" />
@@ -345,6 +346,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
+    <ClCompile Include="3rdparty\r2d\r2dLoad.cpp" />
     <ClCompile Include="3rdparty\stb\stb_impl.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <ForcedIncludeFiles>

--- a/renderdoc/renderdoc.vcxproj.filters
+++ b/renderdoc/renderdoc.vcxproj.filters
@@ -139,6 +139,9 @@
     <Filter Include="3rdparty\md5">
       <UniqueIdentifier>{fcbf71ce-3767-435c-9aa2-e1327b9016f4}</UniqueIdentifier>
     </Filter>
+    <Filter Include="3rdparty\r2d">
+      <UniqueIdentifier>{8829cd11-b6a7-4af2-8376-f56dcec2cb08}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="maths\camera.h">
@@ -564,6 +567,9 @@
     <ClInclude Include="core\gpu_address_range_tracker.h">
       <Filter>Core</Filter>
     </ClInclude>
+    <ClInclude Include="3rdparty\r2d\r2dLoad.h">
+      <Filter>3rdparty\r2d</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="maths\camera.cpp">
@@ -961,6 +967,9 @@
     </ClCompile>
     <ClCompile Include="core\gpu_address_range_tracker.cpp">
       <Filter>Core</Filter>
+    </ClCompile>
+    <ClCompile Include="3rdparty\r2d\r2dLoad.cpp">
+      <Filter>3rdparty\r2d</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/renderdoc/serialise/rdcfile.cpp
+++ b/renderdoc/serialise/rdcfile.cpp
@@ -29,6 +29,7 @@
 #include "common/formatting.h"
 #include "jpeg-compressor/jpge.h"
 #include "stb/stb_image.h"
+#include "r2d/r2dLoad.h"
 #include "lz4io.h"
 #include "zstdio.h"
 
@@ -280,6 +281,9 @@ void RDCFile::Open(const rdcstr &path)
 
     if(is_exr_file(m_File))
       ret = x = y = comp = 1;
+
+    if ( r2dIsMagicHeader(headerBuffer))
+        ret = x = y = comp = 1;
 
     FileIO::fseek64(m_File, 0, SEEK_SET);
 


### PR DESCRIPTION
Unity will use .r2d new file format to store large floating point pictures ( instead of .exr ) for speed. As Renderdoc is able to load .exr files as a visual debug tool, this PR adds .r2d support to RD.
