### PR TITLE
Vulkan AS rebuild-on-replay: Copy AS input buffers on build

### DIFF
--- a/renderdoc/driver/vulkan/vk_acceleration_structure.h
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.h
@@ -107,14 +107,13 @@ public:
   // are copied.
   RDResult CopyInputBuffers(VkCommandBuffer commandBuffer,
                             const VkAccelerationStructureBuildGeometryInfoKHR &info,
-                            const VkAccelerationStructureBuildRangeInfoKHR *buildRange,
-                            CaptureState state);
+                            const VkAccelerationStructureBuildRangeInfoKHR *buildRange);
 
   // Copies the metadata from src to dst, the input buffers are identical so don't need to be
   // duplicated.  Compaction is ignored but the copy is still performed so the dst handle is valid
   // on replay
   void CopyAccelerationStructure(VkCommandBuffer commandBuffer,
-                                 const VkCopyAccelerationStructureInfoKHR &pInfo, CaptureState state);
+                                 const VkCopyAccelerationStructureInfoKHR &pInfo);
 
   // Called when the initial state is prepared.  Any TLAS and BLAS data is copied into temporary
   // buffers and the handles for that memory and the buffers is stored in the init state
@@ -135,7 +134,7 @@ private:
   RecordAndOffset GetDeviceAddressData(VkDeviceAddress address) const;
 
   template <typename T>
-  void DeletePreviousInfo(VkCommandBuffer commandBuffer, T *info, CaptureState state);
+  void DeletePreviousInfo(VkCommandBuffer commandBuffer, T *info);
 
   VkDeviceSize SerialisedASSize(VkAccelerationStructureKHR unwrappedAs);
 

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1225,6 +1225,7 @@ public:
   void RemapQueueFamilyIndices(uint32_t &srcQueueFamily, uint32_t &dstQueueFamily);
   uint32_t GetQueueFamilyIndex() const { return m_QueueFamilyIdx; }
   bool ReleaseResource(WrappedVkRes *res);
+  const rdcarray<uint32_t> &GetQueueFamilyIndices() const { return m_QueueFamilyIndices; }
 
   void AddDebugMessage(MessageCategory c, MessageSeverity sv, MessageSource src, rdcstr d);
 
@@ -1275,6 +1276,7 @@ public:
 
   void TrackBufferAddress(VkDevice device, VkBuffer buffer);
   void UntrackBufferAddress(VkDevice device, VkBuffer buffer);
+  void GetResIDFromAddr(GPUAddressRange::Address addr, ResourceId &id, uint64_t &offs);
 
   EventFlags GetEventFlags(uint32_t eid) { return m_EventFlags[eid]; }
   rdcarray<EventUsage> GetUsage(ResourceId id) { return m_ResourceUses[id]; }

--- a/renderdoc/driver/vulkan/vk_memory.cpp
+++ b/renderdoc/driver/vulkan/vk_memory.cpp
@@ -77,6 +77,11 @@ void WrappedVulkan::UntrackBufferAddress(VkDevice device, VkBuffer buffer)
   m_AddressTracker.RemoveFrom(rng);
 }
 
+void WrappedVulkan::GetResIDFromAddr(GPUAddressRange::Address addr, ResourceId &id, uint64_t &offs)
+{
+  m_AddressTracker.GetResIDFromAddr(addr, id, offs);
+}
+
 void WrappedVulkan::ChooseMemoryIndices()
 {
   // we need to do this little dance because Get*MemoryIndex checks to see if the existing

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3996,8 +3996,8 @@ VkResourceRecord::~VkResourceRecord()
   if(resType == eResCommandPool)
     SAFE_DELETE(cmdPoolInfo);
 
-  if(resType == eResAccelerationStructureKHR)
-    SAFE_DELETE(accelerationStructureInfo);
+  if(resType == eResAccelerationStructureKHR && accelerationStructureInfo)
+    accelerationStructureInfo->Release();
 }
 
 void VkResourceRecord::MarkImageFrameReferenced(VkResourceRecord *img, const ImageRange &range,

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -3948,6 +3948,107 @@ void ImgRefs::Split(bool splitAspects, bool splitLevels, bool splitLayers)
   areLayersSplit = newSplitLayerCount > 1;
 }
 
+void QueryPoolInfo::Add(uint32_t firstQuery, rdcarray<uint64_t> values)
+{
+  Reset(firstQuery, (uint32_t)values.size());
+
+  m_Entries.reserve(m_Entries.size() + values.size());
+  for(uint64_t value : values)
+    m_Entries.emplace_back(firstQuery++, value);
+
+  std::sort(m_Entries.begin(), m_Entries.end());
+}
+
+void QueryPoolInfo::Reset(uint32_t firstQuery, uint32_t queryCount)
+{
+  m_Entries.removeIf([&](const auto &entry) {
+    return (entry.index >= firstQuery) && (entry.index < (firstQuery + queryCount));
+  });
+}
+
+void QueryPoolInfo::Replace(uint32_t firstQuery, uint32_t queryCount, void *pData,
+                            VkDeviceSize stride, VkQueryResultFlags flags) const
+{
+  const auto writeEntry = [&](Entry queryPoolInfoEntry) {
+    const size_t num_bytes = (flags & VK_QUERY_RESULT_64_BIT) ? 8 : 4;
+
+    byte *pStart = (byte *)pData + (queryPoolInfoEntry.index * stride);
+    memcpy(pStart, &queryPoolInfoEntry.value, num_bytes);
+  };
+
+  Replace(firstQuery, queryCount, writeEntry);
+}
+
+void QueryPoolInfo::Replace(uint32_t firstQuery, uint32_t queryCount,
+                            const std::function<void(uint32_t, rdcarray<uint64_t>)> &writeEntry) const
+{
+  rdcarray<Entry> entries;
+  entries.reserve(queryCount);
+
+  // Swap out any AS compaction sizes with the replacements
+  Replace(firstQuery, queryCount, [&](Entry entry) { entries.push_back(entry); });
+
+  std::sort(entries.begin(), entries.end());
+
+  // Now batch into contiguous ranges and dispatch
+  for(size_t i = 0; i < entries.size();)
+  {
+    uint32_t queryIndex = entries[i].index;
+    rdcarray<uint64_t> batch;
+
+    while(queryIndex == entries[++i].index)
+    {
+      batch.push_back(entries[i].value);
+      ++queryIndex;
+    }
+
+    writeEntry(queryIndex, std::move(batch));
+  }
+}
+
+bool QueryPoolInfo::HasReplacementEntries(uint32_t firstQuery, uint32_t queryCount) const
+{
+  uint32_t start, end;
+  rdctie(start, end) = GetIntersection(firstQuery, queryCount);
+  return start <= end;
+}
+
+rdcpair<uint32_t, uint32_t> QueryPoolInfo::GetIntersection(uint32_t firstQuery,
+                                                           uint32_t queryCount) const
+{
+  if(m_Entries.empty())
+    return {1, 0};    // Invalid
+
+  const uint32_t start = RDCMAX(firstQuery, m_Entries.front().index);
+  const uint32_t end = RDCMIN(firstQuery + queryCount - 1, (uint32_t)m_Entries.back().index);
+  return {start, end};
+}
+
+void QueryPoolInfo::Replace(uint32_t firstQuery, uint32_t queryCount,
+                            const std::function<void(Entry)> &writeEntry) const
+{
+  if(!m_Entries.empty())
+  {
+    // Find the intersection of the two query ranges
+    uint32_t start, end;
+    rdctie(start, end) = GetIntersection(firstQuery, queryCount);
+    if(end < start)
+      return;
+
+    uint32_t j = 0;
+    for(uint32_t i = start; i < end; ++i)
+    {
+      // The indices are sparse but ordered
+      while(i != m_Entries[j].index)
+      {
+        ++j;
+      }
+
+      writeEntry(m_Entries[j]);
+    }
+  }
+}
+
 VkResourceRecord::~VkResourceRecord()
 {
   // bufferviews and imageviews have non-owning pointers to the sparseinfo struct
@@ -3995,6 +4096,9 @@ VkResourceRecord::~VkResourceRecord()
 
   if(resType == eResCommandPool)
     SAFE_DELETE(cmdPoolInfo);
+
+  if(resType == eResQueryPool)
+    SAFE_DELETE(queryPoolInfo);
 
   if(resType == eResAccelerationStructureKHR && accelerationStructureInfo)
     accelerationStructureInfo->Release();

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -2236,6 +2236,41 @@ inline FrameRefType MarkMemoryReferenced(std::unordered_map<ResourceId, MemRefs>
   return MarkMemoryReferenced(memRefs, mem, offset, size, refType, ComposeFrameRefs);
 }
 
+// Used to replace QueryPool results
+class QueryPoolInfo
+{
+public:
+  void Add(uint32_t firstQuery, rdcarray<uint64_t> values);
+
+  void Reset(uint32_t firstQuery, uint32_t queryCount);
+
+  void Replace(uint32_t firstQuery, uint32_t queryCount, void *pData, VkDeviceSize stride,
+               VkQueryResultFlags flags) const;
+
+  // Calls writeEntry with matching contiguous entries, buffered into an array.
+  void Replace(uint32_t firstQuery, uint32_t queryCount,
+               const std::function<void(uint32_t, rdcarray<uint64_t>)> &writeEntry) const;
+
+  bool HasReplacementEntries(uint32_t firstQuery, uint32_t queryCount) const;
+
+private:
+  struct Entry
+  {
+    Entry(uint32_t i, uint64_t v) : index(i), value(v) {}
+    bool operator<(Entry other) const { return index < other.index; }
+
+    uint32_t index;
+    uint64_t value;
+  };
+
+  rdcpair<uint32_t, uint32_t> GetIntersection(uint32_t firstQuery, uint32_t queryCount) const;
+
+  void Replace(uint32_t firstQuery, uint32_t queryCount,
+               const std::function<void(Entry)> &writeEntry) const;
+
+  rdcarray<Entry> m_Entries;
+};
+
 struct DescUpdateTemplate;
 struct ImageLayouts;
 struct VkAccelerationStructureInfo;
@@ -2332,6 +2367,7 @@ public:
     DescPoolInfo *descPoolInfo;              // only for descriptor pools
     CmdPoolInfo *cmdPoolInfo;                // only for command pools
     uint32_t queueFamilyIndex;               // only for queues
+    QueryPoolInfo *queryPoolInfo;            // only for query pools
     VkAccelerationStructureInfo *accelerationStructureInfo;    // only for acceleration structures
   };
 

--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -2236,39 +2236,15 @@ inline FrameRefType MarkMemoryReferenced(std::unordered_map<ResourceId, MemRefs>
   return MarkMemoryReferenced(memRefs, mem, offset, size, refType, ComposeFrameRefs);
 }
 
-// Used to replace QueryPool results
+// Used as an alternative backing store to VkQueryPool to replace query results
 class QueryPoolInfo
 {
 public:
-  void Add(uint32_t firstQuery, rdcarray<uint64_t> values);
+  QueryPoolInfo(WrappedVulkan *driver, VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo);
+  ~QueryPoolInfo();
 
-  void Reset(uint32_t firstQuery, uint32_t queryCount);
-
-  void Replace(uint32_t firstQuery, uint32_t queryCount, void *pData, VkDeviceSize stride,
-               VkQueryResultFlags flags) const;
-
-  // Calls writeEntry with matching contiguous entries, buffered into an array.
-  void Replace(uint32_t firstQuery, uint32_t queryCount,
-               const std::function<void(uint32_t, rdcarray<uint64_t>)> &writeEntry) const;
-
-  bool HasReplacementEntries(uint32_t firstQuery, uint32_t queryCount) const;
-
-private:
-  struct Entry
-  {
-    Entry(uint32_t i, uint64_t v) : index(i), value(v) {}
-    bool operator<(Entry other) const { return index < other.index; }
-
-    uint32_t index;
-    uint64_t value;
-  };
-
-  rdcpair<uint32_t, uint32_t> GetIntersection(uint32_t firstQuery, uint32_t queryCount) const;
-
-  void Replace(uint32_t firstQuery, uint32_t queryCount,
-               const std::function<void(Entry)> &writeEntry) const;
-
-  rdcarray<Entry> m_Entries;
+  GPUBuffer m_Buffer;
+  byte *m_MappedMem;
 };
 
 struct DescUpdateTemplate;

--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -7873,6 +7873,15 @@ void WrappedVulkan::vkCmdBuildAccelerationStructuresKHR(
 
       // Add to the command buffer metadata, so we can know when it has been submitted
       record->cmdInfo->accelerationStructures.push_back(GetRecord(geomInfo.dstAccelerationStructure));
+
+      const RDResult copyResult = GetAccelerationStructureManager()->CopyInputBuffers(
+          commandBuffer, geomInfo, ppBuildRangeInfos[i], m_State);
+      if(copyResult != ResultCode::Succeeded)
+      {
+        m_LastCaptureError = copyResult;
+        RDCERR("%s", copyResult.message.c_str());
+        m_CaptureFailure = true;
+      }
     }
   }
 }

--- a/renderdoc/driver/vulkan/wrappers/vk_get_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_get_funcs.cpp
@@ -860,8 +860,9 @@ void WrappedVulkan::vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice
 
   if(accStruct && accStruct->accelerationStructureHostCommands)
   {
-    RDCWARN("Disabling support for acceleration structure host commands");
+    RDCWARN("Disabling support for acceleration structure host commands and indirect builds");
     accStruct->accelerationStructureHostCommands = VK_FALSE;
+    accStruct->accelerationStructureIndirectBuild = VK_FALSE;
   }
 }
 

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -3389,7 +3389,6 @@ VkResult WrappedVulkan::vkCreateAccelerationStructureKHR(
       record->baseResource = bufferRecord->GetResourceID();
       record->baseResourceMem = bufferRecord->baseResource;
       record->dedicated = bufferRecord->dedicated;
-      record->resInfo = bufferRecord->resInfo;
       record->storable = bufferRecord->storable;
       record->memOffset = bufferRecord->memOffset + pCreateInfo->offset;
       record->memSize = pCreateInfo->size;


### PR DESCRIPTION
When `vkCmdBuildAccelerationStructuresKHR` is called, the input buffers used for the build are copied into host-accessible memory, so when initial state serialisation is triggered it can be copied into the capture file.

To unify the behaviour of the different geometry types, there is only one readback buffer per AS, and in the case of triangle data it can contain the vertex, index, and transform data concatenated into a single contiguous block.

The buffer data along with build arguments are stored in a `VkAccelerationStructureInfo` object owned by the AS's `VkResourceRecord`.  If this record is freed, then the copied buffer mem is also freed.  If this destruction occurs during the active capture phase, the AS info is kept alive until the end of the active capture.

Serialisation of the initial state will follow in later patches.

Caveats:
* `vkCmdBuildAccelerationStructuresIndirectKHR` is not handled
* `VkAccelerationStructureGeometryInstancesDataKHR::arrayOfPointers` mode is not handled