### PR TITLE
Add "verbose logging" option for librenderdoc build

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -14,6 +14,12 @@ if(ENABLE_DLSYM_HOOKING)
     message(WARNING "Enabling dlsym() hooking - may cause issues, segfaults, crashes, or bad behaviour. Only enable if absolutely required")
 endif()
 
+option(ENABLE_VERBOSE_LOGGING "Enable verbose logging during RenderDoc capture and replay" OFF)
+if (ENABLE_VERBOSE_LOGGING)
+    set(RDOC_DEFINITIONS ${RDOC_DEFINITIONS} PRIVATE -DRENDERDOC_VERBOSE_LOGGING)
+    message(STATUS "Enabling verbose logging during RenderDoc capture and replay")
+endif()
+
 if(ANDROID)
     list(APPEND RDOC_LIBRARIES
         PRIVATE -lm

--- a/renderdoc/common/globalconfig.h
+++ b/renderdoc/common/globalconfig.h
@@ -58,6 +58,12 @@
 #define RDOC_MSVS OPTION_OFF
 #endif
 
+#if defined(RENDERDOC_VERBOSE_LOGGING)
+#define RDOC_VERBOSE_LOGGING OPTION_ON
+#else
+#define RDOC_VERBOSE_LOGGING OPTION_OFF
+#endif
+
 // translate from build system defines, so they don't have to be defined to anything in
 // particular
 #if defined(RENDERDOC_PLATFORM_WIN32)
@@ -187,7 +193,12 @@ enum
 #define INCLUDE_LOCATION_IN_LOG OPTION_ON
 
 // logs go to stdout/stderr
-#if ENABLED(RDOC_WIN32)
+#if ENABLED(RDOC_VERBOSE_LOGGING)
+
+#define OUTPUT_LOG_TO_STDOUT OPTION_OFF
+#define OUTPUT_LOG_TO_STDERR OPTION_ON
+
+#elif ENABLED(RDOC_WIN32)
 
 #define OUTPUT_LOG_TO_STDOUT OPTION_OFF
 #define OUTPUT_LOG_TO_STDERR OPTION_OFF
@@ -207,7 +218,7 @@ enum
 
 // normally only in a debug build do we
 // include debug logs. This prints them all the time
-#define FORCE_DEBUG_LOGS OPTION_OFF
+#define FORCE_DEBUG_LOGS RDOC_VERBOSE_LOGGING
 // this strips them completely
 #define STRIP_DEBUG_LOGS OPTION_OFF
 

--- a/renderdoc/core/core.cpp
+++ b/renderdoc/core/core.cpp
@@ -529,9 +529,14 @@ void RenderDoc::Initialise()
 
   // begin printing to stdout/stderr after this point, earlier logging is debugging
   // cruft that we don't want cluttering output.
-  // However we don't want to print in captured applications, since they may be outputting important
-  // information to stdout/stderr and being piped around and processed!
-  if(IsReplayApp())
+  // However we generally don't want to print in captured applications, since they may be outputting
+  // important information to stdout/stderr and being piped around and processed!
+#if defined(RENDERDOC_VERBOSE_LOGGING)
+  bool enable_log_output = true;
+#else
+  bool enable_log_output = IsReplayApp();
+#endif
+  if(enable_log_output)
     RDCLOGOUTPUT();
 
   ProcessConfig();


### PR DESCRIPTION
Adds a renderdoc CMake option to enable stderr logging during captures.