### PR TITLE
Use GLSL 460 for built-in spirv-cross -> GLSL calls

### DIFF
--- a/qrenderdoc/Code/Interface/PersistantConfig.cpp
+++ b/qrenderdoc/Code/Interface/PersistantConfig.cpp
@@ -705,7 +705,7 @@ ShaderProcessingTool::ShaderProcessingTool(const QVariant &var)
 rdcstr ShaderProcessingTool::DefaultArguments() const
 {
   if(tool == KnownShaderTool::SPIRV_Cross)
-    return "--vulkan-semantics --entry {entry_point} --stage {glsl_stage4}";
+    return "--vulkan-semantics --entry {entry_point} --stage {glsl_stage4} --version 460";
   else if(tool == KnownShaderTool::SPIRV_Cross_OpenGL)
     return "--entry {entry_point} --stage {glsl_stage4}";
   else if(tool == KnownShaderTool::spirv_dis || tool == KnownShaderTool::spirv_dis_OpenGL)


### PR DESCRIPTION
spirv-cross defaults to 450 but will not parse shaders containing the RayQuery capability unless the version is set to 460.

This change modifies the built-in GLSL cross tool to set `--version 460`.  This change does not affect user-specified spirv-cross configurations.

Tested on a capture containing RQ content on a Mali G715.