### PR TITLE
Make the bytecode to ShaderEntry cast work for compute shaders

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -842,6 +842,8 @@ bool WrappedID3D12Device::Serialise_CreateComputePipelineState(
     WrappedID3D12Shader *entry = WrappedID3D12Shader::AddShader(wrapped->compute->CS, this);
     entry->AddRef();
 
+    wrapped->compute->CS.pShaderBytecode = entry;
+
     wrapped->FetchRootSig(GetShaderCache());
 
     if(m_GlobalEXTUAV != ~0U)


### PR DESCRIPTION
## Description

The ShaderEntry *CS() function returned bogus data (at least for me) which crashed RenderDoc in FetchRootSig when trying to extract the root signature (when compute->pRootSignature is NULL). It worked fine for other shaders so I looked for relevant differences between Serialise_CreateComputePipelineState and Serialise_CreateGraphicsPipelineState and I think I found one...
But I'm not sure about this change because I do not fully understand what's happening with those ShaderEntry-casts.