### PR TITLE
Increase default remote server timeout to 15s

### DIFF
--- a/docs/python_api/examples/renderdoc/remote_capture.py
+++ b/docs/python_api/examples/renderdoc/remote_capture.py
@@ -106,7 +106,7 @@ if result.result != rd.ResultCode.Succeeded:
     raise RuntimeError(f"Couldn't launch {exe}, got error {str(result.result)}")
 
 # Spin up a thread to keep the remote server connection alive while we make a capture,
-# as it will time out after 5 seconds of inactivity
+# as it will time out after 15 seconds of inactivity
 def ping_remote(remote, kill):
     success = True
     while success and not kill.is_set():
@@ -182,7 +182,7 @@ if result != rd.ResultCode.Succeeded:
 # The replay is tunnelled over the remote connection, so you don't have to keep
 # pinging the remote connection while using the controller. Use of the remote
 # connection and controller can be interleaved though you should only access
-# them from one thread at once. If they are both unused for 5 seconds though,
+# them from one thread at once. If they are both unused for 15 seconds though,
 # the timeout will happen, so if the controller is idle it's advisable to ping
 # the remote connection
 

--- a/docs/python_api/examples/renderdoc/remote_capture.rst
+++ b/docs/python_api/examples/renderdoc/remote_capture.rst
@@ -58,7 +58,7 @@ If the connection fails, normally we must fail but if we have a device protocol 
 
 .. note::
 
-   The remote server connection has a default timeout of 5 seconds. If the connection is unused for 5 seconds, the other side will disconnect and subsequent use of the interface will fail.
+   The remote server connection has a default timeout of 15 seconds. If the connection is unused for 15 seconds, the other side will disconnect and subsequent use of the interface will fail.
 
 Once we have a remote server connection, we can browse the remote filesystem for the executable we want to launch using :py:meth:`~renderdoc.RemoteServer.GetHomeFolder` and :py:meth:`~renderdoc.RemoteServer.ListFolder`.
 

--- a/renderdoc/core/remote_server.cpp
+++ b/renderdoc/core/remote_server.cpp
@@ -38,7 +38,7 @@
 #include "strings/string_utils.h"
 #include "replay_proxy.h"
 
-RDOC_CONFIG(uint32_t, RemoteServer_TimeoutMS, 5000,
+RDOC_CONFIG(uint32_t, RemoteServer_TimeoutMS, 15000,
             "Timeout in milliseconds for remote server operations.");
 
 RDOC_CONFIG(bool, RemoteServer_DebugLogging, false,

--- a/renderdoc/os/os_specific.h
+++ b/renderdoc/os/os_specific.h
@@ -181,7 +181,7 @@ namespace Network
 class Socket
 {
 public:
-  Socket(ptrdiff_t s) : socket(s), timeoutMS(5000) {}
+  Socket(ptrdiff_t s) : socket(s), timeoutMS(15000) {}
   ~Socket();
   void Shutdown();
 


### PR DESCRIPTION
We've had several bug reports from different entities complaining of unreliable Android remote server connections, due remote server timeouts being hit.

We're not sure the precise reasons as to why the timeouts are being hit, though it's likely to be caused by badly behaving test apps swamping the CPU, and organisations using ADB-over-HTTP rather than a local USB connection.

In all circumstances just asking the reporters to increase the `RemoteServer_TimeoutMS` value to 15000 fixes the issue.  This change will only affect those who don't have a `renderdoc.conf` or those who reset the config value.