### PR TITLE
Fix uninitialized reftype during image state merge

### DIFF
--- a/renderdoc/driver/vulkan/vk_image_states.cpp
+++ b/renderdoc/driver/vulkan/vk_image_states.cpp
@@ -50,6 +50,9 @@ void ImageSubresourceState::Update(const ImageSubresourceState &other, FrameRefC
   if(other.newLayout != UNKNOWN_PREV_IMG_LAYOUT)
     newLayout = other.newLayout;
 
+  if(refType == eFrameRef_Unknown)
+    refType = other.refType;
+
   refType = compose(refType, other.refType);
 }
 


### PR DESCRIPTION
This PR targets an error that can occur if images are referenced by a secondary command buffer before being referenced by a primary command buffer that executes the secondary.

Image states tracked by secondary command buffers are merged into their executing primaries in the hook for VkCmdExecuteCommands. If an image state refers to an image that was not previously referenced by the primary, a new, uninitialized image state is added to the primary. The new image state is initialized with elements of the original, including subresource states, but the frameref type of subresource states is uninitialized. An error is logged when the subresource state reftypes are passed to the reftype composition function.

This PR adds logic to initialize the reftype of the new subresource state with the value of the original if it remains uninitialized before the composition function.
