### PR TITLE
Vulkan AS rebuild-on-replay: Serialise and Replay

### DIFF
--- a/renderdoc/driver/vulkan/vk_acceleration_structure.h
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.h
@@ -46,8 +46,6 @@ struct VkAccelerationStructureInfo
       VkDeviceSize stride;
     };
 
-    uint64_t GetSerialisedSize() const;
-
     VkGeometryTypeKHR geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
     VkGeometryFlagsKHR flags;
 
@@ -65,10 +63,8 @@ struct VkAccelerationStructureInfo
 
   uint64_t GetSerialisedSize() const;
 
-  rdcarray<VkAccelerationStructureGeometryKHR> convertGeometryData() const;
+  void convertGeometryData(rdcarray<VkAccelerationStructureGeometryKHR> &geometry) const;
   rdcarray<VkAccelerationStructureBuildRangeInfoKHR> getBuildRanges() const;
-
-  VkDevice device = VK_NULL_HANDLE;
 
   VkAccelerationStructureTypeKHR type =
       VkAccelerationStructureTypeKHR::VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
@@ -76,10 +72,10 @@ struct VkAccelerationStructureInfo
 
   rdcarray<GeometryData> geometryData;
 
-  VkDeviceMemory readbackMem = VK_NULL_HANDLE;
+  GPUBuffer readbackMem;
   VkDeviceSize memSize = 0;
 
-  VkDeviceMemory uploadMem = VK_NULL_HANDLE;
+  MemoryAllocation uploadAlloc;
   VkBuffer uploadBuf = VK_NULL_HANDLE;
   VkAccelerationStructureKHR replayAS = VK_NULL_HANDLE;
 
@@ -118,8 +114,7 @@ public:
 private:
   struct Allocation
   {
-    VkDeviceMemory mem = VK_NULL_HANDLE;
-    VkDeviceSize size = 0;
+    MemoryAllocation memAlloc;
     VkBuffer buf = VK_NULL_HANDLE;
   };
 
@@ -130,11 +125,11 @@ private:
     VkDeviceSize offset = 0;
   };
 
-  Allocation CreateReadBackMemory(VkDevice device, VkDeviceSize size, VkDeviceSize alignment = 0);
-  Allocation CreateReplayMemory(MemoryType memType, VkDeviceSize size,
-                                VkBufferUsageFlags extraUsageFlags = 0);
+  GPUBuffer CreateTempReadBackBuffer(VkDevice device, VkDeviceSize size);
+  Allocation CreateTempReplayBuffer(MemoryType memType, VkDeviceSize size, VkDeviceSize alignment,
+                                    VkBufferUsageFlags extraUsageFlags = 0);
 
-  bool FixUpReplayBDAs(VkAccelerationStructureInfo *asInfo,
+  bool FixUpReplayBDAs(VkAccelerationStructureInfo *asInfo, VkBuffer buf,
                        rdcarray<VkAccelerationStructureGeometryKHR> &geoms);
 
   void UpdateScratch(VkDeviceSize requiredSize);

--- a/renderdoc/driver/vulkan/vk_acceleration_structure.h
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.h
@@ -39,7 +39,6 @@ struct VkAccelerationStructureInfo
       VkDeviceSize vertexStride;
       uint32_t maxVertex;
       VkIndexType indexType;
-      bool hasTransformData;
     };
 
     struct Aabbs
@@ -52,15 +51,11 @@ struct VkAccelerationStructureInfo
     VkGeometryTypeKHR geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
     VkGeometryFlagsKHR flags;
 
-    VkDeviceMemory readbackMem;
-    VkDeviceSize memSize;
-
-    VkBuffer replayBuf;
-
     Triangles tris;
     Aabbs aabbs;
 
     VkAccelerationStructureBuildRangeInfoKHR buildRangeInfo;
+    VkDeviceSize memOffset;
   };
 
   ~VkAccelerationStructureInfo();
@@ -80,6 +75,11 @@ struct VkAccelerationStructureInfo
   VkBuildAccelerationStructureFlagsKHR flags = 0;
 
   rdcarray<GeometryData> geometryData;
+
+  VkDeviceMemory readbackMem = VK_NULL_HANDLE;
+  VkDeviceSize memSize = 0;
+
+  VkBuffer replayBuf = VK_NULL_HANDLE;
 
   bool accelerationStructureBuilt = false;
 
@@ -106,9 +106,8 @@ public:
 
   uint64_t GetSize_InitialState(ResourceId id, const VkInitialContents &initial);
 
-  bool Serialise(WriteSerialiser &ser, ResourceId id, const VkInitialContents *initial,
-                 CaptureState state);
-  bool Serialise(ReadSerialiser &ser, ResourceId id, const VkInitialContents *initial,
+  template <typename SerialiserType>
+  bool Serialise(SerialiserType &ser, ResourceId id, const VkInitialContents *initial,
                  CaptureState state);
 
   // Called when the initial state is applied.  The AS data is deserialised from the upload buffer

--- a/renderdoc/driver/vulkan/vk_acceleration_structure.h
+++ b/renderdoc/driver/vulkan/vk_acceleration_structure.h
@@ -79,7 +79,9 @@ struct VkAccelerationStructureInfo
   VkDeviceMemory readbackMem = VK_NULL_HANDLE;
   VkDeviceSize memSize = 0;
 
-  VkBuffer replayBuf = VK_NULL_HANDLE;
+  VkDeviceMemory uploadMem = VK_NULL_HANDLE;
+  VkBuffer uploadBuf = VK_NULL_HANDLE;
+  VkAccelerationStructureKHR replayAS = VK_NULL_HANDLE;
 
   bool accelerationStructureBuilt = false;
 
@@ -110,9 +112,8 @@ public:
   bool Serialise(SerialiserType &ser, ResourceId id, const VkInitialContents *initial,
                  CaptureState state);
 
-  // Called when the initial state is applied.  The AS data is deserialised from the upload buffer
-  // into the acceleration structure
-  void Apply(ResourceId id, const VkInitialContents &initial);
+  // Called when the initial state is applied.
+  void Apply(ResourceId id, VkInitialContents &initial);
 
 private:
   struct Allocation

--- a/renderdoc/driver/vulkan/vk_common.h
+++ b/renderdoc/driver/vulkan/vk_common.h
@@ -454,6 +454,8 @@ enum class MemoryScope : uint8_t
   // allocated the same way
   ImmutableReplayDebug = InitialContents,
   IndirectReadback,
+  // Same as initial contents but freed after first Serialise/Apply cycle
+  InitialContentsFirstApplyOnly,
   Count,
 };
 

--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -2305,6 +2305,8 @@ void WrappedVulkan::StartFrameCapture(DeviceOwnedWindow devWnd)
   GetResourceManager()->ClearReferencedResources();
   GetResourceManager()->ClearReferencedMemory();
 
+  CheckPendingCommandBufferCallbacks();
+
   // need to do all this atomically so that no other commands
   // will check to see if they need to markdirty or markpendingdirty
   // and go into the frame record.
@@ -2346,7 +2348,6 @@ void WrappedVulkan::StartFrameCapture(DeviceOwnedWindow devWnd)
     }
 
     m_PreparedNotSerialisedInitStates.clear();
-    CheckPendingCommandBufferCallbacks();
     GetResourceManager()->PrepareInitialContents();
 
     {
@@ -3264,7 +3265,7 @@ RDResult WrappedVulkan::ReadLogInitialisation(RDCFile *rdc, bool storeStructured
   GetReplay()->WriteFrameRecord().frameInfo.initDataSize =
       chunkInfos[(VulkanChunk)SystemChunk::InitialContents].totalsize;
 
-  RDCDEBUG("Allocating %llu persistant bytes of memory for the log.",
+  RDCDEBUG("Allocating %llu persistent bytes of memory for the log.",
            GetReplay()->WriteFrameRecord().frameInfo.persistentSize);
 
   // ensure the capture at least created a device and fetched a queue.
@@ -3780,6 +3781,8 @@ void WrappedVulkan::ApplyInitialContents()
     SubmitCmds();
     FlushQ();
   }
+
+  FreeAllMemory(MemoryScope::InitialContentsFirstApplyOnly);
 }
 
 bool WrappedVulkan::ContextProcessChunk(ReadSerialiser &ser, VulkanChunk chunk)

--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -124,8 +124,6 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
     {
       VkInitialContents initData = GetResourceManager()->GetInitialContents(flushId);
 
-      GetResourceManager()->SetInitialContents(flushId, VkInitialContents());
-
       uint64_t start = ser.GetWriter()->GetOffset();
       {
         uint64_t size = GetSize_InitialState(flushId, initData);
@@ -134,6 +132,7 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
 
         // record is not needed on vulkan
         Serialise_InitialState(ser, flushId, NULL, &initData);
+        GetResourceManager()->SetInitialContents(flushId, VkInitialContents());
       }
       uint64_t end = ser.GetWriter()->GetOffset();
 

--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -588,10 +588,6 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
       return true;
     }
 
-    // Skip empty AS input data (BLASes are force ref-ed)
-    if(record->accelerationStructureInfo->memSize == 0)
-      return true;
-
     // The input buffers and metadata have all been created by this point, so we just need to
     // assemble a VkInitialContents
     VkInitialContents ic;

--- a/renderdoc/driver/vulkan/vk_manager.cpp
+++ b/renderdoc/driver/vulkan/vk_manager.cpp
@@ -1042,9 +1042,17 @@ rdcarray<ResourceId> VulkanResourceManager::InitialContentResources()
     const InitialContentData &bData = m_InitialContents[b].data;
 
     // Always sort BLASs before TLASs, as a TLAS holds device addresses for it's BLASs
-    // and we make sure those addresses are valid
-    if(!aData.isTLAS && bData.isTLAS)
-      return true;
+    // and we make sure those addresses are valid.  There's no good handling for the generic types,
+    // so we just assume it is a TLAS
+    if(aData.accelerationStructureInfo && bData.accelerationStructureInfo)
+    {
+      const VkAccelerationStructureTypeKHR aType = aData.accelerationStructureInfo->type;
+      const VkAccelerationStructureTypeKHR bType = bData.accelerationStructureInfo->type;
+      if(aType == VkAccelerationStructureTypeKHR::VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
+         (bType == VkAccelerationStructureTypeKHR::VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR ||
+          bType == VkAccelerationStructureTypeKHR::VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR))
+        return true;
+    }
 
     return aData.type < bData.type;
   });

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -114,8 +114,7 @@ struct VkInitialContents
     SAFE_DELETE(sparseTables);
     SAFE_DELETE(sparseBind);
 
-    if(accelerationStructureInfo)
-      accelerationStructureInfo->Release();
+    SAFE_RELEASE(accelerationStructureInfo);
 
     // MemoryAllocation ise not free'd here
   }

--- a/renderdoc/driver/vulkan/vk_manager.h
+++ b/renderdoc/driver/vulkan/vk_manager.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "core/resource_manager.h"
+#include "vk_acceleration_structure.h"
 #include "vk_resources.h"
 
 class WrappedVulkan;
@@ -113,7 +114,10 @@ struct VkInitialContents
     SAFE_DELETE(sparseTables);
     SAFE_DELETE(sparseBind);
 
-    // MemoryAllocation and serialised ASes are not free'd here
+    if(accelerationStructureInfo)
+      accelerationStructureInfo->Release();
+
+    // MemoryAllocation ise not free'd here
   }
 
   // for descriptor heaps, when capturing we save the slots, when replaying we store direct writes
@@ -139,7 +143,7 @@ struct VkInitialContents
   rdcarray<AspectSparseTable> *sparseTables;
   SparseBinding *sparseBind;
 
-  bool isTLAS;    // If the contents are an AS, this determines if it is a TLAS or BLAS
+  VkAccelerationStructureInfo *accelerationStructureInfo;
 };
 
 struct VulkanResourceManagerConfiguration

--- a/renderdoc/driver/vulkan/vk_resources.cpp
+++ b/renderdoc/driver/vulkan/vk_resources.cpp
@@ -4012,8 +4012,8 @@ VkResourceRecord::~VkResourceRecord()
   if(resType == eResQueryPool)
     SAFE_DELETE(queryPoolInfo);
 
-  if(resType == eResAccelerationStructureKHR && accelerationStructureInfo)
-    accelerationStructureInfo->Release();
+  if(resType == eResAccelerationStructureKHR)
+    SAFE_RELEASE(accelerationStructureInfo);
 }
 
 void VkResourceRecord::MarkImageFrameReferenced(VkResourceRecord *img, const ImageRange &range,

--- a/renderdoc/driver/vulkan/vk_stringise.cpp
+++ b/renderdoc/driver/vulkan/vk_stringise.cpp
@@ -298,6 +298,7 @@ rdcstr DoStringise(const MemoryScope &el)
   {
     STRINGISE_ENUM_CLASS(InitialContents);
     STRINGISE_ENUM_CLASS(IndirectReadback);
+    STRINGISE_ENUM_CLASS(InitialContentsFirstApplyOnly);
   }
   END_ENUM_STRINGISE()
 }

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -1014,6 +1014,7 @@ void WrappedVulkan::Shutdown()
   }
 
   FreeAllMemory(MemoryScope::InitialContents);
+  FreeAllMemory(MemoryScope::InitialContentsFirstApplyOnly);
 
   if(m_MemoryFreeThread)
   {


### PR DESCRIPTION
The `VkAccelerationStructureInfo` structure is serialised followed by the unified geometry readback buffer.  On replay the upload buffer is populated from the capture and then copied to GPU local mem, at which point the upload mem is freed as replay cannot modify the AS input data.

When the initial state Apply() is called the ASes are built from the input data one at a time so that a single scratch buffer can be built (enlarging when needed) and re-used.  Although this is slower it is necessary on Mali as it has poor space efficiency for the scratch buffer and so can easily OOM a device if all the ASes are built in a single command buffer submission.

Tested on:

- Android Mali G715 r49p1 with various Arm tech demos (some based on UE5) and Vulkan Samples ray_queries
- Ubuntu 24.04 NV 3090FE 535.183.06, same above but ported to x86_64