### PR TITLE
allow d3d12 insert null rt descriptor

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -1585,9 +1585,9 @@ void D3D12Replay::SavePipelineState(uint32_t eventId)
     {
       const D3D12Descriptor &desc = rs.rts[i];
 
+      state.outputMerger.renderTargets.push_back(Descriptor());
       if(desc.GetResResourceId() != ResourceId())
       {
-        state.outputMerger.renderTargets.push_back(Descriptor());
         FillDescriptor(state.outputMerger.renderTargets.back(), &desc);
       }
     }


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
d3d12 allow create null rendertarget view, 
when replay rdc, we need  allow null rendertarget view
display, match application behavior

old ui display 
![image](https://github.com/user-attachments/assets/1b75b6cc-929a-4b43-a28a-abb723105468)


new ui display 
![image](https://github.com/user-attachments/assets/b83f0668-54e0-4676-8808-f42d60f894ef)


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
