### PR TITLE
EXR: optimize exr image load time

### DIFF
--- a/renderdoc/3rdparty/tinyexr/tinyexr.cpp
+++ b/renderdoc/3rdparty/tinyexr/tinyexr.cpp
@@ -26,5 +26,7 @@
 // compatible functions to be available, which miniz does.
 #define TINYEXR_USE_MINIZ 0
 
+#define TINYEXR_USE_THREAD 1
+
 #define TINYEXR_IMPLEMENTATION
 #include "tinyexr.h"


### PR DESCRIPTION
Faster loading of EXR images:
- Multi-threaded (within one image; tinyexr option)
- Simpler channel planes -> RGBA data swizzling

Tested on two 4K UHD video resolution EXR files, on Ryzen 5950X/VS2022, Release config.
- FP16 file (27MB): 536ms -> 75ms
- FP32 file (69MB): 793ms -> 113ms