### PR TITLE
Display GL_POINTS instead of GL_NONE when capturing points.

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -3409,10 +3409,34 @@ void WrappedOpenGL::glBindTransformFeedback(GLenum target, GLuint id)
   }
 }
 
+enum GLprimitiveMode
+{
+  points = eGL_POINTS,
+  lines = eGL_LINES,
+  triangles = eGL_TRIANGLES,
+};
+
+DECLARE_REFLECTION_ENUM(GLprimitiveMode);
+
+template <>
+rdcstr DoStringise(const GLprimitiveMode &el)
+{
+  RDCCOMPILE_ASSERT(sizeof(GLprimitiveMode) == sizeof(GLenum) && sizeof(GLprimitiveMode) == sizeof(uint32_t),
+                    "Fake bitfield enum must be uint32_t sized");
+
+  BEGIN_ENUM_STRINGISE(GLprimitiveMode);
+  {
+    STRINGISE_ENUM_NAMED(points, "GL_POINTS");
+    STRINGISE_ENUM_NAMED(lines, "GL_LINES");
+    STRINGISE_ENUM_NAMED(triangles, "GL_TRIANGLES");
+  }
+  END_ENUM_STRINGISE();
+}
+
 template <typename SerialiserType>
 bool WrappedOpenGL::Serialise_glBeginTransformFeedback(SerialiserType &ser, GLenum primitiveMode)
 {
-  SERIALISE_ELEMENT(primitiveMode);
+  SERIALISE_ELEMENT_TYPED(GLprimitiveMode, primitiveMode);
 
   SERIALISE_CHECK_READ_ERRORS();
 

--- a/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_buffer_funcs.cpp
@@ -3421,8 +3421,9 @@ DECLARE_REFLECTION_ENUM(GLprimitiveMode);
 template <>
 rdcstr DoStringise(const GLprimitiveMode &el)
 {
-  RDCCOMPILE_ASSERT(sizeof(GLprimitiveMode) == sizeof(GLenum) && sizeof(GLprimitiveMode) == sizeof(uint32_t),
-                    "Fake bitfield enum must be uint32_t sized");
+  RDCCOMPILE_ASSERT(
+      sizeof(GLprimitiveMode) == sizeof(GLenum) && sizeof(GLprimitiveMode) == sizeof(uint32_t),
+      "Fake bitfield enum must be uint32_t sized");
 
   BEGIN_ENUM_STRINGISE(GLprimitiveMode);
   {


### PR DESCRIPTION
## Description
When analyzing a captured frame with transform feedback, renderdoc displayed `GL_NONE` as primitive type when capturing points. This is due the fact that `GL_POINTS == 0 == GL_NONE`. 

![image](https://github.com/user-attachments/assets/c8bd05dc-3feb-4ef6-9fae-082b1dfdfab3)

I added a similar contraption as for all the draw commands, that translates this correctly to `GL_POINTS`. 

I'm very grateful for renderdoc, it's an awesome tool. It's so awesome that it took me 4 days to realize that this is not my applications fault but indeed a display bug. (tthe actual problem was else where)

Now it looks like this:
![image](https://github.com/user-attachments/assets/6b40a81f-bb2c-46c7-806d-7a2a1d29c579)
