### PR TITLE
Do not access baseResourceMem on unbound buffer

### DIFF
--- a/renderdoc/driver/vulkan/vk_memory.cpp
+++ b/renderdoc/driver/vulkan/vk_memory.cpp
@@ -42,6 +42,10 @@ GPUAddressRange WrappedVulkan::CreateAddressRange(VkDevice device, VkBuffer buff
   VkResourceRecord *record = GetRecord(buffer);
   VkResourceRecord *memrecord = GetResourceManager()->GetResourceRecord(record->baseResourceMem);
 
+  // Just in case this is called when a buffer is being destroyed without being bound
+  if(!memrecord)
+    return {};
+
   const VkBufferDeviceAddressInfo addrInfo = {
       VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
       NULL,

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -1912,10 +1912,16 @@ VkResult WrappedVulkan::vkCreateBuffer(VkDevice device, const VkBufferCreateInfo
         ObjDisp(device)->GetBufferMemoryRequirements(Unwrap(device), Unwrap(*pBuffer),
                                                      &record->resInfo->memreqs);
 
-        // initialise the sparse page table
         if(isSparse)
+        {
+          // initialise the sparse page table
           record->resInfo->sparseTable.Initialise(pCreateInfo->size,
                                                   record->resInfo->memreqs.alignment & 0xFFFFFFFFU);
+
+          // Track the buffer address.  We only do this here for sparse buffers as they aren't
+          // bound against a single allocation
+          TrackBufferAddress(device, *pBuffer);
+        }
 
         // for external buffers, try creating a non-external version and take the worst case of
         // memory requirements, in case the non-external one (as we will replay it) needs more


### PR DESCRIPTION
If a `VkBuffer` handle is destroyed before being bound, then its removal will be attempted by the GPU address range tracker which will access the base mem record - but this will be `NULL` on an unbound buffer.  Buffers aren't added to the tracker unless bound, so exiting early is the correct thing to do in this case.