### PR TITLE
EXR: support mipmaps in exr image files

### DIFF
--- a/renderdoc/CMakeLists.txt
+++ b/renderdoc/CMakeLists.txt
@@ -132,6 +132,7 @@ set(sources
     common/result.h
     common/shader_cache.h
     common/jobsystem.cpp
+    common/tex_data.h
     common/threading.h
     common/timing.h
     common/wrapped_pool.h

--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -673,7 +673,7 @@ DXGI_FORMAT ResourceFormat2DXGIFormat(ResourceFormat format)
   return DXGI_FORMAT_UNKNOWN;
 }
 
-RDResult write_dds_to_file(FILE *f, const write_dds_data &data)
+RDResult write_dds_to_file(FILE *f, const write_tex_data &data)
 {
   if(!f)
     return RDResult(ResultCode::InvalidParameter, "Missing file handle writing DDS file");
@@ -961,7 +961,7 @@ bool is_dds_file(byte *headerBuffer, size_t size)
   return memcmp(headerBuffer, &dds_fourcc, 4) == 0;
 }
 
-RDResult load_dds_from_file(StreamReader *reader, read_dds_data &ret)
+RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
 {
   uint64_t fileSize = reader->GetSize();
 

--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -952,7 +952,7 @@ RDResult write_dds_to_file(FILE *f, const write_tex_data &data)
   return RDResult();
 }
 
-bool is_dds_file(byte *headerBuffer, size_t size)
+bool is_dds_file(const byte *headerBuffer, size_t size)
 {
   if(size < 4)
   {

--- a/renderdoc/common/dds_readwrite.h
+++ b/renderdoc/common/dds_readwrite.h
@@ -28,6 +28,6 @@
 #include "serialise/streamio.h"
 #include "tex_data.h"
 
-extern bool is_dds_file(byte *headerBuffer, size_t size);
+extern bool is_dds_file(const byte *headerBuffer, size_t size);
 extern RDResult load_dds_from_file(StreamReader *reader, read_tex_data &data);
 extern RDResult write_dds_to_file(FILE *f, const write_tex_data &data);

--- a/renderdoc/common/tex_data.h
+++ b/renderdoc/common/tex_data.h
@@ -24,10 +24,34 @@
 
 #pragma once
 
-#include <stdio.h>
-#include "serialise/streamio.h"
-#include "tex_data.h"
+#include "api/replay/data_types.h"
 
-extern bool is_dds_file(byte *headerBuffer, size_t size);
-extern RDResult load_dds_from_file(StreamReader *reader, read_tex_data &data);
-extern RDResult write_dds_to_file(FILE *f, const write_tex_data &data);
+// Texture data for file reading/writing. Used in more complex cases
+// than just a single image, e.g. DDS (can have arrays, mips) or EXR
+// (can have mips).
+struct tex_data
+{
+  uint32_t width;
+  uint32_t height;
+  uint32_t depth;
+
+  uint32_t mips;
+  uint32_t slices;
+
+  bool cubemap;
+
+  ResourceFormat format;
+};
+
+struct read_tex_data : public tex_data
+{
+  bytebuf buffer;
+
+  // pairs of {offset, size} into above data buffer
+  rdcarray<rdcpair<size_t, size_t>> subresources;
+};
+
+struct write_tex_data : public tex_data
+{
+  rdcarray<byte *> subresources;
+};

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -42,7 +42,7 @@ struct ReplayOptions;
 struct SDObject;
 
 // not provided by tinyexr, just do by hand
-bool is_exr_file(FILE *f);
+bool is_exr_file(const byte *headerBuffer, size_t size);
 void LogReplayOptions(const ReplayOptions &opts);
 
 enum class RDCDriver : uint32_t;

--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -395,7 +395,7 @@ public:
   void FileChanged() { RefreshFile(); }
 private:
   void RefreshFile();
-  void CreateProxyTexture(TextureDescription &texDetails, read_dds_data &read_data);
+  void CreateProxyTexture(TextureDescription &texDetails, read_tex_data &read_data);
 
   APIProperties m_Props;
   FrameRecord m_FrameRecord;
@@ -515,7 +515,7 @@ RDResult IMG_CreateReplayDevice(RDCFile *rdc, IReplayDriver **driver)
   {
     FileIO::fseek64(f, 0, SEEK_SET);
     StreamReader reader(f);
-    read_dds_data read_data = {};
+    read_tex_data read_data = {};
     RDResult res = load_dds_from_file(&reader, read_data);
     f = NULL;
 
@@ -899,7 +899,7 @@ void ImageViewer::RefreshFile()
   m_FrameRecord.frameInfo.persistentSize = 0;
   m_FrameRecord.frameInfo.uncompressedFileSize = datasize;
 
-  read_dds_data read_data = {};
+  read_tex_data read_data = {};
 
   if(dds)
   {
@@ -1003,7 +1003,7 @@ void ImageViewer::RefreshFile()
     FileIO::fclose(f);
 }
 
-void ImageViewer::CreateProxyTexture(TextureDescription &texDetails, read_dds_data &read_data)
+void ImageViewer::CreateProxyTexture(TextureDescription &texDetails, read_tex_data &read_data)
 {
   if(m_Proxy->IsTextureSupported(texDetails))
   {

--- a/renderdoc/core/image_viewer.cpp
+++ b/renderdoc/core/image_viewer.cpp
@@ -433,7 +433,7 @@ RDResult IMG_CreateReplayDevice(RDCFile *rdc, IReplayDriver **driver)
   FileIO::fseek64(f, 0, SEEK_SET);
 
   // make sure the file is a type we recognise before going further
-  if(is_exr_file(f))
+  if(is_exr_file(headerBuffer, headerSize))
   {
     FileIO::fseek64(f, 0, SEEK_END);
     uint64_t size = FileIO::ftell64(f);
@@ -645,7 +645,7 @@ void ImageViewer::RefreshFile()
   uint64_t fileSize = FileIO::ftell64(f);
   FileIO::fseek64(f, 0, SEEK_SET);
 
-  if(is_exr_file(f))
+  if(is_exr_file(headerBuffer, headerSize))
   {
     texDetails.format = rgba32_float;
 

--- a/renderdoc/os/win32/win32_shellext.cpp
+++ b/renderdoc/os/win32/win32_shellext.cpp
@@ -54,7 +54,7 @@ struct RDCThumbnailProvider : public IThumbnailProvider, IInitializeWithStream
   unsigned int m_iRefcount;
   bool m_Inited;
   RDCThumb m_Thumb;
-  read_dds_data m_ddsData;
+  read_tex_data m_ddsData;
 
   RDCThumbnailProvider() : m_iRefcount(1), m_Inited(false) { InterlockedIncrement(&numProviders); }
   virtual ~RDCThumbnailProvider() { InterlockedDecrement(&numProviders); }

--- a/renderdoc/renderdoc.vcxproj
+++ b/renderdoc/renderdoc.vcxproj
@@ -202,6 +202,7 @@
     <ClInclude Include="common\globalconfig.h" />
     <ClInclude Include="common\result.h" />
     <ClInclude Include="common\shader_cache.h" />
+    <ClInclude Include="common\tex_data.h" />
     <ClInclude Include="common\threading.h" />
     <ClInclude Include="common\timing.h" />
     <ClInclude Include="common\wrapped_pool.h" />

--- a/renderdoc/renderdoc.vcxproj.filters
+++ b/renderdoc/renderdoc.vcxproj.filters
@@ -570,6 +570,9 @@
     <ClInclude Include="replay\common\var_dispatch_helpers.h">
       <Filter>Replay\Common</Filter>
     </ClInclude>
+    <ClInclude Include="common\tex_data.h">
+      <Filter>Common\File Formats</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="maths\camera.cpp">

--- a/renderdoc/replay/replay_controller.cpp
+++ b/renderdoc/replay/replay_controller.cpp
@@ -1226,7 +1226,7 @@ ResultDetails ReplayController::SaveTexture(const TextureSave &saveData, const r
   {
     if(sd.destType == FileType::DDS)
     {
-      write_dds_data ddsData;
+      write_tex_data ddsData;
 
       ResourceFormat saveFmt = td.format;
       // use typeCast to inform typeless saving, otherwise it will get lost


### PR DESCRIPTION
Tiled EXR files can have mipmaps levels. When they do, and the odd size rounding mode matches what all the graphics APIs do ("round down"), load them when loading the exr file. Using the same machinery that the DDS mipmap loading uses.

`Bonita.exr` from OpenEXR test images, for example, now loads with the mip levels: https://github.com/AcademySoftwareFoundation/openexr-images/blob/main/MultiResolution/Bonita.exr

I've also tested on Animal Lab "ALab" USD data set which has exrs with mipmaps. Seems to work!
