### PR TITLE
Add support for Vulkan Loader v1.3+ on Mac

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -410,6 +410,19 @@ RDResult WrappedVulkan::Initialise(VkInitParams &params, uint64_t sectionVersion
     instNext = &flagsEXT;
   }
 
+  VkInstanceCreateFlags instCreateFlags = 0;
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+  if(supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
+     supportedExtensions.end())
+  {
+    if(!params.Extensions.contains(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME))
+    {
+      params.Extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+    }
+    instCreateFlags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+  }
+#endif
+
   const char **layerscstr = new const char *[params.Layers.size()];
   for(size_t i = 0; i < params.Layers.size(); i++)
     layerscstr[i] = params.Layers[i].c_str();
@@ -421,7 +434,7 @@ RDResult WrappedVulkan::Initialise(VkInitParams &params, uint64_t sectionVersion
   VkInstanceCreateInfo instinfo = {
       VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
       instNext,
-      0,
+      instCreateFlags,
       &renderdocAppInfo,
       (uint32_t)params.Layers.size(),
       layerscstr,


### PR DESCRIPTION
## Description

Per MacOS Vulkan SDK docs:
(https://vulkan.lunarg.com/doc/view/latest/mac/getting_started.html)

"Beginning with the 1.3.216 Vulkan SDK, the Vulkan Loader is strictly enforcing 
the new VK_KHR_PORTABILITY_subset extension. The most likely cause of this error 
message on instance creation is failure to adhere to this extension, which prevents 
applications on all platforms from selecting by default a non-conformant Vulkan 
implementation without opting in. 
MoltenVK is currently not fully conformant, and thus supporting this extension is 
necessary for building robust and portable Vulkan-based applications that are 
good citizens in the Vulkan ecosystem.

This commit fixes VK_ERROR_INCOMPATIBLE_DRIVER on vkCreateInstance
on MacOS by conforming to the above loader specification.
