### PR TITLE
Synchronise renderdoc.conf on all remote device platforms

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -1231,18 +1231,11 @@ struct AndroidController : public IDeviceProtocolHandler
           deviceID,
           "shell setprop debug.oculus.usepackagedvvl." RENDERDOC_ANDROID_PACKAGE_BASE ".arm64 1");
 
-      rdcstr package = GetRenderDocPackageForABI(abis.back());
-
-      rdcstr folderName = Android::GetFolderName(deviceID);
-
-      // push settings file into our folder
-      Android::adbExecCommand(deviceID, "push \"" + FileIO::GetAppFolderFilename("renderdoc.conf") +
-                                            "\" /sdcard/Android/" + folderName + package +
-                                            "/files/renderdoc.conf");
-
       // launch the last ABI, as the 64-bit version where possible, or 32-bit version where not.
       // Captures are portable across bitness and in some cases a 64-bit capture can't replay on a
       // 32-bit remote server.
+      rdcstr package = GetRenderDocPackageForABI(abis.back());
+
       Android::adbExecCommand(
           deviceID, "shell am start -n " + package + "/.Loader -e renderdoccmd remoteserver");
     });
@@ -1297,7 +1290,10 @@ struct AndroidController : public IDeviceProtocolHandler
       portbase = it->second.portbase;
     }
 
-    return new AndroidRemoteServer(sock, deviceID, portbase);
+    AndroidRemoteServer *server = new AndroidRemoteServer(sock, deviceID, portbase);
+    server->CopyConfToRemote();
+
+    return server;
   }
 
   int32_t running = 0;
@@ -1492,9 +1488,7 @@ ExecuteResult AndroidRemoteServer::ExecuteAndInject(const rdcstr &packageAndActi
                                               opts.EncodeAsString().c_str()));
 
     // try to push our settings file into the appdata folder
-    Android::adbExecCommand(m_deviceID, "push \"" + FileIO::GetAppFolderFilename("renderdoc.conf") +
-                                            "\" /sdcard/Android/" + folderName + processName +
-                                            "/files/renderdoc.conf");
+    CopyConfToRemote("/sdcard/Android/" + folderName + processName + "/files/renderdoc.conf");
 
     rdcstr installedPath = Android::GetPathForPackage(m_deviceID, packageName);
 

--- a/renderdoc/core/core.h
+++ b/renderdoc/core/core.h
@@ -614,6 +614,8 @@ public:
   void CycleActiveWindow();
   uint32_t GetCapturableWindowCount();
 
+  void ProcessConfig();
+
 private:
   RenderDoc();
   ~RenderDoc();
@@ -719,8 +721,6 @@ private:
 
   ICrashHandler *m_ExHandler;
   Threading::RWLock m_ExHandlerLock;
-
-  void ProcessConfig();
 
   SDObject *FindConfigSetting(const rdcstr &name);
 

--- a/renderdoc/core/remote_server.cpp
+++ b/renderdoc/core/remote_server.cpp
@@ -86,6 +86,7 @@ enum RemoteServerPacket
   eRemoteServer_GetSectionContents,
   eRemoteServer_WriteSection,
   eRemoteServer_GetAvailableGPUs,
+  eRemoteServer_CopyConfToRemote,
   eRemoteServer_RemoteServerCount,
 };
 
@@ -130,6 +131,7 @@ rdcstr DoStringise(const RemoteServerPacket &el)
     STRINGISE_ENUM_NAMED(eRemoteServer_GetSectionContents, "GetSectionContents");
     STRINGISE_ENUM_NAMED(eRemoteServer_WriteSection, "WriteSection");
     STRINGISE_ENUM_NAMED(eRemoteServer_GetAvailableGPUs, "GetAvailableGPUs");
+    STRINGISE_ENUM_NAMED(eRemoteServer_CopyConfToRemote, "CopyConfToRemote");
     STRINGISE_ENUM_NAMED(eRemoteServer_RemoteServerCount, "RemoteServerCount");
   }
   END_ENUM_STRINGISE();
@@ -481,6 +483,49 @@ static void ActiveRemoteClientThread(ClientThread *threadData,
         SCOPED_SERIALISE_CHUNK(eRemoteServer_GetAvailableGPUs);
         SERIALISE_ELEMENT(gpus);
       }
+    }
+    else if(type == eRemoteServer_CopyConfToRemote)
+    {
+      rdcstr confFile;
+      rdcstr confFileTmp;
+
+      {
+        READ_DATA_SCOPE();
+
+        SERIALISE_ELEMENT(confFile);
+
+        // If dst is empty then the default platform-specific path is used
+        if(confFile.empty())
+          confFile = FileIO::GetAppFolderFilename("renderdoc.conf");
+
+        RDCLOG("Copying new configuration to local path '%s'.", confFile.c_str());
+
+        confFileTmp = confFile + ".tmp";
+
+        StreamWriter streamWriter(FileIO::fopen(confFileTmp, FileIO::WriteBinary), Ownership::Stream);
+        ser.SerialiseStream(confFileTmp, streamWriter, NULL);
+      }
+
+      reader.EndChunk();
+
+      if(reader.IsErrored())
+      {
+        FileIO::Delete(confFileTmp);
+
+        RDCERR("Network error receiving file");
+        break;
+      }
+
+      if(!FileIO::Copy(confFileTmp, confFile, true))
+      {
+        RDCERR("Failed to replace configuration");
+        break;
+      }
+
+      tempFiles.push_back(confFileTmp);
+
+      RDCLOG("New configuration received.");
+      RenderDoc::Inst().ProcessConfig();
     }
     else if(type == eRemoteServer_ShutdownServer)
     {
@@ -1255,7 +1300,12 @@ RENDERDOC_CreateRemoteServerConnection(const rdcstr &URL, IRemoteServer **rend)
   if(protocol)
     *rend = protocol->CreateRemoteServer(sock, deviceID);
   else
-    *rend = new RemoteServer(sock, deviceID);
+  {
+    RemoteServer *server = new RemoteServer(sock, deviceID);
+    server->CopyConfToRemote();
+
+    *rend = server;
+  }
 
   if(*rend == NULL)
     return RDResult(ResultCode::NetworkIOFailed);
@@ -1800,6 +1850,22 @@ rdcarray<GPUDevice> RemoteServer::GetAvailableGPUs()
   }
 
   return gpus;
+}
+
+void RemoteServer::CopyConfToRemote(const rdcstr &dst)
+{
+  rdcstr confFile = FileIO::GetAppFolderFilename("renderdoc.conf");
+
+  {
+    WRITE_DATA_SCOPE();
+    SCOPED_SERIALISE_CHUNK(eRemoteServer_CopyConfToRemote);
+
+    SERIALISE_ELEMENT(dst);
+
+    // this will take ownership of and close the file
+    StreamReader fileReader(FileIO::fopen(confFile, FileIO::ReadBinary));
+    ser.SerialiseStream(confFile, fileReader, NULL);
+  }
 }
 
 int RemoteServer::GetSectionCount()

--- a/renderdoc/core/remote_server.h
+++ b/renderdoc/core/remote_server.h
@@ -82,6 +82,9 @@ public:
 
   virtual rdcarray<GPUDevice> GetAvailableGPUs();
 
+  // If dst is empty then the default platform-specific path is used
+  virtual void CopyConfToRemote(const rdcstr &dst = "");
+
   virtual int32_t GetSectionCount();
 
   virtual int32_t FindSectionByName(const rdcstr &name);


### PR DESCRIPTION
Aligns remote Linux with Android behaviour, by pushing the host's renderdoc.conf to the remote device.  Preivously that was done only on Android via ADB, whereas now it is done over the server connection itself.

The slight regression here is that previously on Android the conf file was pushed before server start so the initial connection used the `RemoteServer_TimeoutMS` setting, whereas now that will be set upon first reconnection.  All other settings are unaffected.
