### PR TITLE
Set RT pipeline capture/replay flags and features

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -3364,6 +3364,19 @@ bool WrappedVulkan::Serialise_vkCreateDevice(SerialiserType &ser, VkPhysicalDevi
         VkPhysicalDeviceProperties2 availPropsBase = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
         availPropsBase.pNext = &rayProps;
         ObjDisp(physicalDevice)->GetPhysicalDeviceProperties2(Unwrap(physicalDevice), &availPropsBase);
+
+        if(ext->rayTracingPipeline && !avail.rayTracingPipelineShaderGroupHandleCaptureReplay)
+        {
+          SET_ERROR_RESULT(m_FailedReplayResult, ResultCode::APIHardwareUnsupported,
+                           "Capture requires rayTracingPipeline support, which is available, but "
+                           "rayTracingPipelineShaderGroupHandleCaptureReplay support is not "
+                           "available which is required to replay\n"
+                           "\n%s",
+                           GetPhysDeviceCompatString(false, false).c_str());
+          return false;
+        }
+        if(ext->rayTracingPipeline)
+          ext->rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
       }
       END_PHYS_EXT_CHECK();
     }


### PR DESCRIPTION
Without this, capture/replaying RT pipelines hangs or crashes on RADV.

Adding `VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR` is required for capture by https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.html#VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-pipeline-03607 and for replay by https://registry.khronos.org/vulkan/specs/latest/man/html/VkRayTracingPipelineCreateInfoKHR.html#VUID-VkRayTracingPipelineCreateInfoKHR-rayTracingPipelineShaderGroupHandleCaptureReplay-03599.

https://registry.khronos.org/vulkan/specs/latest/man/html/VkRayTracingPipelineCreateInfoKHR.html#VUID-VkRayTracingPipelineCreateInfoKHR-flags-03598 mandates that `rayTracingPipelineShaderGroupHandleCaptureReplay` is enabled.

Set the flags and enable the device features accordingly.