### PR TITLE
Fix overflow when texture size is smaller than block size

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -3813,7 +3813,9 @@ void WrappedOpenGL::StoreCompressedTexData(ResourceId texId, GLenum target, GLin
           // GetCompressedByteSize() will factor in the 'partial' blocks at image edges when the
           // image size is not an integer multiple of the block size, so we need to take into
           // account that in the loop
-          size_t roundedUpHeight = AlignUp((uint32_t)height, blockSize[1]);
+          size_t roundedUpHeight = (uint32_t)height < blockSize[1]
+                                       ? (uint32_t)height
+                                       : AlignUp((uint32_t)height, blockSize[1]);
           for(size_t y = 0; y < roundedUpHeight; y += blockSize[1])
           {
             memcpy(cdData.data() + dstOffset, srcPixels + srcOffset, srcRowSize);


### PR DESCRIPTION
If the texture size is smaller than the block size, it can cause an overflow. For example, a texture with size of 4x4 but format is  ASTC 6x6.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->