### PR TITLE
Prevent Android Cached App Freezer from freezing the replay server

### DIFF
--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -246,6 +246,7 @@ ReplayProxy::ReplayProxy(ReadSerialiser &reader, WriteSerialiser &writer, IRepla
       m_Proxy(proxy),
       m_Remote(NULL),
       m_Replay(NULL),
+      m_PreviewWindow(NULL),
       m_RemoteServer(false)
 {
   m_StructuredFile = new SDFile;

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -224,6 +224,7 @@ if(ANDROID)
 
     # Copy in android package files, replacing the package name with the architecture-specific package name
     configure_file(android/Loader.java ${CMAKE_CURRENT_BINARY_DIR}/src/org/renderdoc/renderdoccmd/Loader.java)
+    configure_file(android/DummyService.java ${CMAKE_CURRENT_BINARY_DIR}/src/org/renderdoc/renderdoccmd/DummyService.java)
     configure_file(android/AndroidManifest.xml ${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml)
     configure_file(android/icon.png ${CMAKE_CURRENT_BINARY_DIR}/res/drawable/icon.png COPYONLY)
 

--- a/renderdoccmd/android/AndroidManifest.xml
+++ b/renderdoccmd/android/AndroidManifest.xml
@@ -7,7 +7,7 @@
   <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.INTERNET" />
-
+  
   <!-- Use GL ES 3.2 version -->
   <uses-feature android:glEsVersion="0x00030000" android:required="true" />
 
@@ -15,7 +15,9 @@
     <activity android:name=".Loader" android:label="RenderDoc" android:exported="true" android:screenOrientation="landscape" android:configChanges="orientation|keyboardHidden" android:theme="@android:style/Theme.NoTitleBar">
       <meta-data android:name="android.app.lib_name" android:value="renderdoccmd"/>
     </activity>
-
+    
+    <service android:name=".DummyService" android:exported="false" />
+    
   </application>
 </manifest>
 <!-- END_INCLUDE(manifest) -->

--- a/renderdoccmd/android/DummyService.java
+++ b/renderdoccmd/android/DummyService.java
@@ -1,0 +1,48 @@
+package @RENDERDOC_ANDROID_PACKAGE_NAME@;
+import android.app.Notification;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
+import android.os.Process;
+
+public class DummyService extends android.app.Service
+{
+    private Looper serviceLooper;
+    private Handler serviceHandler;
+
+    @Override
+    public void onCreate() {
+        HandlerThread thread = new HandlerThread("DummyServiceThread", Process.THREAD_PRIORITY_BACKGROUND);
+        thread.start();
+
+        serviceLooper = thread.getLooper();
+        serviceHandler = new Handler(serviceLooper);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Notification notification = new Notification.Builder(this)
+            .setPriority(Notification.PRIORITY_LOW)
+            .setSmallIcon(R.drawable.icon)
+            .setContentTitle("RenderDoc Dummy Foreground Service")
+            .setContentText("RenderDoc needs this dummy foreground service to prevent cached app freezer from interrupting the network connection")
+            .build();
+        startForeground(startId, notification);
+
+        // If we get killed, don't restart
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+    }
+}

--- a/renderdoccmd/android/Loader.java
+++ b/renderdoccmd/android/Loader.java
@@ -1,9 +1,10 @@
 package @RENDERDOC_ANDROID_PACKAGE_NAME@;
-import android.os.Build;
 import android.app.Activity;
-import android.view.WindowManager;
-import android.os.Environment;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Environment;
+import android.view.WindowManager;
 
 public class Loader extends android.app.NativeActivity
 {
@@ -16,6 +17,11 @@ public class Loader extends android.app.NativeActivity
     protected void onCreate(android.os.Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+        Context context = getApplicationContext();
+        if(context != null) {
+            context.startService(new Intent(this, DummyService.class));
+        }
 
         // if we're running on something older than Android M (6.0), return now
         // before requesting permissions as it's not supported


### PR DESCRIPTION
Since Android assigns a low oom_score_adj to foreground services, which prevent cached app freezer from freezing the replay server. Therefore adding a dummy service to RenderDoc will prevent cached app freezer from freezing the replay server.

[Cached app freezer](https://source.android.com/docs/core/perf/cached-apps-freezer) stops execution for cached processes and reduces resource usage by misbehaving apps that might attempt to operate while cached. This can happen for the RenderDoc replay server when user simply stopped using RenderDoc for a short period of time because the RenderDoc replay server only produces user perceptible changes when actions are taken on the RenderDoc client.