### PR TITLE
Android: Automaticaly add `MANAGE_EXTERNAL_STORAGE` permission to apps

### DIFF
--- a/renderdoc/android/android.cpp
+++ b/renderdoc/android/android.cpp
@@ -1220,6 +1220,17 @@ struct AndroidController : public IDeviceProtocolHandler
       for(Android::ABI abi : abis)
         Android::adbExecCommand(deviceID, "shell am force-stop " + GetRenderDocPackageForABI(abi));
 
+      // Attempt to prevent the user needing to click through on permissions
+      rdcstr auto_grant_permissions =
+          Android::adbExecCommand(deviceID, "shell getprop debug.renderdoc.autograntpermissions")
+              .strStdout.trimmed();
+      if(apiVersion >= 30 && atoi(auto_grant_permissions.c_str()) == 1)
+      {
+        for(Android::ABI abi : abis)
+          Android::adbExecCommand(deviceID, "shell pm grant " + GetRenderDocPackageForABI(abi) +
+                                                " android.permission.MANAGE_EXTERNAL_STORAGE");
+      }
+
       Android::adbForwardPorts(dev.portbase, deviceID, 0, 0, false);
       Android::ResetCaptureSettings(deviceID);
 


### PR DESCRIPTION
## Description

This prevents the user from needing to click through a permission granting screen on their device before the agent is able to run on the device.  Presumably, if you have `adb` access to the device, we can assume it's alright to add this permission automatically.  This is only relevant on API >= 30, as the `MANAGE_EXTERNAL_STORAGE` permission is not available on earlier Android versions [0].

[0] https://developer.android.com/reference/android/Manifest.permission#MANAGE_EXTERNAL_STORAGE
