### PR TITLE
Dynamically allocate Vulkan output window swapchain arrays

### DIFF
--- a/renderdoc/driver/vulkan/vk_replay.h
+++ b/renderdoc/driver/vulkan/vk_replay.h
@@ -549,9 +549,8 @@ private:
 
     VkSurfaceKHR surface;
     VkSwapchainKHR swap;
-    uint32_t numImgs;
-    VkImage colimg[8];
-    VkImageMemoryBarrier colBarrier[8];
+    rdcarray<VkImage> colimg;
+    rdcarray<VkImageMemoryBarrier> colBarrier;
 
     VkImage bb;
     VkImageView bbview;


### PR DESCRIPTION
Vivo X90 devices provide 11 swapchain images, increase the Vulkan OutputWindow properties to handle this