### PR TITLE
Add special cases for Fossilize encoding of VkMutableDescriptorTypeCreateInfoEXT

### DIFF
--- a/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/VulkanPipelineStateViewer.cpp
@@ -4624,6 +4624,9 @@ void VulkanPipelineStateViewer::AddFossilizeNexts(QVariantMap &info, const SDObj
                     // VkDescriptorSetLayoutBindingFlagsCreateInfoEXT
                     {"bindingCount", ""},
                     {"pBindingFlags", "bindingFlags"},
+                    // VkMutableDescriptorTypeCreateInfoEXT
+                    {"mutableDescriptorTypeListCount", ""},
+                    {"pMutableDescriptorTypeLists", "mutableDescriptorTypeLists"},
                     // VkSubpassDescriptionDepthStencilResolve
                     {"pDepthStencilResolveAttachment", "depthStencilResolveAttachment"},
                     // VkFragmentShadingRateAttachmentInfoKHR
@@ -4682,6 +4685,12 @@ QVariant VulkanPipelineStateViewer::ConvertSDObjectToFossilizeJSON(const SDObjec
         if(v.isValid())
           map[key] = v;
       }
+
+      // VkMutableDescriptorTypeListEXT
+      if(map.contains(lit("pDescriptorTypes")))
+        return map[lit("pDescriptorTypes")];
+      else if(map.contains(lit("descriptorTypeCount")))
+        return QVariantList();
 
       AddFossilizeNexts(map, obj);
 


### PR DESCRIPTION
## Description

When mutable descriptor sets are used, Fossizlie needs the `VkMutableDescriptorSetCreateInfoEXT`. However, instead of taking it raw like some other inputs, it uses a simplified version that is just a list of lists. If we give it full structs, Fossilize will crash. In order to do this, we need a couple special cases.