### PR TITLE
Fix alignment calculation when copying GLES compressed tex data 

### DIFF
--- a/renderdoc/common/common.h
+++ b/renderdoc/common/common.h
@@ -294,6 +294,12 @@ inline T AlignUpPtr(T x, A a)
   return (T)AlignUp<uintptr_t>((uintptr_t)x, (uintptr_t)a);
 }
 
+template <typename T>
+T AlignToMultiple(T value, T multiple)
+{
+  return ((value + multiple - 1) / multiple) * multiple | 0;
+}
+
 #define MAKE_FOURCC(a, b, c, d) \
   (((uint32_t)(d) << 24) | ((uint32_t)(c) << 16) | ((uint32_t)(b) << 8) | (uint32_t)(a))
 

--- a/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_texture_funcs.cpp
@@ -1514,9 +1514,9 @@ void WrappedOpenGL::glCopyImageSubData(GLuint srcName, GLenum srcTarget, GLint s
             // image size is not an integer multiple of the block size, so we need to take into
             // account that in the loop
             size_t roundedUpDepth =
-                srcIsCompressed ? AlignUp((uint32_t)srcDepth, srcBlockSize[2]) : srcDepth;
+                srcIsCompressed ? AlignToMultiple((uint32_t)srcDepth, srcBlockSize[2]) : srcDepth;
             size_t roundedUpHeight =
-                srcIsCompressed ? AlignUp((uint32_t)srcHeight, srcBlockSize[1]) : srcHeight;
+                srcIsCompressed ? AlignToMultiple((uint32_t)srcHeight, srcBlockSize[1]) : srcHeight;
             for(size_t z = 0; z < roundedUpDepth; z += srcBlockSize[2])
             {
               size_t srcOffset = srcSliceSize * ((srcZ + z) / (GLsizei)srcBlockSize[2]) +
@@ -3813,7 +3813,7 @@ void WrappedOpenGL::StoreCompressedTexData(ResourceId texId, GLenum target, GLin
           // GetCompressedByteSize() will factor in the 'partial' blocks at image edges when the
           // image size is not an integer multiple of the block size, so we need to take into
           // account that in the loop
-          size_t roundedUpHeight = AlignUp((uint32_t)height, blockSize[1]);
+          size_t roundedUpHeight = AlignToMultiple((uint32_t)height, blockSize[1]);
           for(size_t y = 0; y < roundedUpHeight; y += blockSize[1])
           {
             memcpy(cdData.data() + dstOffset, srcPixels + srcOffset, srcRowSize);


### PR DESCRIPTION
## Description
* Fix alignment calculation to match intended behavior when block size is not a power of 2
* Address #3510 and #3501
* Tested with a repro for #3510 and the sample from #3432
