### PR TITLE
Warn user if layer config application failed before JDWP failure

### DIFF
--- a/renderdoc/api/replay/renderdoc_tostr.inl
+++ b/renderdoc/api/replay/renderdoc_tostr.inl
@@ -100,6 +100,8 @@ rdcstr DoStringise(const ResultCode &el)
     STRINGISE_ENUM_CLASS_NAMED(InvalidParameter,
                                "An invalid parameter was passed to RenderDoc's API");
     STRINGISE_ENUM_CLASS_NAMED(CompressionFailed, "Compression or decompression failed");
+    STRINGISE_ENUM_CLASS_NAMED(AndroidLayerConfFailed,
+                               "Debug layer configuration failed on Android");
   }
   END_ENUM_STRINGISE();
 }

--- a/renderdoc/api/replay/replay_enums.h
+++ b/renderdoc/api/replay/replay_enums.h
@@ -4216,6 +4216,10 @@ a remote server.
 .. data:: CompressionFailed
 
   Compression or decompression failed.
+
+.. data:: AndroidLayerConfFailed
+
+  Debug layer configuration failed on Android.
 )");
 enum class ResultCode : uint32_t
 {
@@ -4251,6 +4255,7 @@ enum class ResultCode : uint32_t
   DataNotAvailable,
   InvalidParameter,
   CompressionFailed,
+  AndroidLayerConfFailed,
 };
 
 DECLARE_REFLECTION_ENUM(ResultCode);


### PR DESCRIPTION
On Android >=10 Vulkan and GL ES debug layering is the preferred injection mechanism, however if that fails to apply, RD falls back to JDWP injection.  JDWP injection is harder to debug and fix than a layer configuration issue (almost always a vender-specific permissions problem), so if the layer conf _and_ JDWP fail, the user should be warned about the layer conf.