### PR TITLE
Fix image state merge with secondary command buffers.

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1593,6 +1593,16 @@ public:
     m_value = ImageSubresourceState(VK_QUEUE_FAMILY_IGNORED, UNKNOWN_PREV_IMG_LAYOUT, refType);
   }
 
+  bool IsInitialised() const
+  {
+    // When merging image states from a secondary command buffer into a primary, some of those image
+    // states may have been added in an unknown layout when the image was referenced and never
+    // updated. These cases need to be detected and handled separately, otherwise the layout
+    // transitions recorded to the primary may be improperly overwritten.
+    return (!m_values.empty() || m_value.oldLayout != UNKNOWN_PREV_IMG_LAYOUT ||
+            m_value.newLayout != UNKNOWN_PREV_IMG_LAYOUT);
+  }
+
   void ToArray(rdcarray<ImageSubresourceStateForRange> &arr);
 
   void FromArray(const rdcarray<ImageSubresourceStateForRange> &arr);


### PR DESCRIPTION
This PR fixes an issue with vulkan capture that would occur if a secondary command buffer referenced an image but did not record a layout transition for it.

In such an instance, when the secondary command buffer is executed in VkCmdExecuteCommands, any ImageStates recorded by the secondary are merged into the primary.

If the primary has not encountered the image before, an initial state for the image is first added to the primary, then the current state is merged in from the secondary.

In cases where the image state in the secondary is for an image that did not record a layout transition, the newLayout and oldLayout fields of any subresource states will be UNKNOWN_PREV_IMG_LAYOUT. This special image layout does not overwrite other layouts, so the initial image state added to the primary will have whatever the image's initial layout is for both oldLayout and newLayout. This will either be VK_IMAGE_LAYOUT_UNDEFINED or VK_IMAGE_LAYOUT_PREINITIALIZED.

This causes an issue when command buffer image states are merged into the capture image state record in CaptureQueueSubmit, as defined image states may be overwritten with undefined, causing image initial contents to be ignored.

To resolve this I've added a function ImageSubresourceMap::IsInitialised that checks whether a subresource map either has subresources or has at least one known layout. When merging in an image state, if the original image state is uninitialized, a copy is added instead of an initial state.

This prevents any defined layouts from being improperly overwritten with undefined layouts.
