### PR TITLE
"Prompt on close" user setting for unsaved captures

### DIFF
--- a/qrenderdoc/Code/Interface/PersistantConfig.h
+++ b/qrenderdoc/Code/Interface/PersistantConfig.h
@@ -475,6 +475,13 @@ DECLARE_REFLECTION_STRUCT(BugReport);
   CONFIG_SETTING_VAL(public, bool, bool, AllowProcessInject, false)                                \
                                                                                                    \
   DOCUMENT(                                                                                        \
+      "``True`` if the user wishes to be prompted to save unsaved or modified captures on "        \
+      "closing the application.\n"                                                                 \
+      "\n"                                                                                         \
+      "Defaults to ``True``.");                                                                    \
+  CONFIG_SETTING_VAL(public, bool, bool, PromptOnClose, true)                                      \
+                                                                                                   \
+  DOCUMENT(                                                                                        \
       "A list of :class:`ShaderProcessingTool` detailing shader processing programs. The list "    \
       "comes in priority order, with earlier processors preferred over later ones.\n"              \
       "\n"                                                                                         \

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.cpp
@@ -199,6 +199,8 @@ SettingsDialog::SettingsDialog(ICaptureContext &ctx, QWidget *parent)
 
   ui->AlwaysReplayLocally->setChecked(m_Ctx.Config().AlwaysReplayLocally);
 
+  ui->PromptOnClose->setChecked(m_Ctx.Config().PromptOnClose);
+
   {
     const SDObject *getPaths = RENDERDOC_GetConfigSetting("DXBC.Debug.SearchDirPaths");
     if(!getPaths)
@@ -556,6 +558,13 @@ void SettingsDialog::on_Font_PreferMonospaced_toggled(bool checked)
 void SettingsDialog::on_AlwaysReplayLocally_toggled(bool checked)
 {
   m_Ctx.Config().AlwaysReplayLocally = ui->AlwaysReplayLocally->isChecked();
+
+  m_Ctx.Config().Save();
+}
+
+void SettingsDialog::on_PromptOnClose_toggled(bool checked)
+{
+  m_Ctx.Config().PromptOnClose = ui->PromptOnClose->isChecked();
 
   m_Ctx.Config().Save();
 }

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.h
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.h
@@ -69,6 +69,7 @@ private slots:
   void on_CheckUpdate_AllowChecks_toggled(bool checked);
   void on_Font_PreferMonospaced_toggled(bool checked);
   void on_AlwaysReplayLocally_toggled(bool checked);
+  void on_PromptOnClose_toggled(bool checked);
   void on_analyticsAutoSubmit_toggled(bool checked);
   void on_analyticsManualCheck_toggled(bool checked);
   void on_analyticsOptOut_toggled(bool checked);

--- a/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
+++ b/qrenderdoc/Windows/Dialogs/SettingsDialog.ui
@@ -473,7 +473,27 @@ This option overrides that and will always replay locally if the local context i
             </property>
            </widget>
           </item>
+          <item row="19" column="0">
+            <widget class="QLabel" name="label_11">
+              <property name="toolTip">
+                <string>Creates a prompt to save unsaved or modified captures to appear when renderdoc is closing.</string>
+              </property>
+              <property name="text">
+                <string>Prompt to save captures on close</string>
+              </property>
+            </widget>
+          </item>
           <item row="19" column="1">
+            <widget class="QCheckBox" name="PromptOnClose">
+              <property name="toolTip">
+                <string>Creates a prompt to save unsaved or modified captures to appear when renderdoc is closing.</string>
+              </property>
+              <property name="text">
+                <string/>
+              </property>
+            </widget>
+          </item>
+          <item row="20" column="1">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/qrenderdoc/Windows/MainWindow.cpp
+++ b/qrenderdoc/Windows/MainWindow.cpp
@@ -2947,13 +2947,18 @@ void MainWindow::closeEvent(QCloseEvent *event)
     return;
   }
 
-  if(!PromptCloseCapture())
+  if(m_Ctx.Config().PromptOnClose)
   {
-    event->ignore();
-    return;
+    if(!PromptCloseCapture())
+    {
+      event->ignore();
+      return;
+    }
   }
 
-  bool noToAll = false;
+  // if the user doesn't want to be prompted on close, that can be treated as saying 'no to all'
+  // when asked to save all live captures
+  bool noToAll = !m_Ctx.Config().PromptOnClose;
 
   QList<QPointer<LiveCapture>> liveCaptures;
 


### PR DESCRIPTION
## Description
"Prompt on close" user setting for unsaved captures.

This option is useful for users and workflows that use transient captures often, especially when multiple renderdoc windows are present. In these cases, being able to close all windows with one click is a big convenience.