### PR TITLE
Reset planar flag when remapping textures on vulkan replay

### DIFF
--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -4189,6 +4189,7 @@ void VulkanReplay::GetTextureData(ResourceId tex, const Subresource &sub,
     // no longer depth, if it was
     isDepth = false;
     isStencil = false;
+    isPlanar = false;
   }
   else if(wasms && resolve)
   {


### PR DESCRIPTION
## Description

Reset the planar flag at the end of any texture remapping during Vulkan replays. Without this we can run into issues copying the remapped image as the image is treat as a planar image despite no longer being one.