### PR TITLE
Retain initial contents type on softmem flush reset

### DIFF
--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -132,7 +132,11 @@ bool WrappedVulkan::Prepare_InitialState(WrappedVkRes *res)
 
         // record is not needed on vulkan
         Serialise_InitialState(ser, flushId, NULL, &initData);
-        GetResourceManager()->SetInitialContents(flushId, VkInitialContents());
+
+        // Clear the existing init contents, but retain the type
+        VkInitialContents clearedContents;
+        clearedContents.type = initData.type;
+        GetResourceManager()->SetInitialContents(flushId, clearedContents);
       }
       uint64_t end = ser.GetWriter()->GetOffset();
 


### PR DESCRIPTION
Otherwise resources are filtered out before writing, due to https://github.com/baldurk/renderdoc/blob/v1.x/renderdoc/driver/vulkan/vk_manager.cpp#L1071