### PR TITLE
Fix crash in DX11 unmap if map was called before frame capture

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
@@ -7861,7 +7861,8 @@ bool WrappedID3D11DeviceContext::Serialise_Unmap(SerialiserType &ser, ID3D11Reso
     // while actively capturing, on large buffers being updated, try to locate the range of data
     // being
     // updated and update the diffStart/diffEnd/len variables
-    if(IsActiveCapturing(m_State) && len > 512 && intercept.MapType != D3D11_MAP_WRITE_DISCARD)
+    if(IsActiveCapturing(m_State) && len > 512 && intercept.MapType != D3D11_MAP_WRITE_DISCARD &&
+       record->GetShadowPtr(ctxMapID, 1))
     {
       size_t s = diffStart;
       size_t e = diffEnd;


### PR DESCRIPTION
The problem can be reproduced by calling map of a DX11 buffer and then keeping that open until a frame is captured in which unmap is called. The call to
```cpp
bool found = FindDiffRange(MapWrittenData, record->GetShadowPtr(ctxMapID, 1), len, s, e);
```
would crash as `record->GetShadowPtr(ctxMapID, 1)` returns nullptr and `FindDiffRange` does not guard against this.

