### PR TITLE
Fixed crash by extended_dynamic_state2 functions in pixel history

### DIFF
--- a/renderdoc/driver/vulkan/vk_state.cpp
+++ b/renderdoc/driver/vulkan/vk_state.cpp
@@ -527,12 +527,14 @@ void VulkanRenderState::BindDynamicState(WrappedVulkan *vk, VkCommandBuffer cmd)
   if(vk->ExtendedDynamicState2Logic() || vk->ShaderObject())
   {
     if(dynamicStates[VkDynamicLogicOpEXT])
-      ObjDisp(cmd)->CmdSetLogicOpEXT(Unwrap(cmd), logicOp);
+      if(ObjDisp(cmd)->CmdSetLogicOpEXT)
+        ObjDisp(cmd)->CmdSetLogicOpEXT(Unwrap(cmd), logicOp);
   }
   if(vk->ExtendedDynamicState2CPs() || vk->ShaderObject())
   {
     if(dynamicStates[VkDynamicControlPointsEXT])
-      ObjDisp(cmd)->CmdSetPatchControlPointsEXT(Unwrap(cmd), patchControlPoints);
+      if(ObjDisp(cmd)->CmdSetPatchControlPointsEXT)
+        ObjDisp(cmd)->CmdSetPatchControlPointsEXT(Unwrap(cmd), patchControlPoints);
   }
 
   if(vk->ExtendedDynamicState3AlphaToCover() || vk->ShaderObject())


### PR DESCRIPTION
vkCmdSetPatchControlPointsEXT and vkCmdSetLogicOpEXT were not promoted to 1.3. I guess because of that Mesa driver returns NULL when tries to get proc address of those functions.