### PR TITLE
fix EGL error and possible incorrect sample count in `eglSwapBuffers_renderdoc_hooked`

### DIFF
--- a/renderdoc/driver/gl/egl_hooks.cpp
+++ b/renderdoc/driver/gl/egl_hooks.cpp
@@ -554,6 +554,9 @@ HOOK_EXPORT EGLBoolean EGLAPIENTRY eglSwapBuffers_renderdoc_hooked(EGLDisplay dp
     data.egl_wnd = surface;
     data.egl_ctx = EGL.GetCurrentContext();
 
+    // we could query this out technically but it's easier to keep a map
+    data.egl_cfg = eglhook.configs[data.egl_ctx];
+
     eglhook.RefreshWindowParameters(data);
 
     SurfaceConfig cfg = eglhook.windows[surface];


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

Fixes #3623 

This patch makes sure `data.egl_cfg` is set before calling `eglSwapBuffers_renderdoc_hooked`, making sure that `EGL.GetConfigAttrib` does not produce an error. Incidentally, as this likely didn't work before, this will probably get the correct sample count of the config via `EGL.GetConfigAttrib`.
