### PR TITLE
disable mismatched new-delete warning for GCC 11.1+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
             list(APPEND warning_flags -Wimplicit-fallthrough=2)
         endif()
+
+        # False positives due to function inlining decisions
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103993
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.0.9)
+            list(APPEND warning_flags -Wno-mismatched-new-delete)
+        endif()
         
         if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.9)
             list(APPEND warning_flags -Wno-unused-value)


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

GCC can emit a `mismatched-new-delete` due to a difference in inlining decisions with overloaded `new` and `delete` operators. The [bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103993) suggests using attributes to indicate to the compiler to always inline both operators.

Only reproduced with GCC 11.3.0 on the SDK for an embedded ARM platform.

Disable the warning in CMake for GCC 11.1 onwards (where the warning was introduced)
