### PR TITLE
cmake fixes for MacOS SDK 15.5 build (AppleClang 17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND warning_flags -Wno-deprecated-literal-operator)
     endif()
 
-    if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17 AND APPLE)
         # See related https://github.com/swig/swig/issues/1259
         list(APPEND warning_flags -Wno-cast-function-type-mismatch)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND warning_flags -Wno-deprecated-literal-operator)
     endif()
 
+    if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
+        # See related https://github.com/swig/swig/issues/1259
+        list(APPEND warning_flags -Wno-cast-function-type-mismatch)
+    endif()
+
     if(NOT RELEASE_MODE)
         list(APPEND warning_flags -Werror)
     endif()

--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -115,14 +115,15 @@ include(ExternalProject)
 # Need bison for swig
 find_package(BISON)
 
-set(SWIG_CONFIGURE_CC ${CMAKE_C_COMPILER})
-set(SWIG_CONFIGURE_CXX ${CMAKE_CXX_COMPILER})
-
+set(SWIG_CONFIGURE_CC_DEFAULT ${CMAKE_C_COMPILER})
+set(SWIG_CONFIGURE_CXX_DEFAULT ${CMAKE_CXX_COMPILER})
 # macOS 10.14+ ships broken compilers, need to disable CC/CXX inheritance
 if(APPLE)
-    set(SWIG_CONFIGURE_CC "")
-    set(SWIG_CONFIGURE_CXX "")
+    set(SWIG_CONFIGURE_CC_DEFAULT "")
+    set(SWIG_CONFIGURE_CXX_DEFAULT "")
 endif()
+set(SWIG_CONFIGURE_CC ${SWIG_CONFIGURE_CC_DEFAULT} CACHE STRING "C Compiler for external SWIG project. Default is the main project C compiler")
+set(SWIG_CONFIGURE_CXX ${SWIG_CONFIGURE_CXX_DEFAULT} CACHE STRING "C++ Compiler for external SWIG project. Default is the main project C++ compiler")
 
 set( GENERATOR_MAKE "$(MAKE)" )
 set( GENERATOR_MAKE_PARAMS "" )
@@ -157,10 +158,15 @@ ExternalProject_Add(custom_swig
     # using an URL to a zip directly so we don't clone the history etc
     URL ${RENDERDOC_SWIG_PACKAGE}
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ${SET_SYSTEM_PATH_COMMAND} ./autogen.sh > /dev/null 2>&1
-    COMMAND CC=${SWIG_CONFIGURE_CC} CXX=${SWIG_CONFIGURE_CXX} CFLAGS=-fPIC CXXFLAGS=-fPIC ${SET_SYSTEM_PATH_COMMAND} ./configure --with-pcre=yes --prefix=${CMAKE_BINARY_DIR} > /dev/null
-    BUILD_COMMAND ${GENERATOR_MAKE} ${GENERATOR_MAKE_PARAMS} > /dev/null 2>&1
-    INSTALL_COMMAND ${GENERATOR_MAKE} install > /dev/null 2>&1)
+    CONFIGURE_COMMAND ${SET_SYSTEM_PATH_COMMAND} ./autogen.sh
+    COMMAND ${CMAKE_COMMAND} -E env CC=${SWIG_CONFIGURE_CC} CXX=${SWIG_CONFIGURE_CXX} CFLAGS=-fPIC CXXFLAGS=-fPIC ${SET_SYSTEM_PATH_COMMAND} ./configure --with-pcre=yes --prefix=${CMAKE_BINARY_DIR}
+    BUILD_COMMAND ${GENERATOR_MAKE} ${GENERATOR_MAKE_PARAMS}
+    INSTALL_COMMAND ${GENERATOR_MAKE} install
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+    LOG_INSTALL ON
+    LOG_OUTPUT_ON_FAILURE ON
+)
 
 find_package(Shiboken2 QUIET)
 find_package(PySide2 QUIET)

--- a/qrenderdoc/CMakeLists.txt
+++ b/qrenderdoc/CMakeLists.txt
@@ -115,15 +115,19 @@ include(ExternalProject)
 # Need bison for swig
 find_package(BISON)
 
-set(SWIG_CONFIGURE_CC_DEFAULT ${CMAKE_C_COMPILER})
-set(SWIG_CONFIGURE_CXX_DEFAULT ${CMAKE_CXX_COMPILER})
-# macOS 10.14+ ships broken compilers, need to disable CC/CXX inheritance
 if(APPLE)
-    set(SWIG_CONFIGURE_CC_DEFAULT "")
-    set(SWIG_CONFIGURE_CXX_DEFAULT "")
+    # macOS 10.14+ ships broken compilers, need to disable CC/CXX inheritance
+    # If SWIG configuration fails, try configuring CMake with these vars set to clang and clang++ respectively
+    if (NOT DEFINED SWIG_CONFIGURE_CC)
+        set(SWIG_CONFIGURE_CC "")
+    endif()
+    if (NOT DEFINED SWIG_CONFIGURE_CXX)
+        set(SWIG_CONFIGURE_CXX "")
+    endif()
+else()
+    set(SWIG_CONFIGURE_CC ${CMAKE_C_COMPILER})
+    set(SWIG_CONFIGURE_CXX ${CMAKE_CXX_COMPILER})
 endif()
-set(SWIG_CONFIGURE_CC ${SWIG_CONFIGURE_CC_DEFAULT} CACHE STRING "C Compiler for external SWIG project. Default is the main project C compiler")
-set(SWIG_CONFIGURE_CXX ${SWIG_CONFIGURE_CXX_DEFAULT} CACHE STRING "C++ Compiler for external SWIG project. Default is the main project C++ compiler")
 
 set( GENERATOR_MAKE "$(MAKE)" )
 set( GENERATOR_MAKE_PARAMS "" )
@@ -158,15 +162,10 @@ ExternalProject_Add(custom_swig
     # using an URL to a zip directly so we don't clone the history etc
     URL ${RENDERDOC_SWIG_PACKAGE}
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ${SET_SYSTEM_PATH_COMMAND} ./autogen.sh
-    COMMAND ${CMAKE_COMMAND} -E env CC=${SWIG_CONFIGURE_CC} CXX=${SWIG_CONFIGURE_CXX} CFLAGS=-fPIC CXXFLAGS=-fPIC ${SET_SYSTEM_PATH_COMMAND} ./configure --with-pcre=yes --prefix=${CMAKE_BINARY_DIR}
-    BUILD_COMMAND ${GENERATOR_MAKE} ${GENERATOR_MAKE_PARAMS}
-    INSTALL_COMMAND ${GENERATOR_MAKE} install
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
-    LOG_INSTALL ON
-    LOG_OUTPUT_ON_FAILURE ON
-)
+    CONFIGURE_COMMAND ${SET_SYSTEM_PATH_COMMAND} ./autogen.sh > /dev/null 2>&1
+    COMMAND CC=${SWIG_CONFIGURE_CC} CXX=${SWIG_CONFIGURE_CXX} CFLAGS=-fPIC CXXFLAGS=-fPIC ${SET_SYSTEM_PATH_COMMAND} ./configure --with-pcre=yes --prefix=${CMAKE_BINARY_DIR} > /dev/null
+    BUILD_COMMAND ${GENERATOR_MAKE} ${GENERATOR_MAKE_PARAMS} > /dev/null 2>&1
+    INSTALL_COMMAND ${GENERATOR_MAKE} install > /dev/null 2>&1)
 
 find_package(Shiboken2 QUIET)
 find_package(PySide2 QUIET)


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

CMake changes to support MacOS build on Sequoia with SDK 15.5

* Added Cache variables for the SWIG compilers. Simply setting these to `clang` and `clang++` was sufficient to build on AppleClang 17
* Suppressed `-Wno-cast-function-type-mismatch` when compiling the SWIG code (see https://github.com/swig/swig/issues/1259)
