### PR TITLE
Serialise GLSL shader processing

### DIFF
--- a/renderdoc/data/glsl_shaders.cpp
+++ b/renderdoc/data/glsl_shaders.cpp
@@ -25,6 +25,7 @@
 #include "glsl_shaders.h"
 #include "common/common.h"
 #include "common/formatting.h"
+#include "common/threading.h"
 #include "driver/shaders/spirv/glslang_compile.h"
 #include "glslang/glslang/Public/ResourceLimits.h"
 #include "glslang/glslang/Public/ShaderLang.h"
@@ -136,6 +137,9 @@ rdcstr GenerateGLSLShader(const rdcstr &shader, ShaderType type, int version, co
   bool success;
 
   {
+    static Threading::CriticalSection *lock = new Threading::CriticalSection();
+    SCOPED_LOCK(*lock);
+
     std::string outstr;
     success =
         sh.preprocess(GetDefaultResources(), 100, ENoProfile, false, false, flags, &outstr, incl);


### PR DESCRIPTION
During Android >=15 app start `android::uirenderer` (i.e. the renderer for the APK's 'window') creates a `VkInstance` and `VkDevice` before the app does but after our layer has initialised. This is fine in principle because RD doesn't support multi-device capturing so the latter just replaces the former - unfortunately though the built-in shader construction is already underway at this point across the multiple threads.  glslang's shader preprocessing is not threadsafe causing intermittent aborts and segfaults.

I haven't seen this on any app other than the RD demo app, presumably because 'real' apps take much longer to start up effectively serialising the shader processing.