### PR TITLE
Support for viewing decoded ASTC in RenderDoc TextureViewer

### DIFF
--- a/qrenderdoc/Windows/TextureViewer.cpp
+++ b/qrenderdoc/Windows/TextureViewer.cpp
@@ -1257,6 +1257,14 @@ void TextureViewer::UI_UpdateTextureDetails()
 
   status = current.format.Name();
 
+  if(current.format.ASTCDecoded())
+  {
+    ResourceFormat astcFormat = {};
+    astcFormat.type = ResourceFormatType::ASTC;
+    astcFormat.compType = current.format.compType;
+    status += tr(" Decoded | Original format %1").arg(astcFormat.Name());
+  }
+
   const bool yuv = (current.format.type == ResourceFormatType::YUV8 ||
                     current.format.type == ResourceFormatType::YUV10 ||
                     current.format.type == ResourceFormatType::YUV12 ||

--- a/renderdoc/3rdparty/astc_dec/LICENSE
+++ b/renderdoc/3rdparty/astc_dec/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/renderdoc/3rdparty/astc_dec/README.md
+++ b/renderdoc/3rdparty/astc_dec/README.md
@@ -1,0 +1,36 @@
+# astc_dec
+astc_dec is a single source file **LDR** ASTC texture decompressor with the Apache 2.0 license, derived from Google's open source Android sources. The code currently only supports the LDR modes, but it would be easy to get HDR modes working again (the code is just remarked out because it depends on an FP16 class I didn't have time to reimplement). Please note that this is not an official Google repo, and is unsupported by Google. I have only placed it here for convienance to others.
+
+This decoder is derived from the original code here:
+
+https://chromium.googlesource.com/external/deqp/+/refs/heads/master/framework/common/tcuAstcUtil.cpp
+https://chromium.googlesource.com/external/deqp/+/refs/heads/master/framework/common/tcuAstcUtil.hpp
+
+Unlike Google's astc-codec decompressor, I found no bugs in this decoder, and it's also still usable in debug builds (astc-codec is extremely slow in debug).
+
+The testing code was removed to reduce the code size and number of external dependencies. I also replaced the external dependencies with custom implementations, to reduce the code size. 
+
+This codec was validated at various block sizes by feeding it random blocks, decompressing them, and comparing the decoded output vs. astc_codec:
+
+https://github.com/google/astc-codec
+
+Note that there were several decoding bugs in astc-codec which I locally fixed (and reported to astc-codec's github bug tracker). I have validated 4x4, 8x8, 12x12, and a few other block sizes, with both sRGB decoding enabled or disabled.
+
+Call this function to decode ASTC blocks to 8-bit RGBA pixels:
+
+`bool decompress(uint8_t* pDst, const uint8_t* data, bool isSRGB, int blockWidth, int blockHeight);`
+
+pDst is a pointer to the output pixels. The component byte order from lowest to highest memory location is is R, G, B, A.
+
+data is a pointer to the ASTC block data.
+
+Set isSRGB to true to enable sRGB 8->16 upscaling during decompression (before weight application). It's important that you set this flag to match whatever the encoder did, otherwise you'll introduce an extra ~1 LSB of error in the output:
+https://www.khronos.org/registry/DataFormat/specs/1.2/dataformat.1.2.html#astc_weight_application
+
+blockWidth/BlockHeight are the ASTC block dimensions, like 4x4, etc.
+
+false is returned if the block is invalid or uses an HDR mode.
+
+To re-enable HDR decoding, you would need to implement the FP16 class, and remark out the #if 0'd lines prefixed with a "rg" comment.
+
+Note that internally, when sRGB is disabled the codec unpacks to linear float values, then it converts this back to linear 8-bit/component. Another decode function that provides floating point output could easily be added.

--- a/renderdoc/3rdparty/astc_dec/astc_decomp.cpp
+++ b/renderdoc/3rdparty/astc_dec/astc_decomp.cpp
@@ -1,0 +1,1550 @@
+// basisu_astc_decomp.cpp: Only used for ASTC decompression, to validate the transcoder's output.
+// This version does not support HDR.
+
+/*-------------------------------------------------------------------------
+ * drawElements Quality Program Tester Core
+ * ----------------------------------------
+ *
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * rg: Removed external dependencies, remarked out HDR support because
+ * we don't need it, minor fix to decompress() so it converts non-sRGB
+ * output to 8-bits correctly. I've compared this decoder's output
+ * vs. astc-codec with random inputs on 4x4 blocks, and after fixing a few obvious
+ * bugs in astc-codec where it didn't correctly follow the spec they match so 
+ * I'm assuming they are both correct for 4x4 now.
+ * HDR support should be easily added back in, but as we don't need it 
+ * I'm leaving this for someone else.
+ * 
+ *//*!
+ * \file
+ * \brief ASTC Utilities.
+ *//*--------------------------------------------------------------------*/
+#include "astc_decomp.h"
+#include <assert.h>
+#include <algorithm>
+
+#define DE_LENGTH_OF_ARRAY(x) (sizeof(x)/sizeof(x[0]))
+#define DE_UNREF(x) (void)x
+
+typedef uint8_t deUint8;
+typedef int8_t deInt8;
+typedef uint32_t deUint32;
+typedef int32_t deInt32;
+typedef uint16_t deUint16;
+typedef int16_t deInt16;
+typedef int64_t deInt64;
+typedef uint64_t deUint64;
+
+#define DE_ASSERT assert
+
+namespace basisu
+{
+	//static bool inBounds(int v, int l, int h)
+	//{
+	//	return (v >= l) && (v < h);
+	//}
+
+	//static bool inRange(int v, int l, int h)
+	//{
+	//	return (v >= l) && (v <= h);
+	//}
+
+	template<typename T>
+	static inline T max(T a, T b)
+	{
+		return (a > b) ? a : b;
+	}
+
+	template<typename T>
+	static inline T min(T a, T b)
+	{
+		return (a < b) ? a : b;
+	}
+
+	template<typename T>
+	static inline T clamp(T a, T l, T h)
+	{
+		if (a < l)
+			return l;
+		else if (a > h)
+			return h;
+		return a;
+	}
+
+	struct UVec4
+	{
+		uint32_t m_c[4];
+
+		UVec4()
+		{
+			m_c[0] = 0;
+			m_c[1] = 0;
+			m_c[2] = 0;
+			m_c[3] = 0;
+		}
+
+		UVec4(uint32_t x, uint32_t y, uint32_t z, uint32_t w)
+		{
+			m_c[0] = x;
+			m_c[1] = y;
+			m_c[2] = z;
+			m_c[3] = w;
+		}
+
+		uint32_t x() const { return m_c[0]; }
+		uint32_t y() const { return m_c[1]; }
+		uint32_t z() const { return m_c[2]; }
+		uint32_t w() const { return m_c[3]; }
+
+		uint32_t& x() { return m_c[0]; }
+		uint32_t& y() { return m_c[1]; }
+		uint32_t& z() { return m_c[2]; }
+		uint32_t& w() { return m_c[3]; }
+
+		uint32_t operator[] (uint32_t idx) const { assert(idx < 4);  return m_c[idx]; }
+		uint32_t& operator[] (uint32_t idx) { assert(idx < 4);  return m_c[idx]; }
+	};
+
+	struct IVec4
+	{
+		int32_t m_c[4];
+
+		IVec4()
+		{
+			m_c[0] = 0;
+			m_c[1] = 0;
+			m_c[2] = 0;
+			m_c[3] = 0;
+		}
+
+		IVec4(int32_t x, int32_t y, int32_t z, int32_t w)
+		{
+			m_c[0] = x;
+			m_c[1] = y;
+			m_c[2] = z;
+			m_c[3] = w;
+		}
+
+		int32_t x() const { return m_c[0]; }
+		int32_t y() const { return m_c[1]; }
+		int32_t z() const { return m_c[2]; }
+		int32_t w() const { return m_c[3]; }
+
+		int32_t& x() { return m_c[0]; }
+		int32_t& y() { return m_c[1]; }
+		int32_t& z() { return m_c[2]; }
+		int32_t& w() { return m_c[3]; }
+
+		UVec4 asUint() const
+		{
+			return UVec4(std::max(0, m_c[0]), std::max(0, m_c[1]), std::max(0, m_c[2]), std::max(0, m_c[3]));
+		}
+
+		int32_t operator[] (uint32_t idx) const { assert(idx < 4);  return m_c[idx]; }
+		int32_t& operator[] (uint32_t idx) { assert(idx < 4);  return m_c[idx]; }
+	};
+
+	struct IVec3
+	{
+		int32_t m_c[3];
+
+		IVec3()
+		{
+			m_c[0] = 0;
+			m_c[1] = 0;
+			m_c[2] = 0;
+		}
+
+		IVec3(int32_t x, int32_t y, int32_t z)
+		{
+			m_c[0] = x;
+			m_c[1] = y;
+			m_c[2] = z;
+		}
+
+		int32_t x() const { return m_c[0]; }
+		int32_t y() const { return m_c[1]; }
+		int32_t z() const { return m_c[2]; }
+
+		int32_t& x() { return m_c[0]; }
+		int32_t& y() { return m_c[1]; }
+		int32_t& z() { return m_c[2]; }
+
+		int32_t operator[] (uint32_t idx) const { assert(idx < 3);  return m_c[idx]; }
+		int32_t& operator[] (uint32_t idx) { assert(idx < 3);  return m_c[idx]; }
+	};
+
+	static uint32_t deDivRoundUp32(uint32_t a, uint32_t b)
+	{
+		return (a + b - 1) / b;
+	}
+
+	//static bool deInBounds32(uint32_t v, uint32_t l, uint32_t h)
+	//{
+	//	return (v >= l) && (v < h);
+	//}
+
+namespace astc
+{
+using std::vector;
+namespace
+{
+// Common utilities
+enum
+{
+	MAX_BLOCK_WIDTH		= 12,
+	MAX_BLOCK_HEIGHT	= 12
+};
+inline deUint32 getBit (deUint32 src, int ndx)
+{
+	DE_ASSERT(basisu::inBounds(ndx, 0, 32));
+	return (src >> ndx) & 1;
+}
+inline deUint32 getBits (deUint32 src, int low, int high)
+{
+	const int numBits = (high-low) + 1;
+	DE_ASSERT(basisu::inRange(numBits, 1, 32));
+	if (numBits < 32)
+		return (deUint32)((src >> low) & ((1u<<numBits)-1));
+	else
+		return (deUint32)((src >> low) & 0xFFFFFFFFu);
+}
+inline bool isBitSet (deUint32 src, int ndx)
+{
+	return getBit(src, ndx) != 0;
+}
+inline deUint32 reverseBits (deUint32 src, int numBits)
+{
+	DE_ASSERT(basisu::inRange(numBits, 0, 32));
+	deUint32 result = 0;
+	for (int i = 0; i < numBits; i++)
+		result |= ((src >> i) & 1) << (numBits-1-i);
+	return result;
+}
+inline deUint32 bitReplicationScale (deUint32 src, int numSrcBits, int numDstBits)
+{
+	DE_ASSERT(numSrcBits <= numDstBits);
+	DE_ASSERT((src & ((1<<numSrcBits)-1)) == src);
+	deUint32 dst = 0;
+	for (int shift = numDstBits-numSrcBits; shift > -numSrcBits; shift -= numSrcBits)
+		dst |= shift >= 0 ? src << shift : src >> -shift;
+	return dst;
+}
+
+inline deInt32 signExtend (deInt32 src, int numSrcBits)
+{
+	DE_ASSERT(basisu::inRange(numSrcBits, 2, 31));
+	const bool negative = (src & (1 << (numSrcBits-1))) != 0;
+	return src | (negative ? ~((1 << numSrcBits) - 1) : 0);
+}
+
+//inline bool isFloat16InfOrNan (deFloat16 v)
+//{
+//	return getBits(v, 10, 14) == 31;
+//}
+
+enum ISEMode
+{
+	ISEMODE_TRIT = 0,
+	ISEMODE_QUINT,
+	ISEMODE_PLAIN_BIT,
+	ISEMODE_LAST
+};
+struct ISEParams
+{
+	ISEMode		mode;
+	int			numBits;
+	ISEParams (ISEMode mode_, int numBits_) : mode(mode_), numBits(numBits_) {}
+};
+inline int computeNumRequiredBits (const ISEParams& iseParams, int numValues)
+{
+	switch (iseParams.mode)
+	{
+		case ISEMODE_TRIT:			return deDivRoundUp32(numValues*8, 5) + numValues*iseParams.numBits;
+		case ISEMODE_QUINT:			return deDivRoundUp32(numValues*7, 3) + numValues*iseParams.numBits;
+		case ISEMODE_PLAIN_BIT:		return numValues*iseParams.numBits;
+		default:
+			DE_ASSERT(false);
+			return -1;
+	}
+}
+ISEParams computeMaximumRangeISEParams (int numAvailableBits, int numValuesInSequence)
+{
+	int curBitsForTritMode		= 6;
+	int curBitsForQuintMode		= 5;
+	int curBitsForPlainBitMode	= 8;
+	while (true)
+	{
+		DE_ASSERT(curBitsForTritMode > 0 || curBitsForQuintMode > 0 || curBitsForPlainBitMode > 0);
+		const int tritRange			= curBitsForTritMode > 0		? (3 << curBitsForTritMode) - 1			: -1;
+		const int quintRange		= curBitsForQuintMode > 0		? (5 << curBitsForQuintMode) - 1		: -1;
+		const int plainBitRange		= curBitsForPlainBitMode > 0	? (1 << curBitsForPlainBitMode) - 1		: -1;
+		const int maxRange			= basisu::max(basisu::max(tritRange, quintRange), plainBitRange);
+		if (maxRange == tritRange)
+		{
+			const ISEParams params(ISEMODE_TRIT, curBitsForTritMode);
+			if (computeNumRequiredBits(params, numValuesInSequence) <= numAvailableBits)
+				return ISEParams(ISEMODE_TRIT, curBitsForTritMode);
+			curBitsForTritMode--;
+		}
+		else if (maxRange == quintRange)
+		{
+			const ISEParams params(ISEMODE_QUINT, curBitsForQuintMode);
+			if (computeNumRequiredBits(params, numValuesInSequence) <= numAvailableBits)
+				return ISEParams(ISEMODE_QUINT, curBitsForQuintMode);
+			curBitsForQuintMode--;
+		}
+		else
+		{
+			const ISEParams params(ISEMODE_PLAIN_BIT, curBitsForPlainBitMode);
+			DE_ASSERT(maxRange == plainBitRange);
+			if (computeNumRequiredBits(params, numValuesInSequence) <= numAvailableBits)
+				return ISEParams(ISEMODE_PLAIN_BIT, curBitsForPlainBitMode);
+			curBitsForPlainBitMode--;
+		}
+	}
+}
+inline int computeNumColorEndpointValues (deUint32 endpointMode)
+{
+	DE_ASSERT(endpointMode < 16);
+	return (endpointMode/4 + 1) * 2;
+}
+// Decompression utilities
+enum DecompressResult
+{
+	DECOMPRESS_RESULT_VALID_BLOCK	= 0,	//!< Decompressed valid block
+	DECOMPRESS_RESULT_ERROR,				//!< Encountered error while decompressing, error color written
+	DECOMPRESS_RESULT_LAST
+};
+// A helper for getting bits from a 128-bit block.
+class Block128
+{
+private:
+	typedef deUint64 Word;
+	enum
+	{
+		WORD_BYTES	= sizeof(Word),
+		WORD_BITS	= 8*WORD_BYTES,
+		NUM_WORDS	= 128 / WORD_BITS
+	};
+	//DE_STATIC_ASSERT(128 % WORD_BITS == 0);
+public:
+	Block128 (const deUint8* src)
+	{
+		for (int wordNdx = 0; wordNdx < NUM_WORDS; wordNdx++)
+		{
+			m_words[wordNdx] = 0;
+			for (int byteNdx = 0; byteNdx < WORD_BYTES; byteNdx++)
+				m_words[wordNdx] |= (Word)src[wordNdx*WORD_BYTES + byteNdx] << (8*byteNdx);
+		}
+	}
+	deUint32 getBit (int ndx) const
+	{
+		DE_ASSERT(basisu::inBounds(ndx, 0, 128));
+		return (m_words[ndx / WORD_BITS] >> (ndx % WORD_BITS)) & 1;
+	}
+	deUint32 getBits (int low, int high) const
+	{
+		DE_ASSERT(basisu::inBounds(low, 0, 128));
+		DE_ASSERT(basisu::inBounds(high, 0, 128));
+		DE_ASSERT(basisu::inRange(high-low+1, 0, 32));
+		if (high-low+1 == 0)
+			return 0;
+		const int word0Ndx = low / WORD_BITS;
+		const int word1Ndx = high / WORD_BITS;
+		// \note "foo << bar << 1" done instead of "foo << (bar+1)" to avoid overflow, i.e. shift amount being too big.
+		if (word0Ndx == word1Ndx)
+			return (deUint32)((m_words[word0Ndx] & ((((Word)1 << high%WORD_BITS << 1) - 1))) >> ((Word)low % WORD_BITS));
+		else
+		{
+			DE_ASSERT(word1Ndx == word0Ndx + 1);
+			return (deUint32)(m_words[word0Ndx] >> (low%WORD_BITS)) |
+				   (deUint32)((m_words[word1Ndx] & (((Word)1 << high%WORD_BITS << 1) - 1)) << (high-low - high%WORD_BITS));
+		}
+	}
+	bool isBitSet (int ndx) const
+	{
+		DE_ASSERT(basisu::inBounds(ndx, 0, 128));
+		return getBit(ndx) != 0;
+	}
+private:
+	Word m_words[NUM_WORDS];
+};
+// A helper for sequential access into a Block128.
+class BitAccessStream
+{
+public:
+	BitAccessStream (const Block128& src, int startNdxInSrc, int length, bool forward)
+		: m_src				(src)
+		, m_startNdxInSrc	(startNdxInSrc)
+		, m_length			(length)
+		, m_forward			(forward)
+		, m_ndx				(0)
+	{
+	}
+	// Get the next num bits. Bits at positions greater than or equal to m_length are zeros.
+	deUint32 getNext (int num)
+	{
+		if (num == 0 || m_ndx >= m_length)
+			return 0;
+		const int end				= m_ndx + num;
+		const int numBitsFromSrc	= basisu::max(0, basisu::min(m_length, end) - m_ndx);
+		const int low				= m_ndx;
+		const int high				= m_ndx + numBitsFromSrc - 1;
+		m_ndx += num;
+		return m_forward ?			   m_src.getBits(m_startNdxInSrc + low,  m_startNdxInSrc + high)
+						 : reverseBits(m_src.getBits(m_startNdxInSrc - high, m_startNdxInSrc - low), numBitsFromSrc);
+	}
+private:
+	const Block128&		m_src;
+	const int			m_startNdxInSrc;
+	const int			m_length;
+	const bool			m_forward;
+	int					m_ndx;
+};
+struct ISEDecodedResult
+{
+	deUint32 m;
+	deUint32 tq; //!< Trit or quint value, depending on ISE mode.
+	deUint32 v;
+};
+// Data from an ASTC block's "block mode" part (i.e. bits [0,10]).
+struct ASTCBlockMode
+{
+	bool		isError;
+	// \note Following fields only relevant if !isError.
+	bool		isVoidExtent;
+	// \note Following fields only relevant if !isVoidExtent.
+	bool		isDualPlane;
+	int			weightGridWidth;
+	int			weightGridHeight;
+	ISEParams	weightISEParams;
+	ASTCBlockMode (void)
+		: isError			(true)
+		, isVoidExtent		(true)
+		, isDualPlane		(true)
+		, weightGridWidth	(-1)
+		, weightGridHeight	(-1)
+		, weightISEParams	(ISEMODE_LAST, -1)
+	{
+	}
+};
+inline int computeNumWeights (const ASTCBlockMode& mode)
+{
+	return mode.weightGridWidth * mode.weightGridHeight * (mode.isDualPlane ? 2 : 1);
+}
+struct ColorEndpointPair
+{
+	UVec4 e0;
+	UVec4 e1;
+};
+struct TexelWeightPair
+{
+	deUint32 w[2];
+};
+ASTCBlockMode getASTCBlockMode (deUint32 blockModeData)
+{
+	ASTCBlockMode blockMode;
+	blockMode.isError = true; // \note Set to false later, if not error.
+	blockMode.isVoidExtent = getBits(blockModeData, 0, 8) == 0x1fc;
+	if (!blockMode.isVoidExtent)
+	{
+		if ((getBits(blockModeData, 0, 1) == 0 && getBits(blockModeData, 6, 8) == 7) || getBits(blockModeData, 0, 3) == 0)
+			return blockMode; // Invalid ("reserved").
+		deUint32 r = (deUint32)-1; // \note Set in the following branches.
+		if (getBits(blockModeData, 0, 1) == 0)
+		{
+			const deUint32 r0	= getBit(blockModeData, 4);
+			const deUint32 r1	= getBit(blockModeData, 2);
+			const deUint32 r2	= getBit(blockModeData, 3);
+			const deUint32 i78	= getBits(blockModeData, 7, 8);
+			r = (r2 << 2) | (r1 << 1) | (r0 << 0);
+			if (i78 == 3)
+			{
+				const bool i5 = isBitSet(blockModeData, 5);
+				blockMode.weightGridWidth	= i5 ? 10 : 6;
+				blockMode.weightGridHeight	= i5 ? 6  : 10;
+			}
+			else
+			{
+				const deUint32 a = getBits(blockModeData, 5, 6);
+				switch (i78)
+				{
+					case 0:		blockMode.weightGridWidth = 12;		blockMode.weightGridHeight = a + 2;									break;
+					case 1:		blockMode.weightGridWidth = a + 2;	blockMode.weightGridHeight = 12;									break;
+					case 2:		blockMode.weightGridWidth = a + 6;	blockMode.weightGridHeight = getBits(blockModeData, 9, 10) + 6;		break;
+					default: DE_ASSERT(false);
+				}
+			}
+		}
+		else
+		{
+			const deUint32 r0	= getBit(blockModeData, 4);
+			const deUint32 r1	= getBit(blockModeData, 0);
+			const deUint32 r2	= getBit(blockModeData, 1);
+			const deUint32 i23	= getBits(blockModeData, 2, 3);
+			const deUint32 a	= getBits(blockModeData, 5, 6);
+			r = (r2 << 2) | (r1 << 1) | (r0 << 0);
+			if (i23 == 3)
+			{
+				const deUint32	b	= getBit(blockModeData, 7);
+				const bool		i8	= isBitSet(blockModeData, 8);
+				blockMode.weightGridWidth	= i8 ? b+2 : a+2;
+				blockMode.weightGridHeight	= i8 ? a+2 : b+6;
+			}
+			else
+			{
+				const deUint32 b = getBits(blockModeData, 7, 8);
+				switch (i23)
+				{
+					case 0:		blockMode.weightGridWidth = b + 4;	blockMode.weightGridHeight = a + 2;	break;
+					case 1:		blockMode.weightGridWidth = b + 8;	blockMode.weightGridHeight = a + 2;	break;
+					case 2:		blockMode.weightGridWidth = a + 2;	blockMode.weightGridHeight = b + 8;	break;
+					default: DE_ASSERT(false);
+				}
+			}
+		}
+		const bool	zeroDH		= getBits(blockModeData, 0, 1) == 0 && getBits(blockModeData, 7, 8) == 2;
+		const bool	h			= zeroDH ? 0 : isBitSet(blockModeData, 9);
+		blockMode.isDualPlane	= zeroDH ? 0 : isBitSet(blockModeData, 10);
+		{
+			ISEMode&	m	= blockMode.weightISEParams.mode;
+			int&		b	= blockMode.weightISEParams.numBits;
+			m = ISEMODE_PLAIN_BIT;
+			b = 0;
+			if (h)
+			{
+				switch (r)
+				{
+					case 2:							m = ISEMODE_QUINT;	b = 1;	break;
+					case 3:		m = ISEMODE_TRIT;						b = 2;	break;
+					case 4:												b = 4;	break;
+					case 5:							m = ISEMODE_QUINT;	b = 2;	break;
+					case 6:		m = ISEMODE_TRIT;						b = 3;	break;
+					case 7:												b = 5;	break;
+					default:	DE_ASSERT(false);
+				}
+			}
+			else
+			{
+				switch (r)
+				{
+					case 2:												b = 1;	break;
+					case 3:		m = ISEMODE_TRIT;								break;
+					case 4:												b = 2;	break;
+					case 5:							m = ISEMODE_QUINT;			break;
+					case 6:		m = ISEMODE_TRIT;						b = 1;	break;
+					case 7:												b = 3;	break;
+					default:	DE_ASSERT(false);
+				}
+			}
+		}
+	}
+	blockMode.isError = false;
+	return blockMode;
+}
+inline void setASTCErrorColorBlock (void* dst, int blockWidth, int blockHeight, bool isSRGB)
+{
+	if (isSRGB)
+	{
+		deUint8* const dstU = (deUint8*)dst;
+		for (int i = 0; i < blockWidth*blockHeight; i++)
+		{
+			dstU[4*i + 0] = 0xff;
+			dstU[4*i + 1] = 0;
+			dstU[4*i + 2] = 0xff;
+			dstU[4*i + 3] = 0xff;
+		}
+	}
+	else
+	{
+		float* const dstF = (float*)dst;
+		for (int i = 0; i < blockWidth*blockHeight; i++)
+		{
+			dstF[4*i + 0] = 1.0f;
+			dstF[4*i + 1] = 0.0f;
+			dstF[4*i + 2] = 1.0f;
+			dstF[4*i + 3] = 1.0f;
+		}
+	}
+}
+DecompressResult decodeVoidExtentBlock (void* dst, const Block128& blockData, int blockWidth, int blockHeight, bool isSRGB, bool isLDRMode)
+{
+	const deUint32	minSExtent			= blockData.getBits(12, 24);
+	const deUint32	maxSExtent			= blockData.getBits(25, 37);
+	const deUint32	minTExtent			= blockData.getBits(38, 50);
+	const deUint32	maxTExtent			= blockData.getBits(51, 63);
+	const bool		allExtentsAllOnes	= minSExtent == 0x1fff && maxSExtent == 0x1fff && minTExtent == 0x1fff && maxTExtent == 0x1fff;
+	const bool		isHDRBlock			= blockData.isBitSet(9);
+	if ((isLDRMode && isHDRBlock) || (!allExtentsAllOnes && (minSExtent >= maxSExtent || minTExtent >= maxTExtent)))
+	{
+		setASTCErrorColorBlock(dst, blockWidth, blockHeight, isSRGB);
+		return DECOMPRESS_RESULT_ERROR;
+	}
+	const deUint32 rgba[4] =
+	{
+		blockData.getBits(64,  79),
+		blockData.getBits(80,  95),
+		blockData.getBits(96,  111),
+		blockData.getBits(112, 127)
+	};
+	if (isSRGB)
+	{
+		deUint8* const dstU = (deUint8*)dst;
+		for (int i = 0; i < blockWidth*blockHeight; i++)
+		for (int c = 0; c < 4; c++)
+			dstU[i*4 + c] = (deUint8)((rgba[c] & 0xff00) >> 8);
+	}
+	else
+	{
+		float* const dstF = (float*)dst;
+		if (isHDRBlock)
+		{
+			// rg - REMOVING HDR SUPPORT FOR NOW
+#if 0
+			for (int c = 0; c < 4; c++)
+			{
+				if (isFloat16InfOrNan((deFloat16)rgba[c]))
+					throw InternalError("Infinity or NaN color component in HDR void extent block in ASTC texture (behavior undefined by ASTC specification)");
+			}
+			for (int i = 0; i < blockWidth*blockHeight; i++)
+			for (int c = 0; c < 4; c++)
+				dstF[i*4 + c] = deFloat16To32((deFloat16)rgba[c]);
+#endif
+		}
+		else
+		{
+			for (int i = 0; i < blockWidth*blockHeight; i++)
+			for (int c = 0; c < 4; c++)
+				dstF[i*4 + c] = rgba[c] == 65535 ? 1.0f : (float)rgba[c] / 65536.0f;
+		}
+	}
+	return DECOMPRESS_RESULT_VALID_BLOCK;
+}
+void decodeColorEndpointModes (deUint32* endpointModesDst, const Block128& blockData, int numPartitions, int extraCemBitsStart)
+{
+	if (numPartitions == 1)
+		endpointModesDst[0] = blockData.getBits(13, 16);
+	else
+	{
+		const deUint32 highLevelSelector = blockData.getBits(23, 24);
+		if (highLevelSelector == 0)
+		{
+			const deUint32 mode = blockData.getBits(25, 28);
+			for (int i = 0; i < numPartitions; i++)
+				endpointModesDst[i] = mode;
+		}
+		else
+		{
+			for (int partNdx = 0; partNdx < numPartitions; partNdx++)
+			{
+				const deUint32 cemClass		= highLevelSelector - (blockData.isBitSet(25 + partNdx) ? 0 : 1);
+				const deUint32 lowBit0Ndx	= numPartitions + 2*partNdx;
+				const deUint32 lowBit1Ndx	= numPartitions + 2*partNdx + 1;
+				const deUint32 lowBit0		= blockData.getBit(lowBit0Ndx < 4 ? 25+lowBit0Ndx : extraCemBitsStart+lowBit0Ndx-4);
+				const deUint32 lowBit1		= blockData.getBit(lowBit1Ndx < 4 ? 25+lowBit1Ndx : extraCemBitsStart+lowBit1Ndx-4);
+				endpointModesDst[partNdx] = (cemClass << 2) | (lowBit1 << 1) | lowBit0;
+			}
+		}
+	}
+}
+int computeNumColorEndpointValues (const deUint32* endpointModes, int numPartitions)
+{
+	int result = 0;
+	for (int i = 0; i < numPartitions; i++)
+		result += computeNumColorEndpointValues(endpointModes[i]);
+	return result;
+}
+void decodeISETritBlock (ISEDecodedResult* dst, int numValues, BitAccessStream& data, int numBits)
+{
+	DE_ASSERT(basisu::inRange(numValues, 1, 5));
+	deUint32 m[5];
+	m[0]			= data.getNext(numBits);
+	deUint32 T01	= data.getNext(2);
+	m[1]			= data.getNext(numBits);
+	deUint32 T23	= data.getNext(2);
+	m[2]			= data.getNext(numBits);
+	deUint32 T4		= data.getNext(1);
+	m[3]			= data.getNext(numBits);
+	deUint32 T56	= data.getNext(2);
+	m[4]			= data.getNext(numBits);
+	deUint32 T7		= data.getNext(1);
+	switch (numValues)
+	{
+		// \note Fall-throughs.
+		case 1: T23		= 0;
+		case 2: T4		= 0;
+		case 3: T56		= 0;
+		case 4: T7		= 0;
+		case 5: break;
+		default:
+			DE_ASSERT(false);
+	}
+	const deUint32 T = (T7 << 7) | (T56 << 5) | (T4 << 4) | (T23 << 2) | (T01 << 0);
+	static const deUint32 tritsFromT[256][5] =
+	{
+		{ 0,0,0,0,0 }, { 1,0,0,0,0 }, { 2,0,0,0,0 }, { 0,0,2,0,0 }, { 0,1,0,0,0 }, { 1,1,0,0,0 }, { 2,1,0,0,0 }, { 1,0,2,0,0 }, { 0,2,0,0,0 }, { 1,2,0,0,0 }, { 2,2,0,0,0 }, { 2,0,2,0,0 }, { 0,2,2,0,0 }, { 1,2,2,0,0 }, { 2,2,2,0,0 }, { 2,0,2,0,0 },
+		{ 0,0,1,0,0 }, { 1,0,1,0,0 }, { 2,0,1,0,0 }, { 0,1,2,0,0 }, { 0,1,1,0,0 }, { 1,1,1,0,0 }, { 2,1,1,0,0 }, { 1,1,2,0,0 }, { 0,2,1,0,0 }, { 1,2,1,0,0 }, { 2,2,1,0,0 }, { 2,1,2,0,0 }, { 0,0,0,2,2 }, { 1,0,0,2,2 }, { 2,0,0,2,2 }, { 0,0,2,2,2 },
+		{ 0,0,0,1,0 }, { 1,0,0,1,0 }, { 2,0,0,1,0 }, { 0,0,2,1,0 }, { 0,1,0,1,0 }, { 1,1,0,1,0 }, { 2,1,0,1,0 }, { 1,0,2,1,0 }, { 0,2,0,1,0 }, { 1,2,0,1,0 }, { 2,2,0,1,0 }, { 2,0,2,1,0 }, { 0,2,2,1,0 }, { 1,2,2,1,0 }, { 2,2,2,1,0 }, { 2,0,2,1,0 },
+		{ 0,0,1,1,0 }, { 1,0,1,1,0 }, { 2,0,1,1,0 }, { 0,1,2,1,0 }, { 0,1,1,1,0 }, { 1,1,1,1,0 }, { 2,1,1,1,0 }, { 1,1,2,1,0 }, { 0,2,1,1,0 }, { 1,2,1,1,0 }, { 2,2,1,1,0 }, { 2,1,2,1,0 }, { 0,1,0,2,2 }, { 1,1,0,2,2 }, { 2,1,0,2,2 }, { 1,0,2,2,2 },
+		{ 0,0,0,2,0 }, { 1,0,0,2,0 }, { 2,0,0,2,0 }, { 0,0,2,2,0 }, { 0,1,0,2,0 }, { 1,1,0,2,0 }, { 2,1,0,2,0 }, { 1,0,2,2,0 }, { 0,2,0,2,0 }, { 1,2,0,2,0 }, { 2,2,0,2,0 }, { 2,0,2,2,0 }, { 0,2,2,2,0 }, { 1,2,2,2,0 }, { 2,2,2,2,0 }, { 2,0,2,2,0 },
+		{ 0,0,1,2,0 }, { 1,0,1,2,0 }, { 2,0,1,2,0 }, { 0,1,2,2,0 }, { 0,1,1,2,0 }, { 1,1,1,2,0 }, { 2,1,1,2,0 }, { 1,1,2,2,0 }, { 0,2,1,2,0 }, { 1,2,1,2,0 }, { 2,2,1,2,0 }, { 2,1,2,2,0 }, { 0,2,0,2,2 }, { 1,2,0,2,2 }, { 2,2,0,2,2 }, { 2,0,2,2,2 },
+		{ 0,0,0,0,2 }, { 1,0,0,0,2 }, { 2,0,0,0,2 }, { 0,0,2,0,2 }, { 0,1,0,0,2 }, { 1,1,0,0,2 }, { 2,1,0,0,2 }, { 1,0,2,0,2 }, { 0,2,0,0,2 }, { 1,2,0,0,2 }, { 2,2,0,0,2 }, { 2,0,2,0,2 }, { 0,2,2,0,2 }, { 1,2,2,0,2 }, { 2,2,2,0,2 }, { 2,0,2,0,2 },
+		{ 0,0,1,0,2 }, { 1,0,1,0,2 }, { 2,0,1,0,2 }, { 0,1,2,0,2 }, { 0,1,1,0,2 }, { 1,1,1,0,2 }, { 2,1,1,0,2 }, { 1,1,2,0,2 }, { 0,2,1,0,2 }, { 1,2,1,0,2 }, { 2,2,1,0,2 }, { 2,1,2,0,2 }, { 0,2,2,2,2 }, { 1,2,2,2,2 }, { 2,2,2,2,2 }, { 2,0,2,2,2 },
+		{ 0,0,0,0,1 }, { 1,0,0,0,1 }, { 2,0,0,0,1 }, { 0,0,2,0,1 }, { 0,1,0,0,1 }, { 1,1,0,0,1 }, { 2,1,0,0,1 }, { 1,0,2,0,1 }, { 0,2,0,0,1 }, { 1,2,0,0,1 }, { 2,2,0,0,1 }, { 2,0,2,0,1 }, { 0,2,2,0,1 }, { 1,2,2,0,1 }, { 2,2,2,0,1 }, { 2,0,2,0,1 },
+		{ 0,0,1,0,1 }, { 1,0,1,0,1 }, { 2,0,1,0,1 }, { 0,1,2,0,1 }, { 0,1,1,0,1 }, { 1,1,1,0,1 }, { 2,1,1,0,1 }, { 1,1,2,0,1 }, { 0,2,1,0,1 }, { 1,2,1,0,1 }, { 2,2,1,0,1 }, { 2,1,2,0,1 }, { 0,0,1,2,2 }, { 1,0,1,2,2 }, { 2,0,1,2,2 }, { 0,1,2,2,2 },
+		{ 0,0,0,1,1 }, { 1,0,0,1,1 }, { 2,0,0,1,1 }, { 0,0,2,1,1 }, { 0,1,0,1,1 }, { 1,1,0,1,1 }, { 2,1,0,1,1 }, { 1,0,2,1,1 }, { 0,2,0,1,1 }, { 1,2,0,1,1 }, { 2,2,0,1,1 }, { 2,0,2,1,1 }, { 0,2,2,1,1 }, { 1,2,2,1,1 }, { 2,2,2,1,1 }, { 2,0,2,1,1 },
+		{ 0,0,1,1,1 }, { 1,0,1,1,1 }, { 2,0,1,1,1 }, { 0,1,2,1,1 }, { 0,1,1,1,1 }, { 1,1,1,1,1 }, { 2,1,1,1,1 }, { 1,1,2,1,1 }, { 0,2,1,1,1 }, { 1,2,1,1,1 }, { 2,2,1,1,1 }, { 2,1,2,1,1 }, { 0,1,1,2,2 }, { 1,1,1,2,2 }, { 2,1,1,2,2 }, { 1,1,2,2,2 },
+		{ 0,0,0,2,1 }, { 1,0,0,2,1 }, { 2,0,0,2,1 }, { 0,0,2,2,1 }, { 0,1,0,2,1 }, { 1,1,0,2,1 }, { 2,1,0,2,1 }, { 1,0,2,2,1 }, { 0,2,0,2,1 }, { 1,2,0,2,1 }, { 2,2,0,2,1 }, { 2,0,2,2,1 }, { 0,2,2,2,1 }, { 1,2,2,2,1 }, { 2,2,2,2,1 }, { 2,0,2,2,1 },
+		{ 0,0,1,2,1 }, { 1,0,1,2,1 }, { 2,0,1,2,1 }, { 0,1,2,2,1 }, { 0,1,1,2,1 }, { 1,1,1,2,1 }, { 2,1,1,2,1 }, { 1,1,2,2,1 }, { 0,2,1,2,1 }, { 1,2,1,2,1 }, { 2,2,1,2,1 }, { 2,1,2,2,1 }, { 0,2,1,2,2 }, { 1,2,1,2,2 }, { 2,2,1,2,2 }, { 2,1,2,2,2 },
+		{ 0,0,0,1,2 }, { 1,0,0,1,2 }, { 2,0,0,1,2 }, { 0,0,2,1,2 }, { 0,1,0,1,2 }, { 1,1,0,1,2 }, { 2,1,0,1,2 }, { 1,0,2,1,2 }, { 0,2,0,1,2 }, { 1,2,0,1,2 }, { 2,2,0,1,2 }, { 2,0,2,1,2 }, { 0,2,2,1,2 }, { 1,2,2,1,2 }, { 2,2,2,1,2 }, { 2,0,2,1,2 },
+		{ 0,0,1,1,2 }, { 1,0,1,1,2 }, { 2,0,1,1,2 }, { 0,1,2,1,2 }, { 0,1,1,1,2 }, { 1,1,1,1,2 }, { 2,1,1,1,2 }, { 1,1,2,1,2 }, { 0,2,1,1,2 }, { 1,2,1,1,2 }, { 2,2,1,1,2 }, { 2,1,2,1,2 }, { 0,2,2,2,2 }, { 1,2,2,2,2 }, { 2,2,2,2,2 }, { 2,1,2,2,2 }
+	};
+	const deUint32 (& trits)[5] = tritsFromT[T];
+	for (int i = 0; i < numValues; i++)
+	{
+		dst[i].m	= m[i];
+		dst[i].tq	= trits[i];
+		dst[i].v	= (trits[i] << numBits) + m[i];
+	}
+}
+void decodeISEQuintBlock (ISEDecodedResult* dst, int numValues, BitAccessStream& data, int numBits)
+{
+	DE_ASSERT(basisu::inRange(numValues, 1, 3));
+	deUint32 m[3];
+	m[0]			= data.getNext(numBits);
+	deUint32 Q012	= data.getNext(3);
+	m[1]			= data.getNext(numBits);
+	deUint32 Q34	= data.getNext(2);
+	m[2]			= data.getNext(numBits);
+	deUint32 Q56	= data.getNext(2);
+	switch (numValues)
+	{
+		// \note Fall-throughs.
+		case 1: Q34		= 0;
+		case 2: Q56		= 0;
+		case 3: break;
+		default:
+			DE_ASSERT(false);
+	}
+	const deUint32 Q = (Q56 << 5) | (Q34 << 3) | (Q012 << 0);
+	static const deUint32 quintsFromQ[256][3] =
+	{
+		{ 0,0,0 }, { 1,0,0 }, { 2,0,0 }, { 3,0,0 }, { 4,0,0 }, { 0,4,0 }, { 4,4,0 }, { 4,4,4 }, { 0,1,0 }, { 1,1,0 }, { 2,1,0 }, { 3,1,0 }, { 4,1,0 }, { 1,4,0 }, { 4,4,1 }, { 4,4,4 },
+		{ 0,2,0 }, { 1,2,0 }, { 2,2,0 }, { 3,2,0 }, { 4,2,0 }, { 2,4,0 }, { 4,4,2 }, { 4,4,4 }, { 0,3,0 }, { 1,3,0 }, { 2,3,0 }, { 3,3,0 }, { 4,3,0 }, { 3,4,0 }, { 4,4,3 }, { 4,4,4 },
+		{ 0,0,1 }, { 1,0,1 }, { 2,0,1 }, { 3,0,1 }, { 4,0,1 }, { 0,4,1 }, { 4,0,4 }, { 0,4,4 }, { 0,1,1 }, { 1,1,1 }, { 2,1,1 }, { 3,1,1 }, { 4,1,1 }, { 1,4,1 }, { 4,1,4 }, { 1,4,4 },
+		{ 0,2,1 }, { 1,2,1 }, { 2,2,1 }, { 3,2,1 }, { 4,2,1 }, { 2,4,1 }, { 4,2,4 }, { 2,4,4 }, { 0,3,1 }, { 1,3,1 }, { 2,3,1 }, { 3,3,1 }, { 4,3,1 }, { 3,4,1 }, { 4,3,4 }, { 3,4,4 },
+		{ 0,0,2 }, { 1,0,2 }, { 2,0,2 }, { 3,0,2 }, { 4,0,2 }, { 0,4,2 }, { 2,0,4 }, { 3,0,4 }, { 0,1,2 }, { 1,1,2 }, { 2,1,2 }, { 3,1,2 }, { 4,1,2 }, { 1,4,2 }, { 2,1,4 }, { 3,1,4 },
+		{ 0,2,2 }, { 1,2,2 }, { 2,2,2 }, { 3,2,2 }, { 4,2,2 }, { 2,4,2 }, { 2,2,4 }, { 3,2,4 }, { 0,3,2 }, { 1,3,2 }, { 2,3,2 }, { 3,3,2 }, { 4,3,2 }, { 3,4,2 }, { 2,3,4 }, { 3,3,4 },
+		{ 0,0,3 }, { 1,0,3 }, { 2,0,3 }, { 3,0,3 }, { 4,0,3 }, { 0,4,3 }, { 0,0,4 }, { 1,0,4 }, { 0,1,3 }, { 1,1,3 }, { 2,1,3 }, { 3,1,3 }, { 4,1,3 }, { 1,4,3 }, { 0,1,4 }, { 1,1,4 },
+		{ 0,2,3 }, { 1,2,3 }, { 2,2,3 }, { 3,2,3 }, { 4,2,3 }, { 2,4,3 }, { 0,2,4 }, { 1,2,4 }, { 0,3,3 }, { 1,3,3 }, { 2,3,3 }, { 3,3,3 }, { 4,3,3 }, { 3,4,3 }, { 0,3,4 }, { 1,3,4 }
+	};
+	const deUint32 (& quints)[3] = quintsFromQ[Q];
+	for (int i = 0; i < numValues; i++)
+	{
+		dst[i].m	= m[i];
+		dst[i].tq	= quints[i];
+		dst[i].v	= (quints[i] << numBits) + m[i];
+	}
+}
+inline void decodeISEBitBlock (ISEDecodedResult* dst, BitAccessStream& data, int numBits)
+{
+	dst[0].m = data.getNext(numBits);
+	dst[0].v = dst[0].m;
+}
+void decodeISE (ISEDecodedResult* dst, int numValues, BitAccessStream& data, const ISEParams& params)
+{
+	if (params.mode == ISEMODE_TRIT)
+	{
+		const int numBlocks = deDivRoundUp32(numValues, 5);
+		for (int blockNdx = 0; blockNdx < numBlocks; blockNdx++)
+		{
+			const int numValuesInBlock = blockNdx == numBlocks-1 ? numValues - 5*(numBlocks-1) : 5;
+			decodeISETritBlock(&dst[5*blockNdx], numValuesInBlock, data, params.numBits);
+		}
+	}
+	else if (params.mode == ISEMODE_QUINT)
+	{
+		const int numBlocks = deDivRoundUp32(numValues, 3);
+		for (int blockNdx = 0; blockNdx < numBlocks; blockNdx++)
+		{
+			const int numValuesInBlock = blockNdx == numBlocks-1 ? numValues - 3*(numBlocks-1) : 3;
+			decodeISEQuintBlock(&dst[3*blockNdx], numValuesInBlock, data, params.numBits);
+		}
+	}
+	else
+	{
+		DE_ASSERT(params.mode == ISEMODE_PLAIN_BIT);
+		for (int i = 0; i < numValues; i++)
+			decodeISEBitBlock(&dst[i], data, params.numBits);
+	}
+}
+void unquantizeColorEndpoints (deUint32* dst, const ISEDecodedResult* iseResults, int numEndpoints, const ISEParams& iseParams)
+{
+	if (iseParams.mode == ISEMODE_TRIT || iseParams.mode == ISEMODE_QUINT)
+	{
+		const int rangeCase				= iseParams.numBits*2 - (iseParams.mode == ISEMODE_TRIT ? 2 : 1);
+		DE_ASSERT(basisu::inRange(rangeCase, 0, 10));
+		static const deUint32	Ca[11]	= { 204, 113, 93, 54, 44, 26, 22, 13, 11, 6, 5 };
+		const deUint32			C		= Ca[rangeCase];
+		for (int endpointNdx = 0; endpointNdx < numEndpoints; endpointNdx++)
+		{
+			const deUint32 a = getBit(iseResults[endpointNdx].m, 0);
+			const deUint32 b = getBit(iseResults[endpointNdx].m, 1);
+			const deUint32 c = getBit(iseResults[endpointNdx].m, 2);
+			const deUint32 d = getBit(iseResults[endpointNdx].m, 3);
+			const deUint32 e = getBit(iseResults[endpointNdx].m, 4);
+			const deUint32 f = getBit(iseResults[endpointNdx].m, 5);
+			const deUint32 A = a == 0 ? 0 : (1<<9)-1;
+			const deUint32 B = rangeCase == 0	? 0
+							 : rangeCase == 1	? 0
+							 : rangeCase == 2	? (b << 8) |									(b << 4) |				(b << 2) |	(b << 1)
+							 : rangeCase == 3	? (b << 8) |												(b << 3) |	(b << 2)
+							 : rangeCase == 4	? (c << 8) | (b << 7) |										(c << 3) |	(b << 2) |	(c << 1) |	(b << 0)
+							 : rangeCase == 5	? (c << 8) | (b << 7) |													(c << 2) |	(b << 1) |	(c << 0)
+							 : rangeCase == 6	? (d << 8) | (c << 7) | (b << 6) |										(d << 2) |	(c << 1) |	(b << 0)
+							 : rangeCase == 7	? (d << 8) | (c << 7) | (b << 6) |													(d << 1) |	(c << 0)
+							 : rangeCase == 8	? (e << 8) | (d << 7) | (c << 6) | (b << 5) |										(e << 1) |	(d << 0)
+							 : rangeCase == 9	? (e << 8) | (d << 7) | (c << 6) | (b << 5) |													(e << 0)
+							 : rangeCase == 10	? (f << 8) | (e << 7) | (d << 6) | (c << 5) |	(b << 4) |										(f << 0)
+							 : (deUint32)-1;
+			DE_ASSERT(B != (deUint32)-1);
+			dst[endpointNdx] = (((iseResults[endpointNdx].tq*C + B) ^ A) >> 2) | (A & 0x80);
+		}
+	}
+	else
+	{
+		DE_ASSERT(iseParams.mode == ISEMODE_PLAIN_BIT);
+		for (int endpointNdx = 0; endpointNdx < numEndpoints; endpointNdx++)
+			dst[endpointNdx] = bitReplicationScale(iseResults[endpointNdx].v, iseParams.numBits, 8);
+	}
+}
+inline void bitTransferSigned (deInt32& a, deInt32& b)
+{
+	b >>= 1;
+	b |= a & 0x80;
+	a >>= 1;
+	a &= 0x3f;
+	if (isBitSet(a, 5))
+		a -= 0x40;
+}
+inline UVec4 clampedRGBA (const IVec4& rgba)
+{
+	return UVec4(basisu::clamp(rgba.x(), 0, 0xff),
+		basisu::clamp(rgba.y(), 0, 0xff),
+		basisu::clamp(rgba.z(), 0, 0xff),
+		basisu::clamp(rgba.w(), 0, 0xff));
+}
+inline IVec4 blueContract (int r, int g, int b, int a)
+{
+	return IVec4((r+b)>>1, (g+b)>>1, b, a);
+}
+inline bool isColorEndpointModeHDR (deUint32 mode)
+{
+	return mode == 2	||
+		   mode == 3	||
+		   mode == 7	||
+		   mode == 11	||
+		   mode == 14	||
+		   mode == 15;
+}
+void decodeHDREndpointMode7 (UVec4& e0, UVec4& e1, deUint32 v0, deUint32 v1, deUint32 v2, deUint32 v3)
+{
+	const deUint32 m10		= getBit(v1, 7) | (getBit(v2, 7) << 1);
+	const deUint32 m23		= getBits(v0, 6, 7);
+	const deUint32 majComp	= m10 != 3	? m10
+							: m23 != 3	? m23
+							:			  0;
+	const deUint32 mode		= m10 != 3	? m23
+							: m23 != 3	? 4
+							:			  5;
+	deInt32			red		= (deInt32)getBits(v0, 0, 5);
+	deInt32			green	= (deInt32)getBits(v1, 0, 4);
+	deInt32			blue	= (deInt32)getBits(v2, 0, 4);
+	deInt32			scale	= (deInt32)getBits(v3, 0, 4);
+	{
+#define SHOR(DST_VAR, SHIFT, BIT_VAR) (DST_VAR) |= (BIT_VAR) << (SHIFT)
+#define ASSIGN_X_BITS(V0,S0, V1,S1, V2,S2, V3,S3, V4,S4, V5,S5, V6,S6) do { SHOR(V0,S0,x0); SHOR(V1,S1,x1); SHOR(V2,S2,x2); SHOR(V3,S3,x3); SHOR(V4,S4,x4); SHOR(V5,S5,x5); SHOR(V6,S6,x6); } while (false)
+		const deUint32	x0	= getBit(v1, 6);
+		const deUint32	x1	= getBit(v1, 5);
+		const deUint32	x2	= getBit(v2, 6);
+		const deUint32	x3	= getBit(v2, 5);
+		const deUint32	x4	= getBit(v3, 7);
+		const deUint32	x5	= getBit(v3, 6);
+		const deUint32	x6	= getBit(v3, 5);
+		deInt32&		R	= red;
+		deInt32&		G	= green;
+		deInt32&		B	= blue;
+		deInt32&		S	= scale;
+		switch (mode)
+		{
+			case 0: ASSIGN_X_BITS(R,9,  R,8,  R,7,  R,10,  R,6,  S,6,   S,5); break;
+			case 1: ASSIGN_X_BITS(R,8,  G,5,  R,7,  B,5,   R,6,  R,10,  R,9); break;
+			case 2: ASSIGN_X_BITS(R,9,  R,8,  R,7,  R,6,   S,7,  S,6,   S,5); break;
+			case 3: ASSIGN_X_BITS(R,8,  G,5,  R,7,  B,5,   R,6,  S,6,   S,5); break;
+			case 4: ASSIGN_X_BITS(G,6,  G,5,  B,6,  B,5,   R,6,  R,7,   S,5); break;
+			case 5: ASSIGN_X_BITS(G,6,  G,5,  B,6,  B,5,   R,6,  S,6,   S,5); break;
+			default:
+				DE_ASSERT(false);
+		}
+#undef ASSIGN_X_BITS
+#undef SHOR
+	}
+	static const int shiftAmounts[] = { 1, 1, 2, 3, 4, 5 };
+	DE_ASSERT(mode < DE_LENGTH_OF_ARRAY(shiftAmounts));
+	red		<<= shiftAmounts[mode];
+	green	<<= shiftAmounts[mode];
+	blue	<<= shiftAmounts[mode];
+	scale	<<= shiftAmounts[mode];
+	if (mode != 5)
+	{
+		green	= red - green;
+		blue	= red - blue;
+	}
+	if (majComp == 1)
+		std::swap(red, green);
+	else if (majComp == 2)
+		std::swap(red, blue);
+	e0 = UVec4(basisu::clamp(red	- scale,	0, 0xfff),
+		basisu::clamp(green	- scale,	0, 0xfff),
+		basisu::clamp(blue	- scale,	0, 0xfff),
+			   0x780);
+	e1 = UVec4(basisu::clamp(red,				0, 0xfff),
+		basisu::clamp(green,				0, 0xfff),
+		basisu::clamp(blue,				0, 0xfff),
+			   0x780);
+}
+void decodeHDREndpointMode11 (UVec4& e0, UVec4& e1, deUint32 v0, deUint32 v1, deUint32 v2, deUint32 v3, deUint32 v4, deUint32 v5)
+{
+	const deUint32 major = (getBit(v5, 7) << 1) | getBit(v4, 7);
+	if (major == 3)
+	{
+		e0 = UVec4(v0<<4, v2<<4, getBits(v4,0,6)<<5, 0x780);
+		e1 = UVec4(v1<<4, v3<<4, getBits(v5,0,6)<<5, 0x780);
+	}
+	else
+	{
+		const deUint32 mode = (getBit(v3, 7) << 2) | (getBit(v2, 7) << 1) | getBit(v1, 7);
+		deInt32 a	= (deInt32)((getBit(v1, 6) << 8) | v0);
+		deInt32 c	= (deInt32)(getBits(v1, 0, 5));
+		deInt32 b0	= (deInt32)(getBits(v2, 0, 5));
+		deInt32 b1	= (deInt32)(getBits(v3, 0, 5));
+		deInt32 d0	= (deInt32)(getBits(v4, 0, 4));
+		deInt32 d1	= (deInt32)(getBits(v5, 0, 4));
+		{
+#define SHOR(DST_VAR, SHIFT, BIT_VAR) (DST_VAR) |= (BIT_VAR) << (SHIFT)
+#define ASSIGN_X_BITS(V0,S0, V1,S1, V2,S2, V3,S3, V4,S4, V5,S5) do { SHOR(V0,S0,x0); SHOR(V1,S1,x1); SHOR(V2,S2,x2); SHOR(V3,S3,x3); SHOR(V4,S4,x4); SHOR(V5,S5,x5); } while (false)
+			const deUint32 x0 = getBit(v2, 6);
+			const deUint32 x1 = getBit(v3, 6);
+			const deUint32 x2 = getBit(v4, 6);
+			const deUint32 x3 = getBit(v5, 6);
+			const deUint32 x4 = getBit(v4, 5);
+			const deUint32 x5 = getBit(v5, 5);
+			switch (mode)
+			{
+				case 0: ASSIGN_X_BITS(b0,6,  b1,6,   d0,6,  d1,6,  d0,5,  d1,5); break;
+				case 1: ASSIGN_X_BITS(b0,6,  b1,6,   b0,7,  b1,7,  d0,5,  d1,5); break;
+				case 2: ASSIGN_X_BITS(a,9,   c,6,    d0,6,  d1,6,  d0,5,  d1,5); break;
+				case 3: ASSIGN_X_BITS(b0,6,  b1,6,   a,9,   c,6,   d0,5,  d1,5); break;
+				case 4: ASSIGN_X_BITS(b0,6,  b1,6,   b0,7,  b1,7,  a,9,   a,10); break;
+				case 5: ASSIGN_X_BITS(a,9,   a,10,   c,7,   c,6,   d0,5,  d1,5); break;
+				case 6: ASSIGN_X_BITS(b0,6,  b1,6,   a,11,  c,6,   a,9,   a,10); break;
+				case 7: ASSIGN_X_BITS(a,9,   a,10,   a,11,  c,6,   d0,5,  d1,5); break;
+				default:
+					DE_ASSERT(false);
+			}
+#undef ASSIGN_X_BITS
+#undef SHOR
+		}
+		static const int numDBits[] = { 7, 6, 7, 6, 5, 6, 5, 6 };
+		DE_ASSERT(mode < DE_LENGTH_OF_ARRAY(numDBits));
+		d0 = signExtend(d0, numDBits[mode]);
+		d1 = signExtend(d1, numDBits[mode]);
+		const int shiftAmount = (mode >> 1) ^ 3;
+		a	<<= shiftAmount;
+		c	<<= shiftAmount;
+		b0	<<= shiftAmount;
+		b1	<<= shiftAmount;
+		d0	<<= shiftAmount;
+		d1	<<= shiftAmount;
+		e0 = UVec4(basisu::clamp(a-c,			0, 0xfff),
+			basisu::clamp(a-b0-c-d0,		0, 0xfff),
+			basisu::clamp(a-b1-c-d1,		0, 0xfff),
+				   0x780);
+		e1 = UVec4(basisu::clamp(a,				0, 0xfff),
+			basisu::clamp(a-b0,			0, 0xfff),
+			basisu::clamp(a-b1,			0, 0xfff),
+				   0x780);
+		if (major == 1)
+		{
+			std::swap(e0.x(), e0.y());
+			std::swap(e1.x(), e1.y());
+		}
+		else if (major == 2)
+		{
+			std::swap(e0.x(), e0.z());
+			std::swap(e1.x(), e1.z());
+		}
+	}
+}
+void decodeHDREndpointMode15(UVec4& e0, UVec4& e1, deUint32 v0, deUint32 v1, deUint32 v2, deUint32 v3, deUint32 v4, deUint32 v5, deUint32 v6In, deUint32 v7In)
+{
+	decodeHDREndpointMode11(e0, e1, v0, v1, v2, v3, v4, v5);
+	const deUint32	mode	= (getBit(v7In, 7) << 1) | getBit(v6In, 7);
+	deInt32			v6		= (deInt32)getBits(v6In, 0, 6);
+	deInt32			v7		= (deInt32)getBits(v7In, 0, 6);
+	if (mode == 3)
+	{
+		e0.w() = v6 << 5;
+		e1.w() = v7 << 5;
+	}
+	else
+	{
+		v6 |= (v7 << (mode+1)) & 0x780;
+		v7 &= (0x3f >> mode);
+		v7 ^= 0x20 >> mode;
+		v7 -= 0x20 >> mode;
+		v6 <<= 4-mode;
+		v7 <<= 4-mode;
+		v7 += v6;
+		v7 = basisu::clamp(v7, 0, 0xfff);
+		e0.w() = v6;
+		e1.w() = v7;
+	}
+}
+void decodeColorEndpoints (ColorEndpointPair* dst, const deUint32* unquantizedEndpoints, const deUint32* endpointModes, int numPartitions)
+{
+	int unquantizedNdx = 0;
+	for (int partitionNdx = 0; partitionNdx < numPartitions; partitionNdx++)
+	{
+		const deUint32		endpointMode	= endpointModes[partitionNdx];
+		const deUint32*		v				= &unquantizedEndpoints[unquantizedNdx];
+		UVec4&				e0				= dst[partitionNdx].e0;
+		UVec4&				e1				= dst[partitionNdx].e1;
+		unquantizedNdx += computeNumColorEndpointValues(endpointMode);
+		switch (endpointMode)
+		{
+			case 0:
+				e0 = UVec4(v[0], v[0], v[0], 0xff);
+				e1 = UVec4(v[1], v[1], v[1], 0xff);
+				break;
+			case 1:
+			{
+				const deUint32 L0 = (v[0] >> 2) | (getBits(v[1], 6, 7) << 6);
+				const deUint32 L1 = basisu::min(0xffu, L0 + getBits(v[1], 0, 5));
+				e0 = UVec4(L0, L0, L0, 0xff);
+				e1 = UVec4(L1, L1, L1, 0xff);
+				break;
+			}
+			case 2:
+			{
+				const deUint32 v1Gr		= v[1] >= v[0];
+				const deUint32 y0		= v1Gr ? v[0]<<4 : (v[1]<<4) + 8;
+				const deUint32 y1		= v1Gr ? v[1]<<4 : (v[0]<<4) - 8;
+				e0 = UVec4(y0, y0, y0, 0x780);
+				e1 = UVec4(y1, y1, y1, 0x780);
+				break;
+			}
+			case 3:
+			{
+				const bool		m	= isBitSet(v[0], 7);
+				const deUint32	y0	= m ? (getBits(v[1], 5, 7) << 9) | (getBits(v[0], 0, 6) << 2)
+										: (getBits(v[1], 4, 7) << 8) | (getBits(v[0], 0, 6) << 1);
+				const deUint32	d	= m ? getBits(v[1], 0, 4) << 2
+										: getBits(v[1], 0, 3) << 1;
+				const deUint32	y1	= basisu::min(0xfffu, y0+d);
+				e0 = UVec4(y0, y0, y0, 0x780);
+				e1 = UVec4(y1, y1, y1, 0x780);
+				break;
+			}
+			case 4:
+				e0 = UVec4(v[0], v[0], v[0], v[2]);
+				e1 = UVec4(v[1], v[1], v[1], v[3]);
+				break;
+			case 5:
+			{
+				deInt32 v0 = (deInt32)v[0];
+				deInt32 v1 = (deInt32)v[1];
+				deInt32 v2 = (deInt32)v[2];
+				deInt32 v3 = (deInt32)v[3];
+				bitTransferSigned(v1, v0);
+				bitTransferSigned(v3, v2);
+				e0 = clampedRGBA(IVec4(v0,		v0,		v0,		v2));
+				e1 = clampedRGBA(IVec4(v0+v1,	v0+v1,	v0+v1,	v2+v3));
+				break;
+			}
+			case 6:
+				e0 = UVec4((v[0]*v[3]) >> 8,	(v[1]*v[3]) >> 8,	(v[2]*v[3]) >> 8,	0xff);
+				e1 = UVec4(v[0],				v[1],				v[2],				0xff);
+				break;
+			case 7:
+				decodeHDREndpointMode7(e0, e1, v[0], v[1], v[2], v[3]);
+				break;
+			case 8:
+				if (v[1]+v[3]+v[5] >= v[0]+v[2]+v[4])
+				{
+					e0 = UVec4(v[0], v[2], v[4], 0xff);
+					e1 = UVec4(v[1], v[3], v[5], 0xff);
+				}
+				else
+				{
+					e0 = blueContract(v[1], v[3], v[5], 0xff).asUint();
+					e1 = blueContract(v[0], v[2], v[4], 0xff).asUint();
+				}
+				break;
+			case 9:
+			{
+				deInt32 v0 = (deInt32)v[0];
+				deInt32 v1 = (deInt32)v[1];
+				deInt32 v2 = (deInt32)v[2];
+				deInt32 v3 = (deInt32)v[3];
+				deInt32 v4 = (deInt32)v[4];
+				deInt32 v5 = (deInt32)v[5];
+				bitTransferSigned(v1, v0);
+				bitTransferSigned(v3, v2);
+				bitTransferSigned(v5, v4);
+				if (v1+v3+v5 >= 0)
+				{
+					e0 = clampedRGBA(IVec4(v0,		v2,		v4,		0xff));
+					e1 = clampedRGBA(IVec4(v0+v1,	v2+v3,	v4+v5,	0xff));
+				}
+				else
+				{
+					e0 = clampedRGBA(blueContract(v0+v1,	v2+v3,	v4+v5,	0xff));
+					e1 = clampedRGBA(blueContract(v0,		v2,		v4,		0xff));
+				}
+				break;
+			}
+			case 10:
+				e0 = UVec4((v[0]*v[3]) >> 8,	(v[1]*v[3]) >> 8,	(v[2]*v[3]) >> 8,	v[4]);
+				e1 = UVec4(v[0],				v[1],				v[2],				v[5]);
+				break;
+			case 11:
+				decodeHDREndpointMode11(e0, e1, v[0], v[1], v[2], v[3], v[4], v[5]);
+				break;
+			case 12:
+				if (v[1]+v[3]+v[5] >= v[0]+v[2]+v[4])
+				{
+					e0 = UVec4(v[0], v[2], v[4], v[6]);
+					e1 = UVec4(v[1], v[3], v[5], v[7]);
+				}
+				else
+				{
+					e0 = clampedRGBA(blueContract(v[1], v[3], v[5], v[7]));
+					e1 = clampedRGBA(blueContract(v[0], v[2], v[4], v[6]));
+				}
+				break;
+			case 13:
+			{
+				deInt32 v0 = (deInt32)v[0];
+				deInt32 v1 = (deInt32)v[1];
+				deInt32 v2 = (deInt32)v[2];
+				deInt32 v3 = (deInt32)v[3];
+				deInt32 v4 = (deInt32)v[4];
+				deInt32 v5 = (deInt32)v[5];
+				deInt32 v6 = (deInt32)v[6];
+				deInt32 v7 = (deInt32)v[7];
+				bitTransferSigned(v1, v0);
+				bitTransferSigned(v3, v2);
+				bitTransferSigned(v5, v4);
+				bitTransferSigned(v7, v6);
+				if (v1+v3+v5 >= 0)
+				{
+					e0 = clampedRGBA(IVec4(v0,		v2,		v4,		v6));
+					e1 = clampedRGBA(IVec4(v0+v1,	v2+v3,	v4+v5,	v6+v7));
+				}
+				else
+				{
+					e0 = clampedRGBA(blueContract(v0+v1,	v2+v3,	v4+v5,	v6+v7));
+					e1 = clampedRGBA(blueContract(v0,		v2,		v4,		v6));
+				}
+				break;
+			}
+			case 14:
+				decodeHDREndpointMode11(e0, e1, v[0], v[1], v[2], v[3], v[4], v[5]);
+				e0.w() = v[6];
+				e1.w() = v[7];
+				break;
+			case 15:
+				decodeHDREndpointMode15(e0, e1, v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]);
+				break;
+			default:
+				DE_ASSERT(false);
+		}
+	}
+}
+void computeColorEndpoints (ColorEndpointPair* dst, const Block128& blockData, const deUint32* endpointModes, int numPartitions, int numColorEndpointValues, const ISEParams& iseParams, int numBitsAvailable)
+{
+	const int			colorEndpointDataStart = numPartitions == 1 ? 17 : 29;
+	ISEDecodedResult	colorEndpointData[18];
+	{
+		BitAccessStream dataStream(blockData, colorEndpointDataStart, numBitsAvailable, true);
+		decodeISE(&colorEndpointData[0], numColorEndpointValues, dataStream, iseParams);
+	}
+	{
+		deUint32 unquantizedEndpoints[18];
+		unquantizeColorEndpoints(&unquantizedEndpoints[0], &colorEndpointData[0], numColorEndpointValues, iseParams);
+		decodeColorEndpoints(dst, &unquantizedEndpoints[0], &endpointModes[0], numPartitions);
+	}
+}
+void unquantizeWeights (deUint32 dst[64], const ISEDecodedResult* weightGrid, const ASTCBlockMode& blockMode)
+{
+	const int			numWeights	= computeNumWeights(blockMode);
+	const ISEParams&	iseParams	= blockMode.weightISEParams;
+	if (iseParams.mode == ISEMODE_TRIT || iseParams.mode == ISEMODE_QUINT)
+	{
+		const int rangeCase = iseParams.numBits*2 + (iseParams.mode == ISEMODE_QUINT ? 1 : 0);
+		if (rangeCase == 0 || rangeCase == 1)
+		{
+			static const deUint32 map0[3]	= { 0, 32, 63 };
+			static const deUint32 map1[5]	= { 0, 16, 32, 47, 63 };
+			const deUint32* const map		= rangeCase == 0 ? &map0[0] : &map1[0];
+			for (int i = 0; i < numWeights; i++)
+			{
+				DE_ASSERT(weightGrid[i].v < (rangeCase == 0 ? 3u : 5u));
+				dst[i] = map[weightGrid[i].v];
+			}
+		}
+		else
+		{
+			DE_ASSERT(rangeCase <= 6);
+			static const deUint32	Ca[5]	= { 50, 28, 23, 13, 11 };
+			const deUint32			C		= Ca[rangeCase-2];
+			for (int weightNdx = 0; weightNdx < numWeights; weightNdx++)
+			{
+				const deUint32 a = getBit(weightGrid[weightNdx].m, 0);
+				const deUint32 b = getBit(weightGrid[weightNdx].m, 1);
+				const deUint32 c = getBit(weightGrid[weightNdx].m, 2);
+				const deUint32 A = a == 0 ? 0 : (1<<7)-1;
+				const deUint32 B = rangeCase == 2 ? 0
+								 : rangeCase == 3 ? 0
+								 : rangeCase == 4 ? (b << 6) |					(b << 2) |				(b << 0)
+								 : rangeCase == 5 ? (b << 6) |								(b << 1)
+								 : rangeCase == 6 ? (c << 6) | (b << 5) |					(c << 1) |	(b << 0)
+								 : (deUint32)-1;
+				dst[weightNdx] = (((weightGrid[weightNdx].tq*C + B) ^ A) >> 2) | (A & 0x20);
+			}
+		}
+	}
+	else
+	{
+		DE_ASSERT(iseParams.mode == ISEMODE_PLAIN_BIT);
+		for (int weightNdx = 0; weightNdx < numWeights; weightNdx++)
+			dst[weightNdx] = bitReplicationScale(weightGrid[weightNdx].v, iseParams.numBits, 6);
+	}
+	for (int weightNdx = 0; weightNdx < numWeights; weightNdx++)
+		dst[weightNdx] += dst[weightNdx] > 32 ? 1 : 0;
+	// Initialize nonexistent weights to poison values
+	for (int weightNdx = numWeights; weightNdx < 64; weightNdx++)
+		dst[weightNdx] = ~0u;
+}
+void interpolateWeights (TexelWeightPair* dst, const deUint32 (&unquantizedWeights) [64], int blockWidth, int blockHeight, const ASTCBlockMode& blockMode)
+{
+	const int		numWeightsPerTexel	= blockMode.isDualPlane ? 2 : 1;
+	const deUint32	scaleX				= (1024 + blockWidth/2) / (blockWidth-1);
+	const deUint32	scaleY				= (1024 + blockHeight/2) / (blockHeight-1);
+	DE_ASSERT(blockMode.weightGridWidth*blockMode.weightGridHeight*numWeightsPerTexel <= DE_LENGTH_OF_ARRAY(unquantizedWeights));
+	for (int texelY = 0; texelY < blockHeight; texelY++)
+	{
+		for (int texelX = 0; texelX < blockWidth; texelX++)
+		{
+			const deUint32 gX	= (scaleX*texelX*(blockMode.weightGridWidth-1) + 32) >> 6;
+			const deUint32 gY	= (scaleY*texelY*(blockMode.weightGridHeight-1) + 32) >> 6;
+			const deUint32 jX	= gX >> 4;
+			const deUint32 jY	= gY >> 4;
+			const deUint32 fX	= gX & 0xf;
+			const deUint32 fY	= gY & 0xf;
+			const deUint32 w11	= (fX*fY + 8) >> 4;
+			const deUint32 w10	= fY - w11;
+			const deUint32 w01	= fX - w11;
+			const deUint32 w00	= 16 - fX - fY + w11;
+			const deUint32 i00	= jY*blockMode.weightGridWidth + jX;
+			const deUint32 i01	= i00 + 1;
+			const deUint32 i10	= i00 + blockMode.weightGridWidth;
+			const deUint32 i11	= i00 + blockMode.weightGridWidth + 1;
+			// These addresses can be out of bounds, but respective weights will be 0 then.
+			DE_ASSERT(deInBounds32(i00, 0, blockMode.weightGridWidth*blockMode.weightGridHeight) || w00 == 0);
+			DE_ASSERT(deInBounds32(i01, 0, blockMode.weightGridWidth*blockMode.weightGridHeight) || w01 == 0);
+			DE_ASSERT(deInBounds32(i10, 0, blockMode.weightGridWidth*blockMode.weightGridHeight) || w10 == 0);
+			DE_ASSERT(deInBounds32(i11, 0, blockMode.weightGridWidth*blockMode.weightGridHeight) || w11 == 0);
+			for (int texelWeightNdx = 0; texelWeightNdx < numWeightsPerTexel; texelWeightNdx++)
+			{
+				// & 0x3f clamps address to bounds of unquantizedWeights
+				const deUint32 p00	= unquantizedWeights[(i00 * numWeightsPerTexel + texelWeightNdx) & 0x3f];
+				const deUint32 p01	= unquantizedWeights[(i01 * numWeightsPerTexel + texelWeightNdx) & 0x3f];
+				const deUint32 p10	= unquantizedWeights[(i10 * numWeightsPerTexel + texelWeightNdx) & 0x3f];
+				const deUint32 p11	= unquantizedWeights[(i11 * numWeightsPerTexel + texelWeightNdx) & 0x3f];
+				dst[texelY*blockWidth + texelX].w[texelWeightNdx] = (p00*w00 + p01*w01 + p10*w10 + p11*w11 + 8) >> 4;
+			}
+		}
+	}
+}
+void computeTexelWeights (TexelWeightPair* dst, const Block128& blockData, int blockWidth, int blockHeight, const ASTCBlockMode& blockMode)
+{
+	ISEDecodedResult weightGrid[64];
+	{
+		BitAccessStream dataStream(blockData, 127, computeNumRequiredBits(blockMode.weightISEParams, computeNumWeights(blockMode)), false);
+		decodeISE(&weightGrid[0], computeNumWeights(blockMode), dataStream, blockMode.weightISEParams);
+	}
+	{
+		deUint32 unquantizedWeights[64];
+		unquantizeWeights(&unquantizedWeights[0], &weightGrid[0], blockMode);
+		interpolateWeights(dst, unquantizedWeights, blockWidth, blockHeight, blockMode);
+	}
+}
+inline deUint32 hash52 (deUint32 v)
+{
+	deUint32 p = v;
+	p ^= p >> 15;	p -= p << 17;	p += p << 7;	p += p << 4;
+	p ^= p >>  5;	p += p << 16;	p ^= p >> 7;	p ^= p >> 3;
+	p ^= p <<  6;	p ^= p >> 17;
+	return p;
+}
+int computeTexelPartition (deUint32 seedIn, deUint32 xIn, deUint32 yIn, deUint32 zIn, int numPartitions, bool smallBlock)
+{
+	DE_ASSERT(zIn == 0);
+	const deUint32	x		= smallBlock ? xIn << 1 : xIn;
+	const deUint32	y		= smallBlock ? yIn << 1 : yIn;
+	const deUint32	z		= smallBlock ? zIn << 1 : zIn;
+	const deUint32	seed	= seedIn + 1024*(numPartitions-1);
+	const deUint32	rnum	= hash52(seed);
+	deUint8			seed1	= (deUint8)( rnum							& 0xf);
+	deUint8			seed2	= (deUint8)((rnum >>  4)					& 0xf);
+	deUint8			seed3	= (deUint8)((rnum >>  8)					& 0xf);
+	deUint8			seed4	= (deUint8)((rnum >> 12)					& 0xf);
+	deUint8			seed5	= (deUint8)((rnum >> 16)					& 0xf);
+	deUint8			seed6	= (deUint8)((rnum >> 20)					& 0xf);
+	deUint8			seed7	= (deUint8)((rnum >> 24)					& 0xf);
+	deUint8			seed8	= (deUint8)((rnum >> 28)					& 0xf);
+	deUint8			seed9	= (deUint8)((rnum >> 18)					& 0xf);
+	deUint8			seed10	= (deUint8)((rnum >> 22)					& 0xf);
+	deUint8			seed11	= (deUint8)((rnum >> 26)					& 0xf);
+	deUint8			seed12	= (deUint8)(((rnum >> 30) | (rnum << 2))	& 0xf);
+	seed1  = (deUint8)(seed1  * seed1 );
+	seed2  = (deUint8)(seed2  * seed2 );
+	seed3  = (deUint8)(seed3  * seed3 );
+	seed4  = (deUint8)(seed4  * seed4 );
+	seed5  = (deUint8)(seed5  * seed5 );
+	seed6  = (deUint8)(seed6  * seed6 );
+	seed7  = (deUint8)(seed7  * seed7 );
+	seed8  = (deUint8)(seed8  * seed8 );
+	seed9  = (deUint8)(seed9  * seed9 );
+	seed10 = (deUint8)(seed10 * seed10);
+	seed11 = (deUint8)(seed11 * seed11);
+	seed12 = (deUint8)(seed12 * seed12);
+	const int shA = (seed & 2) != 0		? 4		: 5;
+	const int shB = numPartitions == 3	? 6		: 5;
+	const int sh1 = (seed & 1) != 0		? shA	: shB;
+	const int sh2 = (seed & 1) != 0		? shB	: shA;
+	const int sh3 = (seed & 0x10) != 0	? sh1	: sh2;
+	seed1  = (deUint8)(seed1  >> sh1);
+	seed2  = (deUint8)(seed2  >> sh2);
+	seed3  = (deUint8)(seed3  >> sh1);
+	seed4  = (deUint8)(seed4  >> sh2);
+	seed5  = (deUint8)(seed5  >> sh1);
+	seed6  = (deUint8)(seed6  >> sh2);
+	seed7  = (deUint8)(seed7  >> sh1);
+	seed8  = (deUint8)(seed8  >> sh2);
+	seed9  = (deUint8)(seed9  >> sh3);
+	seed10 = (deUint8)(seed10 >> sh3);
+	seed11 = (deUint8)(seed11 >> sh3);
+	seed12 = (deUint8)(seed12 >> sh3);
+	const int a =						0x3f & (seed1*x + seed2*y + seed11*z + (rnum >> 14));
+	const int b =						0x3f & (seed3*x + seed4*y + seed12*z + (rnum >> 10));
+	const int c = numPartitions >= 3 ?	0x3f & (seed5*x + seed6*y + seed9*z  + (rnum >>  6))	: 0;
+	const int d = numPartitions >= 4 ?	0x3f & (seed7*x + seed8*y + seed10*z + (rnum >>  2))	: 0;
+	return a >= b && a >= c && a >= d	? 0
+		 : b >= c && b >= d				? 1
+		 : c >= d						? 2
+		 :								  3;
+}
+DecompressResult setTexelColors (void* dst, ColorEndpointPair* colorEndpoints, TexelWeightPair* texelWeights, int ccs, deUint32 partitionIndexSeed,
+								 int numPartitions, int blockWidth, int blockHeight, bool isSRGB, bool isLDRMode, const deUint32* colorEndpointModes)
+{
+	const bool			smallBlock	= blockWidth*blockHeight < 31;
+	DecompressResult	result		= DECOMPRESS_RESULT_VALID_BLOCK;
+	bool				isHDREndpoint[4];
+	for (int i = 0; i < numPartitions; i++)
+	{
+		isHDREndpoint[i] = isColorEndpointModeHDR(colorEndpointModes[i]);
+		
+		// rg - REMOVING HDR SUPPORT FOR NOW
+		if (isHDREndpoint[i])
+			return DECOMPRESS_RESULT_ERROR;
+	}
+
+	for (int texelY = 0; texelY < blockHeight; texelY++)
+	for (int texelX = 0; texelX < blockWidth; texelX++)
+	{
+		const int				texelNdx			= texelY*blockWidth + texelX;
+		const int				colorEndpointNdx	= numPartitions == 1 ? 0 : computeTexelPartition(partitionIndexSeed, texelX, texelY, 0, numPartitions, smallBlock);
+		DE_ASSERT(colorEndpointNdx < numPartitions);
+		const UVec4&			e0					= colorEndpoints[colorEndpointNdx].e0;
+		const UVec4&			e1					= colorEndpoints[colorEndpointNdx].e1;
+		const TexelWeightPair&	weight				= texelWeights[texelNdx];
+		if (isLDRMode && isHDREndpoint[colorEndpointNdx])
+		{
+			if (isSRGB)
+			{
+				((deUint8*)dst)[texelNdx*4 + 0] = 0xff;
+				((deUint8*)dst)[texelNdx*4 + 1] = 0;
+				((deUint8*)dst)[texelNdx*4 + 2] = 0xff;
+				((deUint8*)dst)[texelNdx*4 + 3] = 0xff;
+			}
+			else
+			{
+				((float*)dst)[texelNdx*4 + 0] = 1.0f;
+				((float*)dst)[texelNdx*4 + 1] = 0;
+				((float*)dst)[texelNdx*4 + 2] = 1.0f;
+				((float*)dst)[texelNdx*4 + 3] = 1.0f;
+			}
+			result = DECOMPRESS_RESULT_ERROR;
+		}
+		else
+		{
+			for (int channelNdx = 0; channelNdx < 4; channelNdx++)
+			{
+				if (!isHDREndpoint[colorEndpointNdx] || (channelNdx == 3 && colorEndpointModes[colorEndpointNdx] == 14)) // \note Alpha for mode 14 is treated the same as LDR.
+				{
+					const deUint32 c0	= (e0[channelNdx] << 8) | (isSRGB ? 0x80 : e0[channelNdx]);
+					const deUint32 c1	= (e1[channelNdx] << 8) | (isSRGB ? 0x80 : e1[channelNdx]);
+					const deUint32 w	= weight.w[ccs == channelNdx ? 1 : 0];
+					const deUint32 c	= (c0*(64-w) + c1*w + 32) / 64;
+					if (isSRGB)
+						((deUint8*)dst)[texelNdx*4 + channelNdx] = (deUint8)((c & 0xff00) >> 8);
+					else
+						((float*)dst)[texelNdx*4 + channelNdx] = c == 65535 ? 1.0f : (float)c / 65536.0f;
+				}
+				else
+				{
+					//DE_STATIC_ASSERT((basisu::meta::TypesSame<deFloat16, deUint16>::Value));
+					// rg - REMOVING HDR SUPPORT FOR NOW
+#if 0
+					const deUint32		c0	= e0[channelNdx] << 4;
+					const deUint32		c1	= e1[channelNdx] << 4;
+					const deUint32		w	= weight.w[ccs == channelNdx ? 1 : 0];
+					const deUint32		c	= (c0*(64-w) + c1*w + 32) / 64;
+					const deUint32		e	= getBits(c, 11, 15);
+					const deUint32		m	= getBits(c, 0, 10);
+					const deUint32		mt	= m < 512		? 3*m
+											: m >= 1536		? 5*m - 2048
+											:				  4*m - 512;
+					const deFloat16		cf	= (deFloat16)((e << 10) + (mt >> 3));
+					((float*)dst)[texelNdx*4 + channelNdx] = deFloat16To32(isFloat16InfOrNan(cf) ? 0x7bff : cf);
+#endif
+				}
+			}
+		}
+	}
+	return result;
+}
+DecompressResult decompressBlock (void* dst, const Block128& blockData, int blockWidth, int blockHeight, bool isSRGB, bool isLDR)
+{
+	DE_ASSERT(isLDR || !isSRGB);
+	// Decode block mode.
+	const ASTCBlockMode blockMode = getASTCBlockMode(blockData.getBits(0, 10));
+	// Check for block mode errors.
+	if (blockMode.isError)
+	{
+		setASTCErrorColorBlock(dst, blockWidth, blockHeight, isSRGB);
+		return DECOMPRESS_RESULT_ERROR;
+	}
+	// Separate path for void-extent.
+	if (blockMode.isVoidExtent)
+		return decodeVoidExtentBlock(dst, blockData, blockWidth, blockHeight, isSRGB, isLDR);
+	// Compute weight grid values.
+	const int numWeights			= computeNumWeights(blockMode);
+	const int numWeightDataBits		= computeNumRequiredBits(blockMode.weightISEParams, numWeights);
+	const int numPartitions			= (int)blockData.getBits(11, 12) + 1;
+	// Check for errors in weight grid, partition and dual-plane parameters.
+	if (numWeights > 64								||
+		numWeightDataBits > 96						||
+		numWeightDataBits < 24						||
+		blockMode.weightGridWidth > blockWidth		||
+		blockMode.weightGridHeight > blockHeight	||
+		(numPartitions == 4 && blockMode.isDualPlane))
+	{
+		setASTCErrorColorBlock(dst, blockWidth, blockHeight, isSRGB);
+		return DECOMPRESS_RESULT_ERROR;
+	}
+	// Compute number of bits available for color endpoint data.
+	const bool	isSingleUniqueCem			= numPartitions == 1 || blockData.getBits(23, 24) == 0;
+	const int	numConfigDataBits			= (numPartitions == 1 ? 17 : isSingleUniqueCem ? 29 : 25 + 3*numPartitions) +
+											  (blockMode.isDualPlane ? 2 : 0);
+	const int	numBitsForColorEndpoints	= 128 - numWeightDataBits - numConfigDataBits;
+	const int	extraCemBitsStart			= 127 - numWeightDataBits - (isSingleUniqueCem		? -1
+																		: numPartitions == 4	? 7
+																		: numPartitions == 3	? 4
+																		: numPartitions == 2	? 1
+																		: 0);
+	// Decode color endpoint modes.
+	deUint32 colorEndpointModes[4];
+	decodeColorEndpointModes(&colorEndpointModes[0], blockData, numPartitions, extraCemBitsStart);
+	const int numColorEndpointValues = computeNumColorEndpointValues(colorEndpointModes, numPartitions);
+	// Check for errors in color endpoint value count.
+	if (numColorEndpointValues > 18 || numBitsForColorEndpoints < (int)deDivRoundUp32(13*numColorEndpointValues, 5))
+	{
+		setASTCErrorColorBlock(dst, blockWidth, blockHeight, isSRGB);
+		return DECOMPRESS_RESULT_ERROR;
+	}
+	// Compute color endpoints.
+	ColorEndpointPair colorEndpoints[4];
+	computeColorEndpoints(&colorEndpoints[0], blockData, &colorEndpointModes[0], numPartitions, numColorEndpointValues,
+						  computeMaximumRangeISEParams(numBitsForColorEndpoints, numColorEndpointValues), numBitsForColorEndpoints);
+	// Compute texel weights.
+	TexelWeightPair texelWeights[MAX_BLOCK_WIDTH*MAX_BLOCK_HEIGHT];
+	computeTexelWeights(&texelWeights[0], blockData, blockWidth, blockHeight, blockMode);
+	// Set texel colors.
+	const int		ccs						= blockMode.isDualPlane ? (int)blockData.getBits(extraCemBitsStart-2, extraCemBitsStart-1) : -1;
+	const deUint32	partitionIndexSeed		= numPartitions > 1 ? blockData.getBits(13, 22) : (deUint32)-1;
+	return setTexelColors(dst, &colorEndpoints[0], &texelWeights[0], ccs, partitionIndexSeed, numPartitions, blockWidth, blockHeight, isSRGB, isLDR, &colorEndpointModes[0]);
+}
+
+} // anonymous
+
+bool decompress(uint8_t *pDst, const uint8_t * data, bool isSRGB, int blockWidth, int blockHeight)
+{
+	// rg - We only support LDR here, although adding back in HDR would be easy.
+	const bool isLDR = true;
+	DE_ASSERT(isLDR || !isSRGB);
+	
+	float linear[MAX_BLOCK_WIDTH * MAX_BLOCK_HEIGHT * 4];
+
+	const Block128 blockData(data);
+	if (decompressBlock(isSRGB ? (void*)pDst : (void*)& linear[0],
+		blockData, blockWidth, blockHeight, isSRGB, isLDR) != DECOMPRESS_RESULT_VALID_BLOCK)
+		return false;
+	
+	if (!isSRGB)
+	{
+		int pix = 0;
+		for (int i = 0; i < blockHeight; i++)
+		{
+			for (int j = 0; j < blockWidth; j++, pix++)
+			{
+				pDst[4 * pix + 0] = (uint8_t)(basisu::clamp<int>((int)(linear[pix * 4 + 0] * 65536.0f + .5f), 0, 65535) >> 8);
+				pDst[4 * pix + 1] = (uint8_t)(basisu::clamp<int>((int)(linear[pix * 4 + 1] * 65536.0f + .5f), 0, 65535) >> 8);
+				pDst[4 * pix + 2] = (uint8_t)(basisu::clamp<int>((int)(linear[pix * 4 + 2] * 65536.0f + .5f), 0, 65535) >> 8);
+				pDst[4 * pix + 3] = (uint8_t)(basisu::clamp<int>((int)(linear[pix * 4 + 3] * 65536.0f + .5f), 0, 65535) >> 8);
+			}
+		}
+	}
+
+	return true;
+}
+
+} // astc
+} // basisu

--- a/renderdoc/3rdparty/astc_dec/astc_decomp.h
+++ b/renderdoc/3rdparty/astc_dec/astc_decomp.h
@@ -1,0 +1,41 @@
+#ifndef _TCUASTCUTIL_HPP
+#define _TCUASTCUTIL_HPP
+/*-------------------------------------------------------------------------
+ * drawElements Quality Program Tester Core
+ * ----------------------------------------
+ *
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *//*!
+ * \file
+ * \brief ASTC Utilities.
+ *//*--------------------------------------------------------------------*/
+
+#include <vector>
+
+namespace basisu
+{
+namespace astc
+{
+
+// Unpacks a single ASTC block to pDst
+// If isSRGB is true, the spec requires the decoder to scale the LDR 8-bit endpoints to 16-bit before interpolation slightly differently, 
+// which will lead to different outputs. So be sure to set it correctly (ideally it should match whatever the encoder did).
+bool decompress(uint8_t* pDst, const uint8_t* data, bool isSRGB, int blockWidth, int blockHeight);
+
+} // astc
+} // basisu
+
+#endif

--- a/renderdoc/api/replay/data_types.h
+++ b/renderdoc/api/replay/data_types.h
@@ -288,6 +288,13 @@ For other formats, 1 is returned.
     return 1;
   }
 
+  DOCUMENT(R"(Check if format is ASTC decoded. Originally ASTC decoded to RGBA for viewing
+
+:return: ``True`` if the format is ASTC decoded.
+:rtype: bool
+)");
+  bool ASTCDecoded() const { return (flags & ResourceFormat_ASTC_Decode) != 0; }
+
   DOCUMENT(R"(Set BGRA order flag. See :meth:`BGRAOrder`.
 
 :param bool flag: The new flag value.
@@ -330,6 +337,16 @@ Invalid values will result in 1 being set.
       flags |= ResourceFormat_2Planes;
     else if(planes == 3)
       flags |= ResourceFormat_3Planes;
+  }
+
+  DOCUMENT(R"(Set ASTC decode flag for ASTC decoded texture viewer.
+)");
+  void SetASTCDecode(bool flag)
+  {
+    if(flag)
+      flags |= ResourceFormat_ASTC_Decode;
+    else
+      flags &= ~ResourceFormat_ASTC_Decode;
   }
 
   DOCUMENT(R"(:return: ``True`` if the ``ResourceFormat`` is a block-compressed type.
@@ -446,6 +463,8 @@ private:
     ResourceFormat_2Planes = 0x020,
     ResourceFormat_3Planes = 0x040,
     ResourceFormat_Planes_Mask = 0x060,
+
+    ResourceFormat_ASTC_Decode = 0x080,
   };
   uint16_t flags;
 

--- a/renderdoc/common/dds_readwrite.cpp
+++ b/renderdoc/common/dds_readwrite.cpp
@@ -24,6 +24,7 @@
 
 #include "dds_readwrite.h"
 #include <stdint.h>
+#include "3rdparty/astc_dec/astc_decomp.h"
 #include "common/common.h"
 #include "common/formatting.h"
 #include "common/result.h"
@@ -192,6 +193,51 @@ enum DXGI_FORMAT
   DXGI_FORMAT_P8 = 113,
   DXGI_FORMAT_A8P8 = 114,
   DXGI_FORMAT_B4G4R4A4_UNORM = 115,
+
+  // ASTC Format
+  DXGI_FORMAT_ASTC_4X4_TYPELESS = 133,
+  DXGI_FORMAT_ASTC_4X4_UNORM = 134,
+  DXGI_FORMAT_ASTC_4X4_UNORM_SRGB = 135,
+  DXGI_FORMAT_ASTC_5X4_TYPELESS = 137,
+  DXGI_FORMAT_ASTC_5X4_UNORM = 138,
+  DXGI_FORMAT_ASTC_5X4_UNORM_SRGB = 139,
+  DXGI_FORMAT_ASTC_5X5_TYPELESS = 141,
+  DXGI_FORMAT_ASTC_5X5_UNORM = 142,
+  DXGI_FORMAT_ASTC_5X5_UNORM_SRGB = 143,
+  DXGI_FORMAT_ASTC_6X5_TYPELESS = 145,
+  DXGI_FORMAT_ASTC_6X5_UNORM = 146,
+  DXGI_FORMAT_ASTC_6X5_UNORM_SRGB = 147,
+  DXGI_FORMAT_ASTC_6X6_TYPELESS = 149,
+  DXGI_FORMAT_ASTC_6X6_UNORM = 150,
+  DXGI_FORMAT_ASTC_6X6_UNORM_SRGB = 151,
+  DXGI_FORMAT_ASTC_8X5_TYPELESS = 153,
+  DXGI_FORMAT_ASTC_8X5_UNORM = 154,
+  DXGI_FORMAT_ASTC_8X5_UNORM_SRGB = 155,
+  DXGI_FORMAT_ASTC_8X6_TYPELESS = 157,
+  DXGI_FORMAT_ASTC_8X6_UNORM = 158,
+  DXGI_FORMAT_ASTC_8X6_UNORM_SRGB = 159,
+  DXGI_FORMAT_ASTC_8X8_TYPELESS = 161,
+  DXGI_FORMAT_ASTC_8X8_UNORM = 162,
+  DXGI_FORMAT_ASTC_8X8_UNORM_SRGB = 163,
+  DXGI_FORMAT_ASTC_10X5_TYPELESS = 165,
+  DXGI_FORMAT_ASTC_10X5_UNORM = 166,
+  DXGI_FORMAT_ASTC_10X5_UNORM_SRGB = 167,
+  DXGI_FORMAT_ASTC_10X6_TYPELESS = 169,
+  DXGI_FORMAT_ASTC_10X6_UNORM = 170,
+  DXGI_FORMAT_ASTC_10X6_UNORM_SRGB = 171,
+  DXGI_FORMAT_ASTC_10X8_TYPELESS = 173,
+  DXGI_FORMAT_ASTC_10X8_UNORM = 174,
+  DXGI_FORMAT_ASTC_10X8_UNORM_SRGB = 175,
+  DXGI_FORMAT_ASTC_10X10_TYPELESS = 177,
+  DXGI_FORMAT_ASTC_10X10_UNORM = 178,
+  DXGI_FORMAT_ASTC_10X10_UNORM_SRGB = 179,
+  DXGI_FORMAT_ASTC_12X10_TYPELESS = 181,
+  DXGI_FORMAT_ASTC_12X10_UNORM = 182,
+  DXGI_FORMAT_ASTC_12X10_UNORM_SRGB = 183,
+  DXGI_FORMAT_ASTC_12X12_TYPELESS = 185,
+  DXGI_FORMAT_ASTC_12X12_UNORM = 186,
+  DXGI_FORMAT_ASTC_12X12_UNORM_SRGB = 187,
+
   DXGI_FORMAT_FORCE_UINT = 0xffffffff
 };
 
@@ -297,6 +343,27 @@ ResourceFormat DXGIFormat2ResourceFormat(DXGI_FORMAT format)
       special.type = ResourceFormatType::BC7;
       special.compType =
           (format == DXGI_FORMAT_BC7_UNORM_SRGB) ? CompType::UNormSRGB : CompType::UNorm;
+      return special;
+    case DXGI_FORMAT_ASTC_4X4_TYPELESS:
+    case DXGI_FORMAT_ASTC_4X4_UNORM:
+    case DXGI_FORMAT_ASTC_4X4_UNORM_SRGB:
+    case DXGI_FORMAT_ASTC_5X5_TYPELESS:
+    case DXGI_FORMAT_ASTC_5X5_UNORM:
+    case DXGI_FORMAT_ASTC_5X5_UNORM_SRGB:
+    case DXGI_FORMAT_ASTC_6X6_TYPELESS:
+    case DXGI_FORMAT_ASTC_6X6_UNORM:
+    case DXGI_FORMAT_ASTC_6X6_UNORM_SRGB:
+    case DXGI_FORMAT_ASTC_8X8_TYPELESS:
+    case DXGI_FORMAT_ASTC_8X8_UNORM:
+    case DXGI_FORMAT_ASTC_8X8_UNORM_SRGB:
+    case DXGI_FORMAT_ASTC_10X10_TYPELESS:
+    case DXGI_FORMAT_ASTC_10X10_UNORM:
+    case DXGI_FORMAT_ASTC_10X10_UNORM_SRGB:
+    case DXGI_FORMAT_ASTC_12X12_TYPELESS:
+    case DXGI_FORMAT_ASTC_12X12_UNORM:
+    case DXGI_FORMAT_ASTC_12X12_UNORM_SRGB:
+      special.type = ResourceFormatType::ASTC;
+      special.compType = (format % 2) ? CompType::UNormSRGB : CompType::UNorm;
       return special;
     case DXGI_FORMAT_R10G10B10A2_UNORM:
     case DXGI_FORMAT_R10G10B10A2_UINT:
@@ -1191,7 +1258,8 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
     default: bytesPerPixel = ret.format.compCount * ret.format.compByteWidth;
   }
 
-  bool blockFormat = false;
+  bool decodeFormat = false;
+  uint8_t blockDim = 4;
 
   if(ret.format.Special())
   {
@@ -1203,10 +1271,44 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
       case ResourceFormatType::BC4:
       case ResourceFormatType::BC5:
       case ResourceFormatType::BC6:
-      case ResourceFormatType::BC7: blockFormat = true; break;
+      case ResourceFormatType::BC7: break;
+      case ResourceFormatType::ASTC:
+      {
+        decodeFormat = true;
+        switch(headerDXT10.dxgiFormat)
+        {
+          case DXGI_FORMAT_ASTC_4X4_TYPELESS:
+          case DXGI_FORMAT_ASTC_4X4_UNORM:
+          case DXGI_FORMAT_ASTC_4X4_UNORM_SRGB: blockDim = 4; break;
+          case DXGI_FORMAT_ASTC_5X5_TYPELESS:
+          case DXGI_FORMAT_ASTC_5X5_UNORM:
+          case DXGI_FORMAT_ASTC_5X5_UNORM_SRGB: blockDim = 5; break;
+          case DXGI_FORMAT_ASTC_6X6_TYPELESS:
+          case DXGI_FORMAT_ASTC_6X6_UNORM:
+          case DXGI_FORMAT_ASTC_6X6_UNORM_SRGB: blockDim = 6; break;
+          case DXGI_FORMAT_ASTC_8X8_TYPELESS:
+          case DXGI_FORMAT_ASTC_8X8_UNORM:
+          case DXGI_FORMAT_ASTC_8X8_UNORM_SRGB: blockDim = 8; break;
+          case DXGI_FORMAT_ASTC_10X10_TYPELESS:
+          case DXGI_FORMAT_ASTC_10X10_UNORM:
+          case DXGI_FORMAT_ASTC_10X10_UNORM_SRGB: blockDim = 10; break;
+          case DXGI_FORMAT_ASTC_12X12_TYPELESS:
+          case DXGI_FORMAT_ASTC_12X12_UNORM:
+          case DXGI_FORMAT_ASTC_12X12_UNORM_SRGB: blockDim = 12; break;
+          default:
+          {
+            RETURN_ERROR_RESULT(ResultCode::ImageUnsupported,
+                                "Unsupported file format %s to load from DDS",
+                                ToStr(ret.format.type).c_str());
+          }
+          break;
+        }
+
+        ret.format.SetASTCDecode(true);
+        break;
+      }
       case ResourceFormatType::ETC2:
       case ResourceFormatType::EAC:
-      case ResourceFormatType::ASTC:
       {
         RETURN_ERROR_RESULT(ResultCode::ImageUnsupported,
                             "Unsupported file format %s to load from DDS",
@@ -1215,6 +1317,9 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
       default: break;
     }
   }
+
+  const bool blockFormat = ret.format.BlockFormat();
+  const uint8_t blockDimMinusOne = blockDim - 1;
 
   // catch any invalid dimensions here, including the total dimension with a very conservative 1/16
   // byte per pixel
@@ -1232,6 +1337,9 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
         ret.width, ret.height, ret.depth, ret.slices, ret.mips, fileSize);
   }
 
+  bytebuf decodedBuffer;
+  const uint32_t blockSize = ret.format.ElementSize();
+
   // we reserve space for a full mip-chain (twice the size of the top mip) just to be conservative
   {
     uint32_t rowlen = AlignUp(ret.width, subsamplePacking);
@@ -1241,17 +1349,15 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
     // pitch/rows are in blocks, not pixels, for block formats.
     if(blockFormat)
     {
-      numRows = RDCMAX(1U, (numRows + 3) / 4);
-
-      uint32_t blockSize =
-          (ret.format.type == ResourceFormatType::BC1 || ret.format.type == ResourceFormatType::BC4)
-              ? 8
-              : 16;
-
-      pitch = RDCMAX(blockSize, (((rowlen + 3) / 4)) * blockSize);
+      numRows = RDCMAX(1U, (numRows + blockDimMinusOne) / blockDim);
+      pitch = RDCMAX(blockSize, (((rowlen + blockDimMinusOne) / blockDim)) * blockSize);
     }
 
     ret.buffer.reserve(ret.slices * 2 * ret.depth * numRows * pitch);
+    if(decodeFormat)
+    {
+      decodedBuffer.reserve(ret.slices * 2 * ret.width * ret.height * ret.depth * sizeof(uint32_t));
+    }
   }
   ret.subresources.reserve(ret.slices * ret.mips);
 
@@ -1260,33 +1366,45 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
   {
     for(uint32_t mip = 0; mip < ret.mips; mip++)
     {
-      uint32_t rowlen = RDCMAX(1U, ret.width >> mip);
+      const uint32_t mipWidth = RDCMAX(1U, ret.width >> mip);
+      const uint32_t mipHeight = RDCMAX(1U, ret.height >> mip);
+      const uint32_t mipDepth = RDCMAX(1U, ret.depth >> mip);
+      uint32_t rowlen = mipWidth;
       rowlen = AlignUp(rowlen, subsamplePacking);
-      uint32_t numRows = RDCMAX(1U, ret.height >> mip);
-      uint32_t numdepths = RDCMAX(1U, ret.depth >> mip);
+      uint32_t numRows = mipHeight;
+      uint32_t numdepths = mipDepth;
       uint32_t pitch = RDCMAX(1U, rowlen * bytesPerPixel);
+
+      size_t decodedSubOffs = decodedBuffer.size();
+      size_t decodedSubSize = mipWidth * mipHeight * mipDepth * sizeof(uint32_t);
+      if(decodeFormat)
+      {
+        decodedBuffer.resize(decodedBuffer.size() + decodedSubSize);
+      }
 
       // pitch/rows are in blocks, not pixels, for block formats.
       if(blockFormat)
       {
-        numRows = RDCMAX(1U, (numRows + 3) / 4);
-
-        uint32_t blockSize = (ret.format.type == ResourceFormatType::BC1 ||
-                              ret.format.type == ResourceFormatType::BC4)
-                                 ? 8
-                                 : 16;
-
-        pitch = RDCMAX(blockSize, (((rowlen + 3) / 4)) * blockSize);
+        numRows = RDCMAX(1U, (numRows + blockDimMinusOne) / blockDim);
+        pitch = RDCMAX(blockSize, (((rowlen + blockDimMinusOne) / blockDim)) * blockSize);
       }
 
       size_t subOffs = ret.buffer.size();
       size_t subSize = numdepths * numRows * pitch;
 
-      ret.subresources.push_back({subOffs, subSize});
+      if(decodeFormat)
+      {
+        ret.subresources.push_back({decodedSubOffs, decodedSubSize});
+      }
+      else
+      {
+        ret.subresources.push_back({subOffs, subSize});
+      }
 
       ret.buffer.resize(ret.buffer.size() + subSize);
 
       byte *bytedata = ret.buffer.data() + subOffs;
+      byte *decodedBytedata = decodedBuffer.data() + decodedSubOffs;
 
       for(uint32_t d = 0; d < numdepths; d++)
       {
@@ -1318,10 +1436,86 @@ RDResult load_dds_from_file(StreamReader *reader, read_tex_data &ret)
 
           bytedata += pitch;
         }
+
+        // If format cannot be viewed by the graphics driver, decode to RGBA
+        if(decodeFormat)
+        {
+          for(uint32_t y = 0; y < mipHeight; y += blockDim)
+          {
+            for(uint32_t x = 0; x < mipWidth; x += blockDim)
+            {
+              const uint32_t maxBlockWidth = 12;
+              const uint32_t maxBlockHeight = 12;
+
+              uint32_t blockIndexX = x / blockDim;
+              uint32_t blockIndexY = y / blockDim;
+              const byte *compressedBlock =
+                  &(ret.buffer.data() +
+                    subOffs)[(blockIndexY * (pitch / blockSize) + blockIndexX) * blockSize];
+
+              // Contains decoded RGBA data for this block - Considering max block size of 12x12 =
+              // 144 pixels - 144 * 4 bytes
+              uint8_t decodedBlock[maxBlockWidth * maxBlockHeight * sizeof(uint32_t)] = {};
+
+              if(!basisu::astc::decompress(decodedBlock, compressedBlock,
+                                           ret.format.SRGBCorrected(), blockDim, blockDim))
+              {
+                // Handle decompression error (fill with a default invalid astc color - purple)
+                for(uint8_t row = 0; row < blockDim; ++row)
+                {
+                  for(uint8_t col = 0; col < blockDim; ++col)
+                  {
+                    uint8_t *pixel = &decodedBlock[(row * blockDim + col) * sizeof(uint32_t)];
+                    // RGBA
+                    pixel[0] = 255;
+                    pixel[1] = 0;
+                    pixel[2] = 255;
+                    pixel[3] = 255;
+                  }
+                }
+              }
+
+              // Fill the RGBA pixels for this block
+              // If we have a ASTC 8x8 block, this means we will fill 64 pixels - 8 rows, 8 columns
+              for(uint8_t row = 0; row < blockDim; ++row)
+              {
+                for(uint8_t col = 0; col < blockDim; ++col)
+                {
+                  // Mip size not aligned to block size - Dont fill out of bounds pixels
+                  if(y + row >= mipHeight || x + col >= mipWidth)
+                  {
+                    break;
+                  }
+                  uint8_t *src = &decodedBlock[(row * blockDim + col) * sizeof(uint32_t)];
+                  uint8_t *dst =
+                      &decodedBytedata[((y + row) * RDCMAX(1U, ret.width >> mip) + (x + col)) *
+                                       sizeof(uint32_t)];
+                  // RGBA
+                  dst[0] = src[0];
+                  dst[1] = src[1];
+                  dst[2] = src[2];
+                  dst[3] = src[3];
+                }
+              }
+            }
+          }
+        }
       }
 
       i++;
     }
+  }
+
+  if(decodeFormat)
+  {
+    const DXGI_FORMAT decodedDxgiFormat =
+        ret.format.SRGBCorrected() ? DXGI_FORMAT_R8G8B8A8_UNORM_SRGB : DXGI_FORMAT_R8G8B8A8_UNORM;
+    ResourceFormat decodedFormat = DXGIFormat2ResourceFormat(decodedDxgiFormat);
+    ret.format.type = decodedFormat.type;
+    ret.format.compType = decodedFormat.compType;
+    ret.format.compCount = decodedFormat.compCount;
+    ret.format.compByteWidth = decodedFormat.compByteWidth;
+    ret.buffer = decodedBuffer;
   }
 
   return RDResult();

--- a/renderdoc/renderdoc.vcxproj
+++ b/renderdoc/renderdoc.vcxproj
@@ -105,6 +105,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="3rdparty\astc_dec\astc_decomp.h" />
     <ClInclude Include="3rdparty\catch\catch.hpp" />
     <ClInclude Include="3rdparty\catch\official\catch.hpp" />
     <ClInclude Include="3rdparty\compressonator\BC1_Encode_kernel.h" />
@@ -256,6 +257,7 @@
     <ClInclude Include="strings\string_utils.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="3rdparty\astc_dec\astc_decomp.cpp" />
     <ClCompile Include="3rdparty\catch\catch.cpp" />
     <ClCompile Include="3rdparty\compressonator\BC1_Encode_kernel.cpp" />
     <ClCompile Include="3rdparty\compressonator\BC2_Encode_kernel.cpp" />

--- a/renderdoc/renderdoc.vcxproj.filters
+++ b/renderdoc/renderdoc.vcxproj.filters
@@ -145,6 +145,9 @@
     <Filter Include="Shaders">
       <UniqueIdentifier>{d8130624-7075-486d-91fc-b5ab8cd2b811}</UniqueIdentifier>
     </Filter>
+    <Filter Include="3rdparty\astc_dec">
+      <UniqueIdentifier>{8db6f0b0-e9e2-4dd3-aa5e-b97521b4498f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="maths\camera.h">
@@ -582,6 +585,9 @@
     <ClInclude Include="core\rdcbytetrie.h">
       <Filter>Core</Filter>
     </ClInclude>
+    <ClInclude Include="3rdparty\astc_dec\astc_decomp.h">
+      <Filter>3rdparty\astc_dec</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="maths\camera.cpp">
@@ -988,6 +994,9 @@
     </ClCompile>
     <ClCompile Include="shaders\controlflow.cpp">
       <Filter>Shaders</Filter>
+    </ClCompile>
+    <ClCompile Include="3rdparty\astc_dec\astc_decomp.cpp">
+      <Filter>3rdparty\astc_dec</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Adds support for viewing decoded ASTC stored in dds files. We store ASTC in dds and this path makes it convenient to verify the integrity of the content. Currently only supports ASTC blocks with same width and height. For the remaining ASTC formats, the same old message is still printed

== Code ==
- Using 3rdparty single file astc decoder - https://github.com/richgel999/astc_dec/tree/master
- dds_readwrite.cpp
  - Add a check for ASTC. If true, decode to RGBA so it is viewable on all graphics drivers
  - TextureDescription is filled as regular RGBA8/RGBA8Srgb with a new flag ResourceFormat_ASTC_Decode which is used by TextureViewer to display the original format

TextureViewer with the decoded ASTC
<img width="561" height="844" alt="image" src="https://github.com/user-attachments/assets/97f211b1-243f-4199-9804-78f0977f1ad8" />

