### PR TITLE
avoid erase map's end()

### DIFF
--- a/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
+++ b/renderdoc/driver/d3d11/d3d11_context_wrap.cpp
@@ -8088,7 +8088,10 @@ void WrappedID3D11DeviceContext::Unmap(ID3D11Resource *pResource, UINT Subresour
             "unsuccessful");
         m_SuccessfulCapture = false;
         m_FailureReason = CaptureFailed_UncappedUnmap;
-        m_OpenMaps.erase(it);
+        if(it != m_OpenMaps.end())
+        {
+          m_OpenMaps.erase(it);
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Similar to issue #3603, inhouse engine may have `Map`/`Unmap` between different frames. 
Previous code protects crash, but may leave `m_OpenMaps` corrupted.

[std::map<Key,T,Compare,Allocator>::erase
](https://en.cppreference.com/w/cpp/container/map/erase)
> The iterator pos must be dereferenceable. Thus the [end()](https://en.cppreference.com/w/cpp/container/map/end.html) iterator (which is valid, but is not dereferenceable) cannot be used as a value for pos.