### PR TITLE
Use defined(_WIN32) is enough in renderdoc_app.h for RENDERDOC_CC

### DIFF
--- a/renderdoc/api/app/renderdoc_app.h
+++ b/renderdoc/api/app/renderdoc_app.h
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #endif
 
-#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
+#if defined(_WIN32)
 #define RENDERDOC_CC __cdecl
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__sun__)
 #define RENDERDOC_CC


### PR DESCRIPTION
_WIN32 always present for windows compilers, other defines are redundant.
