### PR TITLE
disable `readDirectly` when copying depth texture in GLES

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -2832,9 +2832,9 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
     readDirectly = false;
   }
 
-  if((format == eGL_DEPTH_COMPONENT && !HasExt[NV_read_depth]) ||
-     (format == eGL_STENCIL && !HasExt[NV_read_stencil]) ||
-     (format == eGL_DEPTH_STENCIL && !HasExt[NV_read_depth_stencil]))
+  if((format == eGL_DEPTH_COMPONENT && (!HasExt[NV_read_depth] || IsGLES)) ||
+     (format == eGL_STENCIL && (!HasExt[NV_read_stencil] || IsGLES)) ||
+     (format == eGL_DEPTH_STENCIL && (!HasExt[NV_read_depth_stencil] || IsGLES)))
   {
     readDirectly = false;
   }


### PR DESCRIPTION
When capturing GLES on PC, depth texture (shadowmap) is not correctly captured:
> Implementation reported format GL_NONE / type GL_NONE readback format for GL_DEPTH_COMPONENT16. Trying with desired format GL_DEPTH_COMPONENT / type GL_UNSIGNED_SHORT pair anyway.

Also I checked document: [glReadPixels in GLES](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glReadPixels.xhtml) doesn't support depth component as format, while [glReadPixels in GL](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glReadPixels.xhtml) does.