### PR TITLE
fix `readCompSize` with depth format

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -3496,7 +3496,7 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
       size_t readCompSize = GetByteSize(1, 1, 1, eGL_RED, readType);
 
       if(depthFormat)
-        readCompSize = 4;
+        readCompSize = GetByteSize(1, 1, 1, readFormat, readType);
 
       // if the type didn't change from what the caller expects, we only changed the number of
       // components. This is easy to remap


### PR DESCRIPTION
Fix hard coded `readCompSize` with depth format.

`GL_DEPTH_COMPONENT16` and `GL_DEPTH_COMPONENT32F` tested:
<img width="414" height="180" alt="Snipaste_2025-08-13_11-26-28" src="https://github.com/user-attachments/assets/61e8228c-0d2a-430f-963e-be51e0e58cf0" />
<img width="445" height="190" alt="Snipaste_2025-08-13_11-32-07" src="https://github.com/user-attachments/assets/36946361-bdf7-40ca-b3d0-dd4ea0f6e3bb" />
