### PR TITLE
use string var for VULKAN_LAYER_FOLDER

### DIFF
--- a/renderdoc/driver/vulkan/CMakeLists.txt
+++ b/renderdoc/driver/vulkan/CMakeLists.txt
@@ -83,7 +83,10 @@ endif()
 # prefix is, since the loader only looks in a set location (and /usr/share is reserved for distribution
 # packages). For people who want to 'make install' to another folder, perhaps for preparing a package,
 # they can set this variable to make sure it stays local
-set(VULKAN_LAYER_FOLDER ${VULKAN_LAYER_FOLDER_DEFAULT} CACHE PATH "Path to install the vulkan layer file")
+#
+# Note that this must be a STRING var not a PATH, otherwise CMake will prepend the current working dir.
+# See https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry
+set(VULKAN_LAYER_FOLDER ${VULKAN_LAYER_FOLDER_DEFAULT} CACHE STRING "Path to install the vulkan layer file")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set_property(SOURCE vk_shaderdebug.cpp


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

For the `VULKAN_LAYER_FOLDER` to work as described (for the purpose of installing the layer config into a local folder), it needs to be a `STRING` variable rather than a `PATH`. From https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry:

> if the <type> is PATH or FILEPATH and the <value> provided on the command line is a relative path, then the set command will treat the path as relative to the current working directory and convert it to an absolute path.
