### PR TITLE
Use correct SpecID when descriptor array size <64

### DIFF
--- a/renderdoc/driver/vulkan/vk_postvs.cpp
+++ b/renderdoc/driver/vulkan/vk_postvs.cpp
@@ -5239,12 +5239,21 @@ void VulkanReplay::FetchVSOut(uint32_t eventId, VulkanRenderState &state)
                         "KHR and EXT buffer_device_address should be interchangeable here.");
       VkBufferDeviceAddressInfo getAddressInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO};
 
+      uint32_t specIdOffset = i;
       if(i < MeshOutputBufferArraySize)
+      {
         getAddressInfo.buffer = vbuffers[i].buf;
+      }
       else if(i == MeshOutputBufferArraySize)
+      {
         getAddressInfo.buffer = uniqIdxBuf;
+        specIdOffset = MeshOutputIBufferSpecConstant;
+      }
       else if(i == MeshOutputBufferArraySize + 1)
+      {
         getAddressInfo.buffer = meshBuffer;
+        specIdOffset = MeshOutputOutputSpecConstant;
+      }
 
       // skip
       if(getAddressInfo.buffer == VK_NULL_HANDLE)
@@ -5257,7 +5266,7 @@ void VulkanReplay::FetchVSOut(uint32_t eventId, VulkanRenderState &state)
 
       VkSpecializationMapEntry entry;
       entry.offset = baseOffset + i * sizeof(uint64_t);
-      entry.constantID = baseSpecConstant + i * 2 + 0;
+      entry.constantID = baseSpecConstant + specIdOffset * 2 + 0;
 
       // for EXT we have one 64-bit spec constant per address, for KHR we have a uvec2 - two
       // constants


### PR DESCRIPTION
Fixes #3643

If the GPU has less than the default number of descriptor buffers (64) then the SpecIDs written into the PostVS SPIR-V do not align with the specialization constant IDs.

Tested on Mali-G52 (Bifrost arch, 35 descriptor storage buffers) and Mali-G715 (Valhall arch, 8388608 descriptor storage buffers).