### PR TITLE
[Vulkan][macOS] A few fixes to allow MoltenVK capture + replay on macOS

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -1699,6 +1699,10 @@ static const VkExtensionProperties supportedExtensions[] = {
         VK_KHR_PIPELINE_LIBRARY_SPEC_VERSION,
     },
     {
+        VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
+        VK_KHR_PORTABILITY_ENUMERATION_SPEC_VERSION,
+    },
+    {
         VK_KHR_PRESENT_ID_EXTENSION_NAME,
         VK_KHR_PRESENT_ID_SPEC_VERSION,
     },

--- a/renderdoc/driver/vulkan/vk_layer.cpp
+++ b/renderdoc/driver/vulkan/vk_layer.cpp
@@ -46,7 +46,7 @@ extern "C" const rdcstr VulkanLayerJSONBasename;
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT extern "C" __declspec(dllexport)
 
-#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID)
+#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID) || ENABLED(RDOC_APPLE)
 
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -364,8 +364,8 @@ RDResult WrappedVulkan::Initialise(VkInitParams &params, uint64_t sectionVersion
   }
 #if RENDERDOC_PLATFORM_APPLE
   // macOS / moltenVK is not fully conformant Vulkan implementation, so we need to enable this
-  if (supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
-      supportedExtensions.end())
+  if(supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
+     supportedExtensions.end())
   {
     if(!m_Replay->IsRemoteProxy())
       RDCLOG("Enabling VK_KHR_portability_enumeration");
@@ -454,8 +454,8 @@ RDResult WrappedVulkan::Initialise(VkInitParams &params, uint64_t sectionVersion
 
 #if RENDERDOC_PLATFORM_APPLE
   // macOS / moltenVK is not fully conformant Vulkan implementation
-  if (supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
-      supportedExtensions.end())
+  if(supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
+     supportedExtensions.end())
   {
     instinfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
   }

--- a/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_device_funcs.cpp
@@ -362,6 +362,16 @@ RDResult WrappedVulkan::Initialise(VkInitParams &params, uint64_t sectionVersion
                           params.Extensions[i].c_str());
     }
   }
+#if RENDERDOC_PLATFORM_APPLE
+  // macOS / moltenVK is not fully conformant Vulkan implementation, so we need to enable this
+  if (supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
+      supportedExtensions.end())
+  {
+    if(!m_Replay->IsRemoteProxy())
+      RDCLOG("Enabling VK_KHR_portability_enumeration");
+    params.Extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+  }
+#endif
 
   // we always want debug extensions if it available, and not already enabled
   if(supportedExtensions.find(VK_EXT_DEBUG_UTILS_EXTENSION_NAME) != supportedExtensions.end() &&
@@ -441,6 +451,15 @@ RDResult WrappedVulkan::Initialise(VkInitParams &params, uint64_t sectionVersion
       (uint32_t)params.Extensions.size(),
       extscstr,
   };
+
+#if RENDERDOC_PLATFORM_APPLE
+  // macOS / moltenVK is not fully conformant Vulkan implementation
+  if (supportedExtensions.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) !=
+      supportedExtensions.end())
+  {
+    instinfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+  }
+#endif
 
   if(params.APIVersion >= VK_API_VERSION_1_0)
     renderdocAppInfo.apiVersion = params.APIVersion;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

A couple of minor fixes to allow Vulkan frame capture and replay on macOS:
- VK_KHR_portability_enumeration added to the list of known extensions
- Replay Vulkan instance needs to use that extension for MoltenVK
- macOS build of the renderdoc dylib did not expose the capture layer entrypoints

With the attached fixes, Vulkan frame capture and replay is mostly operational on macOS. Shader debugger seems to barf inside moltenVK due to SPIR-V-to-MSL conversion error, but other functionality seems to mostly work. UPDATE: The debugger is hitting a bug relating to MSL translation of boolean specialization constants (found a bug in SPIRV-Cross, fix PR submitted). Compute shader debugging seems to work fine, fragment shaders still crash inside MoltenVK

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
