### PR TITLE
Add descriptor type to descriptor uniqueness key.

### DIFF
--- a/renderdoc/driver/vulkan/vk_resources.h
+++ b/renderdoc/driver/vulkan/vk_resources.h
@@ -1028,23 +1028,25 @@ DECLARE_REFLECTION_STRUCT(AspectSparseTable);
 
 struct DescriptorUniquenessKey
 {
-  DescriptorUniquenessKey(VkImageLayout layout)
-      : layout(layout), offset(0), size(0), fmt(VK_FORMAT_UNDEFINED)
+  DescriptorUniquenessKey(VkImageLayout layout, VkDescriptorType type)
+      : layout(layout), offset(0), size(0), fmt(VK_FORMAT_UNDEFINED), type(type)
   {
   }
-  DescriptorUniquenessKey(uint64_t offset, uint64_t size, VkFormat fmt)
-      : layout(VK_IMAGE_LAYOUT_UNDEFINED), offset(offset), size(size), fmt(fmt)
+  DescriptorUniquenessKey(uint64_t offset, uint64_t size, VkFormat fmt, VkDescriptorType type)
+      : layout(VK_IMAGE_LAYOUT_UNDEFINED), offset(offset), size(size), fmt(fmt), type(type)
   {
   }
 
   bool operator==(const DescriptorUniquenessKey &key) const
   {
-    return layout == key.layout && offset == key.offset && size == key.size && fmt == key.fmt;
+    return layout == key.layout && offset == key.offset && size == key.size && fmt == key.fmt &&
+           type == key.type;
   }
 
   VkImageLayout layout;
   uint64_t offset, size;
   VkFormat fmt;
+  VkDescriptorType type;
 };
 
 namespace std
@@ -1058,6 +1060,7 @@ struct hash<DescriptorUniquenessKey>
     hash ^= std::hash<uint64_t>()(key.offset) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^= std::hash<uint64_t>()(key.size) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^= std::hash<uint32_t>()(key.fmt) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    hash ^= std::hash<uint32_t>()(key.type) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     return hash;
   }
 };

--- a/renderdoc/driver/vulkan/wrappers/vk_descriptor_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_descriptor_funcs.cpp
@@ -3452,9 +3452,9 @@ void WrappedVulkan::vkGetDescriptorEXT(VkDevice device, const VkDescriptorGetInf
           dstRecord = GetRecord(pDescriptorInfo->data.pSampledImage->imageView);
 
           DescriptorUniquenessKey descKey(
-              m_IgnoreLayoutForDescriptors
-                  ? VK_IMAGE_LAYOUT_UNDEFINED
-                  : pDescriptorInfo->data.pCombinedImageSampler->imageLayout);
+              m_IgnoreLayoutForDescriptors ? VK_IMAGE_LAYOUT_UNDEFINED
+                                           : pDescriptorInfo->data.pCombinedImageSampler->imageLayout,
+              pDescriptorInfo->type);
 
           // this is internally locked
           if(!dstRecord->resInfo->AddDescriptor(descKey))
@@ -3523,7 +3523,8 @@ void WrappedVulkan::vkGetDescriptorEXT(VkDevice device, const VkDescriptorGetInf
 
           dstRecord = GetResourceManager()->GetResourceRecord(id);
 
-          DescriptorUniquenessKey descKey(offs, pDescriptorInfo->data.pUniformBuffer->range, fmt);
+          DescriptorUniquenessKey descKey(offs, pDescriptorInfo->data.pUniformBuffer->range, fmt,
+                                          pDescriptorInfo->type);
 
           // this is internally locked
           if(!dstRecord->resInfo->AddDescriptor(descKey))

--- a/renderdoc/replay/replay_controller.cpp
+++ b/renderdoc/replay/replay_controller.cpp
@@ -2327,7 +2327,7 @@ void ReplayController::FetchPipelineState(uint32_t eventId)
 
     // if the last range is contiguous with this access, append this access as a new range to query
     if(!ranges.empty() && ranges.back().descriptorSize == acc.byteSize &&
-       ranges.back().offset + ranges.back().descriptorSize == acc.byteOffset &&
+       ranges.back().offset + ranges.back().count * ranges.back().descriptorSize == acc.byteOffset &&
        ranges.back().type == acc.type)
     {
       ranges.back().count++;


### PR DESCRIPTION
Avoids problem when storage image and sampled image are extracted from the same view object for example.