### PR TITLE
fix readCompSize for depth format

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -3322,6 +3322,9 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
     level = 0;
     readFormat = remapformat;
     readType = remaptype;
+    // always reset depthFormat. If the target format is depth, it was remapped
+    // and read-back will happen on remapped texture.
+    depthFormat = false;
 
     attachment = eGL_COLOR_ATTACHMENT0;
 


### PR DESCRIPTION
fix readCompSize for emulated depth readback on GL.

The previous logic recalculated readCompSize for depth formats using GetByteSize(). It returns the pixel size, instead of the component size. It is not correct, as each pixel in the texture uses [4 components](https://github.com/baldurk/renderdoc/blob/cab10bcefe6e8d27623052c83f0e587276edc4c7/renderdoc/driver/gl/wrappers/gl_emulated.cpp#L2944-L2947). The incorrect readCompSize caused problem later, e.g: [srcPixel += readCompSize * readCompCount;](https://github.com/baldurk/renderdoc/blob/cab10bcefe6e8d27623052c83f0e587276edc4c7/renderdoc/driver/gl/wrappers/gl_emulated.cpp#L3629) and [RDCERR("Unexpected format to convert from %u %u", fmt.compByteWidth, compType);](https://github.com/baldurk/renderdoc/blob/cab10bcefe6e8d27623052c83f0e587276edc4c7/renderdoc/maths/formatpacking.cpp#L851).
