### PR TITLE
Update memory type for some external images on replay

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -333,6 +333,25 @@ bool WrappedVulkan::Serialise_vkAllocateMemory(SerialiserType &ser, VkDevice dev
           else
             RemoveNextStruct(&patched, VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO);
         }
+
+        // If this memory was bound to an external image, check if the memory type on replay is
+        // allowed for regular image. If not, attempt to use a different memory type to replay the
+        // original capture.
+        VulkanCreationInfo::Image &imgInfo = m_CreationInfo.m_Image[GetResID(dedicated->image)];
+        if(imgInfo.external && (((1 << patched.memoryTypeIndex) & mrq.memoryTypeBits) == 0))
+        {
+          for(uint32_t i = 0; i < m_PhysicalDeviceData.memProps.memoryTypeCount; i++)
+          {
+            if(mrq.memoryTypeBits & (1U << i))
+            {
+              RDCDEBUG("Patching memory type for memory used by an external image, from %u to %u",
+                       patched.memoryTypeIndex, i);
+              patched.memoryTypeIndex = i;
+              AllocateInfo.memoryTypeIndex = i;
+              break;
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
For cases where an external image is a regular image on replay and the original memory type for external memory cannot be used for regular memory. This can only be done for dedicated allocation (which some handle types require), since we know which image the memory will be bound to when vkAllocateMemory is called and memory type is specified.

On some drivers, for externally imported AHB backed images the allowed memory type bits (reported via vkGetAndroidHardwareBufferPropertiesANDROID) has no overlap with the memory type bits for a similar non-external image (reported via vkGetImageMemoryRequirements). In those cases, RenderDoc is currently not able to replay a capture. It would be very helpful if RenderDoc is capable of updating memory type on replay.