### PR TITLE
Fix component sizing for GL texture copies

### DIFF
--- a/renderdoc/driver/gl/wrappers/gl_emulated.cpp
+++ b/renderdoc/driver/gl/wrappers/gl_emulated.cpp
@@ -3499,7 +3499,7 @@ void APIENTRY _glGetTexImage(GLenum target, GLint level, const GLenum format, co
       size_t readCompSize = GetByteSize(1, 1, 1, eGL_RED, readType);
 
       if(depthFormat)
-        readCompSize = GetByteSize(1, 1, 1, readFormat, readType);
+        readCompSize = GetByteSize(1, 1, 1, readFormat, readType) / readCompCount;
 
       // if the type didn't change from what the caller expects, we only changed the number of
       // components. This is easy to remap


### PR DESCRIPTION
Divide by the component count to obtain the correct component size