### PR TITLE
Fix gpu driver crash caused by pixel history

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -1586,6 +1586,8 @@ bool WrappedVulkan::Serialise_vkBeginCommandBuffer(SerialiserType &ser, VkComman
               m_CreationInfo.m_RenderPass[GetResID(unwrappedInheritInfo.renderPass)];
           unwrappedInheritInfo.renderPass = Unwrap(rpinfo.loadRPs[unwrappedInheritInfo.subpass]);
         }
+
+        unwrappedInheritInfo.subpass = 0;
       }
       else
       {


### PR DESCRIPTION
Force load renderpass contains only one subpass, if not set subpass, the subpass passed to gpu driver mismatch the actual subpass, and then causes crash.