### PR TITLE
egl crash fdix

### DIFF
--- a/renderdoc/driver/gl/egl_hooks.cpp
+++ b/renderdoc/driver/gl/egl_hooks.cpp
@@ -251,6 +251,9 @@ HOOK_EXPORT EGLContext EGLAPIENTRY eglCreateContext_renderdoc_hooked(EGLDisplay 
                                                                      EGLContext shareContext,
                                                                      EGLint const *attribList)
 {
+  if(!config)
+    return 0;
+
   if(RenderDoc::Inst().IsReplayApp())
   {
     if(!EGL.CreateContext)


### PR DESCRIPTION
* simple crash fix for EGL hooks (crashed in to **libglesv2.dll**)

<img width="1394" height="432" alt="изображение" src="https://github.com/user-attachments/assets/2951663a-699d-4043-a11a-37622e40cfe7" />
