### PR TITLE
Pass -rdynamic to renderdoccmd link, ensures replay marker sym is exported

### DIFF
--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -67,7 +67,7 @@ elseif(UNIX)
 
     # Make sure that for the target executable we don't throw away
     # any shared libraries.
-    set(LINKER_FLAGS "-Wl,--no-as-needed")
+    set(LINKER_FLAGS "-Wl,--no-as-needed -rdynamic")
 endif()
 
 if(ANDROID)


### PR DESCRIPTION
This matches qrenderdoc.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

I came across this because I was trying to run `renderdoccmd capture` in an environment with `LD_LIBRARY_PATH` set to something important, but the environment variable was being cleared in the child process.  I found that `renderdoccmd` was immediately clearing the environment variables via `library_loaded` -> `ResetHookingEnvVars`.  That eventually led me to the fact that this test was failing:

```
  if(LibraryHooks::Detect(STRINGIZE(RDOC_BASE_NAME) "__replay__marker"))
```

Then I found the difference in linker flags.  The qrenderdoc one was added in 80ec87fdd2cfd45c7c60d46798fa7042ffaf258a.

I'm sure I had this working since 2017, so I did try to track down what might have broken since then, but so far no luck.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
