### PR TITLE
Sync GPU before decoding NVIDIA Nsight Perf SDK counters on D3D11

### DIFF
--- a/renderdoc/driver/ihv/nv/nv_d3d11_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_d3d11_counters.cpp
@@ -405,6 +405,8 @@ rdcarray<CounterResult> NVD3D11Counters::FetchCounters(const rdcarray<GPUCounter
       break;    // Failure
     }
 
+    d3dImmediateContext->Flush();
+
     nv::perf::profiler::DecodeResult decodeResult;
     if(!rangeProfiler.DecodeCounters(decodeResult))
     {
@@ -421,9 +423,8 @@ rdcarray<CounterResult> NVD3D11Counters::FetchCounters(const rdcarray<GPUCounter
 
     if(replayPass >= maxNumReplayPasses - 1)
     {
-      // FIXME: maxNumReplayPasses does not appear to be calculated correctly for d3d11!
-      // RDCERR("NvPerf exceeded the maximum expected number of replay passes");
-      // break;    // Failure
+      RDCERR("NvPerf exceeded the maximum expected number of replay passes");
+      break;    // Failure
     }
   }
 


### PR DESCRIPTION
## Description

Syncing the GPU before decoding counters resolves an "NVPA_STATUS_INSUFFICIENT_SPACE" error when collecting counters for D3D11 applications with many event ranges.