### PR TITLE
fix crash caused by dlsym cannot find __replay__marker

### DIFF
--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -85,7 +85,15 @@ else()
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
 
     add_executable(renderdoccmd ${sources})
-    
+
+    if(UNIX AND NOT APPLE)
+        if(NOT CMAKE_VERSION VERSION_LESS "3.13")
+            target_link_options(renderdoccmd PRIVATE -rdynamic)
+        else()
+            set_target_properties(renderdoccmd PROPERTIES LINK_FLAGS "-rdynamic")
+        endif()
+    endif()
+
     if(INTERNAL_SELF_CAPTURE)
         set_target_properties(renderdoccmd PROPERTIES OUTPUT_NAME "rdocselfcmd")
     endif()


### PR DESCRIPTION
This issue is caused by gcc upgrade, explicit linking is required.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
renderdoccmd capture app will return 9 when F12 can execute capture without any error.
But meet crash when use renderdoccmd replay this rdc.
The root cause is exactly capture failed due to dlsym cannot find __replay__marker which caused by the renderdoc__replay__marker is only present in the .symtab and not in the .dynsym, so dlsym cannot find it, and therefore we must manually link.

Before fix:
root@imx8mpevk:/opt/renderdoc/build_1.37_6.18_debug/bin# readelf -Ws ./renderdoccmd | grep renderdoc__replay__marker
  3074: 000000000001893c    12 FUNC    GLOBAL DEFAULT   13 renderdoc__replay__marker
root@imx8mpevk:/opt/renderdoc/build_1.37_6.18_debug/bin# nm -D --defined-only ./renderdoccmd | grep renderdoc__replay__marker
root@imx8mpevk:/opt/renderdoc/build_1.37_6.18_debug/bin# objdump -T ./renderdoccmd | grep renderdoc__replay__marker

After fix:
root@imx8mpevk:/opt/renderdoc/build_1.37_6.18_debug_modify/bin# readelf -Ws ./renderdoccmd | grep renderdoc__replay__marker
   183: 0000000000019dbc    12 FUNC    GLOBAL DEFAULT   13 renderdoc__replay__marker
  3278: 0000000000019dbc    12 FUNC    GLOBAL DEFAULT   13 renderdoc__replay__marker
root@imx8mpevk:/opt/renderdoc/build_1.37_6.18_debug_modify/bin# nm -D --defined-only ./renderdoccmd | grep renderdoc__replay__marker
0000000000019dbc T renderdoc__replay__marker
root@imx8mpevk:/opt/renderdoc/build_1.37_6.18_debug_modify/bin# objdump -T ./renderdoccmd | grep renderdoc__replay__marker
0000000000019dbc g    DF .text  000000000000000c  Base        renderdoc__replay__marker


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
