### PR TITLE
d3d12: Implement ID3D12SharingContract on the ID3D12CommandQueue

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_command_queue.h
+++ b/renderdoc/driver/d3d12/d3d12_command_queue.h
@@ -183,6 +183,7 @@ class WrappedID3D12CommandQueue : public ID3D12CommandQueue1,
 
   WrappedID3D12DebugCommandQueue m_WrappedDebug;
   WrappedID3D12CompatibilityQueue m_WrappedCompat;
+  WrappedID3D12SharingContract m_SharingContract;
 
   rdcarray<D3D12ResourceRecord *> m_CmdListRecords;
   rdcarray<D3D12ResourceRecord *> m_CmdListAllocators;

--- a/renderdoc/driver/d3d12/d3d12_commands.cpp
+++ b/renderdoc/driver/d3d12/d3d12_commands.cpp
@@ -499,7 +499,8 @@ WrappedID3D12CommandQueue::WrappedID3D12CommandQueue(ID3D12CommandQueue *real,
       m_pDevice(device),
       m_State(state),
       m_WrappedDownlevel(*this),
-      m_WrappedCompat(*this)
+      m_WrappedCompat(*this),
+      m_SharingContract(*m_pDevice)
 {
   RenderDoc::Inst().RegisterMemoryRegion(this, sizeof(WrappedID3D12CommandQueue));
 
@@ -513,6 +514,7 @@ WrappedID3D12CommandQueue::WrappedID3D12CommandQueue(ID3D12CommandQueue *real,
     m_pReal->QueryInterface(__uuidof(ID3D12CommandQueueDownlevel), (void **)&m_pDownlevel);
     m_pReal->QueryInterface(__uuidof(ID3D12CommandQueue1), (void **)&m_pReal1);
     m_pReal->QueryInterface(__uuidof(ID3D12CompatibilityQueue), (void **)&m_WrappedCompat.m_pReal);
+    m_pReal->QueryInterface(__uuidof(ID3D12SharingContract), (void **)&m_SharingContract.m_pReal);
   }
 
   if(RenderDoc::Inst().IsReplayApp())
@@ -573,6 +575,7 @@ WrappedID3D12CommandQueue::~WrappedID3D12CommandQueue()
   SAFE_RELEASE(m_WrappedCompat.m_pReal);
   SAFE_RELEASE(m_WrappedDebug.m_pReal);
   SAFE_RELEASE(m_WrappedDebug.m_pReal1);
+  SAFE_RELEASE(m_SharingContract.m_pReal);
   SAFE_RELEASE(m_pReal);
 }
 
@@ -628,6 +631,12 @@ HRESULT STDMETHODCALLTYPE WrappedID3D12CommandQueue::QueryInterface(REFIID riid,
     {
       return E_NOINTERFACE;
     }
+  }
+  else if(riid == __uuidof(ID3D12SharingContract))
+  {
+    *ppvObject = (ID3D12SharingContract *)&m_SharingContract;
+    AddRef();
+    return S_OK;
   }
   else if(riid == __uuidof(ID3D12Pageable))
   {

--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -301,25 +301,29 @@ void STDMETHODCALLTYPE WrappedID3D12SharingContract::Present(_In_ ID3D12Resource
 
   m_pDevice.Present(NULL, this, 0, 0);
 
-  m_pReal->Present(Unwrap(pResource), Subresource, window);
+  if(m_pReal != NULL)
+    m_pReal->Present(Unwrap(pResource), Subresource, window);
 }
 
 void STDMETHODCALLTYPE WrappedID3D12SharingContract::SharedFenceSignal(_In_ ID3D12Fence *pFence,
                                                                        UINT64 FenceValue)
 {
-  m_pReal->SharedFenceSignal(Unwrap(pFence), FenceValue);
+  if(m_pReal != NULL)
+    m_pReal->SharedFenceSignal(Unwrap(pFence), FenceValue);
 }
 
 void STDMETHODCALLTYPE WrappedID3D12SharingContract::BeginCapturableWork(_In_ REFGUID guid)
 {
   // undocumented what this does
-  m_pReal->BeginCapturableWork(guid);
+  if(m_pReal != NULL)
+    m_pReal->BeginCapturableWork(guid);
 }
 
 void STDMETHODCALLTYPE WrappedID3D12SharingContract::EndCapturableWork(_In_ REFGUID guid)
 {
   // undocumented what this does
-  m_pReal->EndCapturableWork(guid);
+  if(m_pReal != NULL)
+    m_pReal->EndCapturableWork(guid);
 }
 
 HRESULT STDMETHODCALLTYPE WrappedDRED::QueryInterface(REFIID riid, void **ppvObject)
@@ -1990,9 +1994,13 @@ IUnknown *WrappedID3D12Device::WrapSwapchainBuffer(IDXGISwapper *swapper, DXGI_F
     FreeRTV(m_SwapChains[swapper].rtvs[buffer]);
     m_SwapChains[swapper].rtvs[buffer] = rtv;
 
-    ID3DDevice *swapQ = swapper->GetD3DDevice();
-    RDCASSERT(WrappedID3D12CommandQueue::IsAlloc(swapQ));
-    m_SwapChains[swapper].queue = (WrappedID3D12CommandQueue *)swapQ;
+    ID3DDevice *swapDev = swapper->GetD3DDevice();
+    if(WrappedID3D12CommandQueue::IsAlloc(swapDev))
+      m_SwapChains[swapper].queue = (WrappedID3D12CommandQueue *)swapDev;
+    else if(swapDev == this)
+      m_SwapChains[swapper].queue = m_Queue;
+    else
+      RDCERR("Unexpected swapper D3D device");
   }
 
   return pRes;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->

https://learn.microsoft.com/en-us/windows/win32/api/d3d12sdklayers/nn-d3d12sdklayers-id3d12sharingcontract says:

> You may want to use this interface to enable diagnostic tools to
> capture usage patterns that don't use DXGI swap chains for
> presentation. If so, you can access this interface via
> QueryInterface from a D3D12 command queue.

Currently, this is implemented on the ID3D12Device. Implement it on the D3D12CommandQueue as well.
