### PR TITLE
Sorting array members in the watch window correctly

### DIFF
--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -4560,6 +4560,7 @@ bool ShaderViewer::updateWatchVariable(RDTreeWidgetItem *watchItem, const RDTree
         });
         VariableTag tag = VariableTag(DebugVariableType::Variable, path);
         tag.state = WatchVarState::Valid;
+        tag.offset = i;
         item->setTag(QVariant::fromValue(tag));
         watchItem->addChild(item);
         valid.push_back(false);
@@ -4802,7 +4803,9 @@ bool ShaderViewer::updateWatchVariable(RDTreeWidgetItem *watchItem, const RDTree
   watchItem->setItalic(false);
 
   VariableTag tag = VariableTag(DebugVariableType::Variable, path);
+  uint32_t offset = watchItem->tag().value<VariableTag>().offset; // Grab the offset that is already set
   tag.state = WatchVarState::Valid;
+  tag.offset = offset;
   watchItem->setTag(QVariant::fromValue(tag));
 
   return true;


### PR DESCRIPTION
## Description
When adding an array variable to the Watch window the members do not have offsets so when they are sorted they are sorted by text which causes `[2]` to show after `[10]`:

Before:
<img width="319" height="356" alt="image" src="https://github.com/user-attachments/assets/9574a520-aeea-4826-a203-680735db743c" />

After:
<img width="292" height="350" alt="image" src="https://github.com/user-attachments/assets/0b7adec2-a022-4ce1-b125-a3cc52ab5cd3" />

I'm not 100% sure if this is correct or not. Its worth noting that the High Level Variables
tab does have this sorted correctly and the member `offset` is set to the index. At least
from just a cursory look. So this is just copying that behavior.

Same variable in the High Level Variables tab.
<img width="406" height="354" alt="image" src="https://github.com/user-attachments/assets/54f2eebc-442c-46e9-80c6-56d341b109d3" />
