### PR TITLE
 Sorting array members in the Watch and High Level Variables window

### DIFF
--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -155,6 +155,22 @@ static bool ResourceReferencesMatch(const ShaderVariable &a, const ShaderVariabl
   return false;
 }
 
+void SortRDWidgetItems(QVector<RDTreeWidgetItem *> &members)
+{
+  // Sort the children by offset, then global source var index, then by text.
+  // Using the global source var index allows resource arrays to be presented in index order
+  // rather than by name, so for example arr[2] comes before arr[10]
+  std::sort(members.begin(), members.end(), [](const RDTreeWidgetItem *a, const RDTreeWidgetItem *b) {
+    VariableTag at = a->tag().value<VariableTag>();
+    VariableTag bt = b->tag().value<VariableTag>();
+    if(at.offset != bt.offset)
+      return at.offset < bt.offset;
+    if(at.globalSourceVar && bt.globalSourceVar)
+      return at.sourceVarIdx < bt.sourceVarIdx;
+    return a->text(0) < b->text(0);
+  });
+}
+
 struct AccessedResourceTag
 {
   AccessedResourceTag() : type(VarType::Unknown), step(0)
@@ -3130,17 +3146,7 @@ void ShaderViewer::combineStructures(RDTreeWidgetItem *root, int skipPrefixLengt
       c--;
     }
 
-    // Sort the children by offset, then global source var index, then by text.
-    // Using the global source var index allows resource arrays to be presented in index order
-    // rather than by name, so for example arr[2] comes before arr[10]
-    std::sort(matches.begin(), matches.end(),
-              [](const RDTreeWidgetItem *a, const RDTreeWidgetItem *b) {
-                VariableTag at = a->tag().value<VariableTag>();
-                VariableTag bt = b->tag().value<VariableTag>();
-                if(at.offset != bt.offset)
-                  return at.offset < bt.offset;
-                return a->text(0) < b->text(0);
-              });
+    SortRDWidgetItems(matches);
 
     // create a new parent with just the prefix
     prefix.chop(1);
@@ -4560,6 +4566,7 @@ bool ShaderViewer::updateWatchVariable(RDTreeWidgetItem *watchItem, const RDTree
         });
         VariableTag tag = VariableTag(DebugVariableType::Variable, path);
         tag.state = WatchVarState::Valid;
+        tag.offset = i;
         item->setTag(QVariant::fromValue(tag));
         watchItem->addChild(item);
         valid.push_back(false);
@@ -4586,14 +4593,7 @@ bool ShaderViewer::updateWatchVariable(RDTreeWidgetItem *watchItem, const RDTree
     while(watchItem->childCount())
       members.push_back(watchItem->takeChild(0));
 
-    std::sort(members.begin(), members.end(),
-              [](const RDTreeWidgetItem *a, const RDTreeWidgetItem *b) {
-                VariableTag at = a->tag().value<VariableTag>();
-                VariableTag bt = b->tag().value<VariableTag>();
-                if(at.offset != bt.offset)
-                  return at.offset < bt.offset;
-                return a->text(0) < b->text(0);
-              });
+    SortRDWidgetItems(members);
 
     for(int i = 0; i < members.count(); i++)
       watchItem->addChild(members[i]);
@@ -4604,6 +4604,7 @@ bool ShaderViewer::updateWatchVariable(RDTreeWidgetItem *watchItem, const RDTree
 
     VariableTag tag = VariableTag(DebugVariableType::Variable, path);
     tag.state = WatchVarState::Valid;
+    tag.offset = watchItem->tag().value<VariableTag>().offset;
     watchItem->setTag(QVariant::fromValue(tag));
 
     return true;
@@ -4803,6 +4804,9 @@ bool ShaderViewer::updateWatchVariable(RDTreeWidgetItem *watchItem, const RDTree
 
   VariableTag tag = VariableTag(DebugVariableType::Variable, path);
   tag.state = WatchVarState::Valid;
+  // Grab the offset that is already set
+  uint32_t offset = watchItem->tag().value<VariableTag>().offset;
+  tag.offset = offset;
   watchItem->setTag(QVariant::fromValue(tag));
 
   return true;


### PR DESCRIPTION
## Description
When adding an array variable to the Watch window the VariableTag of the members do not have offsets so when they are sorted they are sorted by text which causes `[2]` to show after `[10]`:

Before:
<img width="319" height="356" alt="image" src="https://github.com/user-attachments/assets/9574a520-aeea-4826-a203-680735db743c" />

After:
<img width="292" height="350" alt="image" src="https://github.com/user-attachments/assets/0b7adec2-a022-4ce1-b125-a3cc52ab5cd3" />

I'm not 100% sure if this is correct or not. Its worth noting that the High Level Variables
tab does have this sorted correctly and the member `offset` is set to the index of the member. At least
from just a cursory look. So this is just copying that behavior.

Same variable in the High Level Variables tab.
<img width="406" height="354" alt="image" src="https://github.com/user-attachments/assets/54f2eebc-442c-46e9-80c6-56d341b109d3" />
