### PR TITLE
UI: Add bookmark reordering

### DIFF
--- a/qrenderdoc/Code/CaptureContext.cpp
+++ b/qrenderdoc/Code/CaptureContext.cpp
@@ -1801,6 +1801,33 @@ void CaptureContext::RemoveBookmark(uint32_t EID)
   RefreshUIStatus({}, true, true);
 }
 
+void CaptureContext::ShiftBookmark(uint32_t EID, int32_t direction)
+{
+  int index = -1;
+
+  for(int i = 0; i < m_Bookmarks.count(); i++)
+  {
+    if(m_Bookmarks[i].eventId == EID)
+    {
+      index = i;
+      break;
+    }
+  }
+
+  if(index == -1)
+    return;
+
+  int newIndex = index + direction;
+
+  if(newIndex < 0 || newIndex >= m_Bookmarks.count())
+    return;
+
+  std::swap(m_Bookmarks[index], m_Bookmarks[newIndex]);
+
+  SetModification(CaptureModifications::Bookmarks);
+  RefreshUIStatus({}, true, true);
+}
+
 void CaptureContext::DelayedCallback(uint32_t milliseconds, std::function<void()> callback)
 {
   QTimer::singleShot(milliseconds, callback);

--- a/qrenderdoc/Code/CaptureContext.h
+++ b/qrenderdoc/Code/CaptureContext.h
@@ -204,6 +204,7 @@ public:
   rdcarray<EventBookmark> GetBookmarks() override { return m_Bookmarks; }
   void SetBookmark(const EventBookmark &mark) override;
   void RemoveBookmark(uint32_t EID) override;
+  void ShiftBookmark(uint32_t EID, int32_t direction) override;
   void EmbedDependentFiles() override;
   void RemoveDependentFiles() override;
 

--- a/qrenderdoc/Code/Interface/QRDInterface.h
+++ b/qrenderdoc/Code/Interface/QRDInterface.h
@@ -2420,6 +2420,15 @@ If no bookmark exists, this function will do nothing.
 )");
   virtual void RemoveBookmark(uint32_t eventId) = 0;
 
+  DOCUMENT(R"(Reorders a bookmark by shifting its position in the bookmark list.This allows manual reordering of bookmarks. 
+
+The bookmark associated with the givenevent ID is swapped with the adjacent bookmark in the specified direction.
+
+:param int EID: The event ID of the bookmark to move.
+:param int direction: The direction to move.
+)");
+  virtual void ShiftBookmark(uint32_t EID, int32_t direction) = 0;
+
   DOCUMENT(R"(Stores the dependent file data into the capture i.e. shader debug files.
 
 This reads the contents of the dependent files and stores their file contents into the capture.

--- a/qrenderdoc/Windows/EventBrowser.cpp
+++ b/qrenderdoc/Windows/EventBrowser.cpp
@@ -5344,9 +5344,7 @@ void EventBrowser::repopulateBookmarks()
 
       highlightBookmarks();
 
-      m_BookmarkStripLayout->removeItem(m_BookmarkSpacer);
-      m_BookmarkStripLayout->addWidget(but);
-      m_BookmarkStripLayout->addItem(m_BookmarkSpacer);
+      m_BookmarkButtons[EID] = but;
     }
   }
 
@@ -5359,6 +5357,17 @@ void EventBrowser::repopulateBookmarks()
       m_BookmarkButtons.remove(EID);
     }
   }
+  m_BookmarkStripLayout->removeItem(m_BookmarkSpacer);
+  for(const EventBookmark &mark : bookmarks)
+  {
+    if(m_BookmarkButtons.contains(mark.eventId))
+    {
+      QRClickToolButton *but = m_BookmarkButtons[mark.eventId];
+      m_BookmarkStripLayout->removeWidget(but);
+      m_BookmarkStripLayout->addWidget(but);
+    }
+  }
+  m_BookmarkStripLayout->addItem(m_BookmarkSpacer);
 
   ui->bookmarkStrip->setVisible(!bookmarks.isEmpty());
 
@@ -5393,12 +5402,17 @@ void EventBrowser::bookmarkContextMenu(QRClickToolButton *button, uint32_t EID)
 
   QAction renameBookmark(tr("&Rename"), this);
   QAction deleteBookmark(tr("&Delete"), this);
+  QAction moveLeft(tr("Move &Left"), this);
+  QAction moveRight(tr("Move &Right"), this);
 
   renameBookmark.setIcon(Icons::page_white_edit());
   deleteBookmark.setIcon(Icons::del());
 
   contextMenu.addAction(&renameBookmark);
   contextMenu.addAction(&deleteBookmark);
+  contextMenu.addSeparator();
+  contextMenu.addAction(&moveLeft);
+  contextMenu.addAction(&moveRight);
 
   QObject::connect(&deleteBookmark, &QAction::triggered, [this, EID]() {
     m_Ctx.RemoveBookmark(EID);
@@ -5428,6 +5442,16 @@ void EventBrowser::bookmarkContextMenu(QRClickToolButton *button, uint32_t EID)
         m_Ctx.SetBookmark(editedBookmark);
       }
     }
+  });
+
+  QObject::connect(&moveLeft, &QAction::triggered, [this, EID]() {
+    m_Ctx.ShiftBookmark(EID, -1);
+    repopulateBookmarks();
+  });
+
+  QObject::connect(&moveRight, &QAction::triggered, [this, EID]() {
+    m_Ctx.ShiftBookmark(EID, 1);
+    repopulateBookmarks();
   });
 
   RDDialog::show(&contextMenu, QCursor::pos());

--- a/qrenderdoc/Windows/PythonShell.cpp
+++ b/qrenderdoc/Windows/PythonShell.cpp
@@ -647,6 +647,10 @@ struct CaptureContextInvoker : ObjectForwarder<ICaptureContext>
   {
     InvokeVoidFunction(&ICaptureContext::RemoveBookmark, EID);
   }
+  virtual void ShiftBookmark(uint32_t EID, int dir) override
+  {
+    InvokeVoidFunction(&ICaptureContext::ShiftBookmark, EID, dir);
+  }
   virtual void EmbedDependentFiles() override
   {
     InvokeVoidFunction(&ICaptureContext::EmbedDependentFiles);


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
This PR introduces the ability to manually reorder event bookmarks in the Event Browser.

**Implementation details:**

*   **Backend Logic**: Implemented the underlying logic to swap a bookmark's position with its neighbor in the capture context's list.
*   **Context Menu**: Extended the bookmark context menu to include "Move Left" and "Move Right" actions, grouped alongside the existing Rename and Delete options.
*   **Layout Refresh**: Modified the bookmark list update mechanism to ensure the button widgets are physically re-ordered in the UI layout when a move occurs, strictly following the new order in the data.
