### PR TITLE
renderdoc_app: Refactor calling convention checks to toolchain vs platform.

### DIFF
--- a/renderdoc/api/app/renderdoc_app.h
+++ b/renderdoc/api/app/renderdoc_app.h
@@ -37,6 +37,8 @@
 #define RENDERDOC_CC __cdecl
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__sun__) || defined(__OpenBSD__)
 #define RENDERDOC_CC
+#elif defined(__HAIKU__)
+#define RENDERDOC_CC
 #elif defined(__APPLE__)
 #define RENDERDOC_CC
 #else


### PR DESCRIPTION
## Description

Adds Haiku platform to renderdoc_app.  Currently it missing is breaking the downstream Mesa build.