### PR TITLE
Add missing IID checks for creating ID3D12CommandQueue1

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -154,7 +154,7 @@ HRESULT WrappedID3D12Device::CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC *
   if(ppCommandQueue == NULL)
     return m_pDevice->CreateCommandQueue(pDesc, riid, NULL);
 
-  if(riid != __uuidof(ID3D12CommandQueue))
+  if(riid != __uuidof(ID3D12CommandQueue) && riid != __uuidof(ID3D12CommandQueue1))
     return E_NOINTERFACE;
 
   ID3D12CommandQueue *real = NULL;

--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -221,7 +221,10 @@ HRESULT WrappedID3D12Device::CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC *
           wrapped->GetCreationRecord()->GetResourceID(), eFrameRef_Read);
     }
 
-    *ppCommandQueue = (ID3D12CommandQueue *)wrapped;
+    if(riid == __uuidof(ID3D12CommandQueue))
+      *ppCommandQueue = (ID3D12CommandQueue *)wrapped;
+    else if(riid == __uuidof(ID3D12CommandQueue1))
+      *ppCommandQueue = (ID3D12CommandQueue1 *)wrapped;
   }
   else
   {

--- a/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap.cpp
@@ -103,8 +103,14 @@ bool WrappedID3D12Device::Serialise_CreateCommandQueue(SerialiserType &ser,
 
   if(IsReplayingAndReading())
   {
+    void *realptr = NULL;
+    HRESULT hr = m_pDevice->CreateCommandQueue(&Descriptor, guid, &realptr);
+
     ID3D12CommandQueue *ret = NULL;
-    HRESULT hr = m_pDevice->CreateCommandQueue(&Descriptor, guid, (void **)&ret);
+    if(guid == __uuidof(ID3D12CommandQueue))
+      ret = (ID3D12CommandQueue *)realptr;
+    else if(guid == __uuidof(ID3D12CommandQueue1))
+      ret = (ID3D12CommandQueue1 *)realptr;
 
     if(FAILED(hr))
     {
@@ -157,9 +163,14 @@ HRESULT WrappedID3D12Device::CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC *
   if(riid != __uuidof(ID3D12CommandQueue) && riid != __uuidof(ID3D12CommandQueue1))
     return E_NOINTERFACE;
 
+  void *realptr = NULL;
+  HRESULT ret = m_pDevice->CreateCommandQueue(pDesc, riid, &realptr);
+
   ID3D12CommandQueue *real = NULL;
-  HRESULT ret;
-  SERIALISE_TIME_CALL(ret = m_pDevice->CreateCommandQueue(pDesc, riid, (void **)&real));
+  if(riid == __uuidof(ID3D12CommandQueue))
+    real = (ID3D12CommandQueue *)realptr;
+  else if(riid == __uuidof(ID3D12CommandQueue1))
+    real = (ID3D12CommandQueue1 *)realptr;
 
   if(SUCCEEDED(ret))
   {

--- a/renderdoc/driver/d3d12/d3d12_device_wrap9.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap9.cpp
@@ -204,7 +204,10 @@ HRESULT WrappedID3D12Device::CreateCommandQueue1(const D3D12_COMMAND_QUEUE_DESC 
           wrapped->GetCreationRecord()->GetResourceID(), eFrameRef_Read);
     }
 
-    *ppCommandQueue = (ID3D12CommandQueue *)wrapped;
+    if(riid == __uuidof(ID3D12CommandQueue))
+      *ppCommandQueue = (ID3D12CommandQueue *)wrapped;
+    else if(riid == __uuidof(ID3D12CommandQueue1))
+      *ppCommandQueue = (ID3D12CommandQueue1 *)wrapped;
   }
   else
   {

--- a/renderdoc/driver/d3d12/d3d12_device_wrap9.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap9.cpp
@@ -79,7 +79,13 @@ bool WrappedID3D12Device::Serialise_CreateCommandQueue1(SerialiserType &ser,
     HRESULT hr = E_NOINTERFACE;
     if(m_pDevice9)
     {
-      hr = m_pDevice9->CreateCommandQueue1(&Descriptor, creator, guid, (void **)&ret);
+      void *realptr = NULL;
+      hr = m_pDevice9->CreateCommandQueue1(&Descriptor, creator, guid, &realptr);
+
+      if(guid == __uuidof(ID3D12CommandQueue))
+        ret = (ID3D12CommandQueue *)realptr;
+      else if(guid == __uuidof(ID3D12CommandQueue1))
+        ret = (ID3D12CommandQueue1 *)realptr;
     }
     else
     {
@@ -139,9 +145,15 @@ HRESULT WrappedID3D12Device::CreateCommandQueue1(const D3D12_COMMAND_QUEUE_DESC 
   if(riid != __uuidof(ID3D12CommandQueue) && riid != __uuidof(ID3D12CommandQueue1))
     return E_NOINTERFACE;
 
-  ID3D12CommandQueue *real = NULL;
+  void *realptr = NULL;
   HRESULT ret;
-  SERIALISE_TIME_CALL(ret = m_pDevice9->CreateCommandQueue1(pDesc, CreatorID, riid, (void **)&real));
+  SERIALISE_TIME_CALL(ret = m_pDevice9->CreateCommandQueue1(pDesc, CreatorID, riid, &realptr));
+
+  ID3D12CommandQueue *real = NULL;
+  if(riid == __uuidof(ID3D12CommandQueue))
+    real = (ID3D12CommandQueue *)realptr;
+  else if(riid == __uuidof(ID3D12CommandQueue1))
+    real = (ID3D12CommandQueue1 *)realptr;
 
   if(SUCCEEDED(ret))
   {

--- a/renderdoc/driver/d3d12/d3d12_device_wrap9.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device_wrap9.cpp
@@ -136,7 +136,7 @@ HRESULT WrappedID3D12Device::CreateCommandQueue1(const D3D12_COMMAND_QUEUE_DESC 
   if(ppCommandQueue == NULL)
     return m_pDevice9->CreateCommandQueue1(pDesc, CreatorID, riid, NULL);
 
-  if(riid != __uuidof(ID3D12CommandQueue))
+  if(riid != __uuidof(ID3D12CommandQueue) && riid != __uuidof(ID3D12CommandQueue1))
     return E_NOINTERFACE;
 
   ID3D12CommandQueue *real = NULL;


### PR DESCRIPTION
## Description

Calls to `ID3D12Device::CreateCommandQueue` and `ID3D12Device9::CreateCommandQueue1` were failing with `E_NOINTERFACE` when passing the IID of `ID3D12CommandQueue1`. The 1 version of the interface is already implemented by `WrappedID3D12CommandQueue`, the IID checks in the wrapped `CreateCommandQueue` functions were just missing the check for `__uuiodof(ID3D12CommandQueue1`. This PR adds the missing checks, and captures now work correctly with `ID3D12CommandQueue1`.