### PR TITLE
Fix crash in NVIDIA HasCounter() called without EnumerateCounters()

### DIFF
--- a/renderdoc/driver/ihv/nv/nv_d3d11_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_d3d11_counters.cpp
@@ -296,6 +296,10 @@ bool NVD3D11Counters::HasCounter(GPUCounter counterID) const
   {
     return counterID == GPUCounter::FirstNvidia;
   }
+  if(!m_Impl->CounterEnumerator)
+  {
+    return false;
+  }
   return m_Impl->CounterEnumerator->HasCounter(counterID);
 }
 

--- a/renderdoc/driver/ihv/nv/nv_d3d12_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_d3d12_counters.cpp
@@ -293,6 +293,12 @@ rdcarray<GPUCounter> NVD3D12Counters::EnumerateCounters(WrappedID3D12Device &dev
   {
     return {GPUCounter::FirstNvidia};
   }
+  // NOTE: Nsight Perf SDK needs access to a D3D12 device handle and command
+  //       queue in order to determine which counters are available on a
+  //       particular NVIDIA device. However, since the D3D12 command queue is
+  //       not available at the time NVD3D12Counters::Init() is called this
+  //       determination must be deferred until the first time
+  //       NVD3D12Counters::EnumerateCounters() is called.
   if(!m_Impl->InitCounterEnumerator(device))
   {
     return {GPUCounter::FirstNvidia};
@@ -305,6 +311,10 @@ bool NVD3D12Counters::HasCounter(GPUCounter counterID) const
   if(m_Impl->LibraryNotFound || m_Impl->LibraryNotSupported)
   {
     return counterID == GPUCounter::FirstNvidia;
+  }
+  if(!m_Impl->CounterEnumerator)
+  {
+    return false;
   }
   return m_Impl->CounterEnumerator->HasCounter(counterID);
 }

--- a/renderdoc/driver/ihv/nv/nv_gl_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_gl_counters.cpp
@@ -292,6 +292,10 @@ bool NVGLCounters::HasCounter(GPUCounter counterID) const
   {
     return counterID == GPUCounter::FirstNvidia;
   }
+  if(!m_Impl->CounterEnumerator)
+  {
+    return false;
+  }
   return m_Impl->CounterEnumerator->HasCounter(counterID);
 }
 

--- a/renderdoc/driver/ihv/nv/nv_vk_counters.cpp
+++ b/renderdoc/driver/ihv/nv/nv_vk_counters.cpp
@@ -282,6 +282,10 @@ bool NVVulkanCounters::HasCounter(GPUCounter counterID) const
   {
     return counterID == GPUCounter::FirstNvidia;
   }
+  if(!m_Impl->CounterEnumerator)
+  {
+    return false;
+  }
   return m_Impl->CounterEnumerator->HasCounter(counterID);
 }
 


### PR DESCRIPTION
## Description

This fix avoids a NULL-pointer dereference when HasCounter() is called without a preceding call to EnumerateCounters() for NVIDIA Nsight Perf SDK counters.