### PR TITLE
fix destroyed BDA buffers staying tracked

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1038,7 +1038,6 @@ private:
   {
     rdcarray<VkDeviceMemory> DeadMemories;
     rdcarray<VkBuffer> DeadBuffers;
-    rdcarray<ResourceId> IDs;
 
     // with descriptor buffers, we also need to hold onto images and image views
     rdcarray<VkImage> DeadImages;

--- a/renderdoc/driver/vulkan/vk_memory.cpp
+++ b/renderdoc/driver/vulkan/vk_memory.cpp
@@ -30,16 +30,10 @@ RDOC_CONFIG(bool, Vulkan_Debug_MemoryAllocationLogging, false,
 
 GPUAddressRange WrappedVulkan::CreateAddressRange(VkDevice device, VkBuffer buffer)
 {
-  bool isBDA = false;
-  {
-    SCOPED_LOCK(m_DeviceAddressResourcesLock);
-    isBDA = m_DeviceAddressResources.IDs.contains(GetResID(buffer));
-  }
-
-  if(!isBDA)
+  VkResourceRecord *record = GetRecord(buffer);
+  if(!record->hasBDA)
     return {};
 
-  VkResourceRecord *record = GetRecord(buffer);
   VkResourceRecord *memrecord = GetResourceManager()->GetResourceRecord(record->baseResourceMem);
 
   const bool isSparse = record->resInfo && record->resInfo->IsSparse();

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -307,13 +307,12 @@ void WrappedVulkan::vkDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAl
   // opaque capture address isn't re-used before the capture completes
   {
     SCOPED_READLOCK(m_CapTransitionLock);
-    SCOPED_LOCK(m_DeviceAddressResourcesLock);
-    if(IsActiveCapturing(m_State) && m_DeviceAddressResources.IDs.contains(GetResID(buffer)))
+    if(IsActiveCapturing(m_State) && GetRecord(buffer)->hasBDA)
     {
+      SCOPED_LOCK(m_DeviceAddressResourcesLock);
       m_DeviceAddressResources.DeadBuffers.push_back(buffer);
       return;
     }
-    m_DeviceAddressResources.IDs.removeOne(GetResID(buffer));
   }
 
   if(IsCaptureMode(m_State))

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -842,10 +842,7 @@ VkResult WrappedVulkan::vkAllocateMemory(VkDevice device, const VkMemoryAllocate
 
         memFlags->flags |= VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
 
-        {
-          SCOPED_LOCK(m_DeviceAddressResourcesLock);
-          m_DeviceAddressResources.IDs.push_back(record->GetResourceID());
-        }
+        record->hasBDA = true;
       }
 
       {
@@ -950,13 +947,12 @@ void WrappedVulkan::vkFreeMemory(VkDevice device, VkDeviceMemory memory, const V
     // opaque capture address isn't re-used before the capture completes
     {
       SCOPED_READLOCK(m_CapTransitionLock);
-      SCOPED_LOCK(m_DeviceAddressResourcesLock);
-      if(IsActiveCapturing(m_State) && m_DeviceAddressResources.IDs.contains(GetResID(memory)))
+      if(IsActiveCapturing(m_State) && wrapped->record->hasBDA)
       {
+        SCOPED_LOCK(m_DeviceAddressResourcesLock);
         m_DeviceAddressResources.DeadMemories.push_back(memory);
         return;
       }
-      m_DeviceAddressResources.IDs.removeOne(GetResID(memory));
     }
 
     MemMapState *memMapState = wrapped->record->memMapState;
@@ -2066,11 +2062,6 @@ bool WrappedVulkan::Serialise_vkCreateBuffer(SerialiserType &ser, VkDevice devic
       }
     }
 
-    if(patchedusage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)
-    {
-      m_DeviceAddressResources.IDs.push_back(GetResID(buf));
-    }
-
     if(patchedusage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT)
       m_ResourceDescBuffers.push_back(GetResID(buf));
 
@@ -2231,10 +2222,7 @@ VkResult WrappedVulkan::vkCreateBuffer(VkDevice device, const VkBufferCreateInfo
         // address
         AddForcedReference(record);
 
-        {
-          SCOPED_LOCK(m_DeviceAddressResourcesLock);
-          m_DeviceAddressResources.IDs.push_back(record->GetResourceID());
-        }
+        record->hasBDA = true;
 
         if(DescriptorBuffers())
         {


### PR DESCRIPTION
UntrackBufferAddress makes use of m_DeviceAddressResources to figure out if the buffer has a BDA or not (and if so, removed it from the tracking system) and currently we're removing the buffer from m_DeviceAddressResources.IDs before Untracking it, so untrack cannot go forward. 

This deprecates m_DeviceAddressResources.IDs entirely and stores BDA-ness (for both buffers and memory) in the resourcerecord instead, which makes it order-independent. One m_DeviceAddressResources.IDs add is removed entirely as it was replay only, which doesn't have a record and also doesn't make use of hasBDA at all, since address tracking is capture-only.

This fixes indirect diffuse on my test, which was deleting BDA buffers every frame and recreating them.