### PR TITLE
Fix a hang when debugging HLSL compute shaders with enum types

### DIFF
--- a/renderdoc/driver/shaders/dxil/dxil_debug.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_debug.cpp
@@ -8214,6 +8214,23 @@ const TypeData &Debugger::AddDebugType(const DXIL::Metadata *typeMD)
           typeData.baseType = compositeType->base;
           break;
         }
+        case DW_TAG_enumeration_type:
+        {
+          typeData.type = VarType::Enum;
+          typeData.sizeInBytes = (uint32_t)(compositeType->sizeInBits / 8);
+          typeData.alignInBytes = (uint32_t)(compositeType->alignInBits / 8);
+          if(compositeType->name)
+            typeData.name = *compositeType->name;
+          else
+            typeData.name = StringFormat::Fmt("__anon_enum%u", compositeType->line);
+
+          if(compositeType->base)
+          {
+            AddDebugType(compositeType->base);
+            typeData.baseType = compositeType->base;
+          }
+          break;
+        }
         default:
           RDCERR("Unhandled DICompositeType tag %s", ToStr(compositeType->tag).c_str());
           break;


### PR DESCRIPTION
This PR fixes a thread hang issue in the HLSL debugger that occurs when stepping through or inspecting a compute shader that contains enum type definitions.

When debugging an HLSL code containing an enum, renderdoc will crash, such as the following HLSL code.

```hlsl
// 1. Define the enumeration
enum ColorMode {
    RedState = 0,
    BlueState = 1
};

// 2. Function that returns an enum type
ColorMode DeterminePixelMode(uint2 pos) {
    // Simple pattern logic: toggle mode every 50 pixels
    return (pos.x % 100 < 50) ? ColorMode::RedState : ColorMode::BlueState;
}

RWTexture2D<float4> OutputTex : register(u0);

[numthreads(8, 8, 1)]
void CSMain(uint3 id : SV_DispatchThreadID) {
    // 3. Receive and evaluate the enum type
    ColorMode mode = DeterminePixelMode(id.xy);
    
    float4 color = (mode == ColorMode::RedState) 
                   ? float4(1.0, 0.0, 0.0, 1.0)  // Red
                   : float4(0.0, 0.0, 1.0, 1.0); // Blue

    OutputTex[id.xy] = color;
}
``` 