### PR TITLE
Use UTF-8 encoding in shader viewer to fix character corruption

### DIFF
--- a/qrenderdoc/Code/ScintillaSyntax.cpp
+++ b/qrenderdoc/Code/ScintillaSyntax.cpp
@@ -335,6 +335,8 @@ row_major column_major unsigned signed rgb
 
 void ConfigureSyntax(ScintillaEdit *scintilla, int language)
 {
+  scintilla->setCodePage(SC_CP_UTF8);
+
   bool hlsl = false;
   bool glsl = false;
   int lexLang = language;


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

Ensures the shader viewer uses UTF-8 encoding when loading source files, preventing character corruption (e.g., in comments) for non-ASCII characters.

The current UTF-8 text displays as unreadable characters, but displays normally after modification.

<img width="1142" height="704" alt="image" src="https://github.com/user-attachments/assets/38cc04da-95f7-49a3-8872-fb881cdae69e" />

<img width="1111" height="874" alt="image" src="https://github.com/user-attachments/assets/1d791bd9-37f8-47a3-8d8d-9150d60c59e8" />


<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
