### PR TITLE
Support #pragma once and multiple inclusions of the same file in HLSL editing

### DIFF
--- a/qrenderdoc/Windows/ShaderViewer.cpp
+++ b/qrenderdoc/Windows/ShaderViewer.cpp
@@ -32,6 +32,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPen>
+#include <QRegularExpression>
 #include <QSet>
 #include <QShortcut>
 #include <QToolTip>
@@ -6289,8 +6290,16 @@ void ShaderViewer::PopulateCompileToolParameters()
 }
 
 bool ShaderViewer::ProcessIncludeDirectives(QString &source, const rdcstrpairs &files,
+                                            rdcarray<rdcstr> &allIncluded,
                                             const rdcarray<rdcstr> &exclude)
 {
+  static const QRegularExpression pragmaOnceRegex(lit("^[ \\t]*#[ \\t]*pragma[ \\t]+once"),
+                                                  QRegularExpression::MultilineOption);
+
+  // always strip #pragma once from the source we're about to process, to avoid warnings if it's
+  // expanded into a larger file.
+  source.replace(pragmaOnceRegex, lit("// #pragma once"));
+
   // try and match up #includes against the files that we have. This isn't always
   // possible as fxc only seems to include the source for files if something in
   // that file was included in the compiled output. So you might end up with
@@ -6358,16 +6367,21 @@ bool ShaderViewer::ProcessIncludeDirectives(QString &source, const rdcstrpairs &
         {
           fileText = QFormatStr("// not recursively including %1\n").arg(fname);
         }
+        else if(allIncluded.contains(kv.first) && QString(kv.second).contains(pragmaOnceRegex))
+        {
+          fileText = QFormatStr("// not re-including %1 (pragma once)\n").arg(fname);
+        }
         else
         {
           fileText = kv.second;
+          allIncluded.push_back(kv.first);
 
           // recurse and do not allow this to be re-included. This assumes #pragma once / header
           // guard behaviour to prevent recursion but allows the same file to be included multiple
           // times in the same parent (if that's done intentionally)
           rdcarray<rdcstr> childExclude = exclude;
           childExclude.push_back(kv.first);
-          ProcessIncludeDirectives(fileText, files, childExclude);
+          ProcessIncludeDirectives(fileText, files, allIncluded, childExclude);
         }
         break;
       }
@@ -6386,16 +6400,21 @@ bool ShaderViewer::ProcessIncludeDirectives(QString &source, const rdcstrpairs &
           {
             fileText = QFormatStr("// not recursively including %1\n").arg(fname);
           }
+          else if(allIncluded.contains(kv.first) && QString(kv.second).contains(pragmaOnceRegex))
+          {
+            fileText = QFormatStr("// not re-including %1 (pragma once)\n").arg(fname);
+          }
           else
           {
             fileText = kv.second;
+            allIncluded.push_back(kv.first);
 
             // recurse and do not allow this to be re-included. This assumes #pragma once / header
             // guard behaviour to prevent recursion but allows the same file to be included multiple
             // times in the same parent (if that's done intentionally)
             rdcarray<rdcstr> childExclude = exclude;
             childExclude.push_back(kv.first);
-            ProcessIncludeDirectives(fileText, files, childExclude);
+            ProcessIncludeDirectives(fileText, files, allIncluded, childExclude);
           }
           break;
         }
@@ -6493,7 +6512,8 @@ void ShaderViewer::on_refresh_clicked()
     if(encoding == ShaderEncoding::HLSL || encoding == ShaderEncoding::Slang ||
        encoding == ShaderEncoding::GLSL)
     {
-      bool success = ProcessIncludeDirectives(source, files);
+      rdcarray<rdcstr> allIncluded = {files[0].first};
+      bool success = ProcessIncludeDirectives(source, files, allIncluded, {files[0].first});
       if(!success)
         return;
     }

--- a/qrenderdoc/Windows/ShaderViewer.h
+++ b/qrenderdoc/Windows/ShaderViewer.h
@@ -238,7 +238,7 @@ private:
   void PopulateCompileTools();
   void PopulateCompileToolParameters();
   bool ProcessIncludeDirectives(QString &source, const rdcstrpairs &files,
-                                const rdcarray<rdcstr> &exclude = {});
+                                rdcarray<rdcstr> &allIncluded, const rdcarray<rdcstr> &exclude = {});
 
   void updateWindowTitle();
   void gotoSourceDebugging();


### PR DESCRIPTION

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
Updated the shader compilation logic during editing to correctly handle #pragma once directives and avoid re-inclusion errors when the same header is included multiple times.

The original implementation simply replaced #include with the file content and used only a local exclude list to prevent circular references. This led to a situation where if a file (especially one using #pragma once) was included multiple times (for example, A includes B and C, and both B and C include D), the expanded single large file would contain multiple copies of D's content, resulting in a redefinition error. Furthermore, the retained #pragma once in the expanded file would also trigger warnings from dxc.


This is my capture file(https://drive.google.com/file/d/12XYiIW-N2RjH6wmydqmQOzi5bpLIEkQc/view). After opening it, you can search for "ScreenSpaceProbeTemporalFilterCS" pass. It uses include and pragma once. Compiling it directly will result in the errors shown in the screenshot. Basically, all passes use include and pragma once, so most passes will fail to compile.

<details><summary>Compile Error log</summary>
<p>
<img width="1143" height="1021" alt="image" src="https://github.com/user-attachments/assets/459ae323-cd35-4cb3-a5d4-fb43a5d70cbd" />


```c++

Running "F:/Users/xxx/scoop/shims/dxc.exe"  -E CSMain -T cs_6_6 -I F:\Code\TestProj\TestProj\Shaders -Qembed_debug -Zi -Od -Fo C:/Users/xxx/AppData/Local/Temp/shader_output C:/Users/xxx/AppData/Local/Temp/shader_input
C:/Users/xxx/AppData/Local/Temp/shader_input:5:9: warning: #pragma once in main file
#pragma once
        ^
C:/Users/xxx/AppData/Local/Temp/shader_input:8:9: warning: #pragma once in main file
#pragma once
        ^
C:/Users/xxx/AppData/Local/Temp/shader_input:172:9: warning: #pragma once in main file
#pragma once
        ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2528:9: warning: #pragma once in main file
#pragma once
        ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2532:9: warning: #pragma once in main file
#pragma once
        ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2535:9: warning: #pragma once in main file
#pragma once
        ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2538:20: error: redefinition of 'PI'
const static float PI = 3.1415926535897932384626433832795f;
                   ^
C:/Users/xxx/AppData/Local/Temp/shader_input:11:20: note: previous definition is here
const static float PI = 3.1415926535897932384626433832795f;
                   ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2539:20: error: redefinition of 'kAngleToRadian'
const static float kAngleToRadian = PI / 180.0f;
                   ^
C:/Users/xxx/AppData/Local/Temp/shader_input:12:20: note: previous definition is here
const static float kAngleToRadian = PI / 180.0f;
                   ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2540:20: error: redefinition of 'kMaxFloat'
const static float kMaxFloat = 3.402823466e+38F;
                   ^
C:/Users/xxx/AppData/Local/Temp/shader_input:13:20: note: previous definition is here
const static float kMaxFloat = 3.402823466e+38F;
                   ^
C:/Users/xxx/AppData/Local/Temp/shader_input:2541:20: error: redefinition of 'kMinFloat'
const static float kMinFloat = -3.402823466e+38F;
``` 

</p>
</details> 


My modifications include:
* Introduce global tracking: During the entire include expansion process, use an allIncluded list to record all files that have been processed.
* When processing #pragma once: During expansion, if a file is found to have already been processed and contains a #pragma once directive, skip the repeated expansion and insert a comment to explain.
* Automatic cleanup instruction: When processing each file (including the main file and included files), #pragma once will be automatically replaced with the comment // #pragma once. This not only preserves the file structure information but also eliminates the warning from dxc regarding "including #pragma once in the main file".
* Corrected recursive logic: Updated the signature of ProcessIncludeDirectives to ensure the correct passing of the global included list and the recursive detection list of the current path during recursive calls.

These changes enable RenderDoc to behave more closely to the actual compiler when manually expanding HLSL files, addressing issues such as redefinition errors and #pragma once warnings.



<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
