### PR TITLE
Fix D3D12 shader edits not taking effect after applying

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_replay.cpp
+++ b/renderdoc/driver/d3d12/d3d12_replay.cpp
@@ -3637,10 +3637,10 @@ void D3D12Replay::RefreshDerivedReplacements()
   for(WrappedID3D12PipelineState *pipe : m_pDevice->GetPipelineList())
   {
     ResourceId pipesrcid = pipe->GetResourceID();
-    ResourceId origsrcid = pipesrcid;
+    ResourceId origsrcid = rm->GetUnreplacedID(pipesrcid);
 
     // only look at pipelines from the capture, no replay-time programs.
-    if(origsrcid == pipesrcid)
+    if(origsrcid != pipesrcid)
       continue;
 
     // if this pipeline has a replacement, remove it and delete the program generated for it


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description
This PR fixes a bug in the D3D12 replay driver where shader modifications (replacements) would not be correctly applied after editing. 

In `D3D12Replay::RefreshDerivedReplacements`, the logic for identifying original pipelines from the capture was incorrect, causing it to skip the necessary refresh of pipelines that depend on modified shaders. This change ensures the original ResourceId is correctly unmasked and used to identify which pipelines need to be updated.

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
