### PR TITLE
Avoid potential address re-use for internal fake backbuffer memory

### DIFF
--- a/renderdoc/driver/vulkan/vk_core.cpp
+++ b/renderdoc/driver/vulkan/vk_core.cpp
@@ -2842,6 +2842,9 @@ bool WrappedVulkan::EndFrameCapture(DeviceOwnedWindow devWnd)
   rdcarray<VkBuffer> DeadBuffers;
   rdcarray<VkImage> DeadImages;
   rdcarray<VkImageView> DeadImageViews;
+  rdcarray<VkDeviceMemory> DeadInternalMemories;
+  rdcarray<VkImage> DeadInternalImages;
+  rdcarray<VkImageView> DeadInternalImageViews;
 
   // transition back to IDLE atomically
   {
@@ -2870,6 +2873,9 @@ bool WrappedVulkan::EndFrameCapture(DeviceOwnedWindow devWnd)
       DeadBuffers.swap(m_DeviceAddressResources.DeadBuffers);
       DeadImages.swap(m_DeviceAddressResources.DeadImages);
       DeadImageViews.swap(m_DeviceAddressResources.DeadImageViews);
+      DeadInternalMemories.swap(m_InternalDeviceAddressResources.DeadMemories);
+      DeadInternalImages.swap(m_InternalDeviceAddressResources.DeadImages);
+      DeadInternalImageViews.swap(m_InternalDeviceAddressResources.DeadImageViews);
     }
   }
 
@@ -3233,6 +3239,24 @@ bool WrappedVulkan::EndFrameCapture(DeviceOwnedWindow devWnd)
   for(VkImageView v : DeadImageViews)
     vkDestroyImageView(m_Device, v, NULL);
 
+  for(VkDeviceMemory m : DeadInternalMemories)
+  {
+    ObjDisp(m_Device)->FreeMemory(Unwrap(m_Device), Unwrap(m), NULL);
+    GetResourceManager()->ReleaseWrappedResource(m, true);
+  }
+
+  for(VkImage i : DeadInternalImages)
+  {
+    ObjDisp(m_Device)->DestroyImage(Unwrap(m_Device), Unwrap(i), NULL);
+    GetResourceManager()->ReleaseWrappedResource(i, true);
+  }
+
+  for(VkImageView v : DeadInternalImageViews)
+  {
+    ObjDisp(m_Device)->DestroyImageView(Unwrap(m_Device), Unwrap(v), NULL);
+    GetResourceManager()->ReleaseWrappedResource(v, true);
+  }
+
   FreeAllMemory(MemoryScope::InitialContents);
   for(rdcstr &fn : m_InitTempFiles)
     FileIO::Delete(fn);
@@ -3258,6 +3282,9 @@ bool WrappedVulkan::DiscardFrameCapture(DeviceOwnedWindow devWnd)
   rdcarray<VkBuffer> DeadBuffers;
   rdcarray<VkImage> DeadImages;
   rdcarray<VkImageView> DeadImageViews;
+  rdcarray<VkDeviceMemory> DeadInternalMemories;
+  rdcarray<VkImage> DeadInternalImages;
+  rdcarray<VkImageView> DeadInternalImageViews;
 
   // transition back to IDLE atomically
   {
@@ -3285,6 +3312,9 @@ bool WrappedVulkan::DiscardFrameCapture(DeviceOwnedWindow devWnd)
       DeadBuffers.swap(m_DeviceAddressResources.DeadBuffers);
       DeadImages.swap(m_DeviceAddressResources.DeadImages);
       DeadImageViews.swap(m_DeviceAddressResources.DeadImageViews);
+      DeadInternalMemories.swap(m_InternalDeviceAddressResources.DeadMemories);
+      DeadInternalImages.swap(m_InternalDeviceAddressResources.DeadImages);
+      DeadInternalImageViews.swap(m_InternalDeviceAddressResources.DeadImageViews);
     }
   }
 
@@ -3299,6 +3329,24 @@ bool WrappedVulkan::DiscardFrameCapture(DeviceOwnedWindow devWnd)
 
   for(VkImageView v : DeadImageViews)
     vkDestroyImageView(m_Device, v, NULL);
+
+  for(VkDeviceMemory m : DeadInternalMemories)
+  {
+    ObjDisp(m_Device)->FreeMemory(Unwrap(m_Device), Unwrap(m), NULL);
+    GetResourceManager()->ReleaseWrappedResource(m, true);
+  }
+
+  for(VkImage i : DeadInternalImages)
+  {
+    ObjDisp(m_Device)->DestroyImage(Unwrap(m_Device), Unwrap(i), NULL);
+    GetResourceManager()->ReleaseWrappedResource(i, true);
+  }
+
+  for(VkImageView v : DeadInternalImageViews)
+  {
+    ObjDisp(m_Device)->DestroyImageView(Unwrap(m_Device), Unwrap(v), NULL);
+    GetResourceManager()->ReleaseWrappedResource(v, true);
+  }
 
   Atomic::Inc32(&m_ReuseEnabled);
 

--- a/renderdoc/driver/vulkan/vk_core.h
+++ b/renderdoc/driver/vulkan/vk_core.h
@@ -1043,6 +1043,13 @@ private:
     rdcarray<VkImage> DeadImages;
     rdcarray<VkImageView> DeadImageViews;
   } m_DeviceAddressResources;
+
+  struct
+  {
+    rdcarray<VkDeviceMemory> DeadMemories;
+    rdcarray<VkImage> DeadImages;
+    rdcarray<VkImageView> DeadImageViews;
+  } m_InternalDeviceAddressResources;
   Threading::CriticalSection m_DeviceAddressResourcesLock;
 
   // holds the current list of coherent mapped memory. Locked against concurrent use

--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -358,31 +358,61 @@ void WrappedVulkan::vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR obj,
     GetResourceManager()->ReleaseWrappedResource(info.rp, true);
     ObjDisp(device)->DestroyRenderPass(Unwrap(device), unwrappedRP, NULL);
 
+    bool fakeBackbuffers = info.imageMemory != VK_NULL_HANDLE;
+
+    // If capturing, we defer freeing swapchain fake backbuffer resources until
+    // the end of the capture to prevent potential device address reuse
+    bool deferFakeBackbuffers = false;
+    if(fakeBackbuffers)
+    {
+      SCOPED_READLOCK(m_CapTransitionLock);
+      deferFakeBackbuffers = IsActiveCapturing(m_State);
+      if(deferFakeBackbuffers)
+      {
+        SCOPED_LOCK(m_DeviceAddressResourcesLock);
+        for(size_t i = 0; i < info.images.size(); i++)
+        {
+          SwapchainInfo::SwapImage &img = info.images[i];
+          m_InternalDeviceAddressResources.DeadImages.push_back(img.userSwapImage);
+          m_InternalDeviceAddressResources.DeadImageViews.push_back(img.view);
+        }
+        m_InternalDeviceAddressResources.DeadMemories.push_back(info.imageMemory);
+      }
+    }
+
     for(size_t i = 0; i < info.images.size(); i++)
     {
-      VkFramebuffer unwrappedFB = Unwrap(info.images[i].fb);
-      VkImage unwrappedImage = Unwrap(info.images[i].userSwapImage);
-      VkImageView unwrappedView = Unwrap(info.images[i].view);
-      VkSemaphore unwrappedSem = Unwrap(info.images[i].overlaydone);
-      VkFence unwrappedFence = Unwrap(info.images[i].fence);
-      GetResourceManager()->ReleaseWrappedResource(info.images[i].fb, true);
-      GetResourceManager()->ReleaseWrappedResource(info.images[i].userSwapImage, true);
-      GetResourceManager()->ReleaseWrappedResource(info.images[i].view, true);
-      GetResourceManager()->ReleaseWrappedResource(info.images[i].overlaydone);
-      GetResourceManager()->ReleaseWrappedResource(info.images[i].fence);
-      // if we had a separate real image, then the unwrappedImage is a fake one we  created and must be destroyed
-      if(info.images[i].unwrappedRealSwapImage != VK_NULL_HANDLE)
-        ObjDisp(device)->DestroyImage(Unwrap(device), unwrappedImage, NULL);
+      SwapchainInfo::SwapImage &img = info.images[i];
+      VkFramebuffer unwrappedFB = Unwrap(img.fb);
+      VkSemaphore unwrappedSem = Unwrap(img.overlaydone);
+      VkFence unwrappedFence = Unwrap(img.fence);
+
+      if(!deferFakeBackbuffers)
+      {
+        VkImage unwrappedImage = Unwrap(img.userSwapImage);
+        VkImageView unwrappedView = Unwrap(img.view);
+        GetResourceManager()->ReleaseWrappedResource(img.userSwapImage, true);
+        GetResourceManager()->ReleaseWrappedResource(img.view, true);
+        // if we had a separate real image, then the unwrappedImage is a fake one we created
+        // and must be destroyed
+        if(img.unwrappedRealSwapImage != VK_NULL_HANDLE)
+          ObjDisp(device)->DestroyImage(Unwrap(device), unwrappedImage, NULL);
+        ObjDisp(device)->DestroyImageView(Unwrap(device), unwrappedView, NULL);
+      }
+
+      GetResourceManager()->ReleaseWrappedResource(img.fb, true);
+      GetResourceManager()->ReleaseWrappedResource(img.overlaydone);
+      GetResourceManager()->ReleaseWrappedResource(img.fence);
+
       ObjDisp(device)->DestroyFramebuffer(Unwrap(device), unwrappedFB, NULL);
-      ObjDisp(device)->DestroyImageView(Unwrap(device), unwrappedView, NULL);
       ObjDisp(device)->DestroySemaphore(Unwrap(device), unwrappedSem, NULL);
       ObjDisp(device)->DestroyFence(Unwrap(device), unwrappedFence, NULL);
 
       // return the command buffers to the pool
-      AddFreeCommandBuffer(info.images[i].cmd);
+      AddFreeCommandBuffer(img.cmd);
     }
 
-    if(info.imageMemory != VK_NULL_HANDLE)
+    if(fakeBackbuffers && !deferFakeBackbuffers)
     {
       ObjDisp(device)->FreeMemory(Unwrap(device), Unwrap(info.imageMemory), NULL);
       GetResourceManager()->ReleaseWrappedResource(info.imageMemory, true);


### PR DESCRIPTION
Track fake backbuffer memory as a device address resource to defer freeing it until the end of the capture
