### PR TITLE
Fix for textures initialized with VkCopyMemoryToImage

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_misc_funcs.cpp
@@ -2164,7 +2164,7 @@ VkResult WrappedVulkan::vkCopyMemoryToImage(VkDevice device,
   {
     SCOPED_READLOCK(m_CapTransitionLock);
 
-    if(IsActiveCapturing(m_State))
+    if(IsCaptureMode(m_State))
     {
       CACHE_THREAD_SERIALISER();
 

--- a/renderdoc/driver/vulkan/wrappers/vk_sync_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_sync_funcs.cpp
@@ -1564,7 +1564,7 @@ VkResult WrappedVulkan::vkTransitionImageLayout(VkDevice device, uint32_t transi
         ret = ObjDisp(device)->TransitionImageLayout(Unwrap(device), transitionCount, im));
   }
 
-  if(IsActiveCapturing(m_State))
+  if(IsCaptureMode(m_State))
   {
     CACHE_THREAD_SERIALISER();
 


### PR DESCRIPTION
## Description

Currently, textures initialized using Vulkan 1.4 vkTransitionImageLayout and vkCopyMemoryToImage functions show up as black with 'Unknown previous layout' in RenderDoc captures. With these changes, these textures show up correctly with the correct layout in captures. 
