### PR TITLE
Expose Vulkan layer entrypoints for mac

### DIFF
--- a/renderdoc/driver/vulkan/vk_layer.cpp
+++ b/renderdoc/driver/vulkan/vk_layer.cpp
@@ -46,7 +46,7 @@ extern "C" const rdcstr VulkanLayerJSONBasename;
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT extern "C" __declspec(dllexport)
 
-#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID)
+#elif ENABLED(RDOC_LINUX) || ENABLED(RDOC_ANDROID) || ENABLED(RDOC_APPLE)
 
 #undef VK_LAYER_EXPORT
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
Expose RenderDoc's Vulkan layer's entrypoints for mac. This is required for the loader to load the layer.

Edit: Some formatting changes sneaked in the first commit, sorry about the noise. Should now be fixed