### PR TITLE
Android fixes on modern host and device

### DIFF
--- a/renderdoc/driver/ihv/arm/CMakeLists.txt
+++ b/renderdoc/driver/ihv/arm/CMakeLists.txt
@@ -54,7 +54,7 @@ set_property(SOURCE ${sources}
     PROPERTY COMPILE_FLAGS "-Wno-unknown-warning-option -Wno-range-loop-construct")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_property(SOURCE ${sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-shadow -Wno-shorten-64-to-32")
+    set_property(SOURCE ${sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-shadow -Wno-shorten-64-to-32 -Wno-vla-cxx-extension")
 endif()
 
 add_library(rdoc_arm OBJECT ${sources})

--- a/renderdoc/driver/ihv/nv/CMakeLists.txt
+++ b/renderdoc/driver/ihv/nv/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT ANDROID AND NOT APPLE)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 18.9)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.0.999)
         set_property(SOURCE ${sources} ${sources_gl} ${sources_vulkan}
             APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-cast-function-type-mismatch")
     endif()

--- a/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_resource_funcs.cpp
@@ -3064,10 +3064,10 @@ VkResult WrappedVulkan::vkCreateImage(VkDevice device, const VkImageCreateInfo *
               resInfo.memreqs.alignment = mrq.alignment;
               resInfo.memreqs.memoryTypeBits = mrq.memoryTypeBits;
 
-              RDCWARN(
-                  "Android hardware buffer backed image, so pre-emptively banning dedicated "
-                  "memory");
-              resInfo.banDedicated = true;
+              resInfo.banDedicated =
+                  m_PhysicalDeviceData.driverProps.driverID != VK_DRIVER_ID_MESA_PANVK;
+              RDCWARN("Android hardware buffer backed image, %s dedicated memory",
+                      resInfo.banDedicated ? "banning" : "allowing");
             }
             else
             {

--- a/renderdoccmd/CMakeLists.txt
+++ b/renderdoccmd/CMakeLists.txt
@@ -120,6 +120,11 @@ if(ANDROID)
 
     if(${Java_VERSION} VERSION_LESS 1.8)
         message(FATAL_ERROR "Building Android requires the 'java' program in your PATH to be at least Java 8 (1.8)")
+    elseif(${Java_VERSION} VERSION_LESS 20.0)
+        set(JAVA_TARGET "1.7")
+    else()
+        message(WARNING "Building with JDK ${Java_VERSION} may cause broken Android binaries, it is recommended to build with JDK 17 or earlier")
+        set(JAVA_TARGET "8")
     endif()
     message(STATUS "Using Java of version ${Java_VERSION}")
 
@@ -302,7 +307,7 @@ if(ANDROID)
 
     add_custom_command(OUTPUT ${APK_FILE} APPEND
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
-                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/org/renderdoc/renderdoccmd/*.java
+                       COMMAND ${JAVA_BIN}/javac -d ./obj -source ${JAVA_TARGET} -target ${JAVA_TARGET} -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/org/renderdoc/renderdoccmd/*.java
                        COMMAND ${DEX_COMMAND}
                        COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml --version-code ${APK_VERSION_CODE} --version-name ${APK_VERSION_NAME} -S res -I ${ANDROID_JAR} -F RenderDocCmd-unaligned.apk bin libs
                        COMMAND ${BUILD_TOOLS}/zipalign -f 4 RenderDocCmd-unaligned.apk RenderDocCmd.apk

--- a/renderdoccmd/renderdoccmd_android.cpp
+++ b/renderdoccmd/renderdoccmd_android.cpp
@@ -523,7 +523,11 @@ void android_main(struct android_app *state)
       }
     }
 
+#if __NDK_MAJOR__ >= 27
+    if(ALooper_pollOnce(1, nullptr, &events, (void **)&source) >= 0)
+#else
     if(ALooper_pollAll(1, nullptr, &events, (void **)&source) >= 0)
+#endif
     {
       if(source != NULL)
         source->process(android_state, source);

--- a/util/test/demos/CMakeLists.txt
+++ b/util/test/demos/CMakeLists.txt
@@ -347,6 +347,11 @@ if(ANDROID)
 
     if(${Java_VERSION} VERSION_LESS 1.8)
         message(FATAL_ERROR "Building Android requires the 'java' program in your PATH to be at least Java 8 (1.8)")
+    elseif(${Java_VERSION} VERSION_LESS 20.0)
+        set(JAVA_TARGET "1.7")
+    else()
+        message(WARNING "Building with JDK ${Java_VERSION} may cause broken Android binaries, it is recommended to build with JDK 17 or earlier")
+        set(JAVA_TARGET "8")
     endif()
     message(STATUS "Using Java of version ${Java_VERSION}")
 
@@ -462,7 +467,7 @@ if(ANDROID)
     add_custom_command(OUTPUT ${APK_FILE} APPEND
                        COMMAND ${CMAKE_COMMAND} -E remove ${APK_FILE} # Don't package any existing artifact into the new one
                        COMMAND ${BUILD_TOOLS}/aapt package -f -m -S res -J src -M AndroidManifest.xml -I ${ANDROID_JAR}
-                       COMMAND ${JAVA_BIN}/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/renderdoc/org/demos/*.java
+		       COMMAND ${JAVA_BIN}/javac -d ./obj -source ${JAVA_TARGET} -target ${JAVA_TARGET} -bootclasspath ${RT_JAR} -classpath "${CLASS_PATH}" -sourcepath src src/renderdoc/org/demos/*.java
                        COMMAND ${DEX_COMMAND}
                        COMMAND ${BUILD_TOOLS}/aapt package -f -M AndroidManifest.xml --version-code ${APK_VERSION_CODE} --version-name ${APK_VERSION_NAME} -S res -I ${ANDROID_JAR} -F demos-unaligned.apk bin libs
                        COMMAND ${BUILD_TOOLS}/zipalign -f 4 demos-unaligned.apk demos.apk

--- a/util/test/demos/main.cpp
+++ b/util/test/demos/main.cpp
@@ -824,7 +824,11 @@ void android_main(struct android_app *state)
   android_poll_source *source;
   do
   {
+#if __NDK_MAJOR__ >= 27
+    if(ALooper_pollOnce(1, nullptr, &events, (void **)&source) >= 0)
+#else
     if(ALooper_pollAll(1, nullptr, &events, (void **)&source) >= 0)
+#endif
     {
       if(source != NULL)
         source->process(android_state, source);


### PR DESCRIPTION
The first 3 commits are small build fixes when cross-compiling on a modern linux machine with openjdk 21 and android ndk 28. They should be safe changes.

The last commit stops setting `banDedicated` for android AHB. Setting `banDedicated` causes spec violation, and casuses segfaults on Mesa panvk driver at least.

/cc @cmannett85-arm who set `banDedicated` in https://github.com/baldurk/renderdoc/pull/3325.