### PR TITLE
Add ppc64le (PowerPC 64-bit LE) architecture support

### DIFF
--- a/renderdoc/os/posix/linux/linux_process.cpp
+++ b/renderdoc/os/posix/linux/linux_process.cpp
@@ -243,6 +243,16 @@ static uint64_t get_nanotime()
 #define BREAK_INST_BYTES_SIZE 4
 #define BREAK_INST_INST_PTR_ADJUST 4
 
+#elif defined(__powerpc64__)
+
+#define user_regs_struct pt_regs
+#define INST_PTR_REG nip
+
+// trap instruction on ppc64
+#define BREAK_INST 0x7fe00008ULL
+#define BREAK_INST_BYTES_SIZE 4
+#define BREAK_INST_INST_PTR_ADJUST 0
+
 #else
 
 #define BREAK_INST 0xccULL


### PR DESCRIPTION
## Summary

- Adds `#elif defined(__powerpc64__)` block in `linux_process.cpp` to support ppc64le architecture for ptrace-based process tracing
- Maps `user_regs_struct` to `pt_regs`, sets instruction pointer register to `nip`, and defines the ppc64 trap instruction (`0x7fe00008`)

## Problem

On ppc64le systems, `linux_process.cpp` fails to compile because the architecture-specific `#ifdef` chain (ARM, AArch64, RISC-V, LoongArch) has no ppc64le case. The `#else` fallback assumes x86, where `user_regs_struct` is provided by `<sys/user.h>`. On ppc64le, that type does not exist — the equivalent is `pt_regs` from `<asm/ptrace.h>` (already included), and the instruction pointer field is `nip`.

## Testing

Successfully compiled and linked on Fedora 43 ppc64le.