### PR TITLE
(WIP) Support GLES/EGL replaying on macOS through ANGLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,12 +274,6 @@ if(RENDERDOC_VERSION_MINOR STREQUAL "")
     message(FATAL_ERROR "Couldn't calculate minor version")
 endif()
 
-if(APPLE)
-    message(STATUS "Disabling GLES driver on apple")
-    set(ENABLE_GLES OFF CACHE BOOL "" FORCE)
-    set(ENABLE_EGL OFF CACHE BOOL "" FORCE)
-endif()
-
 if(INTERNAL_SELF_CAPTURE)
     message(STATUS "Disabling GL/GLES for self-capture")
     set(ENABLE_GLES OFF CACHE BOOL "" FORCE)

--- a/renderdoc/driver/gl/CMakeLists.txt
+++ b/renderdoc/driver/gl/CMakeLists.txt
@@ -76,19 +76,20 @@ else()
             glx_hooks.cpp
             glx_fake_vk_hooks.cpp)
     endif()
-    if(ENABLE_GLES)
-        list(APPEND sources
-            official/glesext.h)
-    endif()
-    if(ENABLE_EGL)
-        list(APPEND sources
-            official/egl.h
-            official/eglext.h
-            official/eglplatform.h
-            egl_dispatch_table.h
-            egl_platform.cpp
-            egl_hooks.cpp)
-    endif()
+endif()
+
+if(ENABLE_GLES)
+    list(APPEND sources
+        official/glesext.h)
+endif()
+if(ENABLE_EGL)
+    list(APPEND sources
+        official/egl.h
+        official/eglext.h
+        official/eglplatform.h
+        egl_dispatch_table.h
+        egl_platform.cpp
+        egl_hooks.cpp)
 endif()
 
 add_library(rdoc_gl OBJECT ${sources})

--- a/renderdoc/driver/gl/egl_platform.cpp
+++ b/renderdoc/driver/gl/egl_platform.cpp
@@ -45,6 +45,8 @@ static void *GetEGLHandle()
   }
 
   return Process::LoadModule(libEGL);
+#elif ENABLED(RDOC_APPLE)
+  return Process::LoadModule("libEGL.dylib");
 #else
   void *handle = Process::LoadModule("libEGL.so.1");
 
@@ -156,6 +158,8 @@ class EGLPlatform : public GLPlatform
       case WindowingSystem::Win32: win = window.win32.window; break;
 #elif ENABLED(RDOC_ANDROID)
       case WindowingSystem::Android: win = window.android.window; break;
+#elif ENABLED(RDOC_APPLE)
+      case WindowingSystem::MacOS: win = window.macOS.layer; break;
 #elif ENABLED(RDOC_LINUX)
       case WindowingSystem::Xlib:
       {
@@ -373,9 +377,6 @@ class EGLPlatform : public GLPlatform
   void SetDriverType(RDCDriver api) { m_API = api; }
   RDResult InitialiseAPI(GLWindowingData &replayContext, RDCDriver api, bool debug)
   {
-    Display *xlibDisplay = RenderDoc::Inst().GetGlobalEnvironment().xlibDisplay;
-    wl_display *waylandDisplay = RenderDoc::Inst().GetGlobalEnvironment().waylandDisplay;
-
     // we support replaying both GLES and GL through EGL
     RDCASSERT(api == RDCDriver::OpenGLES || api == RDCDriver::OpenGL);
 
@@ -388,10 +389,14 @@ class EGLPlatform : public GLPlatform
       EGL.BindAPI(EGL_OPENGL_API);
 
     EGLNativeDisplayType display = EGL_DEFAULT_DISPLAY;
+#if ENABLED(RDOC_LINUX)
+    Display *xlibDisplay = RenderDoc::Inst().GetGlobalEnvironment().xlibDisplay;
+    wl_display *waylandDisplay = RenderDoc::Inst().GetGlobalEnvironment().waylandDisplay;
     if(waylandDisplay)
       display = (EGLNativeDisplayType)waylandDisplay;
     else if(xlibDisplay)
       display = (EGLNativeDisplayType)xlibDisplay;
+#endif
 
     EGLDisplay eglDisplay = EGL.GetDisplay(display);
     if(!eglDisplay)
@@ -427,6 +432,8 @@ class EGLPlatform : public GLPlatform
 
 #if ENABLED(RDOC_WIN32)
 #define LIBSUFFIX ".dll"
+#elif ENABLED(RDOC_APPLE)
+#define LIBSUFFIX ".dylib"
 #else
 #define LIBSUFFIX ".so"
 #endif

--- a/renderdoc/driver/gl/gl_common.h
+++ b/renderdoc/driver/gl/gl_common.h
@@ -191,6 +191,11 @@ struct GLWindowingData
 
 #include "official/cgl.h"
 
+#include "official/eglplatform.h"
+
+#include "official/egl.h"
+#include "official/eglext.h"
+
 struct GLWindowingData
 {
   GLWindowingData()
@@ -198,16 +203,25 @@ struct GLWindowingData
     ctx = NULL;
     wnd = NULL;
     pix = NULL;
+    egl_ctx = NULL;
+    egl_dpy = NULL;
+    egl_wnd = NULL;
+    egl_cfg = NULL;
   }
 
   union
   {
     CGLContextObj ctx;
     void *nsgl_ctx;    // during replay only, this is the NSOpenGLContext
+    EGLContext egl_ctx;
   };
 
   void *wnd;    // during capture, this is the CGL window ID. During replay, it's the NSView
   CGLPixelFormatObj pix;
+
+  EGLDisplay egl_dpy;
+  EGLSurface egl_wnd;
+  EGLConfig egl_cfg;
 };
 
 #define DECL_HOOK_EXPORT(function)                                               \


### PR DESCRIPTION
The rationale here was to use ANGLE for better validation and debugging, since I miss using "MESA_DEBUG=1" on Linux. But ANGLE with Metal only supports GLES 3.0, so you don't get much more out of it over the built-in OpenGL 4.1.

Testing this is actually easy if you point `DYLD_LIBRARY_PATH` to wherever you find libEGL/libGLESv2 in any installed Chromium browser/Electron app, or whatever.

With `ANGLE_DEFAULT_PLATFORM=swiftshader` you get GLES 3.1, but only renderdoccmd works with it. With `ANGLE_DEFAULT_PLATFORM=metal` qrenderdoc does work, but with some issues. I've seen people use MoltenVK through ANGLE since GLES 3.2 is supported with Vulkan, but it sounds more complex and I haven't tried it yet

Here's an example of some issues I see with Metal (vs Linux on the left), the gamma is wrong and some things don't render. For some captures I see no output.
![image](https://github.com/user-attachments/assets/3411bb6c-a38d-417e-9bd6-c9be354ddbfa)
![image](https://github.com/user-attachments/assets/4b308cd6-0d48-40b0-a2cd-fd95f86bd79b)

I could not get capturing working, it doesn't inject into the program and says "API none".

So overall, this is a WIP for now unless I or anyone else picks this back up.