### PR TITLE
GL: Fix ddy_fine macro in shader debugger quad swizzle

### DIFF
--- a/renderdoc/driver/gl/gl_shaderdebug.cpp
+++ b/renderdoc/driver/gl/gl_shaderdebug.cpp
@@ -2439,7 +2439,7 @@ layout(std140) buffer Output
 #define ddy_fine dFdyFine
 #else
 #define ddx_fine dFdx
-#define ddy_fine dFdx
+#define ddy_fine dFdy
 #endif
 
 #define float4 vec4


### PR DESCRIPTION
<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

The fallback definition of ddy_fine accidentally used dFdx instead of dFdy.This caused incorrect Y-derivatives in the OpenGL shader debugger when fine derivatives are not available. Fix the macro to use dFdy.
Tests: Not run (macro-only fix).