### PR TITLE
Detect unused fields in VkDescriptorImageInfo

### DIFF
--- a/renderdoc/driver/vulkan/vk_serialise.cpp
+++ b/renderdoc/driver/vulkan/vk_serialise.cpp
@@ -10469,20 +10469,19 @@ void DoSerialise(SerialiserType &ser, VkDescriptorGetInfoEXT &el)
   RDCASSERT(ser.IsReading() || el.sType == VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT);
   SerialiseNext(ser, el.sType, el.pNext);
 
-  // these fields must either be NULL or valid if present, never garbage
-  ser.SetStructArg(
-      uint64_t(VkDescriptorImageInfoValidity::Sampler | VkDescriptorImageInfoValidity::ImageView));
-
   SERIALISE_MEMBER(type);
   switch(el.type)
   {
     case VK_DESCRIPTOR_TYPE_SAMPLER:
     {
+      ser.SetStructArg(uint64_t(VkDescriptorImageInfoValidity::Sampler));
       SERIALISE_MEMBER_OPT(data.pSampler).Named("pSampler");
       break;
     }
     case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
     {
+      ser.SetStructArg(uint64_t(VkDescriptorImageInfoValidity::Sampler |
+                                VkDescriptorImageInfoValidity::ImageView));
       SERIALISE_MEMBER_OPT(data.pCombinedImageSampler).Named("pCombinedImageSampler");
       break;
     }
@@ -10490,6 +10489,7 @@ void DoSerialise(SerialiserType &ser, VkDescriptorGetInfoEXT &el)
     case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
     case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
     {
+      ser.SetStructArg(uint64_t(VkDescriptorImageInfoValidity::ImageView));
       SERIALISE_MEMBER_OPT(data.pStorageImage).Named("pStorageImage");
       break;
     }


### PR DESCRIPTION
The Vulkan specification allows to have uninitialized fields in `VkDescriptorImageInfo` based on descriptor type. The implementation should not assume that unused fields are null values. This change is done in the context of descriptor buffers for which I have a specific repro case.

Can be reproduced with https://github.com/kennyalive/vulkan-base.
Commit 405d0214c407df318529f7da58fe6702e42bbbb4  or `last-descriptor-buffer` git tag (the latest code does not have descriptor buffers enabled).

https://github.com/kennyalive/vulkan-base/blob/405d0214c407df318529f7da58fe6702e42bbbb4/src/demo.cpp#L207
```
VkDescriptorImageInfo image_info; // NOTE: sampler field is not initialized
image_info.imageView = texture.view;
image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;

VkDescriptorGetInfoEXT descriptor_info{ VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT };
descriptor_info.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
descriptor_info.data.pSampledImage = &image_info;
```

This is a valid Vulkan code even though one could say it's better to initialize unused fields.
RenderDoc crashes when tries to serialize garbage sampler value. 

#### Specification references
The spec lists which fields are "used" depending on descriptor type.
https://docs.vulkan.org/spec/latest/chapters/descriptorsets.html#VkDescriptorImageInfo

Ignored fields:
> Members of VkDescriptorImageInfo that are not used in an update (as described above) are ignored.

The handle validity check is done only for non-ignored parameters:
> Both of imageView, and sampler that are valid handles of non-ignored parameters must have been created, allocated, or retrieved from the same [VkDevice](https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VkDevice)

