### PR TITLE
D3D12: Move ref buffer/queue Release outside CapTransitionLock in DscardFrameCapture

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_device.cpp
+++ b/renderdoc/driver/d3d12/d3d12_device.cpp
@@ -3377,6 +3377,9 @@ bool WrappedID3D12Device::DiscardFrameCapture(DeviceOwnedWindow devWnd)
 
   rdcarray<WrappedID3D12CommandQueue *> queues;
 
+  rdcarray<WrappedID3D12CommandQueue *> refQueues;
+  rdcarray<ID3D12Resource *> refBuffers;
+
   // transition back to IDLE and readback initial states atomically
   {
     SCOPED_WRITELOCK(m_CapTransitionLock);
@@ -3387,12 +3390,8 @@ bool WrappedID3D12Device::DiscardFrameCapture(DeviceOwnedWindow devWnd)
 
     queues = m_Queues;
 
-    // remove the reference held during capture, potentially releasing the queue.
-    for(WrappedID3D12CommandQueue *q : m_RefQueues)
-      q->Release();
-
-    for(ID3D12Resource *r : m_RefBuffers)
-      r->Release();
+    refQueues.swap(m_RefQueues);
+    refBuffers.swap(m_RefBuffers);
   }
 
   rdcarray<MapState> maps = GetMaps();
@@ -3404,6 +3403,13 @@ bool WrappedID3D12Device::DiscardFrameCapture(DeviceOwnedWindow devWnd)
 
   for(auto it = queues.begin(); it != queues.end(); ++it)
     (*it)->ClearAfterCapture();
+
+  // remove the references held during capture, potentially releasing the queue/buffer.
+  for(WrappedID3D12CommandQueue *q : refQueues)
+    q->Release();
+
+  for(ID3D12Resource *r : refBuffers)
+    r->Release();
 
   for(ID3D12Heap *h : m_InitialStateHeaps)
     h->Release();


### PR DESCRIPTION
`DiscardFrameCapture` releases `m_RefBuffers` and `m_RefQueues` while holding a write lock on `m_CapTransitionLock`. When a resource's ref count reaches zero, the destructor calls `Unmap`, which tries to acquire a read lock on the same `m_CapTransitionLock`.

Since SRW locks are not re-entrant, this deadlocks.