### PR TITLE
Fixed missing switch case break on D3D12DescriptorType::CBV

### DIFF
--- a/renderdoc/driver/d3d12/d3d12_dxil_debug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_dxil_debug.cpp
@@ -1969,6 +1969,7 @@ ResourceReferenceInfo D3D12APIWrapper::FetchResourceReferenceInfo(const DXDebug:
       resRefInfo.resClass = DXIL::ResourceClass::CBuffer;
       resRefInfo.descType = DescriptorType::ConstantBuffer;
       resRefInfo.varType = VarType::ConstantBlock;
+      break;
     }
     case D3D12DescriptorType::SRV:
     {


### PR DESCRIPTION
## Description

When using SM6.6 Bindless with DIrectX 12, debugging a shader will log "Uknown CBuffer resource at Descriptor Index" on ConstantBuffer<T> reads from ResourceDescriptorHeap.

Tracked it down to this.
