### PR TITLE
win32_hook: preserve ordinal forwarding

### DIFF
--- a/renderdoc/os/win32/win32_hook.cpp
+++ b/renderdoc/os/win32/win32_hook.cpp
@@ -766,6 +766,9 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
   if(mod == NULL || func == NULL || mod == s_HookData->ownmodule)
     return GetProcAddress(mod, func);
 
+  const LPCSTR originalRequest = func;
+  const bool requestIsOrdinal = OrdinalAsString((void *)originalRequest);
+
 #if ENABLED(VERBOSE_DEBUG_HOOK)
   if(OrdinalAsString((void *)func))
     RDCDEBUG("Hooked_GetProcAddress(%p, %p)", mod, func);
@@ -813,7 +816,7 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
         RDCDEBUG("Ordinal hook");
 #endif
 
-        uint32_t ordinal = (uint16_t)(uintptr_t(func) & 0xffff);
+        uint32_t ordinal = (uint16_t)(uintptr_t(originalRequest) & 0xffff);
 
         if(ordinal < it->second.OrdinalBase)
         {
@@ -821,7 +824,7 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
                  (uint32_t)it->second.OrdinalBase, it->first.c_str());
 
           SetLastError(S_OK);
-          return GetProcAddress(mod, func);
+          return GetProcAddress(mod, originalRequest);
         }
 
         ordinal -= it->second.OrdinalBase;
@@ -832,10 +835,16 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
                  (uint32_t)it->second.OrdinalNames.size(), it->first.c_str());
 
           SetLastError(S_OK);
-          return GetProcAddress(mod, func);
+          return GetProcAddress(mod, originalRequest);
         }
 
         func = it->second.OrdinalNames[ordinal].c_str();
+
+        if(func == NULL || func[0] == 0)
+        {
+          SetLastError(S_OK);
+          return GetProcAddress(mod, originalRequest);
+        }
 
 #if ENABLED(VERBOSE_DEBUG_HOOK)
         RDCDEBUG("found ordinal %s", func);
@@ -848,7 +857,7 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
           std::lower_bound(it->second.FunctionHooks.begin(), it->second.FunctionHooks.end(), search);
       if(found != it->second.FunctionHooks.end() && !(search < *found))
       {
-        FARPROC realfunc = GetProcAddress(mod, func);
+        FARPROC realfunc = GetProcAddress(mod, requestIsOrdinal ? originalRequest : func);
 
 #if ENABLED(VERBOSE_DEBUG_HOOK)
         RDCDEBUG("Found hooked function, returning hook pointer %p", found->hook);
@@ -870,7 +879,7 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
 
   SetLastError(S_OK);
 
-  return GetProcAddress(mod, func);
+  return GetProcAddress(mod, requestIsOrdinal ? originalRequest : func);
 }
 static void InitHookData()
 {

--- a/renderdoc/os/win32/win32_hook.cpp
+++ b/renderdoc/os/win32/win32_hook.cpp
@@ -761,7 +761,7 @@ static bool OrdinalAsString(void *func)
   return uint64_t(func) <= 0xffff;
 }
 
-FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
+FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR const func)
 {
   if(mod == NULL || func == NULL || mod == s_HookData->ownmodule)
     return GetProcAddress(mod, func);
@@ -810,6 +810,8 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
       RDCDEBUG("Located module %s", it->first.c_str());
 #endif
 
+      LPCSTR searchFunc = func;
+
       if(OrdinalAsString((void *)func))
       {
 #if ENABLED(VERBOSE_DEBUG_HOOK)
@@ -822,53 +824,57 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR func)
         {
           RDCERR("Unexpected ordinal - lower than ordinalbase %u for %s",
                  (uint32_t)it->second.OrdinalBase, it->first.c_str());
-
-          SetLastError(S_OK);
-          return GetProcAddress(mod, originalRequest);
+          searchFunc = NULL;
         }
-
-        ordinal -= it->second.OrdinalBase;
-
-        if(ordinal >= it->second.OrdinalNames.size())
+        else
         {
-          RDCERR("Unexpected ordinal - higher than fetched ordinal names (%u) for %s",
-                 (uint32_t)it->second.OrdinalNames.size(), it->first.c_str());
+          ordinal -= it->second.OrdinalBase;
 
-          SetLastError(S_OK);
-          return GetProcAddress(mod, originalRequest);
+          if(ordinal >= it->second.OrdinalNames.size())
+          {
+            RDCERR("Unexpected ordinal - higher than fetched ordinal names (%u) for %s",
+                   (uint32_t)it->second.OrdinalNames.size(), it->first.c_str());
+            searchFunc = NULL;
+          }
+          else
+          {
+            searchFunc = it->second.OrdinalNames[ordinal].c_str();
+
+            if(searchFunc && searchFunc[0] != 0)
+            {
+  #if ENABLED(VERBOSE_DEBUG_HOOK)
+              RDCDEBUG("found ordinal %s", searchFunc);
+  #endif
+            }
+            else
+            {
+              searchFunc = NULL;
+            }
+          }
         }
-
-        func = it->second.OrdinalNames[ordinal].c_str();
-
-        if(func == NULL || func[0] == 0)
-        {
-          SetLastError(S_OK);
-          return GetProcAddress(mod, originalRequest);
-        }
-
-#if ENABLED(VERBOSE_DEBUG_HOOK)
-        RDCDEBUG("found ordinal %s", func);
-#endif
       }
 
-      FunctionHook search(func, NULL, NULL);
-
-      auto found =
-          std::lower_bound(it->second.FunctionHooks.begin(), it->second.FunctionHooks.end(), search);
-      if(found != it->second.FunctionHooks.end() && !(search < *found))
+      if(searchFunc && searchFunc[0] != 0)
       {
-        FARPROC realfunc = GetProcAddress(mod, requestIsOrdinal ? originalRequest : func);
+        FunctionHook search(searchFunc, NULL, NULL);
+
+        auto found =
+            std::lower_bound(it->second.FunctionHooks.begin(), it->second.FunctionHooks.end(), search);
+        if(found != it->second.FunctionHooks.end() && !(search < *found))
+        {
+          FARPROC realfunc = GetProcAddress(mod, requestIsOrdinal ? originalRequest : searchFunc);
 
 #if ENABLED(VERBOSE_DEBUG_HOOK)
-        RDCDEBUG("Found hooked function, returning hook pointer %p", found->hook);
+          RDCDEBUG("Found hooked function, returning hook pointer %p", found->hook);
 #endif
 
-        SetLastError(S_OK);
+          SetLastError(S_OK);
 
-        if(realfunc == NULL)
-          return NULL;
+          if(realfunc == NULL)
+            return NULL;
 
-        return (FARPROC)found->hook;
+          return (FARPROC)found->hook;
+        }
       }
     }
   }

--- a/renderdoc/os/win32/win32_hook.cpp
+++ b/renderdoc/os/win32/win32_hook.cpp
@@ -761,13 +761,10 @@ static bool OrdinalAsString(void *func)
   return uint64_t(func) <= 0xffff;
 }
 
-FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR const func)
+FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, const LPCSTR func)
 {
   if(mod == NULL || func == NULL || mod == s_HookData->ownmodule)
     return GetProcAddress(mod, func);
-
-  const LPCSTR originalRequest = func;
-  const bool requestIsOrdinal = OrdinalAsString((void *)originalRequest);
 
 #if ENABLED(VERBOSE_DEBUG_HOOK)
   if(OrdinalAsString((void *)func))
@@ -818,63 +815,53 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR const func)
         RDCDEBUG("Ordinal hook");
 #endif
 
-        uint32_t ordinal = (uint16_t)(uintptr_t(originalRequest) & 0xffff);
+        uint32_t ordinal = (uint16_t)(uintptr_t(func) & 0xffff);
 
         if(ordinal < it->second.OrdinalBase)
         {
           RDCERR("Unexpected ordinal - lower than ordinalbase %u for %s",
                  (uint32_t)it->second.OrdinalBase, it->first.c_str());
-          searchFunc = NULL;
-        }
-        else
-        {
-          ordinal -= it->second.OrdinalBase;
-
-          if(ordinal >= it->second.OrdinalNames.size())
-          {
-            RDCERR("Unexpected ordinal - higher than fetched ordinal names (%u) for %s",
-                   (uint32_t)it->second.OrdinalNames.size(), it->first.c_str());
-            searchFunc = NULL;
-          }
-          else
-          {
-            searchFunc = it->second.OrdinalNames[ordinal].c_str();
-
-            if(searchFunc && searchFunc[0] != 0)
-            {
-#if ENABLED(VERBOSE_DEBUG_HOOK)
-              RDCDEBUG("found ordinal %s", searchFunc);
-#endif
-            }
-            else
-            {
-              searchFunc = NULL;
-            }
-          }
-        }
-      }
-
-      if(searchFunc && searchFunc[0] != 0)
-      {
-        FunctionHook search(searchFunc, NULL, NULL);
-
-        auto found = std::lower_bound(it->second.FunctionHooks.begin(),
-                                      it->second.FunctionHooks.end(), search);
-        if(found != it->second.FunctionHooks.end() && !(search < *found))
-        {
-          FARPROC realfunc = GetProcAddress(mod, requestIsOrdinal ? originalRequest : searchFunc);
-
-#if ENABLED(VERBOSE_DEBUG_HOOK)
-          RDCDEBUG("Found hooked function, returning hook pointer %p", found->hook);
-#endif
 
           SetLastError(S_OK);
-
-          if(realfunc == NULL)
-            return NULL;
-
-          return (FARPROC)found->hook;
+          return GetProcAddress(mod, func);
         }
+
+        ordinal -= it->second.OrdinalBase;
+
+        if(ordinal >= it->second.OrdinalNames.size())
+        {
+          RDCERR("Unexpected ordinal - higher than fetched ordinal names (%u) for %s",
+                 (uint32_t)it->second.OrdinalNames.size(), it->first.c_str());
+
+          SetLastError(S_OK);
+          return GetProcAddress(mod, func);
+        }
+
+        searchFunc = it->second.OrdinalNames[ordinal].c_str();
+
+#if ENABLED(VERBOSE_DEBUG_HOOK)
+        RDCDEBUG("found ordinal %s", searchFunc);
+#endif
+      }
+
+      FunctionHook search(searchFunc, NULL, NULL);
+
+      auto found =
+          std::lower_bound(it->second.FunctionHooks.begin(), it->second.FunctionHooks.end(), search);
+      if(found != it->second.FunctionHooks.end() && !(search < *found))
+      {
+        FARPROC realfunc = GetProcAddress(mod, func);
+
+#if ENABLED(VERBOSE_DEBUG_HOOK)
+        RDCDEBUG("Found hooked function, returning hook pointer %p", found->hook);
+#endif
+
+        SetLastError(S_OK);
+
+        if(realfunc == NULL)
+          return NULL;
+
+        return (FARPROC)found->hook;
       }
     }
   }
@@ -885,7 +872,7 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR const func)
 
   SetLastError(S_OK);
 
-  return GetProcAddress(mod, requestIsOrdinal ? originalRequest : func);
+  return GetProcAddress(mod, func);
 }
 static void InitHookData()
 {

--- a/renderdoc/os/win32/win32_hook.cpp
+++ b/renderdoc/os/win32/win32_hook.cpp
@@ -842,9 +842,9 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR const func)
 
             if(searchFunc && searchFunc[0] != 0)
             {
-  #if ENABLED(VERBOSE_DEBUG_HOOK)
+#if ENABLED(VERBOSE_DEBUG_HOOK)
               RDCDEBUG("found ordinal %s", searchFunc);
-  #endif
+#endif
             }
             else
             {
@@ -858,8 +858,8 @@ FARPROC WINAPI Hooked_GetProcAddress(HMODULE mod, LPCSTR const func)
       {
         FunctionHook search(searchFunc, NULL, NULL);
 
-        auto found =
-            std::lower_bound(it->second.FunctionHooks.begin(), it->second.FunctionHooks.end(), search);
+        auto found = std::lower_bound(it->second.FunctionHooks.begin(),
+                                      it->second.FunctionHooks.end(), search);
         if(found != it->second.FunctionHooks.end() && !(search < *found))
         {
           FARPROC realfunc = GetProcAddress(mod, requestIsOrdinal ? originalRequest : searchFunc);


### PR DESCRIPTION
## Description

Fix incorrect forwarding of ordinal-based `GetProcAddress` calls in the Win32 hook layer.

On some systems (e.g. WinAppSDK / `CoreMessagingXP`), `GetProcAddress` can be invoked using an ordinal (e.g. `USER32` ordinal `0xA16`). The current hook attempts to resolve such calls via the `OrdinalNames` mapping and forward them as name-based lookups. If the mapping entry is missing or invalid, this results in forwarding with an incorrect name and subsequent lookup failure (`ERROR_PROC_NOT_FOUND`), which can lead to application termination.

This change preserves the original request for ordinal-based lookups:

* Detect whether the request is ordinal or name-based.
* For ordinal requests, forward using the original ordinal value.
* If ordinal-to-name mapping is unavailable or empty, bypass translation and pass the original request directly.
* Name-based requests continue to behave unchanged.

The fix is limited to `renderdoc/os/win32/win32_hook.cpp` and only affects ordinal handling in `Hooked_GetProcAddress`.

Fixes: [https://github.com/baldurk/renderdoc/issues/3822](https://github.com/baldurk/renderdoc/issues/3822)
