### PR TITLE
Vulkan: refresh shader reflection on ReplaceResource for remote replay

### DIFF
--- a/renderdoc/core/replay_proxy.cpp
+++ b/renderdoc/core/replay_proxy.cpp
@@ -1500,6 +1500,15 @@ void ReplayProxy::Proxied_ReplaceResource(ParamSerialiser &paramser, ReturnSeria
       m_Remote->ReplaceResource(from, to);
   }
 
+  // Invalidate cached shader reflections. The remote driver updates its
+  // ShaderModule reflections in place for replaced shaders (e.g. so the new
+  // SPV's NonSemantic.Shader.DebugInfo.100 source info is reported), so any
+  // proxy-side cached ShaderReflection objects are now stale and must be
+  // refetched on the next GetShader call.
+  for(auto it = m_ShaderReflectionCache.begin(); it != m_ShaderReflectionCache.end(); ++it)
+    delete it->second;
+  m_ShaderReflectionCache.clear();
+
   SERIALISE_RETURN_VOID();
 }
 

--- a/renderdoc/driver/vulkan/vk_replay.cpp
+++ b/renderdoc/driver/vulkan/vk_replay.cpp
@@ -5233,6 +5233,38 @@ void VulkanReplay::ReplaceResource(ResourceId from, ResourceId to)
   // replace the shader module or shader object
   m_pDriver->GetResourceManager()->ReplaceResource(from, to);
 
+  // When replacing a shader module, propagate the new SPV's reflection into the
+  // original shader module's existing reflection slots in-place. This is needed
+  // because SavePipelineState reads `c.m_Pipeline[orig_pipeline].shaders[i].refl`
+  // which is a pointer baked in during the original Pipeline::Init, and the
+  // captured render-state keeps reporting the original pipeline id (the new
+  // pipeline that RefreshDerivedReplacements builds is reached transparently via
+  // the resource manager replacement, not via the m_Pipeline map). Without this
+  // copy, source-debug info (NonSemantic.Shader.DebugInfo.100) that the user
+  // built into the replacement SPV is never visible to the shader debugger UI
+  // ("Source debugging Unavailable"). See ShaderModuleReflection::Reload 鈥?it
+  // preserves the refl pointer identity and rebuilds *refl from the new spirv.
+  {
+    auto fromIt = m_pDriver->m_CreationInfo.m_ShaderModule.find(from);
+    auto toIt = m_pDriver->m_CreationInfo.m_ShaderModule.find(to);
+    if(fromIt != m_pDriver->m_CreationInfo.m_ShaderModule.end() &&
+       toIt != m_pDriver->m_CreationInfo.m_ShaderModule.end() &&
+       !toIt->second.spirv.GetSPIRV().empty())
+    {
+      // overwrite the original module's SPV with the new one so any future reflection
+      // lookup via GetShader(from, ...) also reflects the new debug info.
+      fromIt->second.spirv = toIt->second.spirv;
+
+      // rebuild each existing reflection IN PLACE (pointer identity preserved).
+      for(auto reflIt = fromIt->second.m_Reflections.begin();
+          reflIt != fromIt->second.m_Reflections.end(); ++reflIt)
+      {
+        reflIt->second.Reload(m_pDriver->GetResourceManager(), m_pDriver->m_CreationInfo, from,
+                              fromIt->second.spirv);
+      }
+    }
+  }
+
   // now update any derived resources
   RefreshDerivedReplacements();
 


### PR DESCRIPTION
## Summary

Fix two interlocking bugs that make source-level **Debug Pixel** unavailable
for replaced Vulkan shaders during **Android remote replay**, even when the
replacement SPV embeds `NonSemantic.Shader.DebugInfo.100` (i.e. was compiled
with `dxc -fspv-debug=vulkan-with-source` or `glslang -gV`).

After this PR, source debugging works end-to-end against a shader-replaced
draw on a remote Android target.

## Repro on stock `v1.x`

1. Capture a Vulkan frame on an Android device (remote replay).
2. Open the capture in `qrenderdoc` on the PC (local has no source either).
3. Select a draw call.
4. Python Shell:
   ```python
   import renderdoc as rd
   spv = open(r"BasePassPS.with-source.spv", "rb").read()
   def go(r):
       new_id, _ = r.BuildTargetShader("MainPS", rd.ShaderEncoding.SPIRV,
                                        spv, rd.ShaderCompileFlags(),
                                        rd.ShaderStage.Pixel)
       orig = pyrenderdoc.CurPipelineState().GetShader(rd.ShaderStage.Pixel)
       r.ReplaceResource(orig, new_id)
   pyrenderdoc.Replay().BlockInvoke(go)
   ```
5. Texture Viewer → right-click pixel → **Debug Pixel**.

**Expected:** ShaderViewer shows the source tab populated with the embedded
GLSL/HLSL, F10/F11 step through source.
**Actual on `v1.x`:** ShaderViewer top displays
**`Source debugging Unavailable`** and only the SPIRV-Cross disassembly
view is available.

## Root cause

Two independent issues compound:

### 1. Vulkan reflection pointer is baked into the captured pipeline

`SavePipelineState` reads
`c.m_Pipeline[state.graphics.pipeline].shaders[i].refl` (vk_replay.cpp,
~line 1380), which is a pointer set at the original `Pipeline::Init`
time and points at the original shader module's reflection (with
`sourceDebugInformation = false`). After `ReplaceResource`,
`RefreshDerivedReplacements` builds a *new* pipeline entry, but
`state.graphics.pipeline` continues to report the original ID — the
ResourceManager replacement makes this transparent at the `VkPipeline`
level but does not redirect the reflection lookup.

For comparison, D3D12 reads reflection from the live bytecode wrapper
(`d3d12_replay.cpp:1315`), so replacement automatically surfaces the
new reflection. There is no equivalent path on Vulkan today.

### 2. `ReplayProxy::Proxied_ReplaceResource` does not invalidate the host-side reflection cache

`Proxied_GetShader` (`replay_proxy.cpp:~1201`) is the host-side cache for
all shader reflections fetched from the remote. After
`Proxied_ReplaceResource`, the cache still serves the pre-replacement
entry with `sourceDebugInformation = false`. Even if (1) is fixed so the
remote *would* now return a fresh reflection, the host never asks for it.

Existing `ReplayController::ReloadShaderDebugInformation` does not cover
this path — `WrappedVulkan::ReloadShaderDebugInformation` (`vk_core.cpp`)
filters out replay-only IDs (which the new replacement always is) and
also requires `unstrippedPath`, neither of which fits the runtime-replace
case.

## Fix

* **`renderdoc/driver/vulkan/vk_replay.cpp`** — In
  `VulkanReplay::ReplaceResource`, when both the from/to ShaderModules
  exist and `to` has SPV: copy `to`'s spirv into `from`'s module slot and
  call `ShaderModuleReflection::Reload` on each entry of
  `from->m_Reflections` in place. `Reload` rebuilds `*refl` while
  preserving the pointer's identity, so every `p.shaders[i].refl` pointer
  baked at original `Pipeline::Init` now sees the new
  `sourceDebugInformation` / `DebugSource` data on the next state fetch.

* **`renderdoc/core/replay_proxy.cpp`** — In
  `Proxied_ReplaceResource`, after `m_Remote->ReplaceResource`, free and
  `clear()` `m_ShaderReflectionCache`. Subsequent `Proxied_GetShader`
  calls re-fetch from the remote, which (thanks to the first change) now
  returns the new reflection.

42 insertions across 2 files. No new symbols or behaviour changes outside
the replace path.

## Verification

* **Hardware:** Pixel 9 Pro XL (Tensor G4 / Mali, Vulkan 1.3, Android 16,
  16 KiB ELF page size).
* **Capture:** UE5 mobile Vulkan SM5 frame, basepass pixel shader.
* **Replacement SPV:** UE-dumped `BasePassPixelShader.usf` re-compiled via
  `dxc -spirv -E MainPS -fspv-debug=vulkan-with-source` then
  binding-patched against the runtime SPV (228 KB embedded HLSL source,
  validated with `spirv-val`).
* **Result:** `qrenderdoc.exe` patched with this PR (paired with a
  patched `renderdoccmd` APK on the device — both endpoints need it
  because the two changes live on opposite sides of the replay-proxy)
  shows source-level Debug Pixel working: source tab populated with
  the original `.usf`, F10/F11 steps work, no device-lost / rendering
  regressions across 10 replace iterations.

## Notes for review

* The change is symmetric to how D3D12 already behaves. Conceptually
  this is "what `ReplaceResource` always meant" for shader modules; on
  Vulkan it just had no path through `m_CreationInfo` until now.
* `Reload(...)` already exists for the on-disk-debug-info reload path
  (vk_info.cpp); reusing it preserves any natvis/processor invariants.
* The proxy cache `clear()` is unconditional — even on `ReplaceResource`
  to a non-shader resource it just costs one round-trip per shader on
  next access. Could be tightened to "if shader" if desired, but a brief
  re-fetch is far cheaper than a stale-cache silent failure.
* Both patches can land independently and remain bug fixes individually,
  but neither alone makes source-debug work for the Android remote case.

Closes _no existing issue_ (the symptom is reported sporadically as
"`Source debugging Unavailable` after shader replace on Android" but
isn't tracked under a single issue I could find — happy to file one if
that's preferred).
