### PR TITLE
Vulkan: defer DebugValue/Declare when curScope is NULL

### DIFF
--- a/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
+++ b/renderdoc/driver/shaders/spirv/spirv_debug_setup.cpp
@@ -4693,7 +4693,15 @@ void Debugger::RegisterOp(Iter it)
           // bit of a hack - only process declares/values for variables inside a scope that is
           // within that function. If we see a declare/value in another function we defer it hoping
           // that we will encounter a scope later that's valid for it.
-          const bool insideValidScope = m_DebugInfo.curScope->HasAncestor(varDeclScope);
+          //
+          // Also defer when curScope is NULL: it is explicitly cleared after every block
+          // terminator (OpBranch/OpKill/OpReturn/...) below in this same function. dxc-emitted
+          // NonSemantic.Shader.DebugInfo.100 streams have been observed to interleave a
+          // DebugValue/DebugDeclare in the gap between a block terminator and the next
+          // OpDebugScope, which would dereference NULL here. The else branch below already
+          // pushes the mapping into pendingMappings - the deferred path described above.
+          const bool insideValidScope =
+              m_DebugInfo.curScope && m_DebugInfo.curScope->HasAncestor(varDeclScope);
 
           LocalMapping mapping = {curInstIndex, sourceVarId, debugVarId,
                                   dbg.inst == ShaderDbg::Declare};


### PR DESCRIPTION
# Vulkan: defer DebugValue/Declare when curScope is NULL

## Summary

The SPIR-V debugger setup pass has a NULL-deref hazard in
`Debugger::RegisterOp` when the SPIR-V stream interleaves
`NonSemantic.Shader.DebugInfo.100` `DebugValue` / `DebugDeclare`
instructions between a block terminator and the next `OpDebugScope`.
This crashes Debug Pixel against any such shader. Add a one-line
NULL-check that routes the offending instruction to the existing
deferred-mapping fallback path.

## Repro

1. Compile a small HLSL pixel shader with debug info embedded:
   ```
   dxc -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Od ...
   ```
   (any recent dxc — `1.8.2403` reproduces; older versions also possible)

2. In a Vulkan capture, replace the pixel shader's resource with the
   SPV via `ReplayController::ReplaceResource` (e.g. through the
   Python Shell), then select the affected drawcall and click
   *Debug Pixel*.

3. The replay process crashes:
   ```
   signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x8
   #00 rdcspv::ScopeData::HasAncestor   spirv_debug.h:639
   #01 rdcspv::Debugger::RegisterOp     spirv_debug_setup.cpp:4696
   #02 rdcspv::Processor::Parse         spirv_processor.cpp:483
   #03 VulkanReplay::DebugPixel         vk_shaderdebug.cpp:6253
   #04 ReplayProxy::Proxied_DebugPixel  replay_proxy.cpp:1645
   ```

   The fault address `0x8` is the offset of the `parent` field within
   `ScopeData`:

   ```cpp
   struct ScopeData {
       DebugScope type;        // offset 0
       ScopeData *parent;      // offset 8       <-- NULL+8
       ...
   };
   ```

## Root cause

`m_DebugInfo.curScope` is **explicitly set to NULL** after every
block-terminator opcode (`spirv_debug_setup.cpp:4866` in the same
`RegisterOp`):

```cpp
if(leaveScope || it.opcode() == Op::Kill || it.opcode() == Op::Unreachable ||
   it.opcode() == Op::Branch || it.opcode() == Op::BranchConditional ||
   it.opcode() == Op::Switch || it.opcode() == Op::Return || it.opcode() == Op::ReturnValue)
{
    if(m_DebugInfo.curScope)
        m_DebugInfo.curScope->end = it.offs();

    m_DebugInfo.curScope = NULL;
    m_DebugInfo.curInline = NULL;
}
```

The `ShaderDbg::Declare` / `ShaderDbg::Value` case (at
`spirv_debug_setup.cpp:4685`) does:

```cpp
const bool insideValidScope = m_DebugInfo.curScope->HasAncestor(varDeclScope);
```

…with no NULL check, so any `DebugValue`/`DebugDeclare` that lands in
that gap dereferences NULL.

## Fix

The pre-existing comment on these lines already describes the desired
behaviour for the "no valid scope" case:

> bit of a hack - only process declares/values for variables inside a
> scope that is within that function. If we see a declare/value in
> another function we **defer it** hoping that we will encounter a
> scope later that's valid for it.

…and the existing `else` branch already implements the deferral via
`m_DebugInfo.pendingMappings.push_back(...)`. So the fix is just to
guard the call:

```cpp
const bool insideValidScope = m_DebugInfo.curScope &&
                              m_DebugInfo.curScope->HasAncestor(varDeclScope);
```

NULL `curScope` now flows into the existing `pendingMappings` defer
path instead of crashing.

## Tested

- RenderDoc 1.45 Release build, Android arm64 remote replay against a
  Pixel 9 Pro XL (Android 16, Tensor G4 / Mali GPU). Same Vulkan
  capture + replacement SPV that reproduced the crash now reaches
  Break Mode in the Debug Pixel view; F10/F11 step over/into the HLSL
  source.
- The fix is unrelated to platform / build config; the same code path
  exists on PC. Crash also reproduces on PC Release build with the
  same dxc-built SPV; the fix resolves it there too.

No existing test exercises this code path that I could find — the
debug instructions involved come from external shader compilers and
the project's existing `Debugger` tests don't drive
NonSemantic.Shader.DebugInfo.100 SPIR-V end-to-end. Happy to add a
small unit test if you can point at a good fixture pattern.

## Scope

Single one-line behaviour change with surrounding comment update; no
API change, no behaviour change for the non-NULL case.
