### PR TITLE
Fix GLES wireframe overlay with non-indexed draw

### DIFF
--- a/renderdoc/driver/gl/gl_overlay.cpp
+++ b/renderdoc/driver/gl/gl_overlay.cpp
@@ -805,9 +805,10 @@ ResourceId GLReplay::RenderOverlay(ResourceId texid, FloatVector clearCol, Debug
       {
         // generate 'index' list
         rdcarray<uint32_t> idxs;
+        uint32_t offset = action->vertexOffset;
         idxs.resize(action->numIndices);
         for(uint32_t i = 0; i < action->numIndices; i++)
-          idxs[i] = i;
+          idxs[i] = i + offset;
         PatchLineStripIndexBuffer(action, drawParams.topo, NULL, NULL, idxs.data(), patchedIndices);
       }
 


### PR DESCRIPTION
Wireframe overlay was missing the offset of the first vertex in the draw call and resulted in showing an incorrect wireframe.

This is easily fixed by using the vertexOffset as the first index to use, just like an indexOffset.