### PR TITLE
Fix Qt build with newer MSVC STL

### DIFF
--- a/qrenderdoc/3rdparty/qt/include/QtCore/qcompilerdetection.h
+++ b/qrenderdoc/3rdparty/qt/include/QtCore/qcompilerdetection.h
@@ -105,10 +105,14 @@
 #  endif
 #  define Q_DECL_EXPORT __declspec(dllexport)
 #  define Q_DECL_IMPORT __declspec(dllimport)
-#  if _MSC_VER >= 1800
+#  if _MSC_VER >= 1940
+#    define QT_MAKE_UNCHECKED_ARRAY_ITERATOR(x) (x)
+#  elif _MSC_VER >= 1800
 #    define QT_MAKE_UNCHECKED_ARRAY_ITERATOR(x) stdext::make_unchecked_array_iterator(x)
 #  endif
-#  if _MSC_VER >= 1500
+#  if _MSC_VER >= 1940
+#    define QT_MAKE_CHECKED_ARRAY_ITERATOR(x, N) (x)
+#  elif _MSC_VER >= 1500
 #    define QT_MAKE_CHECKED_ARRAY_ITERATOR(x, N) stdext::make_checked_array_iterator(x, size_t(N))
 #  endif
 /* Intel C++ disguising as Visual C++: the `using' keyword avoids warnings */

--- a/qrenderdoc/3rdparty/qt/include/QtCore/qcompilerdetection.h
+++ b/qrenderdoc/3rdparty/qt/include/QtCore/qcompilerdetection.h
@@ -105,14 +105,10 @@
 #  endif
 #  define Q_DECL_EXPORT __declspec(dllexport)
 #  define Q_DECL_IMPORT __declspec(dllimport)
-#  if _MSC_VER >= 1940
-#    define QT_MAKE_UNCHECKED_ARRAY_ITERATOR(x) (x)
-#  elif _MSC_VER >= 1800
+#  if _MSC_VER >= 1800 && _MSC_VER < 1940
 #    define QT_MAKE_UNCHECKED_ARRAY_ITERATOR(x) stdext::make_unchecked_array_iterator(x)
 #  endif
-#  if _MSC_VER >= 1940
-#    define QT_MAKE_CHECKED_ARRAY_ITERATOR(x, N) (x)
-#  elif _MSC_VER >= 1500
+#  if _MSC_VER >= 1500 && _MSC_VER < 1940
 #    define QT_MAKE_CHECKED_ARRAY_ITERATOR(x, N) stdext::make_checked_array_iterator(x, size_t(N))
 #  endif
 /* Intel C++ disguising as Visual C++: the `using' keyword avoids warnings */


### PR DESCRIPTION
This updates the bundled Qt 5.9.4 compiler detection for newer MSVC STL versions where the non-standard stdext checked array iterator helpers are no longer available.  MSVC Ref:https://github.com/microsoft/STL/wiki/Changelog
The fallback uses raw pointers, matching Qt's existing default behavior when these helper macros are not defined.
Testing:
 Built qrenderdoc_local.vcxproj Release x64 with MSVC 14.51 / v145.