### PR TITLE
Add env variable to capture queued frame

### DIFF
--- a/docs/how/how_capture_frame.rst
+++ b/docs/how/how_capture_frame.rst
@@ -52,6 +52,19 @@ This ``.cap`` file can be executed when RenderDoc's file associations are set up
 
 You can also use the "Auto start" option - when this option is enabled then a .cap file will immediately launch the program when it is loaded. This can allow you to configure a .cap which will open RenderDoc and launch the target application with the pre-configured settings in one click. If you wish to disable this, just uncheck the option and re-save to the same ``.cap`` file.
 
+Environment Variables (Linux/POSIX only)
+----------------------------------------
+
+The ``RENDERDOC_CAPTURE_FRAME`` environment variable can be used to automatically queue a capture of a specific frame number when the application starts.
+
+Example usage:
+
+.. code:: bash
+
+    RENDERDOC_CAPTURE_FRAME=100 ./myapp
+
+This will automatically queue frame 100 to be captured when the application starts.
+
 See Also
 --------
 

--- a/renderdoc/os/posix/posix_libentry.cpp
+++ b/renderdoc/os/posix/posix_libentry.cpp
@@ -51,6 +51,7 @@ void library_loaded()
 
     rdcstr capturefile = Process::GetEnvVariable("RENDERDOC_CAPFILE");
     rdcstr opts = Process::GetEnvVariable("RENDERDOC_CAPOPTS");
+    rdcstr capframe = Process::GetEnvVariable("RENDERDOC_CAPTURE_FRAME");
 
     if(!opts.empty())
     {
@@ -65,6 +66,13 @@ void library_loaded()
     if(!capturefile.empty())
     {
       RenderDoc::Inst().SetCaptureFileTemplate(capturefile);
+    }
+
+    if(!capframe.empty())
+    {
+      uint32_t frameNum = (uint32_t)atoi(capframe.c_str());
+      RDCLOG("Queueing capture of frame %u from RENDERDOC_CAPTURE_FRAME", frameNum);
+      RenderDoc::Inst().QueueCapture(frameNum);
     }
 
     rdcstr curfile;


### PR DESCRIPTION
Adds support for the `RENDERDOC_CAPTURE_FRAME` environment variable to automatically queue a frame capture on library load.
