### PR TITLE
Fix GL pixel shader debug failure with gl_FrontFacing

### DIFF
--- a/renderdoc/driver/gl/gl_shaderdebug.cpp
+++ b/renderdoc/driver/gl/gl_shaderdebug.cpp
@@ -2165,8 +2165,8 @@ precision highp float;
   #extension GL_KHR_shader_subgroup_quad : require
 #endif
 
-// bool signature elements get reflected as ints, make macros for their access to cast to int
-#define gl_FrontFacing (gl_FrontFacing ? 1u : 0u)
+// bool-to-uint conversion is explicit at each use site; no macro to avoid
+// contaminating the user's shader code (gl_FrontFacing must remain bool)
 #define gl_HelperInvocation (gl_HelperInvocation ? 1u : 0u)
 
 )EOSHADER";
@@ -2522,7 +2522,7 @@ void main()
   rd_sample = gl_SampleID;
 #endif
 
-  isFrontFace = gl_FrontFacing;
+  isFrontFace = gl_FrontFacing ? 1u : 0u;
 
 #endif
 


### PR DESCRIPTION
   ## Description                                                                                                                   
                                                                                                                                    
   Pixel shader debug fails on any fragment shader that uses `gl_FrontFacing` in a                                                  
   condition, like:                                                                                                                 
                                                                                                                                    
   ```glsl                                                                                                                          
   vec3 N = gl_FrontFacing ? normalize(v_view_normal) : -normalize(v_view_normal);                                                  
 ```                                                                                                                                
                                                                                                                                    
 Turns out CreateInputFetcher() injects a macro:                                                                                    
                                                                                                                                    
 ```glsl                                                                                                                            
   #define gl_FrontFacing (gl_FrontFacing ? 1u : 0u)                                                                                
 ```                                                                                                                                
                                                                                                                                    
 which was meant to convert the built-in bool to uint for the SSBO output.                                                          
 But it's global, so it also changes every use of gl_FrontFacing in the user's                                                      
 own shader code. The ternary above becomes:                                                                                        
                                                                                                                                    
 ```glsl                                                                                                                            
   (gl_FrontFacing ? 1u : 0u) ? normalize(...) : -normalize(...)                                                                    
 ```                                                                                                                                
                                                                                                                                    
 GLSL needs a bool condition there, not uint, so the replacement shader fails                                                       
 to compile.                                                                                                                        
                                                                                                                                    
 ### Fix                                                                                                                            
                                                                                                                                    
 Two lines:                                                                                                                         
                                                                                                                                    
 1. Drop the macro. gl_FrontFacing stays as the native bool built-in.                                                               
 2. Convert explicitly at the only spot that actually needs uint:                                                                   
 isFrontFace = gl_FrontFacing ? 1u : 0u;                                                                                            
                                                                                                                                    
 The inputs.gl_FrontFacing assignment is generated from GL reflection data                                                          
 which already gets the type right — no conversion needed there.                                                                    
                                                                                                                                    
 ### Tested on                                                                                                                      
                                                                                                                                    
 AMD RX 9070, RadeonSI driver, Linux, OpenGL 3.3 core.     