### PR TITLE
Check both resolveImageView and resolveMode before referencing the view

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_cmd_funcs.cpp
@@ -8053,7 +8053,7 @@ void WrappedVulkan::vkCmdBeginRendering(VkCommandBuffer commandBuffer,
       }
 
       record->MarkImageViewFrameReferenced(viewRecord, ImageRange(), refType);
-      if(att->resolveMode)
+      if(att->resolveMode && att->resolveImageView != VK_NULL_HANDLE)
         record->MarkImageViewFrameReferenced(GetRecord(att->resolveImageView), ImageRange(), refType);
     }
   }


### PR DESCRIPTION
Vulkan spec says:
```
 If resolveMode is not VK_RESOLVE_MODE_NONE, and resolveImageView is not
 VK_NULL_HANDLE, a render pass multisample resolve operation is defined
 for the attachment subresource.
```

So both of them should be valid for resolve to happen.

---

Happens with Zink.