### PR TITLE
Retry RENDERDOC_CreateTargetControl on failure

### DIFF
--- a/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
@@ -1263,8 +1263,21 @@ void LiveCapture::selfClose()
 
 void LiveCapture::connectionThreadEntry()
 {
-  ITargetControl *conn =
-      RENDERDOC_CreateTargetControl(m_Hostname, m_RemoteIdent, GetSystemUsername(), true);
+  ITargetControl *conn=nullptr;
+  //Number of retries
+  const int RETRY_NUM = 5;
+  
+  for(int i=0;i<RETRY_NUM;i++){
+    conn=RENDERDOC_CreateTargetControl(m_Hostname, m_RemoteIdent, GetSystemUsername(), true);
+
+    //If it had been successful
+    if(conn!=nullptr&&conn->Connected()){
+      break;      
+    }
+    //Wait a moment before retrying
+    QThread::msleep(100);
+  }
+
   m_Connected.release();
 
   if(!conn || !conn->Connected())

--- a/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
+++ b/qrenderdoc/Windows/Dialogs/LiveCapture.cpp
@@ -1263,18 +1263,20 @@ void LiveCapture::selfClose()
 
 void LiveCapture::connectionThreadEntry()
 {
-  ITargetControl *conn=nullptr;
-  //Number of retries
+  ITargetControl *conn = nullptr;
+  // Number of retries
   const int RETRY_NUM = 5;
-  
-  for(int i=0;i<RETRY_NUM;i++){
-    conn=RENDERDOC_CreateTargetControl(m_Hostname, m_RemoteIdent, GetSystemUsername(), true);
 
-    //If it had been successful
-    if(conn!=nullptr&&conn->Connected()){
-      break;      
+  for(int i = 0; i < RETRY_NUM; i++)
+  {
+    conn = RENDERDOC_CreateTargetControl(m_Hostname, m_RemoteIdent, GetSystemUsername(), true);
+
+    // If it had been successful
+    if(conn != nullptr && conn->Connected())
+    {
+      break;
     }
-    //Wait a moment before retrying
+    // Wait a moment before retrying
     QThread::msleep(100);
   }
 


### PR DESCRIPTION
## Description

> **Note:** This text was translated using translation software.

This issue occurs on **Windows 11** when targeting **DirectX 11** applications.

When launching an application via **Launch Application → Launch**, the connection fails with a high probability.

I tested this on two different PCs running **Windows 11 25H2** and with two different DirectX 11 applications, and observed the same behavior in both cases.

I cannot say for certain, but I believe this issue started occurring with **Windows 11 25H2**.

I found that retrying `RENDERDOC_CreateTargetControl` after it fails in `qrenderdoc/Windows/Dialogs/LiveCapture.cpp` (around line 1272) resolves the problem.

As another workaround, increasing the timeout value (currently `750`) in the following code also appears to resolve the issue:

`renderdoc/core/target_control.cpp` (around line 997)

```cpp
Network::Socket *sock = Network::CreateClientSocket(host, port, 750);
```

I hope this information is helpful.
