### PR TITLE
Fix shader feedback crash with cross-pipe shader objects bound

### DIFF
--- a/renderdoc/driver/vulkan/vk_debug.cpp
+++ b/renderdoc/driver/vulkan/vk_debug.cpp
@@ -3705,6 +3705,13 @@ void VulkanReplay::PrepareStateForPatchedShader(
 
   for(uint32_t i = 0; i < NumShaderStages; i++)
   {
+    // only recreate the shader objects the event actually executes: the compute slot for a
+    // dispatch, the graphics stages for a draw. Shader object binds persist across pipeline
+    // binds, so foreign-pipe slots can still hold objects from earlier commands that this event
+    // never runs.
+    if(compute != (ShaderStage(i) == ShaderStage::Compute))
+      continue;
+
     ResourceId shadId = modifiedstate.shaderObjects[i];
     if(shadId == ResourceId())
       continue;

--- a/renderdoc/driver/vulkan/vk_shader_feedback.cpp
+++ b/renderdoc/driver/vulkan/vk_shader_feedback.cpp
@@ -1770,6 +1770,11 @@ bool VulkanReplay::FetchShaderFeedback(uint32_t eventId)
 
     int idx = StageIndex(stage);
 
+    // the bound pipeline may not cover this stage - e.g. a graphics pipeline lacking a stage
+    // that a later vkCmdBindShadersEXT supplies. With no reflection there is nothing to annotate.
+    if(!pipeInfo.shaders[idx].refl || !pipeInfo.shaders[idx].patchData)
+      return false;
+
     modSpirv = origSpirv;
 
     static const rdcstr filename[NumShaderStages] = {


### PR DESCRIPTION
### Description

When replaying a frame capture that mixes `vkCmdBindPipeline` and `vkCmdBindShadersEXT` in one command buffer, RenderDoc segfault as soon as I select a specific compute dispatch — via the event browser in the UI or `ReplayController.SetFrameEvent` in the python API. The capture loads fine, the initial replay completes, action enumeration and inspecting the shader-object draws themselves all work; only selecting that dispatch crashes, deterministically, every time.

### Root Cause 

`PrepareStateForPatchedShader` walks every bound shader-object slot regardless of the event type. Shader-object binds legally persist across pipeline binds, so at a compute dispatch the graphics `VkShaderEXT`s from earlier draws are still bound; the patch callback then indexes the event's COMPUTE pipeline reflection at a graphics stage and dereferences a NULL `ShaderReflection*` inside `AnnotateShader`.

### Proposed Changes

Skip shader object slots that don't belong to the event's pipe, and return unpatched when the bound pipeline has no reflection for the requested stage. No change for captures without shader objects.

**Note for review**: Shader feedback still sources reflection only from bound pipelines, so events whose shaders come from shader objects produce no feedback data, as before - supporting that would be separate feature work on top of this fix.