### PR TITLE
Support old GEP type instructions

### DIFF
--- a/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
@@ -236,7 +236,8 @@ void Program::ParseConstant(ValueList &values, const LLVMBC::BlockOrRecord &cons
     c->setCompound(alloc, std::move(members));
     values.addValue();
   }
-  else if(IS_KNOWN(constant.id, ConstantsRecord::EVAL_GEP))
+  else if(IS_KNOWN(constant.id, ConstantsRecord::EVAL_GEP) ||
+          IS_KNOWN(constant.id, ConstantsRecord::EVAL_GEP_OLD))
   {
     Constant *c = values.nextValue<Constant>();
 

--- a/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode.cpp
@@ -236,8 +236,8 @@ void Program::ParseConstant(ValueList &values, const LLVMBC::BlockOrRecord &cons
     c->setCompound(alloc, std::move(members));
     values.addValue();
   }
-  else if(IS_KNOWN(constant.id, ConstantsRecord::EVAL_GEP) ||
-          IS_KNOWN(constant.id, ConstantsRecord::EVAL_GEP_OLD))
+  else if(IS_KNOWN(constant.id, ConstantsRecord::EVAL_INBOUNDS_GEP) ||
+          IS_KNOWN(constant.id, ConstantsRecord::EVAL_GEP))
   {
     Constant *c = values.nextValue<Constant>();
 

--- a/renderdoc/driver/shaders/dxil/dxil_bytecode_editor.cpp
+++ b/renderdoc/driver/shaders/dxil/dxil_bytecode_editor.cpp
@@ -1808,7 +1808,7 @@ void ProgramEditor::EncodeConstants(LLVMBC::BitcodeWriter &writer,
         vals.push_back(getValueID(c->getMembers()[m]));
       }
 
-      writer.Record(LLVMBC::ConstantsRecord::EVAL_GEP, vals);
+      writer.Record(LLVMBC::ConstantsRecord::EVAL_INBOUNDS_GEP, vals);
     }
     else if(IsCast(c->op))
     {

--- a/renderdoc/driver/shaders/dxil/llvm_common.h
+++ b/renderdoc/driver/shaders/dxil/llvm_common.h
@@ -111,8 +111,8 @@ enum class ConstantsRecord : uint32_t
   CSTRING = 9,
   EVAL_BINOP = 10,
   EVAL_CAST = 11,
-  EVAL_GEP_OLD = 12,
-  EVAL_GEP = 20,
+  EVAL_GEP = 12,
+  EVAL_INBOUNDS_GEP = 20,
   DATA = 22,
 };
 

--- a/renderdoc/driver/shaders/dxil/llvm_common.h
+++ b/renderdoc/driver/shaders/dxil/llvm_common.h
@@ -111,6 +111,7 @@ enum class ConstantsRecord : uint32_t
   CSTRING = 9,
   EVAL_BINOP = 10,
   EVAL_CAST = 11,
+  EVAL_GEP_OLD = 12,
   EVAL_GEP = 20,
   DATA = 22,
 };


### PR DESCRIPTION
In some situations, old gep instructions can be generated by dxc, this is leading to a crash when replaying the capture (since the instruction _id#12_ is not handled). The code that handles GEP, is already capable of handling both versions, I just added the enum entry so this instruction is handled. A capture will be sent privately showing the problem.
