### PR TITLE
Add Russian translations to the desktop entry

### DIFF
--- a/qrenderdoc/share/renderdoc.desktop
+++ b/qrenderdoc/share/renderdoc.desktop
@@ -2,6 +2,7 @@
 Version=1.0
 Name=RenderDoc
 Comment=A stand-alone graphics API debugger
+Comment[ru]=Автономный отладчик графических API
 GenericName=Graphics Debugger
 Exec=qrenderdoc %f
 Icon=application-x-renderdoc-capture
@@ -9,5 +10,7 @@ Terminal=false
 Type=Application
 X-MultipleArgs=false
 Categories=Development;
+Keywords=RenderDoc;
+Keywords[ru]=РендерДок;
 StartupNotify=true
 MimeType=application/x-renderdoc-capture;


### PR DESCRIPTION
The compromise from #3893: the display name is left alone, and the transliterated name goes into Keywords so RenderDoc can be found from a Cyrillic layout without switching layouts. Plus the translated Comment.

The non-localised `Keywords` key is only there because `desktop-file-validate` rejects `Keywords[ru]` without it. It just repeats the name — no vague keywords added.

Checked with `desktop-file-validate`, and by reading the file back under a Russian locale: Comment and Keywords come out translated, Name stays RenderDoc.
