### PR TITLE
Add missing pipeline barrier in Apply_InitialState()

### DIFF
--- a/renderdoc/driver/vulkan/vk_initstate.cpp
+++ b/renderdoc/driver/vulkan/vk_initstate.cpp
@@ -2084,6 +2084,22 @@ void WrappedVulkan::Apply_InitialState(WrappedVkRes *res, VkInitialContents &ini
       }
       else
       {
+        // srcBuf was initilized with a vkCmdCopyBuffer() or vkCmdFillBuffer() earlier
+        // in this command buffer. Add a barrier to make sure that command finishes
+        // before this copy.
+        VkBufferMemoryBarrier srcBufBarrier = {
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+            NULL,
+            VK_ACCESS_TRANSFER_WRITE_BIT,
+            VK_ACCESS_TRANSFER_READ_BIT,
+            VK_QUEUE_FAMILY_IGNORED,
+            VK_QUEUE_FAMILY_IGNORED,
+            Unwrap(srcBuf),
+            0,
+            VK_WHOLE_SIZE,
+        };
+        DoPipelineBarrier(cmd, 1, &srcBufBarrier);
+
         VkBufferCopy bufCopy;
         bufCopy.srcOffset = boundMemoryOffset;
         bufCopy.size = boundMemorySize;


### PR DESCRIPTION
The commands to initialize srcBuf must complete before it is copied. Sync validation reports this as a READ_AFTER_WRITE hazard.  This also fixes a VK_Image_Layouts test failure when running with KosmicKrisp.

The full error:
```
Validation Error: [ SYNC-HAZARD-READ-AFTER-WRITE ]
vkCmdCopyBuffer(): READ_AFTER_WRITE hazard detected. vkCmdCopyBuffer reads
VkBuffer 0x6a000000006a, which was previously written by another
vkCmdCopyBuffer[!!!!RenderDoc Internal: ApplyInitialContents batched list::
Initial state for ResourceId::182] command.
No sufficient synchronization is present to ensure that a read
(VK_ACCESS_2_TRANSFER_READ_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT does not
conflict with a prior write (VK_ACCESS_2_TRANSFER_WRITE_BIT) at the same stage.
```