### PR TITLE
Fix NULL deref querying EGL extensions on an uninitialised display

### DIFF
--- a/renderdoc/driver/gl/egl_hooks.cpp
+++ b/renderdoc/driver/gl/egl_hooks.cpp
@@ -590,11 +590,15 @@ HOOK_EXPORT const char *EGLAPIENTRY eglQueryString_renderdoc_hooked(EGLDisplay d
 
   if(name == EGL_EXTENSIONS && !Android_AllowAllEGLExtensions())
   {
+    const char *implExts = EGL.QueryString(dpy, name);
+    if(implExts == NULL)
+      return NULL;
+
     rdcstr *extStr = eglhook.extStrings[dpy];
     if(extStr == NULL)
       extStr = eglhook.extStrings[dpy] = new rdcstr;
 
-    const rdcstr implExtStr = EGL.QueryString(dpy, name);
+    const rdcstr implExtStr = implExts;
 
     rdcarray<rdcstr> exts;
     split(implExtStr, exts, ' ');


### PR DESCRIPTION
## Description

`eglQueryString` is allowed to fail and return NULL - `EGL_NOT_INITIALIZED` for a display that was never initialised, for example. The `EGL_EXTENSIONS` filtering path in `eglQueryString_renderdoc_hooked` constructed an `rdcstr` directly from that pointer, so `strlen()` dereferenced NULL:

    signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
    Cause: null pointer dereference

    #00 __strlen_aarch64                       libc.so
    #01 eglQueryString_renderdoc_hooked+324    libVkLayer_GLES_RenderDoc.so
    #02 ...                                    (application querying EGL_EXTENSIONS)

This is reachable on Android whenever the GLES layer is loaded alongside the Vulkan layer - both `gpu_debug_layers` and `gpu_debug_layers_gles` get set without knowing which API the target uses. An application driving Vulkan can still probe EGL for extensions without ever initialising a display, and it then dies a few seconds into startup before any capture can be made.

Returning NULL early matches what the application would have received with no layer loaded. The other two `eglQueryString` callsites - `EGLHook::IsYFlipped` and the sRGB surface check in `egl_platform.cpp` - already guard against NULL.

Tested on a Pixel 6 Pro (Android 17, Mali-G78) with a Vulkan application that reproducibly crashed about three seconds into startup under the official 1.46 arm64 layer. With this fix built into the layer and the exact same `gpu_debug_*` settings, layer injection is confirmed (present in `/proc/<pid>/maps`) and the application keeps running with the overlay reporting normal capture.
