### PR TITLE
Fix back-face dynamic stencil state replay

### DIFF
--- a/renderdoc/driver/vulkan/vk_state.cpp
+++ b/renderdoc/driver/vulkan/vk_state.cpp
@@ -623,8 +623,8 @@ void VulkanRenderState::BindDynamicState(WrappedVulkan *vk, VkCommandBuffer cmd)
     {
       ObjDisp(cmd)->CmdSetStencilOpEXT(Unwrap(cmd), VK_STENCIL_FACE_FRONT_BIT, front.failOp,
                                        front.passOp, front.depthFailOp, front.compareOp);
-      ObjDisp(cmd)->CmdSetStencilOpEXT(Unwrap(cmd), VK_STENCIL_FACE_BACK_BIT, front.failOp,
-                                       front.passOp, front.depthFailOp, front.compareOp);
+      ObjDisp(cmd)->CmdSetStencilOpEXT(Unwrap(cmd), VK_STENCIL_FACE_BACK_BIT, back.failOp,
+                                       back.passOp, back.depthFailOp, back.compareOp);
     }
   }
 


### PR DESCRIPTION
## Description

Fix the back-face `vkCmdSetStencilOpEXT` replay path to use the tracked back-face stencil operations and compare operation, rather than incorrectly reusing the front-face state.

This fixes partial replay and stencil overlays when front and back stencil state differ.
