### PR TITLE
Add missing barrier between fill and copy in ReplayIndirectCB

### DIFF
--- a/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
+++ b/renderdoc/driver/vulkan/wrappers/vk_draw_funcs.cpp
@@ -222,6 +222,12 @@ void WrappedVulkan::ReplayIndirectCB(VkCommandBuffer commandBuffer, VkBuffer buf
 
   const VkDeviceSize regionSize = (drawEnd > drawStart) ? drawEnd - drawStart : 0;
   VkBufferCopy region = {offset + drawStart, drawStart, regionSize};
+
+  // wait for the fill to complete before copying
+  bufBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  bufBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  DoPipelineBarrier(commandBuffer, 1, &bufBarrier);
+
   ObjDisp(commandBuffer)
       ->CmdCopyBuffer(Unwrap(commandBuffer), Unwrap(buffer), m_IndirectBufferCB.UnwrappedBuffer(),
                       1, &region);


### PR DESCRIPTION
Transfer writes are not implicitly ordered, so without a barrier the fill could complete after the copy. This was causing intermittent failures in the VK_Indirect test when running with KosmicKrisp.

Synchronization validation reports this error:

```
vkCmdCopyBuffer(): WRITE_AFTER_WRITE hazard detected. vkCmdCopyBuffer writes to
VkBuffer [m_IndirectBufferActionCB], which was previously written by
vkCmdFillBuffer[Drawcall callback replay (drawCount=1)].
```