### PR TITLE
Don't create a zero-sized patched index buffer for empty draws

### DIFF
--- a/renderdoc/driver/vulkan/vk_overlay.cpp
+++ b/renderdoc/driver/vulkan/vk_overlay.cpp
@@ -647,6 +647,13 @@ void VulkanDebugManager::PatchLineStripIndexBuffer(const ActionDescription *acti
   ::PatchLineStripIndexBuffer(action, MakePrimitiveTopology(rs.primitiveTopology, 3), idx8, idx16,
                               idx32, patchedIndices);
 
+  // don't bother to create a 0 length index buffer which the caller won't use
+  if(patchedIndices.empty())
+  {
+    indexCount = 0;
+    return;
+  }
+
   indexBuffer.Create(m_pDriver, m_Device, patchedIndices.size() * sizeof(uint32_t), 1,
                      GPUBuffer::eGPUBufferIBuffer);
   indexBuffer.Name("PatchedStripIB");


### PR DESCRIPTION
For empty draws, VulkanDebugManager::PatchLineStripIndexBuffer() can end up with an empty list of patched indices, which it then tries to put into a 0 length index buffer. The only caller of this method only uses the index buffer if the returned indexCount is > 0, so this is wasted work.

Creating a 0 length buffer violates VUID-VkBufferCreateInfo-size-00912 and fails on KosmicKrisp. Other mesa drivers silently round the size up to 4096 bytes, the minium allocation size for kernel mode drivers.

This is triggered by check_empty_draw_overlays() in the VK_Indirect test.